### PR TITLE
fix(biome): add missing wrangler.jsonc file ignore to biome.json.hbs

### DIFF
--- a/.changeset/real-chairs-turn.md
+++ b/.changeset/real-chairs-turn.md
@@ -1,0 +1,5 @@
+---
+"create-better-t-stack": patch
+---
+
+Extend biome.json.hbs, add missing wrangler.jsonc file ignore

--- a/apps/cli/templates/addons/biome/biome.json.hbs
+++ b/apps/cli/templates/addons/biome/biome.json.hbs
@@ -21,6 +21,7 @@
 			"!bts.jsonc",
 			"!**/.expo",
 			"!**/.wrangler",
+			"!**/wrangler.jsonc",
 			"!**/.source"
 		]
 	},

--- a/apps/cli/templates/addons/ultracite/biome.json.hbs
+++ b/apps/cli/templates/addons/ultracite/biome.json.hbs
@@ -16,6 +16,7 @@
 			"!bts.jsonc",
 			"!**/.expo",
 			"!**/.wrangler",
+			"!**/wrangler.jsonc",
 			"!**/.source"
 		]
 	}


### PR DESCRIPTION
During biome format the `wrangler.jsonc` is included but shouldn't be as other config files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Template ignore rules updated to also exclude an additional Wrangler config file, preventing it from being picked up by linters/formatters and reducing validation/formatting noise.
* **Chores**
  * Added a patch release note entry to record this change in the package release metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->