### PR TITLE
docs: add Ruler to the Addons list on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ npx create-better-t-stack@latest
 - Databases: SQLite, PostgreSQL, MySQL, MongoDB (or none)
 - ORMs: Drizzle, Prisma, Mongoose (or none)
 - Auth: Better-Auth (optional)
-- Addons: Turborepo, PWA, Tauri, Biome, Husky, Starlight, Fumadocs, Ultracite, Oxlint
+- Addons: Turborepo, PWA, Tauri, Biome, Husky, Starlight, Fumadocs, Ruler, Ultracite, Oxlint
 - Examples: Todo, AI
 - DB Setup: Turso, Neon, Supabase, Prisma PostgreSQL, MongoDB Atlas, Cloudflare D1, Docker
 - Web Deploy: Cloudflare Workers


### PR DESCRIPTION
Add Ruler to the Addons list on the README

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README’s Features section to include a new “Ruler” addon in the Addons list, ensuring the catalog of available addons is current and easier to scan.
  * Clarified the list without altering existing items or their descriptions.
  * No functional, API, or configuration changes—this is a documentation-only update to improve visibility and discoverability for end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->