### PR TITLE
fix(post-installation): use selected package manager

### DIFF
--- a/.changeset/shy-pillows-give.md
+++ b/.changeset/shy-pillows-give.md
@@ -1,0 +1,5 @@
+---
+"create-better-t-stack": patch
+---
+
+fix(post-installation): use selected package manager

--- a/apps/cli/src/helpers/project-generation/post-installation.ts
+++ b/apps/cli/src/helpers/project-generation/post-installation.ts
@@ -108,10 +108,10 @@ export function displayPostInstallInstructions(
 					"IMPORTANT:",
 				)} Complete D1 database setup first (see Database commands below)\n`;
 			}
-			output += `${pc.cyan(`${stepCounter++}.`)} bun dev\n`;
+			output += `${pc.cyan(`${stepCounter++}.`)} ${packageManager} dev\n`;
 			output += `${pc.cyan(
 				`${stepCounter++}.`,
-			)} cd apps/server && bun run cf-typegen\n\n`;
+			)} cd apps/server && ${packageManager} run cf-typegen\n\n`;
 		} else {
 			output += "\n";
 		}

--- a/apps/cli/src/helpers/project-generation/post-installation.ts
+++ b/apps/cli/src/helpers/project-generation/post-installation.ts
@@ -108,7 +108,7 @@ export function displayPostInstallInstructions(
 					"IMPORTANT:",
 				)} Complete D1 database setup first (see Database commands below)\n`;
 			}
-			output += `${pc.cyan(`${stepCounter++}.`)} ${packageManager} dev\n`;
+			output += `${pc.cyan(`${stepCounter++}.`)} ${runCmd} dev\n`;
 			output += `${pc.cyan(
 				`${stepCounter++}.`,
 			)} cd apps/server && ${packageManager} run cf-typegen\n\n`;

--- a/apps/cli/src/helpers/project-generation/post-installation.ts
+++ b/apps/cli/src/helpers/project-generation/post-installation.ts
@@ -111,7 +111,7 @@ export function displayPostInstallInstructions(
 			output += `${pc.cyan(`${stepCounter++}.`)} ${runCmd} dev\n`;
 			output += `${pc.cyan(
 				`${stepCounter++}.`,
-			)} cd apps/server && ${packageManager} run cf-typegen\n\n`;
+			)} cd apps/server && ${runCmd} run cf-typegen\n\n`;
 		} else {
 			output += "\n";
 		}


### PR DESCRIPTION
<img width="558" alt="Screenshot 2025-06-22 at 18 03 12" src="https://github.com/user-attachments/assets/9fe0b53f-0910-4b8c-a1ea-6322e6e8b623" />
I selected pnpm as the project's package manager but still got bun in the post installation steps, this pr should fix this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Post-installation instructions now display the correct package manager commands based on your selected package manager, instead of always showing "bun".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->