### PR TITLE
feat(cli): add disable analytics option

### DIFF
--- a/.changeset/honest-results-tease.md
+++ b/.changeset/honest-results-tease.md
@@ -1,0 +1,5 @@
+---
+"create-better-t-stack": patch
+---
+
+add disable analytics option

--- a/apps/cli/src/helpers/project-generation/command-handlers.ts
+++ b/apps/cli/src/helpers/project-generation/command-handlers.ts
@@ -178,7 +178,7 @@ export async function createProjectHandler(
 		),
 	);
 
-	await trackProjectCreation(config);
+	await trackProjectCreation(config, input.disableAnalytics);
 
 	const elapsedTimeMs = Date.now() - startTime;
 	const elapsedTimeInSeconds = (elapsedTimeMs / 1000).toFixed(2);

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -90,6 +90,11 @@ export const router = t.router({
 					webDeploy: WebDeploySchema.optional(),
 					directoryConflict: DirectoryConflictSchema.optional(),
 					renderTitle: z.boolean().optional(),
+					disableAnalytics: z
+						.boolean()
+						.optional()
+						.default(false)
+						.describe("Disable analytics"),
 				}),
 			]),
 		)
@@ -198,6 +203,7 @@ export function createBtsCli() {
  *   packageManager: "bun",
  *   install: false,
  *   directoryConflict: "increment", // auto-handle conflicts
+ *   disableAnalytics: true, // disable analytics
  * });
  *
  * if (result.success) {

--- a/apps/cli/src/types.ts
+++ b/apps/cli/src/types.ts
@@ -134,6 +134,7 @@ export type CreateInput = {
 	webDeploy?: WebDeploy;
 	directoryConflict?: DirectoryConflict;
 	renderTitle?: boolean;
+	disableAnalytics?: boolean;
 };
 
 export type AddInput = {

--- a/apps/cli/src/utils/analytics.ts
+++ b/apps/cli/src/utils/analytics.ts
@@ -5,8 +5,8 @@ import { isTelemetryEnabled } from "./telemetry";
 const POSTHOG_API_KEY = process.env.POSTHOG_API_KEY || "";
 const POSTHOG_HOST = process.env.POSTHOG_HOST;
 
-export async function trackProjectCreation(config: ProjectConfig) {
-	if (!isTelemetryEnabled()) return;
+export async function trackProjectCreation(config: ProjectConfig, disableAnalytics = false) {
+	if (!isTelemetryEnabled() || disableAnalytics) return;
 
 	const sessionId = `cli_${crypto.randomUUID().replace(/-/g, "")}`;
 	// biome-ignore lint/correctness/noUnusedVariables: `projectName`, `projectDir`, and `relativePath` are not used in the event properties

--- a/apps/cli/test/programmatic-api.test.ts
+++ b/apps/cli/test/programmatic-api.test.ts
@@ -213,6 +213,18 @@ describe("Programmatic API - Fast Tests", () => {
 				addons: ["biome"],
 			});
 		}, 15000);
+
+		test("creates project with analytics disabled", async () => {
+			const result = await init("no-analytics-app", {
+				yes: true,
+				disableAnalytics: true,
+				install: false,
+				git: false,
+			});
+
+			expect(result.success).toBe(true);
+			expect(result.projectConfig.projectName).toBe("no-analytics-app");
+		}, 15000);
 	});
 
 	describe("Error scenarios", () => {

--- a/apps/web/content/docs/cli/programmatic-api.mdx
+++ b/apps/web/content/docs/cli/programmatic-api.mdx
@@ -36,6 +36,7 @@ async function createProject() {
     auth: true,
     packageManager: "bun",
     install: false, // Don't install deps automatically
+    disableAnalytics: true, // Disable analytics
   });
 
   if (result.success) {
@@ -61,6 +62,23 @@ const result = await init("existing-folder", {
   renderTitle: false, // Hide ASCII art
 });
 ```
+
+### Disabling Analytics
+
+You can disable analytics:
+
+```typescript
+import { init } from "create-better-t-stack";
+
+const result = await init("my-private-project", {
+  yes: true,
+  disableAnalytics: true, // No analytics data will be sent
+  frontend: ["tanstack-router"],
+  backend: "hono",
+});
+```
+
+> **Note:** Analytics help improve Better-T Stack by providing insights into usage patterns. When disabled, no data is collected or transmitted.
 
 ## API Reference
 
@@ -130,6 +148,7 @@ interface CreateInput {
   webDeploy?: WebDeploy;          // Web deployment setup
   directoryConflict?: DirectoryConflict; // "merge" | "overwrite" | "increment" | "error"
   renderTitle?: boolean;           // Show ASCII art title
+  disableAnalytics?: boolean;      // Disable analytics and telemetry
 }
 ```
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a disableAnalytics option to the CLI programmatic API to turn off telemetry; defaults to false.
  - Analytics tracking now respects the disableAnalytics flag.

- Documentation
  - Updated programmatic API docs with the new option, including Quick Start and a “Disabling Analytics” section and API reference updates.

- Tests
  - Added a test to verify analytics can be disabled via the new option.

- Chores
  - Added a changeset for a patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->