### PR TITLE
feat(cli): optimize oRPC client dependencies by removing server dependency

### DIFF
--- a/.changeset/bright-areas-film.md
+++ b/.changeset/bright-areas-film.md
@@ -1,0 +1,5 @@
+---
+"create-better-t-stack": patch
+---
+
+optimize oRPC client dependencies by removing server dependency

--- a/apps/cli/src/helpers/setup/api-setup.ts
+++ b/apps/cli/src/helpers/setup/api-setup.ts
@@ -54,11 +54,7 @@ export async function setupApi(config: ProjectConfig) {
 			if (hasReactWeb) {
 				if (api === "orpc") {
 					await addPackageDependency({
-						dependencies: [
-							"@orpc/tanstack-query",
-							"@orpc/client",
-							"@orpc/server",
-						],
+						dependencies: ["@orpc/tanstack-query", "@orpc/client"],
 						projectDir: webDir,
 					});
 				} else if (api === "trpc") {
@@ -79,7 +75,6 @@ export async function setupApi(config: ProjectConfig) {
 							"@tanstack/vue-query-devtools",
 							"@orpc/tanstack-query",
 							"@orpc/client",
-							"@orpc/server",
 						],
 						projectDir: webDir,
 					});
@@ -90,7 +85,6 @@ export async function setupApi(config: ProjectConfig) {
 						dependencies: [
 							"@orpc/tanstack-query",
 							"@orpc/client",
-							"@orpc/server",
 							"@tanstack/svelte-query",
 						],
 						projectDir: webDir,
@@ -102,7 +96,6 @@ export async function setupApi(config: ProjectConfig) {
 						dependencies: [
 							"@orpc/tanstack-query",
 							"@orpc/client",
-							"@orpc/server",
 							"@tanstack/solid-query",
 						],
 						projectDir: webDir,
@@ -123,11 +116,7 @@ export async function setupApi(config: ProjectConfig) {
 				});
 			} else if (api === "orpc") {
 				await addPackageDependency({
-					dependencies: [
-						"@orpc/tanstack-query",
-						"@orpc/client",
-						"@orpc/server",
-					],
+					dependencies: ["@orpc/tanstack-query", "@orpc/client"],
 					projectDir: nativeDir,
 				});
 			}

--- a/apps/cli/templates/api/orpc/native/utils/orpc.ts.hbs
+++ b/apps/cli/templates/api/orpc/native/utils/orpc.ts.hbs
@@ -1,9 +1,8 @@
 import { createORPCClient } from "@orpc/client";
 import { RPCLink } from "@orpc/client/fetch";
 import { createTanstackQueryUtils } from "@orpc/tanstack-query";
-import type { RouterClient } from "@orpc/server";
 import { QueryCache, QueryClient } from "@tanstack/react-query";
-import type { appRouter } from "../../server/src/routers";
+import type { AppRouterClient } from "../../server/src/routers";
 {{#if auth}}
 import { authClient } from "@/lib/auth-client";
 {{/if}}
@@ -30,6 +29,6 @@ export const link = new RPCLink({
   {{/if}}
 });
 
-export const client: RouterClient<typeof appRouter> = createORPCClient(link);
+export const client: AppRouterClient = createORPCClient(link);
 
 export const orpc = createTanstackQueryUtils(client);

--- a/apps/cli/templates/api/orpc/web/nuxt/app/plugins/orpc.ts.hbs
+++ b/apps/cli/templates/api/orpc/web/nuxt/app/plugins/orpc.ts.hbs
@@ -1,6 +1,5 @@
 import { defineNuxtPlugin, useRuntimeConfig } from '#app'
-import type { RouterClient } from '@orpc/server'
-import type { appRouter } from "../../../server/src/routers/index";
+import type { AppRouterClient } from "../../../server/src/routers/index";
 import { createORPCClient } from '@orpc/client'
 import { RPCLink } from '@orpc/client/fetch'
 import { createTanstackQueryUtils } from "@orpc/tanstack-query";
@@ -24,7 +23,7 @@ export default defineNuxtPlugin(() => {
   })
 
 
-  const client: RouterClient<typeof appRouter> = createORPCClient(rpcLink)
+  const client: AppRouterClient = createORPCClient(rpcLink)
   const orpcUtils = createTanstackQueryUtils(client)
 
   return {

--- a/apps/cli/templates/api/orpc/web/react/base/src/utils/orpc.ts.hbs
+++ b/apps/cli/templates/api/orpc/web/react/base/src/utils/orpc.ts.hbs
@@ -3,8 +3,7 @@ import { RPCLink } from "@orpc/client/fetch";
 import { createTanstackQueryUtils } from "@orpc/tanstack-query";
 import { QueryCache, QueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import type { appRouter } from "../../../server/src/routers/index";
-import type { RouterClient } from "@orpc/server";
+import type { AppRouterClient } from "../../../server/src/routers/index";
 
 export const queryClient = new QueryClient({
   queryCache: new QueryCache({
@@ -37,6 +36,6 @@ export const link = new RPCLink({
   {{/if}}
 });
 
-export const client: RouterClient<typeof appRouter> = createORPCClient(link)
+export const client: AppRouterClient = createORPCClient(link)
 
 export const orpc = createTanstackQueryUtils(client)

--- a/apps/cli/templates/api/orpc/web/solid/src/utils/orpc.ts.hbs
+++ b/apps/cli/templates/api/orpc/web/solid/src/utils/orpc.ts.hbs
@@ -2,8 +2,7 @@ import { createORPCClient } from "@orpc/client";
 import { RPCLink } from "@orpc/client/fetch";
 import { createTanstackQueryUtils } from "@orpc/tanstack-query";
 import { QueryCache, QueryClient } from "@tanstack/solid-query";
-import type { appRouter } from "../../../server/src/routers/index";
-import type { RouterClient } from "@orpc/server";
+import type { AppRouterClient } from "../../../server/src/routers/index";
 
 export const queryClient = new QueryClient({
   queryCache: new QueryCache({
@@ -25,6 +24,6 @@ export const link = new RPCLink({
   {{/if}}
 });
 
-export const client: RouterClient<typeof appRouter> = createORPCClient(link);
+export const client: AppRouterClient = createORPCClient(link);
 
 export const orpc = createTanstackQueryUtils(client);

--- a/apps/cli/templates/api/orpc/web/svelte/src/lib/orpc.ts.hbs
+++ b/apps/cli/templates/api/orpc/web/svelte/src/lib/orpc.ts.hbs
@@ -1,10 +1,9 @@
 import { PUBLIC_SERVER_URL } from "$env/static/public";
 import { createORPCClient } from "@orpc/client";
 import { RPCLink } from "@orpc/client/fetch";
-import type { RouterClient } from "@orpc/server";
 import { createTanstackQueryUtils } from "@orpc/tanstack-query";
 import { QueryCache, QueryClient } from "@tanstack/svelte-query";
-import type { appRouter } from "../../../server/src/routers/index";
+import type { AppRouterClient } from "../../../server/src/routers/index";
 
 export const queryClient = new QueryClient({
 	queryCache: new QueryCache({
@@ -26,6 +25,6 @@ export const link = new RPCLink({
 	{{/if}}
 });
 
-export const client: RouterClient<typeof appRouter> = createORPCClient(link);
+export const client: AppRouterClient = createORPCClient(link);
 
 export const orpc = createTanstackQueryUtils(client);

--- a/apps/cli/templates/backend/server/server-base/src/routers/index.ts.hbs
+++ b/apps/cli/templates/backend/server/server-base/src/routers/index.ts.hbs
@@ -1,5 +1,6 @@
 {{#if (eq api "orpc")}}
 import { {{#if auth}}protectedProcedure, {{/if}}publicProcedure } from "../lib/orpc";
+import type { RouterClient } from "@orpc/server";
 {{#if (includes examples "todo")}}
 import { todoRouter } from "./todo";
 {{/if}}
@@ -21,6 +22,7 @@ export const appRouter = {
   {{/if}}
 };
 export type AppRouter = typeof appRouter;
+export type AppRouterClient = RouterClient<typeof appRouter>;
 {{else if (eq api "trpc")}}
 import {
   {{#if auth}}protectedProcedure, {{/if}}publicProcedure,

--- a/apps/cli/templates/frontend/react/tanstack-router/src/routes/__root.tsx.hbs
+++ b/apps/cli/templates/frontend/react/tanstack-router/src/routes/__root.tsx.hbs
@@ -7,9 +7,8 @@ import { link, orpc } from "@/utils/orpc";
 import type { QueryClient } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { useState } from "react";
-import type { RouterClient } from "@orpc/server";
 import { createTanstackQueryUtils } from "@orpc/tanstack-query";
-import type { appRouter } from "../../../server/src/routers";
+import type { AppRouterClient } from "../../../server/src/routers";
 import { createORPCClient } from "@orpc/client";
 {{/if}}
 {{#if (eq api "trpc")}}
@@ -67,7 +66,7 @@ function RootComponent() {
   });
 
   {{#if (eq api "orpc")}}
-  const [client] = useState<RouterClient<typeof appRouter>>(() => createORPCClient(link));
+  const [client] = useState<AppRouterClient>(() => createORPCClient(link));
   const [orpcUtils] = useState(() => createTanstackQueryUtils(client));
   {{/if}}
 


### PR DESCRIPTION
## Summary

This PR optimizes oRPC client packages by eliminating the unnecessary `@orpc/server` dependency, reducing bundle size and creating cleaner architectural separation.

### Problem

Previously, all oRPC client packages (React, Svelte, Solid, Nuxt, Native) installed `@orpc/server` as a runtime dependency solely for the `RouterClient<T>` type. This created:

- **Bundle bloat**: Client packages included server-only runtime code
- **Unnecessary dependencies**: Server package installed on client-side  
- **Poor separation**: Mixed server and client concerns

### Solution

Export a pre-typed `AppRouterClient` from the server package instead of importing the generic `RouterClient` type on clients.

**Before:**
```typescript
// Client code
import type { appRouter } from "../../../server/src/routers/index";
import type { RouterClient } from "@orpc/server"; // ❌ Server dependency on client

export const client: RouterClient<typeof appRouter> = createORPCClient(link)
```

**After:**
```typescript
// Client code  
import type { AppRouterClient } from "../../../server/src/routers/index"; // ✅ Pre-typed from server

export const client: AppRouterClient = createORPCClient(link)
```

## Changes Made

### 📦 Server Template Updates
- **`apps/cli/templates/backend/server/server-base/src/routers/index.ts.hbs`**
  - Added `AppRouterClient` export: `export type AppRouterClient = RouterClient<typeof appRouter>;`

### 🎯 Client Template Updates (5 files)
- **React**: `apps/cli/templates/api/orpc/web/react/base/src/utils/orpc.ts.hbs`
- **Svelte**: `apps/cli/templates/api/orpc/web/svelte/src/lib/orpc.ts.hbs`  
- **Solid**: `apps/cli/templates/api/orpc/web/solid/src/utils/orpc.ts.hbs`
- **Nuxt**: `apps/cli/templates/api/orpc/web/nuxt/app/plugins/orpc.ts.hbs`
- **Native**: `apps/cli/templates/api/orpc/native/utils/orpc.ts.hbs`
- **TanStack Router**: `apps/cli/templates/frontend/react/tanstack-router/src/routes/__root.tsx.hbs`                

All updated to import `AppRouterClient` instead of `RouterClient` + `appRouter`.

### ⚙️ Dependency Installation Updates
- **`apps/cli/src/helpers/setup/api-setup.ts`**
  - Removed `@orpc/server` from all client dependency arrays
  - Maintained `@orpc/server` only for server packages

## Benefits

- ✅ **Reduced Bundle Size**: Client packages no longer include server-only code
- ✅ **Cleaner Dependencies**: Only necessary packages installed on client-side
- ✅ **Better Architecture**: Clear separation between server and client concerns  
- ✅ **Maintained Type Safety**: Full end-to-end typing preserved across all frameworks
- ✅ **Backward Compatibility**: All existing functionality unchanged

## Test Plan

- [x] CLI builds successfully without errors
- [x] All client templates use `AppRouterClient` type correctly
- [x] No `@orpc/server` imports remain in client templates
- [x] Server packages still install `@orpc/server` dependency 
- [x] Type safety maintained across all frameworks (React, Svelte, Solid, Nuxt, Native)
- [x] TanStack Router template properly updated        

## Frameworks Affected

- ✅ **React** (Next.js, TanStack Router, React Router, TanStack Start)
- ✅ **Svelte** (SvelteKit)
- ✅ **Solid** (SolidStart) 
- ✅ **Nuxt** (Vue.js)
- ✅ **React Native** (NativeWind, Unistyles)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified ORPC client typing across generated templates for consistency.

* **Refactor**
  * Updated frontend and native templates to use the new client type annotation for clearer typings.

* **Chores**
  * Removed an unnecessary server-side ORPC package from frontend and native setups to streamline installs; server-side remains intact.

* **Notes**
  * No runtime behavior or public CLI/API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->