### PR TITLE
fix: Tauri setup command errors with string escaping on Windows with Bun

### DIFF
--- a/apps/cli/src/helpers/setup/tauri-setup.ts
+++ b/apps/cli/src/helpers/setup/tauri-setup.ts
@@ -63,31 +63,55 @@ export async function setupTauri(config: ProjectConfig): Promise<void> {
 						? "../build/client"
 						: "../dist";
 
-		const tauriArgs = [
+		const isWindows = process.platform === "win32";
+
+		const appName = path.basename(projectDir);
+
+		const commonArgs = [
 			"init",
-			`--app-name=${path.basename(projectDir)}`,
-			`--window-title=${path.basename(projectDir)}`,
+			`--app-name=${appName}`,
+			`--window-title=${appName}`,
 			`--frontend-dist=${frontendDist}`,
 			`--dev-url=${devUrl}`,
-			`--before-dev-command=\"${packageManager} run dev\"`,
-			`--before-build-command=\"${packageManager} run build\"`,
 		];
-		const tauriArgsString = tauriArgs.join(" ");
 
-		const commandWithArgs = `@tauri-apps/cli@latest ${tauriArgsString}`;
+		if (isWindows && packageManager === "bun") {
+			const baseCommand = getPackageExecutionCommand(
+				packageManager,
+				"@tauri-apps/cli@latest",
+			);
+			const [executable, ...baseArgs] = baseCommand.split(" ");
 
-		const tauriInitCommand = getPackageExecutionCommand(
-			packageManager,
-			commandWithArgs,
-		);
+			const tauriArgs = [
+				...baseArgs,
+				...commonArgs,
+				`--before-dev-command="${packageManager} run dev"`,
+				`--before-build-command="${packageManager} run build"`,
+			];
 
-		await execa(tauriInitCommand, {
-			cwd: clientPackageDir,
-			env: {
-				CI: "true",
-			},
-			shell: true,
-		});
+			await execa(executable, tauriArgs, {
+				cwd: clientPackageDir,
+				env: { CI: "true" },
+			});
+		} else {
+			const tauriArgs = [
+				...commonArgs,
+				`--before-dev-command=\"${packageManager} run dev\"`,
+				`--before-build-command=\"${packageManager} run build\"`,
+			];
+
+			const commandWithArgs = `@tauri-apps/cli@latest ${tauriArgs.join(" ")}`;
+			const tauriInitCommand = getPackageExecutionCommand(
+				packageManager,
+				commandWithArgs,
+			);
+
+			await execa(tauriInitCommand, {
+				cwd: clientPackageDir,
+				env: { CI: "true" },
+				shell: true,
+			});
+		}
 
 		s.stop("Tauri desktop app support configured successfully!");
 	} catch (error) {


### PR DESCRIPTION
For some reason, when running the generator with the Tauri setup, bunx encounters an issue with parsing the arg command string (eg. `--before-dev-build="bun run dev"`).

```
> bun create better-t-stack@latest test-app-1 --frontend svelte --backend hono --runtime bun --database none --orm none --api orpc --no-auth --addons turborepo tauri biome husky --examples none --db-setup none --no-git --package-manager bun --install

◇  Failed to set up Tauri

[02:24:31]  ERROR  Command failed with exit code 2: "bunx @tauri-apps/cli@latest init --app-name=test-app-1 --window-title=test-app-1 --frontend-dist=../build --dev-url=http://localhost:5173 --before-dev-command=""bun run dev"" --before-build-command=""bun run build"""

Resolving dependencies
Resolved, downloaded and extracted [2]
Saved lockfile
error: unexpected argument 'run' found

Usage: bun run bunx init [OPTIONS]

For more information, try '--help'.
```

 This is happening only on Windows (powershell) with Bun.  So I added a check in tauri-setup for that specific setup and used direct arguments without shell execution. Not sure if this is something Bun has to fix on their end as pnpm and npm works with no issues. Regardless of that, this PR introduces a workaround to the issue.