### PR TITLE
fixed(#269): duplicate logging message during project creation

### DIFF
--- a/.changeset/strong-buttons-explode.md
+++ b/.changeset/strong-buttons-explode.md
@@ -1,0 +1,5 @@
+---
+"create-better-t-stack": patch
+---
+
+fixed(#269): duplicate logging message during project creation

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -627,9 +627,6 @@ function processAndValidateFlags(
 			process.exit(1);
 		}
 		config.examples = [];
-		log.info(
-			"Due to '--backend none', the following options have been automatically set: --auth=false, --database=none, --orm=none, --api=none, --runtime=none, --db-setup=none, --examples=none",
-		);
 	} else {
 		const effectiveDatabase =
 			config.database ?? (options.yes ? DEFAULT_CONFIG.database : undefined);


### PR DESCRIPTION
## Description

This PR addresses an issue where the same informational message about automatically set options is displayed twice when creating a new Better-T-Stack project with `--backend none`.

## Changes

- Modified the logging logic in the project creation process to prevent duplicate messages
- Ensured the informational message about automatically set options appears only once
- Maintained all necessary logging information while eliminating redundancy

## Reason for change

When creating a new project with `--backend none` option, users were seeing duplicate messages:

```
Due to '--backend none', the following options have been automatically set: --auth=false, --database=none, --orm=none, --api=none, --runtime=none, --db-setup=none, --examples=none
```

This redundancy could confuse users and clutter the console output unnecessarily.

## Testing

- Verified that creating a new project with `--backend none` now displays the message only once
- Confirmed all project scaffold options are still correctly applied
- Tested with different frontend options to ensure compatibility

| Before    | After|
| -------- | ------- |
| ![image](https://github.com/user-attachments/assets/90d3be67-edca-4280-a513-41c63feba1d0)  | ![image](https://github.com/user-attachments/assets/feef2e79-874c-49ad-9032-7b370640930f) |

## Related Issues
Fixes #265  - "Duplicate log message during project creation with --backend none option"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Removed an informational log message related to automatic configuration settings when the backend option is set to "none". No changes to application behavior.
  - Fixed duplicate logging messages during project creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->