### PR TITLE
chore: change ruler hint

### DIFF
--- a/apps/cli/src/prompts/addons.ts
+++ b/apps/cli/src/prompts/addons.ts
@@ -44,7 +44,7 @@ function getAddonDisplay(addon: Addons): { label: string; hint: string } {
 			break;
 		case "ruler":
 			label = "Ruler";
-			hint = "Install and apply BTS rules to editors";
+			hint = "Centralize your AI rules";
 			break;
 		case "husky":
 			label = "Husky";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated the hint text for the “Ruler” addon in the CLI addon selection prompt to “Centralize your AI rules” for clearer messaging.
  - Labels and behavior remain unchanged; this is a copy-only update with no functional impact.
  - No changes to other addons or prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->