### PR TITLE
Add missing "@ai-sdk/react" dependency

### DIFF
--- a/apps/cli/src/constants.ts
+++ b/apps/cli/src/constants.ts
@@ -75,6 +75,7 @@ export const dependencyVersionMap = {
 	ai: "^4.2.8",
 	"@ai-sdk/google": "^1.2.3",
 	"@ai-sdk/vue": "^1.2.8",
+	"@ai-sdk/react": "^1.2.9",
 	"@ai-sdk/svelte": "^2.1.9",
 
 	"@prisma/extension-accelerate": "^1.3.0",

--- a/apps/cli/src/helpers/examples-setup.ts
+++ b/apps/cli/src/helpers/examples-setup.ts
@@ -30,7 +30,7 @@ export async function setupExamples(config: ProjectConfig): Promise<void> {
 		}
 
 		await addPackageDependency({
-			dependencies: ["ai", "@ai-sdk/google"],
+			dependencies: ["ai", "@ai-sdk/react", "@ai-sdk/google"],
 			projectDir: serverDir,
 		});
 	}

--- a/apps/cli/src/helpers/examples-setup.ts
+++ b/apps/cli/src/helpers/examples-setup.ts
@@ -15,6 +15,7 @@ export async function setupExamples(config: ProjectConfig): Promise<void> {
 
 		const hasNuxt = frontend.includes("nuxt");
 		const hasSvelte = frontend.includes("svelte");
+		const hasReact = frontend.includes("react");
 
 		if (clientDirExists) {
 			const dependencies: AvailableDependencies[] = ["ai"];
@@ -23,6 +24,9 @@ export async function setupExamples(config: ProjectConfig): Promise<void> {
 			} else if (hasSvelte) {
 				dependencies.push("@ai-sdk/svelte");
 			}
+			} else if (hasReact) {
+				dependencies.push("@ai-sdk/react");
+			}
 			await addPackageDependency({
 				dependencies,
 				projectDir: clientDir,
@@ -30,7 +34,7 @@ export async function setupExamples(config: ProjectConfig): Promise<void> {
 		}
 
 		await addPackageDependency({
-			dependencies: ["ai", "@ai-sdk/react", "@ai-sdk/google"],
+			dependencies: ["ai", "@ai-sdk/google"],
 			projectDir: serverDir,
 		});
 	}


### PR DESCRIPTION
This PR adds the missing "@ai-sdk/react": "^1.2.9", dependency used by AI example. 

### Reproduction of the issue:
run:
```sh
pnpm create better-t-stack@latest my-better-t-app --yes --frontend tanstack-start --database postgres --runtime node --api orpc --package-manager pnpm --addons husky turborepo biome --examples ai todo
```
Does not include this dependency.

### Notice:
I **didn't** check the solution; edit everything from the GitHub web UI. 