### PR TITLE
feat: add metadata to showcase

### DIFF
--- a/apps/web/src/app/(home)/showcase/page.tsx
+++ b/apps/web/src/app/(home)/showcase/page.tsx
@@ -33,6 +33,85 @@ const showcaseProjects = [
 	},
 ];
 
+const ogImage =
+	"https://api.screenshothis.com/v1/screenshots/take?api_key=ss_live_NQJgRXqHcKPwnoMTuQmgiwLIGbVfihjpMyQhgsaMyNBHTyesvrxpYNXmdgcnxipc&url=https%3A%2F%2Fbetter-t-stack.dev%2Fshowcase&width=1200&height=630&block_ads=true&block_cookie_banners=true&block_trackers=true&device_scale_factor=0.75&prefers_color_scheme=dark&is_cached=true";
+
+export const metadata: Metadata = {
+	title: "Better-T Stack",
+	description:
+		"A modern CLI tool for scaffolding end-to-end type-safe TypeScript projects with best practices and customizable configurations",
+	keywords: [
+		"TypeScript",
+		"project scaffolding",
+		"boilerplate",
+		"type safety",
+		"Drizzle",
+		"Prisma",
+		"hono",
+		"elysia",
+		"turborepo",
+		"trpc",
+		"orpc",
+		"turso",
+		"neon",
+		"Better-Auth",
+		"convex",
+		"monorepo",
+		"Better-T Stack",
+		"create-better-t-stack",
+	],
+	authors: [{ name: "Better-T Stack Team" }],
+	creator: "Better-T Stack",
+	publisher: "Better-T Stack",
+	formatDetection: {
+		email: false,
+		telephone: false,
+	},
+	metadataBase: new URL("https://better-t-stack.dev/showcase"),
+	alternates: {
+		canonical: "/",
+	},
+	openGraph: {
+		title: "Better-T Stack",
+		description:
+			"A modern CLI tool for scaffolding end-to-end type-safe TypeScript projects with best practices and customizable configurations",
+		url: "https://better-t-stack.dev",
+		siteName: "Better-T Stack",
+		images: [
+			{
+				url: ogImage,
+				width: 1200,
+				height: 630,
+				alt: "Better-T Stack - Showcase",
+			},
+		],
+		locale: "en_US",
+		type: "website",
+	},
+	twitter: {
+		card: "summary_large_image",
+		title: "Better-T Stack",
+		description:
+			"A modern CLI tool for scaffolding end-to-end type-safe TypeScript projects with best practices and customizable configurations",
+		images: [ogImage],
+	},
+	robots: {
+		index: true,
+		follow: true,
+		googleBot: {
+			index: true,
+			follow: true,
+			"max-image-preview": "large",
+			"max-video-preview": -1,
+			"max-snippet": -1,
+		},
+	},
+	category: "Technology",
+	icons: {
+		icon: "/logo.svg",
+	},
+};
+
 export default function ShowcasePage() {
 	return (
 		<>


### PR DESCRIPTION
I just copy and paste the layout metadata to the showcase page, but the OG is different, feel free to fill up the rest of the metadata with page specific title and description for SEO purposes, but the image is ready to be rendered