### PR TITLE
change check to check-types in turbo.json template

### DIFF
--- a/apps/cli/templates/addons/turborepo/turbo.json.hbs
+++ b/apps/cli/templates/addons/turborepo/turbo.json.hbs
@@ -10,7 +10,7 @@
 		"lint": {
 			"dependsOn": ["^lint"]
 		},
-		"check": {
+		"check-types": {
 			"dependsOn": ["^check-types"]
 		},
 		"dev": {


### PR DESCRIPTION
In the turbo.json template, I changed "check" to "check-types" under tasks. With just "check" I was getting this error in my project, but it resolved when i changed to "check-types":

```× Missing tasks in project
  ╰─▶   × Could not find task `check-types` in project

error: script "check-types" exited with code 1
```