### PR TITLE
feat(cli): add support for dynamic server name

### DIFF
--- a/.changeset/petite-corners-say.md
+++ b/.changeset/petite-corners-say.md
@@ -1,0 +1,5 @@
+---
+'create-better-t-stack': minor
+---
+
+add support for dynamic server name

--- a/apps/cli/src/constants.ts
+++ b/apps/cli/src/constants.ts
@@ -25,6 +25,7 @@ export const DEFAULT_CONFIG: ProjectConfig = {
 	runtime: "bun",
 	api: "trpc",
 	webDeploy: "none",
+	serverName: "server",
 };
 
 export const dependencyVersionMap = {

--- a/apps/cli/src/helpers/database-providers/d1-setup.ts
+++ b/apps/cli/src/helpers/database-providers/d1-setup.ts
@@ -6,9 +6,9 @@ import {
 } from "../project-generation/env-setup";
 
 export async function setupCloudflareD1(config: ProjectConfig) {
-	const { projectDir } = config;
+	const { projectDir, serverName } = config;
 
-	const envPath = path.join(projectDir, "apps/server", ".env");
+	const envPath = path.join(projectDir, "apps", serverName, ".env");
 
 	const variables: EnvVariable[] = [
 		{

--- a/apps/cli/src/helpers/database-providers/docker-compose-setup.ts
+++ b/apps/cli/src/helpers/database-providers/docker-compose-setup.ts
@@ -6,14 +6,14 @@ import {
 } from "../project-generation/env-setup";
 
 export async function setupDockerCompose(config: ProjectConfig) {
-	const { database, projectDir, projectName } = config;
+	const { database, projectDir, projectName, serverName } = config;
 
 	if (database === "none" || database === "sqlite") {
 		return;
 	}
 
 	try {
-		await writeEnvFile(projectDir, database, projectName);
+		await writeEnvFile(projectDir, database, projectName, serverName);
 	} catch (error) {
 		if (error instanceof Error) {
 			console.error(`Error: ${error.message}`);
@@ -25,8 +25,9 @@ async function writeEnvFile(
 	projectDir: string,
 	database: Database,
 	projectName: string,
+	serverName: string,
 ) {
-	const envPath = path.join(projectDir, "apps/server", ".env");
+	const envPath = path.join(projectDir, "apps", serverName, ".env");
 	const variables: EnvVariable[] = [
 		{
 			key: "DATABASE_URL",

--- a/apps/cli/src/helpers/database-providers/mongodb-atlas-setup.ts
+++ b/apps/cli/src/helpers/database-providers/mongodb-atlas-setup.ts
@@ -86,9 +86,13 @@ async function initMongoDBAtlas(
 	}
 }
 
-async function writeEnvFile(projectDir: string, config?: MongoDBConfig) {
+async function writeEnvFile(
+	projectDir: string,
+	serverName: string,
+	config?: MongoDBConfig,
+) {
 	try {
-		const envPath = path.join(projectDir, "apps/server", ".env");
+		const envPath = path.join(projectDir, "apps", serverName, ".env");
 		const variables: EnvVariable[] = [
 			{
 				key: "DATABASE_URL",
@@ -125,11 +129,11 @@ ${pc.green("MongoDB Atlas Manual Setup Instructions:")}
 }
 
 export async function setupMongoDBAtlas(config: ProjectConfig) {
-	const { projectDir } = config;
+	const { projectDir, serverName } = config;
 	const mainSpinner = spinner();
 	mainSpinner.start("Setting up MongoDB Atlas...");
 
-	const serverDir = path.join(projectDir, "apps/server");
+	const serverDir = path.join(projectDir, "apps", serverName);
 	try {
 		await fs.ensureDir(serverDir);
 
@@ -138,7 +142,7 @@ export async function setupMongoDBAtlas(config: ProjectConfig) {
 		const config = await initMongoDBAtlas(serverDir);
 
 		if (config) {
-			await writeEnvFile(projectDir, config);
+			await writeEnvFile(projectDir, serverName, config);
 			log.success(
 				pc.green(
 					"MongoDB Atlas setup complete! Connection saved to .env file.",
@@ -146,7 +150,7 @@ export async function setupMongoDBAtlas(config: ProjectConfig) {
 			);
 		} else {
 			log.warn(pc.yellow("Falling back to local MongoDB configuration"));
-			await writeEnvFile(projectDir);
+			await writeEnvFile(projectDir, serverName);
 			displayManualSetupInstructions();
 		}
 	} catch (error) {
@@ -160,7 +164,7 @@ export async function setupMongoDBAtlas(config: ProjectConfig) {
 		);
 
 		try {
-			await writeEnvFile(projectDir);
+			await writeEnvFile(projectDir, serverName);
 			displayManualSetupInstructions();
 		} catch {}
 	}

--- a/apps/cli/src/helpers/project-generation/command-handlers.ts
+++ b/apps/cli/src/helpers/project-generation/command-handlers.ts
@@ -25,7 +25,7 @@ import { detectProjectConfig } from "./detect-project-config";
 import { installDependencies } from "./install-dependencies";
 
 export async function createProjectHandler(
-	input: CreateInput & { projectName?: string },
+	input: CreateInput & { projectName?: string; serverName: string },
 ) {
 	const startTime = Date.now();
 
@@ -62,6 +62,7 @@ export async function createProjectHandler(
 		const cliInput = {
 			...input,
 			projectDirectory: input.projectName,
+			serverName: input.serverName,
 		};
 
 		const providedFlags = getProvidedFlags(cliInput);
@@ -108,6 +109,7 @@ export async function createProjectHandler(
 				flagConfig,
 				finalBaseName,
 				finalResolvedPath,
+				input.serverName,
 				finalPathInput,
 			);
 		}

--- a/apps/cli/src/helpers/project-generation/create-project.ts
+++ b/apps/cli/src/helpers/project-generation/create-project.ts
@@ -34,22 +34,22 @@ import {
 } from "./template-manager";
 
 export async function createProject(options: ProjectConfig) {
-	const projectDir = options.projectDir;
-	const isConvex = options.backend === "convex";
+	const { backend, projectDir, serverName } = options;
+	const isConvex = backend === "convex";
 
 	try {
 		await fs.ensureDir(projectDir);
 
 		await copyBaseTemplate(projectDir, options);
 		await setupFrontendTemplates(projectDir, options);
-		await setupBackendFramework(projectDir, options);
+		await setupBackendFramework(projectDir, serverName, options);
 		if (!isConvex) {
-			await setupDbOrmTemplates(projectDir, options);
-			await setupDockerComposeTemplates(projectDir, options);
-			await setupAuthTemplate(projectDir, options);
+			await setupDbOrmTemplates(projectDir, serverName, options);
+			await setupDockerComposeTemplates(projectDir, serverName, options);
+			await setupAuthTemplate(projectDir, serverName, options);
 		}
 		if (options.examples.length > 0 && options.examples[0] !== "none") {
-			await setupExamplesTemplate(projectDir, options);
+			await setupExamplesTemplate(projectDir, serverName, options);
 		}
 		await setupAddonsTemplate(projectDir, options);
 

--- a/apps/cli/src/helpers/project-generation/create-readme.ts
+++ b/apps/cli/src/helpers/project-generation/create-readme.ts
@@ -27,6 +27,7 @@ function generateReadmeContent(options: ProjectConfig): string {
 	const {
 		projectName,
 		packageManager,
+		serverName,
 		database,
 		auth,
 		addons = [],
@@ -103,6 +104,7 @@ Follow the prompts to create a new Convex project and connect it to your applica
 				packageManagerRunCmd,
 				orm,
 				options.dbSetup,
+				options.serverName,
 			)
 }
 
@@ -125,6 +127,7 @@ ${
 \`\`\`
 ${generateProjectStructure(
 	projectName,
+	serverName,
 	frontend,
 	backend,
 	addons,
@@ -143,6 +146,7 @@ ${generateScriptsList(
 	hasNative,
 	addons,
 	backend,
+	options.serverName,
 )}
 `;
 }
@@ -248,6 +252,7 @@ function generateRunningInstructions(
 
 function generateProjectStructure(
 	projectName: string,
+	serverName: string,
 	frontend: Frontend[],
 	backend: string,
 	addons: Addons[],
@@ -316,7 +321,9 @@ function generateProjectStructure(
 		const backendName = backend[0].toUpperCase() + backend.slice(1);
 		const apiName = api !== "none" ? api.toUpperCase() : "";
 		const backendDesc = apiName ? `${backendName}, ${apiName}` : backendName;
-		structure.push(`│   └── server/      # Backend API (${backendDesc})`);
+		structure.push(
+			`│   └── ${serverName}/      # Backend API (${backendDesc})`,
+		);
 	}
 
 	return structure.join("\n");
@@ -475,6 +482,7 @@ function generateDatabaseSetup(
 	packageManagerRunCmd: string,
 	orm: ORM,
 	dbSetup: DatabaseSetup,
+	serverName: string,
 ): string {
 	if (database === "none") {
 		return "";
@@ -496,12 +504,12 @@ ${
 	dbSetup === "d1"
 		? "Local development for a Cloudflare D1 database will already be running as part of the `wrangler dev` command."
 		: `\`\`\`bash
-cd apps/server && ${packageManagerRunCmd} db:local
+cd apps/${serverName} && ${packageManagerRunCmd} db:local
 \`\`\`
 `
 }
 
-2. Update your \`.env\` file in the \`apps/server\` directory with the appropriate connection details if needed.
+2. Update your \`.env\` file in the \`apps/${serverName}\` directory with the appropriate connection details if needed.
 `;
 	} else if (database === "postgres") {
 		setup += `This project uses PostgreSQL${
@@ -513,7 +521,7 @@ cd apps/server && ${packageManagerRunCmd} db:local
 		}.
 
 1. Make sure you have a PostgreSQL database set up.
-2. Update your \`apps/server/.env\` file with your PostgreSQL connection details.
+2. Update your \`apps/${serverName}/.env\` file with your PostgreSQL connection details.
 `;
 	} else if (database === "mysql") {
 		setup += `This project uses MySQL${
@@ -525,7 +533,7 @@ cd apps/server && ${packageManagerRunCmd} db:local
 		}.
 
 1. Make sure you have a MySQL database set up.
-2. Update your \`apps/server/.env\` file with your MySQL connection details.
+2. Update your \`apps/${serverName}/.env\` file with your MySQL connection details.
 `;
 	} else if (database === "mongodb") {
 		setup += `This project uses MongoDB ${
@@ -537,7 +545,7 @@ cd apps/server && ${packageManagerRunCmd} db:local
 		}.
 
 1. Make sure you have MongoDB set up.
-2. Update your \`apps/server/.env\` file with your MongoDB connection URI.
+2. Update your \`apps/${serverName}/.env\` file with your MongoDB connection URI.
 `;
 	}
 
@@ -571,6 +579,7 @@ function generateScriptsList(
 	hasNative: boolean,
 	addons: Addons[],
 	backend: string,
+	serverName: string,
 ): string {
 	const isConvex = backend === "convex";
 	const isBackendNone = backend === "none";
@@ -586,7 +595,7 @@ function generateScriptsList(
 - \`${packageManagerRunCmd} dev:setup\`: Setup and configure your Convex project`;
 	} else if (!isBackendNone) {
 		scripts += `
-- \`${packageManagerRunCmd} dev:server\`: Start only the server`;
+- \`${packageManagerRunCmd} dev:${serverName}\`: Start only the ${serverName}`;
 	}
 
 	scripts += `
@@ -604,7 +613,7 @@ function generateScriptsList(
 
 		if (database === "sqlite" && orm === "drizzle") {
 			scripts += `
-- \`cd apps/server && ${packageManagerRunCmd} db:local\`: Start the local SQLite database`;
+- \`cd apps/${serverName} && ${packageManagerRunCmd} db:local\`: Start the local SQLite database`;
 		}
 	}
 

--- a/apps/cli/src/helpers/project-generation/env-setup.ts
+++ b/apps/cli/src/helpers/project-generation/env-setup.ts
@@ -85,8 +85,16 @@ export async function addEnvVariablesToFile(
 }
 
 export async function setupEnvironmentVariables(config: ProjectConfig) {
-	const { backend, frontend, database, auth, examples, dbSetup, projectDir } =
-		config;
+	const {
+		backend,
+		frontend,
+		database,
+		auth,
+		examples,
+		dbSetup,
+		projectDir,
+		serverName,
+	} = config;
 
 	const hasReactRouter = frontend.includes("react-router");
 	const hasTanStackRouter = frontend.includes("tanstack-router");
@@ -167,7 +175,7 @@ export async function setupEnvironmentVariables(config: ProjectConfig) {
 		return;
 	}
 
-	const serverDir = path.join(projectDir, "apps/server");
+	const serverDir = path.join(projectDir, "apps", serverName);
 	if (!(await fs.pathExists(serverDir))) {
 		return;
 	}

--- a/apps/cli/src/helpers/project-generation/post-installation.ts
+++ b/apps/cli/src/helpers/project-generation/post-installation.ts
@@ -25,6 +25,7 @@ export async function displayPostInstallInstructions(
 		backend,
 		dbSetup,
 		webDeploy,
+		serverName,
 	} = config;
 
 	const isConvex = backend === "convex";
@@ -35,7 +36,14 @@ export async function displayPostInstallInstructions(
 
 	const databaseInstructions =
 		!isConvex && database !== "none"
-			? await getDatabaseInstructions(database, orm, runCmd, runtime, dbSetup)
+			? await getDatabaseInstructions(
+					database,
+					serverName,
+					orm,
+					runCmd,
+					runtime,
+					dbSetup,
+				)
 			: "";
 
 	const tauriInstructions = addons?.includes("tauri")
@@ -118,7 +126,7 @@ export async function displayPostInstallInstructions(
 			output += `${pc.cyan(`${stepCounter++}.`)} ${runCmd} dev\n`;
 			output += `${pc.cyan(
 				`${stepCounter++}.`,
-			)} cd apps/server && ${runCmd} run cf-typegen\n\n`;
+			)} cd apps/${serverName} && ${runCmd} run cf-typegen\n\n`;
 		} else {
 			output += "\n";
 		}
@@ -200,6 +208,7 @@ function getLintingInstructions(runCmd?: string): string {
 
 async function getDatabaseInstructions(
 	database: Database,
+	serverName: string,
 	orm?: ORM,
 	runCmd?: string,
 	runtime?: Runtime,
@@ -232,11 +241,11 @@ async function getDatabaseInstructions(
 		instructions.push(
 			`${pc.cyan(
 				"3.",
-			)} Update apps/server/wrangler.jsonc with database_id and database_name`,
+			)} Update apps/${serverName}/wrangler.jsonc with database_id and database_name`,
 		);
 		instructions.push(
 			`${pc.cyan("4.")} Generate migrations: ${pc.white(
-				"cd apps/server && bun db:generate",
+				`cd apps/${serverName} && bun db:generate`,
 			)}`,
 		);
 		instructions.push(
@@ -288,7 +297,7 @@ async function getDatabaseInstructions(
 			instructions.push(
 				`${pc.cyan(
 					"•",
-				)} Start local DB (if needed): ${`cd apps/server && ${runCmd} db:local`}`,
+				)} Start local DB (if needed): ${`cd apps/${serverName} && ${runCmd} db:local`}`,
 			);
 		}
 	} else if (orm === "mongoose") {

--- a/apps/cli/src/helpers/project-generation/project-config.ts
+++ b/apps/cli/src/helpers/project-generation/project-config.ts
@@ -32,7 +32,9 @@ async function updateRootPackageJson(
 	const scripts = packageJson.scripts;
 
 	const backendPackageName =
-		options.backend === "convex" ? `@${options.projectName}/backend` : "server";
+		options.backend === "convex"
+			? `@${options.projectName}/backend`
+			: options.serverName;
 
 	let serverDevScript = "";
 	if (options.addons.includes("turborepo")) {
@@ -65,7 +67,7 @@ async function updateRootPackageJson(
 		scripts["check-types"] = "turbo check-types";
 		scripts["dev:native"] = "turbo -F native dev";
 		scripts["dev:web"] = "turbo -F web dev";
-		scripts["dev:server"] = serverDevScript;
+		scripts[`dev:${options.serverName}`] = serverDevScript;
 		if (options.backend === "convex") {
 			scripts["dev:setup"] = `turbo -F ${backendPackageName} dev:setup`;
 		}
@@ -92,7 +94,7 @@ async function updateRootPackageJson(
 		scripts["check-types"] = "pnpm -r check-types";
 		scripts["dev:native"] = "pnpm --filter native dev";
 		scripts["dev:web"] = "pnpm --filter web dev";
-		scripts["dev:server"] = serverDevScript;
+		scripts[`dev:${options.serverName}`] = serverDevScript;
 		if (options.backend === "convex") {
 			scripts["dev:setup"] = `pnpm --filter ${backendPackageName} dev:setup`;
 		}
@@ -123,7 +125,7 @@ async function updateRootPackageJson(
 		scripts["check-types"] = "npm run check-types --workspaces";
 		scripts["dev:native"] = "npm run dev --workspace native";
 		scripts["dev:web"] = "npm run dev --workspace web";
-		scripts["dev:server"] = serverDevScript;
+		scripts[`dev:${options.serverName}`] = serverDevScript;
 		if (options.backend === "convex") {
 			scripts["dev:setup"] =
 				`npm run dev:setup --workspace ${backendPackageName}`;
@@ -158,7 +160,7 @@ async function updateRootPackageJson(
 		scripts["check-types"] = "bun run --filter '*' check-types";
 		scripts["dev:native"] = "bun run --filter native dev";
 		scripts["dev:web"] = "bun run --filter web dev";
-		scripts["dev:server"] = serverDevScript;
+		scripts[`dev:${options.serverName}`] = serverDevScript;
 		if (options.backend === "convex") {
 			scripts["dev:setup"] = `bun run --filter ${backendPackageName} dev:setup`;
 		}
@@ -226,7 +228,9 @@ async function updateServerPackageJson(
 ) {
 	const serverPackageJsonPath = path.join(
 		projectDir,
-		"apps/server/package.json",
+		"apps",
+		options.serverName,
+		"package.json",
 	);
 
 	if (!(await fs.pathExists(serverPackageJsonPath))) return;

--- a/apps/cli/src/helpers/project-generation/template-manager.ts
+++ b/apps/cli/src/helpers/project-generation/template-manager.ts
@@ -240,13 +240,14 @@ export async function setupFrontendTemplates(
 
 export async function setupBackendFramework(
 	projectDir: string,
+	serverName: string,
 	context: ProjectConfig,
 ) {
 	if (context.backend === "none") {
 		return;
 	}
 
-	const serverAppDir = path.join(projectDir, "apps/server");
+	const serverAppDir = path.join(projectDir, "apps", serverName);
 
 	if (context.backend === "convex") {
 		if (await fs.pathExists(serverAppDir)) {
@@ -331,6 +332,7 @@ export async function setupBackendFramework(
 
 export async function setupDbOrmTemplates(
 	projectDir: string,
+	serverName: string,
 	context: ProjectConfig,
 ) {
 	if (
@@ -340,7 +342,7 @@ export async function setupDbOrmTemplates(
 	)
 		return;
 
-	const serverAppDir = path.join(projectDir, "apps/server");
+	const serverAppDir = path.join(projectDir, "apps", serverName);
 	await fs.ensureDir(serverAppDir);
 
 	const dbOrmSrcDir = path.join(
@@ -356,11 +358,12 @@ export async function setupDbOrmTemplates(
 
 export async function setupAuthTemplate(
 	projectDir: string,
+	serverName: string,
 	context: ProjectConfig,
 ) {
 	if (context.backend === "convex" || !context.auth) return;
 
-	const serverAppDir = path.join(projectDir, "apps/server");
+	const serverAppDir = path.join(projectDir, "apps", serverName);
 	const webAppDir = path.join(projectDir, "apps/web");
 	const nativeAppDir = path.join(projectDir, "apps/native");
 
@@ -568,6 +571,7 @@ export async function setupAddonsTemplate(
 
 export async function setupExamplesTemplate(
 	projectDir: string,
+	serverName: string,
 	context: ProjectConfig,
 ) {
 	if (
@@ -578,7 +582,7 @@ export async function setupExamplesTemplate(
 		return;
 	}
 
-	const serverAppDir = path.join(projectDir, "apps/server");
+	const serverAppDir = path.join(projectDir, "apps", serverName);
 	const webAppDir = path.join(projectDir, "apps/web");
 
 	const serverAppDirExists = await fs.pathExists(serverAppDir);
@@ -824,13 +828,14 @@ export async function handleExtras(projectDir: string, context: ProjectConfig) {
 
 export async function setupDockerComposeTemplates(
 	projectDir: string,
+	serverName: string,
 	context: ProjectConfig,
 ) {
 	if (context.dbSetup !== "docker" || context.database === "none") {
 		return;
 	}
 
-	const serverAppDir = path.join(projectDir, "apps/server");
+	const serverAppDir = path.join(projectDir, "apps", serverName);
 	const dockerSrcDir = path.join(
 		PKG_ROOT,
 		`templates/db-setup/docker-compose/${context.database}`,

--- a/apps/cli/src/helpers/setup/api-setup.ts
+++ b/apps/cli/src/helpers/setup/api-setup.ts
@@ -5,8 +5,15 @@ import type { Frontend, ProjectConfig } from "../../types";
 import { addPackageDependency } from "../../utils/add-package-deps";
 
 export async function setupApi(config: ProjectConfig) {
-	const { api, projectName, frontend, backend, packageManager, projectDir } =
-		config;
+	const {
+		api,
+		projectName,
+		frontend,
+		backend,
+		packageManager,
+		projectDir,
+		serverName,
+	} = config;
 	const isConvex = backend === "convex";
 	const webDir = path.join(projectDir, "apps/web");
 	const nativeDir = path.join(projectDir, "apps/native");
@@ -21,7 +28,7 @@ export async function setupApi(config: ProjectConfig) {
 	const hasSolidWeb = frontend.includes("solid");
 
 	if (!isConvex && api !== "none") {
-		const serverDir = path.join(projectDir, "apps/server");
+		const serverDir = path.join(projectDir, "apps", serverName);
 		const serverDirExists = await fs.pathExists(serverDir);
 
 		if (serverDirExists) {

--- a/apps/cli/src/helpers/setup/auth-setup.ts
+++ b/apps/cli/src/helpers/setup/auth-setup.ts
@@ -6,12 +6,12 @@ import type { ProjectConfig } from "../../types";
 import { addPackageDependency } from "../../utils/add-package-deps";
 
 export async function setupAuth(config: ProjectConfig) {
-	const { auth, frontend, backend, projectDir } = config;
+	const { auth, frontend, backend, projectDir, serverName } = config;
 	if (backend === "convex" || !auth) {
 		return;
 	}
 
-	const serverDir = path.join(projectDir, "apps/server");
+	const serverDir = path.join(projectDir, "apps", serverName);
 	const clientDir = path.join(projectDir, "apps/web");
 	const nativeDir = path.join(projectDir, "apps/native");
 

--- a/apps/cli/src/helpers/setup/backend-setup.ts
+++ b/apps/cli/src/helpers/setup/backend-setup.ts
@@ -4,14 +4,14 @@ import type { ProjectConfig } from "../../types";
 import { addPackageDependency } from "../../utils/add-package-deps";
 
 export async function setupBackendDependencies(config: ProjectConfig) {
-	const { backend, runtime, api, projectDir } = config;
+	const { backend, runtime, api, projectDir, serverName } = config;
 
 	if (backend === "convex") {
 		return;
 	}
 
 	const framework = backend;
-	const serverDir = path.join(projectDir, "apps/server");
+	const serverDir = path.join(projectDir, "apps", serverName);
 
 	const dependencies: AvailableDependencies[] = [];
 	const devDependencies: AvailableDependencies[] = [];

--- a/apps/cli/src/helpers/setup/db-setup.ts
+++ b/apps/cli/src/helpers/setup/db-setup.ts
@@ -14,11 +14,11 @@ import { setupSupabase } from "../database-providers/supabase-setup";
 import { setupTurso } from "../database-providers/turso-setup";
 
 export async function setupDatabase(config: ProjectConfig) {
-	const { database, orm, dbSetup, backend, projectDir } = config;
+	const { database, orm, dbSetup, backend, projectDir, serverName } = config;
 
 	if (backend === "convex" || database === "none") {
 		if (backend !== "convex") {
-			const serverDir = path.join(projectDir, "apps/server");
+			const serverDir = path.join(projectDir, "apps", serverName);
 			const serverDbDir = path.join(serverDir, "src/db");
 			if (await fs.pathExists(serverDbDir)) {
 				await fs.remove(serverDbDir);
@@ -28,7 +28,7 @@ export async function setupDatabase(config: ProjectConfig) {
 	}
 
 	const s = spinner();
-	const serverDir = path.join(projectDir, "apps/server");
+	const serverDir = path.join(projectDir, "apps", serverName);
 
 	if (!(await fs.pathExists(serverDir))) {
 		return;

--- a/apps/cli/src/helpers/setup/examples-setup.ts
+++ b/apps/cli/src/helpers/setup/examples-setup.ts
@@ -5,7 +5,7 @@ import type { ProjectConfig } from "../../types";
 import { addPackageDependency } from "../../utils/add-package-deps";
 
 export async function setupExamples(config: ProjectConfig) {
-	const { examples, frontend, backend, projectDir } = config;
+	const { examples, frontend, backend, projectDir, serverName } = config;
 
 	if (
 		backend === "convex" ||
@@ -19,7 +19,7 @@ export async function setupExamples(config: ProjectConfig) {
 	if (examples.includes("ai")) {
 		const webClientDir = path.join(projectDir, "apps/web");
 		const nativeClientDir = path.join(projectDir, "apps/native");
-		const serverDir = path.join(projectDir, "apps/server");
+		const serverDir = path.join(projectDir, "apps", serverName);
 
 		const webClientDirExists = await fs.pathExists(webClientDir);
 		const nativeClientDirExists = await fs.pathExists(nativeClientDir);

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -58,6 +58,7 @@ const router = t.router({
 					runtime: RuntimeSchema.optional(),
 					api: APISchema.optional(),
 					webDeploy: WebDeploySchema.optional(),
+					serverName: z.string().default("server"),
 				}),
 			]),
 		)

--- a/apps/cli/src/prompts/config-prompts.ts
+++ b/apps/cli/src/prompts/config-prompts.ts
@@ -50,6 +50,7 @@ export async function gatherConfig(
 	flags: Partial<ProjectConfig>,
 	projectName: string,
 	projectDir: string,
+	serverName: string,
 	relativePath: string,
 ): Promise<ProjectConfig> {
 	const result = await group<PromptGroupResults>(
@@ -146,5 +147,6 @@ export async function gatherConfig(
 		dbSetup: result.dbSetup,
 		api: result.api,
 		webDeploy: result.webDeploy,
+		serverName,
 	};
 }

--- a/apps/cli/src/types.ts
+++ b/apps/cli/src/types.ts
@@ -137,6 +137,7 @@ export type AddInput = {
 
 export type CLIInput = CreateInput & {
 	projectDirectory?: string;
+	serverName: string;
 };
 
 export interface ProjectConfig {
@@ -157,6 +158,7 @@ export interface ProjectConfig {
 	dbSetup: DatabaseSetup;
 	api: API;
 	webDeploy: WebDeploy;
+	serverName: string;
 }
 
 export interface BetterTStackConfig {

--- a/apps/cli/src/utils/display-config.ts
+++ b/apps/cli/src/utils/display-config.ts
@@ -21,6 +21,9 @@ export function displayConfig(config: Partial<ProjectConfig>) {
 
 	if (config.backend !== undefined) {
 		configDisplay.push(`${pc.blue("Backend:")} ${String(config.backend)}`);
+		configDisplay.push(
+			`${pc.blue("Backand Path:")} apps/${String(config.serverName)}`,
+		);
 	}
 
 	if (config.runtime !== undefined) {

--- a/apps/cli/src/utils/generate-reproducible-command.ts
+++ b/apps/cli/src/utils/generate-reproducible-command.ts
@@ -33,6 +33,7 @@ export function generateReproducibleCommand(config: ProjectConfig): string {
 	flags.push(config.git ? "--git" : "--no-git");
 	flags.push(`--package-manager ${config.packageManager}`);
 	flags.push(config.install ? "--install" : "--no-install");
+	flags.push(`--server-name ${config.serverName}`);
 
 	let baseCommand = "npx create-better-t-stack@latest";
 	const pkgManager = config.packageManager;

--- a/apps/cli/src/validation.ts
+++ b/apps/cli/src/validation.ts
@@ -96,6 +96,10 @@ export function processAndValidateFlags(
 		config.webDeploy = options.webDeploy as WebDeploy;
 	}
 
+	if (options.serverName) {
+		config.serverName = options.serverName;
+	}
+
 	if (projectName) {
 		const result = ProjectNameSchema.safeParse(path.basename(projectName));
 		if (!result.success) {

--- a/apps/cli/templates/addons/vibe-rules/.bts/rules.md.hbs
+++ b/apps/cli/templates/addons/vibe-rules/.bts/rules.md.hbs
@@ -16,7 +16,7 @@ frontend "solid")}} (SolidStart){{/if}}
 
 {{#if (ne backend "convex")}}
 {{#if (ne backend "none")}}
-- **`apps/server/`** - Backend server{{#if (eq backend "hono")}} (Hono){{else if (eq backend "express")}}
+- **`apps/{{serverName}}/`** - Backend server{{#if (eq backend "hono")}} (Hono){{else if (eq backend "express")}}
 (Express){{else if (eq backend "fastify")}} (Fastify){{else if (eq backend "elysia")}} (Elysia){{else if (eq backend
 "next")}} (Next.js API){{/if}}
 {{/if}}
@@ -38,7 +38,7 @@ frontend "solid")}} (SolidStart){{/if}}
 {{/if}}
 {{#if (ne backend "none")}}
 {{#if (ne backend "convex")}}
-- `{{packageManager}} run dev:server` - Start only the server
+- `{{packageManager}} run dev:{{serverName}}` - Start only the {{serverName}}
 {{/if}}
 {{/if}}
 {{#if (or (includes frontend "native-nativewind") (includes frontend "native-unistyles"))}}
@@ -48,7 +48,7 @@ frontend "solid")}} (SolidStart){{/if}}
 {{#if (and (ne database "none") (ne orm "none") (ne backend "convex"))}}
 ## Database Commands
 
-All database operations should be run from the server workspace:
+All database operations should be run from the {{serverName}} workspace:
 
 - `{{packageManager}} run db:push` - Push schema changes to database
 - `{{packageManager}} run db:studio` - Open database studio
@@ -57,11 +57,11 @@ All database operations should be run from the server workspace:
 - `{{packageManager}} run db:migrate` - Run database migrations
 
 {{#if (eq orm "drizzle")}}
-Database schema files are located in `apps/server/src/db/schema/`
+Database schema files are located in `apps/{{serverName}}/src/db/schema/`
 {{else if (eq orm "prisma")}}
-Database schema is located in `apps/server/prisma/schema.prisma`
+Database schema is located in `apps/{{serverName}}/prisma/schema.prisma`
 {{else if (eq orm "mongoose")}}
-Database models are located in `apps/server/src/db/models/`
+Database models are located in `apps/{{serverName}}/src/db/models/`
 {{/if}}
 {{/if}}
 
@@ -69,10 +69,10 @@ Database models are located in `apps/server/src/db/models/`
 ## API Structure
 
 {{#if (eq api "trpc")}}
-- tRPC routers are in `apps/server/src/routers/`
+- tRPC routers are in `apps/{{serverName}}/src/routers/`
 - Client-side tRPC utils are in `apps/web/src/utils/trpc.ts`
 {{else if (eq api "orpc")}}
-- oRPC endpoints are in `apps/server/src/api/`
+- oRPC endpoints are in `apps/{{serverName}}/src/api/`
 - Client-side API utils are in `apps/web/src/utils/api.ts`
 {{/if}}
 {{/if}}
@@ -82,7 +82,7 @@ Database models are located in `apps/server/src/db/models/`
 
 Authentication is enabled in this project:
 {{#if (ne backend "convex")}}
-- Server auth logic is in `apps/server/src/lib/auth.ts`
+- Server auth logic is in `apps/{{serverName}}/src/lib/auth.ts`
 {{#if (or (includes frontend "tanstack-router") (includes frontend "react-router") (includes frontend "tanstack-start")
 (includes frontend "next") (includes frontend "nuxt") (includes frontend "svelte") (includes frontend "solid"))}}
 - Web app auth client is in `apps/web/src/lib/auth-client.ts`

--- a/apps/cli/templates/api/orpc/native/utils/orpc.ts.hbs
+++ b/apps/cli/templates/api/orpc/native/utils/orpc.ts.hbs
@@ -3,7 +3,7 @@ import { RPCLink } from "@orpc/client/fetch";
 import { createTanstackQueryUtils } from "@orpc/tanstack-query";
 import type { RouterClient } from "@orpc/server";
 import { QueryCache, QueryClient } from "@tanstack/react-query";
-import type { appRouter } from "../../server/src/routers";
+import type { appRouter } from "../../{{serverName}}/src/routers";
 {{#if auth}}
 import { authClient } from "@/lib/auth-client";
 {{/if}}

--- a/apps/cli/templates/api/orpc/web/nuxt/app/plugins/orpc.ts.hbs
+++ b/apps/cli/templates/api/orpc/web/nuxt/app/plugins/orpc.ts.hbs
@@ -1,6 +1,6 @@
 import { defineNuxtPlugin, useRuntimeConfig } from '#app'
 import type { RouterClient } from '@orpc/server'
-import type { appRouter } from "../../../server/src/routers/index";
+import type { appRouter } from "../../../{{serverName}}/src/routers/index";
 import { createORPCClient } from '@orpc/client'
 import { RPCLink } from '@orpc/client/fetch'
 import { createTanstackQueryUtils } from "@orpc/tanstack-query";

--- a/apps/cli/templates/api/orpc/web/react/base/src/utils/orpc.ts.hbs
+++ b/apps/cli/templates/api/orpc/web/react/base/src/utils/orpc.ts.hbs
@@ -3,7 +3,7 @@ import { RPCLink } from "@orpc/client/fetch";
 import { createTanstackQueryUtils } from "@orpc/tanstack-query";
 import { QueryCache, QueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import type { appRouter } from "../../../server/src/routers/index";
+import type { appRouter } from "../../../{{serverName}}/src/routers/index";
 import type { RouterClient } from "@orpc/server";
 
 export const queryClient = new QueryClient({

--- a/apps/cli/templates/api/orpc/web/solid/src/utils/orpc.ts.hbs
+++ b/apps/cli/templates/api/orpc/web/solid/src/utils/orpc.ts.hbs
@@ -2,7 +2,7 @@ import { createORPCClient } from "@orpc/client";
 import { RPCLink } from "@orpc/client/fetch";
 import { createTanstackQueryUtils } from "@orpc/tanstack-query";
 import { QueryCache, QueryClient } from "@tanstack/solid-query";
-import type { appRouter } from "../../../server/src/routers/index";
+import type { appRouter } from "../../../{{serverName}}/src/routers/index";
 import type { RouterClient } from "@orpc/server";
 
 export const queryClient = new QueryClient({

--- a/apps/cli/templates/api/orpc/web/svelte/src/lib/orpc.ts.hbs
+++ b/apps/cli/templates/api/orpc/web/svelte/src/lib/orpc.ts.hbs
@@ -4,7 +4,7 @@ import { RPCLink } from "@orpc/client/fetch";
 import type { RouterClient } from "@orpc/server";
 import { createTanstackQueryUtils } from "@orpc/tanstack-query";
 import { QueryCache, QueryClient } from "@tanstack/svelte-query";
-import type { appRouter } from "../../../server/src/routers/index";
+import type { appRouter } from "../../../{{serverName}}/src/routers/index";
 
 export const queryClient = new QueryClient({
 	queryCache: new QueryCache({

--- a/apps/cli/templates/api/trpc/native/utils/trpc.ts.hbs
+++ b/apps/cli/templates/api/trpc/native/utils/trpc.ts.hbs
@@ -4,7 +4,7 @@ import { authClient } from "@/lib/auth-client";
 import { QueryClient } from "@tanstack/react-query";
 import { createTRPCClient, httpBatchLink } from "@trpc/client";
 import { createTRPCOptionsProxy } from "@trpc/tanstack-react-query";
-import type { AppRouter } from "../../server/src/routers";
+import type { AppRouter } from "../../{{serverName}}/src/routers";
 
 export const queryClient = new QueryClient();
 

--- a/apps/cli/templates/api/trpc/web/react/base/src/utils/trpc.ts.hbs
+++ b/apps/cli/templates/api/trpc/web/react/base/src/utils/trpc.ts.hbs
@@ -2,7 +2,7 @@
 import { QueryCache, QueryClient } from '@tanstack/react-query';
 import { createTRPCClient, httpBatchLink } from '@trpc/client';
 import { createTRPCOptionsProxy } from '@trpc/tanstack-react-query';
-import type { AppRouter } from '../../../server/src/routers';
+import type { AppRouter } from '../../../{{serverName}}/src/routers';
 import { toast } from 'sonner';
 
 export const queryClient = new QueryClient({
@@ -47,13 +47,13 @@ export const trpc = createTRPCOptionsProxy<AppRouter>({
 
 {{else if (includes frontend 'tanstack-start')}}
 import { createTRPCContext } from "@trpc/tanstack-react-query";
-import type { AppRouter } from "../../../server/src/routers";
+import type { AppRouter } from "../../../{{serverName}}/src/routers";
 
 export const { TRPCProvider, useTRPC, useTRPCClient } =
   createTRPCContext<AppRouter>();
 
 {{else}}
-import type { AppRouter } from "../../../server/src/routers";
+import type { AppRouter } from "../../../{{serverName}}/src/routers";
 import { QueryCache, QueryClient } from "@tanstack/react-query";
 import { createTRPCClient, httpBatchLink } from "@trpc/client";
 import { createTRPCOptionsProxy } from "@trpc/tanstack-react-query";

--- a/apps/cli/templates/backend/server/next/package.json.hbs
+++ b/apps/cli/templates/backend/server/next/package.json.hbs
@@ -1,5 +1,5 @@
 {
-  "name": "server",
+  "name": "{{serverName}}",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/apps/cli/templates/backend/server/server-base/package.json.hbs
+++ b/apps/cli/templates/backend/server/server-base/package.json.hbs
@@ -1,5 +1,5 @@
 {
-	"name": "server",
+	"name": "{{serverName}}",
 	"main": "src/index.ts",
 	"type": "module",
 	"scripts": {

--- a/apps/cli/templates/frontend/native/nativewind/tsconfig.json.hbs
+++ b/apps/cli/templates/frontend/native/nativewind/tsconfig.json.hbs
@@ -17,7 +17,7 @@
   ],
   {{#unless (or (eq backend "convex") (eq backend "none"))}}
   "references": [{
-    "path": "../server"
+    "path": "../{{serverName}}"
   }]
   {{/unless}}
 }

--- a/apps/cli/templates/frontend/native/unistyles/tsconfig.json.hbs
+++ b/apps/cli/templates/frontend/native/unistyles/tsconfig.json.hbs
@@ -11,7 +11,7 @@
   "include": ["**/*.ts", "**/*.tsx", ".expo/types/**/*.ts", "expo-env.d.ts"],
   {{#unless (or (eq backend "convex") (eq backend "none"))}}
   "references": [{
-    "path": "../server"
+    "path": "../{{serverName}}"
   }]
   {{/unless}}
 }

--- a/apps/cli/templates/frontend/nuxt/tsconfig.json.hbs
+++ b/apps/cli/templates/frontend/nuxt/tsconfig.json.hbs
@@ -16,7 +16,7 @@
   {{#unless (or (eq backend "convex") (eq backend "none"))}}
     ,
     {
-        "path": "../server"
+        "path": "../{{serverName}}"
     }
   {{/unless}}
   ]

--- a/apps/cli/templates/frontend/react/next/tsconfig.json.hbs
+++ b/apps/cli/templates/frontend/react/next/tsconfig.json.hbs
@@ -29,7 +29,7 @@
     "./**/*.tsx",
     "./.next/types/**/*.ts",
     {{#if (eq runtime "workers")}}
-    "../server/worker-configuration.d.ts"
+    "../{{serverName}}/worker-configuration.d.ts"
     {{/if}}
   ],
   "exclude": [
@@ -38,7 +38,7 @@
   {{#unless (or (eq backend "convex") (eq backend "none"))}}
   "references": [
     {
-      "path": "../server"
+      "path": "../{{serverName}}"
     }
   ]
   {{/unless}}

--- a/apps/cli/templates/frontend/react/react-router/tsconfig.json.hbs
+++ b/apps/cli/templates/frontend/react/react-router/tsconfig.json.hbs
@@ -26,7 +26,7 @@
   },
   {{#unless (or (eq backend "convex") (eq backend "none"))}}
   "references": [{
-    "path": "../server"
+    "path": "../{{serverName}}"
   }]
   {{/unless}}
 }

--- a/apps/cli/templates/frontend/react/tanstack-router/src/routes/__root.tsx.hbs
+++ b/apps/cli/templates/frontend/react/tanstack-router/src/routes/__root.tsx.hbs
@@ -9,7 +9,7 @@ import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { useState } from "react";
 import type { RouterClient } from "@orpc/server";
 import { createTanstackQueryUtils } from "@orpc/tanstack-query";
-import type { appRouter } from "../../../server/src/routers";
+import type { appRouter } from "../../../{{serverName}}/src/routers";
 import { createORPCClient } from "@orpc/client";
 {{/if}}
 {{#if (eq api "trpc")}}

--- a/apps/cli/templates/frontend/react/tanstack-router/tsconfig.json.hbs
+++ b/apps/cli/templates/frontend/react/tanstack-router/tsconfig.json.hbs
@@ -17,7 +17,7 @@
   },
   {{#unless (or (eq backend "convex") (eq backend "none"))}}
   "references": [{
-    "path": "../server"
+    "path": "../{{serverName}}"
   }]
   {{/unless}}
 }

--- a/apps/cli/templates/frontend/react/tanstack-start/src/router.tsx.hbs
+++ b/apps/cli/templates/frontend/react/tanstack-start/src/router.tsx.hbs
@@ -17,7 +17,7 @@ import { QueryCache, QueryClient, QueryClientProvider } from "@tanstack/react-qu
 import { createTRPCClient, httpBatchLink } from "@trpc/client";
 import { createTRPCOptionsProxy } from "@trpc/tanstack-react-query";
 import { toast } from "sonner";
-import type { AppRouter } from "../../server/src/routers";
+import type { AppRouter } from "../../{{serverName}}/src/routers";
 import { TRPCProvider } from "./utils/trpc";
   {{else if (eq api "orpc")}}
 import { QueryClientProvider } from "@tanstack/react-query";

--- a/apps/cli/templates/frontend/react/tanstack-start/src/routes/__root.tsx.hbs
+++ b/apps/cli/templates/frontend/react/tanstack-start/src/routes/__root.tsx.hbs
@@ -28,7 +28,7 @@ export interface RouterAppContext {
 {{else}}
   {{#if (eq api "trpc")}}
 import type { TRPCOptionsProxy } from "@trpc/tanstack-react-query";
-import type { AppRouter } from "../../../server/src/routers";
+import type { AppRouter } from "../../../{{serverName}}/src/routers";
 export interface RouterAppContext {
   trpc: TRPCOptionsProxy<AppRouter>;
   queryClient: QueryClient;

--- a/apps/cli/templates/frontend/react/tanstack-start/tsconfig.json.hbs
+++ b/apps/cli/templates/frontend/react/tanstack-start/tsconfig.json.hbs
@@ -27,7 +27,7 @@
   },
   {{#unless (or (eq backend "convex") (eq backend "none"))}}
   "references": [{
-    "path": "../server"
+    "path": "../{{serverName}}"
   }]
   {{/unless}}
 }

--- a/apps/cli/templates/frontend/solid/tsconfig.json.hbs
+++ b/apps/cli/templates/frontend/solid/tsconfig.json.hbs
@@ -28,7 +28,7 @@
   },
   {{#unless (or (eq backend "convex") (eq backend "none"))}}
   "references": [{
-    "path": "../server"
+    "path": "../{{serverName}}"
   }]
   {{/unless}}
 }

--- a/apps/cli/templates/frontend/svelte/tsconfig.json.hbs
+++ b/apps/cli/templates/frontend/svelte/tsconfig.json.hbs
@@ -13,7 +13,7 @@
 	},
       {{#unless (or (eq backend "convex") (eq backend "none"))}}
   "references": [{
-    "path": "../server"
+    "path": "../{{serverName}}"
   }]
   {{/unless}}
 	// Path aliases are handled by https://svelte.dev/docs/kit/configuration#alias


### PR DESCRIPTION
Attempt to add support for a dynamic server name instead of using the hardcoded `server`.

Fixes #485

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for customizing the backend server directory name throughout project creation, configuration, and templates.
  * Users can now specify a custom server name, which updates all relevant paths, scripts, environment files, and documentation references accordingly.

* **Documentation**
  * Updated generated documentation and templates to reflect the dynamic server directory name instead of a fixed "server".

* **Bug Fixes**
  * Resolved inconsistencies in paths and references by parameterizing the server directory name.

* **Style**
  * Improved consistency across configuration and template files by removing hardcoded server directory references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->