### PR TITLE
Avoid `db:local` script for D1 database

### DIFF
--- a/.changeset/itchy-bikes-sit.md
+++ b/.changeset/itchy-bikes-sit.md
@@ -1,0 +1,5 @@
+---
+"create-better-t-stack": patch
+---
+
+Avoid db:local script for D1 database

--- a/apps/cli/src/helpers/project-generation/create-readme.ts
+++ b/apps/cli/src/helpers/project-generation/create-readme.ts
@@ -5,6 +5,7 @@ import type {
 	Addons,
 	API,
 	Database,
+	DatabaseSetup,
 	Frontend,
 	ORM,
 	ProjectConfig,
@@ -96,7 +97,7 @@ ${packageManagerRunCmd} dev:setup
 \`\`\`
 
 Follow the prompts to create a new Convex project and connect it to your application.`
-		: generateDatabaseSetup(database, auth, packageManagerRunCmd, orm)
+		: generateDatabaseSetup(database, auth, packageManagerRunCmd, orm, options.dbSetup)
 }
 
 Then, run the development server:
@@ -467,6 +468,7 @@ function generateDatabaseSetup(
 	_auth: boolean,
 	packageManagerRunCmd: string,
 	orm: ORM,
+	dbSetup: DatabaseSetup,
 ): string {
 	if (database === "none") {
 		return "";
@@ -484,9 +486,12 @@ function generateDatabaseSetup(
 		}.
 
 1. Start the local SQLite database:
-\`\`\`bash
+${dbSetup === "d1" 
+  ? "Local development for a Cloudflare D1 database will already be running as part of the `wrangler dev` command."
+  : `\`\`\`bash
 cd apps/server && ${packageManagerRunCmd} db:local
 \`\`\`
+`}
 
 2. Update your \`.env\` file in the \`apps/server\` directory with the appropriate connection details if needed.
 `;

--- a/apps/cli/src/helpers/project-generation/create-readme.ts
+++ b/apps/cli/src/helpers/project-generation/create-readme.ts
@@ -97,7 +97,13 @@ ${packageManagerRunCmd} dev:setup
 \`\`\`
 
 Follow the prompts to create a new Convex project and connect it to your application.`
-		: generateDatabaseSetup(database, auth, packageManagerRunCmd, orm, options.dbSetup)
+		: generateDatabaseSetup(
+				database,
+				auth,
+				packageManagerRunCmd,
+				orm,
+				options.dbSetup,
+			)
 }
 
 Then, run the development server:
@@ -486,12 +492,14 @@ function generateDatabaseSetup(
 		}.
 
 1. Start the local SQLite database:
-${dbSetup === "d1" 
-  ? "Local development for a Cloudflare D1 database will already be running as part of the `wrangler dev` command."
-  : `\`\`\`bash
+${
+	dbSetup === "d1"
+		? "Local development for a Cloudflare D1 database will already be running as part of the `wrangler dev` command."
+		: `\`\`\`bash
 cd apps/server && ${packageManagerRunCmd} db:local
 \`\`\`
-`}
+`
+}
 
 2. Update your \`.env\` file in the \`apps/server\` directory with the appropriate connection details if needed.
 `;

--- a/apps/cli/src/helpers/project-generation/project-config.ts
+++ b/apps/cli/src/helpers/project-generation/project-config.ts
@@ -225,7 +225,11 @@ async function updateServerPackageJson(
 	const scripts = serverPackageJson.scripts;
 
 	if (options.database !== "none") {
-		if (options.database === "sqlite" && options.orm === "drizzle" && options.dbSetup !== "d1") {
+		if (
+			options.database === "sqlite" &&
+			options.orm === "drizzle" &&
+			options.dbSetup !== "d1"
+		) {
 			scripts["db:local"] = "turso dev --db-file local.db";
 		}
 

--- a/apps/cli/src/helpers/project-generation/project-config.ts
+++ b/apps/cli/src/helpers/project-generation/project-config.ts
@@ -225,7 +225,7 @@ async function updateServerPackageJson(
 	const scripts = serverPackageJson.scripts;
 
 	if (options.database !== "none") {
-		if (options.database === "sqlite" && options.orm === "drizzle") {
+		if (options.database === "sqlite" && options.orm === "drizzle" && options.dbSetup !== "d1") {
 			scripts["db:local"] = "turso dev --db-file local.db";
 		}
 


### PR DESCRIPTION
I believe the `db:local` script is not needed when Cloudflare D1 was selected?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined when the "db:local" script appears in the server configuration, ensuring it is only included under more specific conditions.
  * Updated local development instructions for SQLite to reflect automatic handling when using Cloudflare D1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->