### PR TITLE
fix: add customViteReactPlugin flag to TanStack Start configurations

### DIFF
--- a/apps/cli/src/helpers/setup/workers-tanstack-start-setup.ts
+++ b/apps/cli/src/helpers/setup/workers-tanstack-start-setup.ts
@@ -61,7 +61,7 @@ export async function setupTanstackStartWorkersDeploy(
 		.getElements()
 		.findIndex((el) => el.getText().includes("tanstackStart("));
 
-	const tanstackPluginText = 'tanstackStart({ target: "cloudflare-module" })';
+	const tanstackPluginText = 'tanstackStart({ target: "cloudflare-module", customViteReactPlugin: true })';
 
 	if (tanstackPluginIndex === -1) {
 		pluginsArray.addElement(tanstackPluginText);

--- a/apps/cli/templates/frontend/react/tanstack-start/vite.config.ts
+++ b/apps/cli/templates/frontend/react/tanstack-start/vite.config.ts
@@ -2,7 +2,8 @@ import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 import tailwindcss from "@tailwindcss/vite";
+import viteReact from "@vitejs/plugin-react";
 
 export default defineConfig({
-  plugins: [tsconfigPaths(), tailwindcss(), tanstackStart({})],
+  plugins: [tsconfigPaths(), tailwindcss(), tanstackStart({ customViteReactPlugin: true }), viteReact()],
 });


### PR DESCRIPTION


Projects created using TanStack Start show this warning:

```
[vite-plugin-start] please add the vite-react plugin to your Vite config and set 'customViteReactPlugin: true' TanStack Start will not configure the vite-react plugin in future anymore.
```


Updated TanStack Start configurations to follow the [TanStack Start documentation](https://tanstack.com/start/latest/docs/framework/react/build-from-scratch#update-configuration-files) by:

- Adding `@vitejs/plugin-react` import
- Setting `customViteReactPlugin: true` in tanstackStart configuration
- Updating Cloudflare Workers deployment to include the flag


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved integration with the React plugin in Vite for TanStack Start projects by enabling custom React plugin support.

* **Chores**
  * Updated project templates to explicitly include the official React plugin for Vite and adjusted plugin configuration for enhanced compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->