### PR TITLE
exclude .expo dir from biome.json.hbs

### DIFF
--- a/apps/cli/templates/addons/biome/biome.json.hbs
+++ b/apps/cli/templates/addons/biome/biome.json.hbs
@@ -18,7 +18,8 @@
 			"!**/routeTree.gen.ts",
 			"!**/src-tauri",
 			"!**/.nuxt",
-			"!bts.jsonc"
+			"!bts.jsonc",
+			"!**/.expo",
 		]
 	},
 	"formatter": {


### PR DESCRIPTION
Exclude the **.expo** directory. This is an automatically generated directory.