### PR TITLE
Added Sao Paulo region

### DIFF
--- a/.changeset/ten-elephants-admire.md
+++ b/.changeset/ten-elephants-admire.md
@@ -1,0 +1,5 @@
+---
+"create-better-t-stack": patch
+---
+
+Added Sao Paulo region

--- a/apps/cli/src/helpers/database-providers/neon-setup.ts
+++ b/apps/cli/src/helpers/database-providers/neon-setup.ts
@@ -29,6 +29,7 @@ const NEON_REGIONS: NeonRegion[] = [
 	{ label: "AWS US West (Oregon)", value: "aws-us-west-2" },
 	{ label: "AWS Europe (Frankfurt)", value: "aws-eu-central-1" },
 	{ label: "AWS Asia Pacific (Singapore)", value: "aws-ap-southeast-1" },
+	{ label: "AWS South America East 1 (São Paulo)", value: "aws-sa-east-1" },
 	{ label: "AWS Asia Pacific (Sydney)", value: "aws-ap-southeast-2" },
 	{ label: "Azure East US 2 region (Virginia)", value: "azure-eastus2" },
 ];


### PR DESCRIPTION
This region is on official docs: https://neon.com/docs/introduction/regions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the AWS South America East 1 (São Paulo) region to the list of selectable Neon project regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->