### PR TITLE
refactor frontend flag 

### DIFF
--- a/apps/web/src/app/(home)/_components/stack-builder.tsx
+++ b/apps/web/src/app/(home)/_components/stack-builder.tsx
@@ -790,34 +790,19 @@ const generateCommand = (stackState: StackState): string => {
 		value: StackState[K],
 	) => isStackDefault(stackState, key, value);
 
-	if (!checkDefault("webFrontend", stackState.webFrontend)) {
-		if (
-			stackState.webFrontend.length === 0 ||
-			stackState.webFrontend[0] === "none"
-		) {
+	const combinedFrontends = [
+		...stackState.webFrontend,
+		...stackState.nativeFrontend,
+	].filter((v, _, arr) => v !== "none" || arr.length === 1);
+
+	if (
+		!checkDefault("webFrontend", stackState.webFrontend) ||
+		!checkDefault("nativeFrontend", stackState.nativeFrontend)
+	) {
+		if (combinedFrontends.length === 0 || combinedFrontends[0] === "none") {
 			flags.push("--frontend none");
 		} else {
-			flags.push(`--frontend ${stackState.webFrontend.join(" ")}`);
-		}
-	}
-
-	if (!checkDefault("nativeFrontend", stackState.nativeFrontend)) {
-		if (
-			stackState.nativeFrontend.length > 0 &&
-			stackState.nativeFrontend[0] !== "none"
-		) {
-			if (checkDefault("webFrontend", stackState.webFrontend)) {
-				flags.push(`--frontend ${stackState.nativeFrontend.join(" ")}`);
-			} else {
-				const existingFrontendIndex = flags.findIndex((f) =>
-					f.startsWith("--frontend "),
-				);
-				if (existingFrontendIndex !== -1) {
-					flags[existingFrontendIndex] += ` ${stackState.nativeFrontend.join(
-						" ",
-					)}`;
-				}
-			}
+			flags.push(`--frontend ${combinedFrontends.join(" ")}`);
 		}
 	}
 


### PR DESCRIPTION
This PR solves the frontend none bug, when there is no frontend but a Native Frontend.

A new array is created by joining webFrontend and nativeFrontend and removes the none if there is more than one element.

Closes #256 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the logic for generating frontend flags, resulting in more consistent and unified command output when selecting web or native frontends. No visible changes to the interface or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->