### PR TITLE
fix(orpc): add Next.js server-side headers support

### DIFF
--- a/apps/cli/templates/api/orpc/web/react/base/src/utils/orpc.ts.hbs
+++ b/apps/cli/templates/api/orpc/web/react/base/src/utils/orpc.ts.hbs
@@ -6,44 +6,44 @@ import { toast } from "sonner";
 import type { AppRouterClient } from "../../../server/src/routers/index";
 
 export const queryClient = new QueryClient({
-queryCache: new QueryCache({
-onError: (error) => {
-toast.error(`Error: ${error.message}`, {
-action: {
-label: "retry",
-onClick: () => {
-queryClient.invalidateQueries();
-},
-},
-});
-},
-}),
+  queryCache: new QueryCache({
+    onError: (error) => {
+      toast.error(`Error: ${error.message}`, {
+        action: {
+          label: "retry",
+          onClick: () => {
+            queryClient.invalidateQueries();
+          },
+        },
+      });
+    },
+  }),
 });
 
 export const link = new RPCLink({
-{{#if (includes frontend "next")}}
-url: `${process.env.NEXT_PUBLIC_SERVER_URL}/rpc`,
-{{else}}
-url: `${import.meta.env.VITE_SERVER_URL}/rpc`,
-{{/if}}
-{{#if auth}}
-fetch(url, options) {
-return fetch(url, {
-...options,
-credentials: "include",
-});
-},
-{{#if (includes frontend "next")}}
-headers: async () => {
-if (typeof window !== "undefined") {
-return {}
-}
+  {{#if (includes frontend "next")}}
+  url: `${process.env.NEXT_PUBLIC_SERVER_URL}/rpc`,
+  {{else}}
+  url: `${import.meta.env.VITE_SERVER_URL}/rpc`,
+  {{/if}}
+  {{#if auth}}
+  fetch(url, options) {
+    return fetch(url, {
+      ...options,
+      credentials: "include",
+    });
+  },
+  {{#if (includes frontend "next")}}
+  headers: async () => {
+    if (typeof window !== "undefined") {
+      return {}
+    }
 
-const { headers } = await import("next/headers")
-return Object.fromEntries(await headers())
-},
-{{/if}}
-{{/if}}
+    const { headers } = await import("next/headers")
+    return Object.fromEntries(await headers())
+  },
+  {{/if}}
+  {{/if}}
 });
 
 export const client: AppRouterClient = createORPCClient(link)

--- a/apps/cli/templates/api/orpc/web/react/base/src/utils/orpc.ts.hbs
+++ b/apps/cli/templates/api/orpc/web/react/base/src/utils/orpc.ts.hbs
@@ -6,34 +6,44 @@ import { toast } from "sonner";
 import type { AppRouterClient } from "../../../server/src/routers/index";
 
 export const queryClient = new QueryClient({
-  queryCache: new QueryCache({
-    onError: (error) => {
-      toast.error(`Error: ${error.message}`, {
-        action: {
-          label: "retry",
-          onClick: () => {
-            queryClient.invalidateQueries();
-          },
-        },
-      });
-    },
-  }),
+queryCache: new QueryCache({
+onError: (error) => {
+toast.error(`Error: ${error.message}`, {
+action: {
+label: "retry",
+onClick: () => {
+queryClient.invalidateQueries();
+},
+},
+});
+},
+}),
 });
 
 export const link = new RPCLink({
-  {{#if (includes frontend "next")}}
-  url: `${process.env.NEXT_PUBLIC_SERVER_URL}/rpc`,
-  {{else}}
-  url: `${import.meta.env.VITE_SERVER_URL}/rpc`,
-  {{/if}}
-  {{#if auth}}
-  fetch(url, options) {
-    return fetch(url, {
-      ...options,
-      credentials: "include",
-    });
-  },
-  {{/if}}
+{{#if (includes frontend "next")}}
+url: `${process.env.NEXT_PUBLIC_SERVER_URL}/rpc`,
+{{else}}
+url: `${import.meta.env.VITE_SERVER_URL}/rpc`,
+{{/if}}
+{{#if auth}}
+fetch(url, options) {
+return fetch(url, {
+...options,
+credentials: "include",
+});
+},
+{{#if (includes frontend "next")}}
+headers: async () => {
+if (typeof window !== "undefined") {
+return {}
+}
+
+const { headers } = await import("next/headers")
+return Object.fromEntries(await headers())
+},
+{{/if}}
+{{/if}}
 });
 
 export const client: AppRouterClient = createORPCClient(link)


### PR DESCRIPTION
## Fix: Add Next.js server-side headers support for oRPC template

### What
Adds automatic header forwarding for Next.js SSR when using oRPC with authentication.

### Why
Authentication cookies and request headers weren't being forwarded during server-side rendering, causing auth failures in server components.

### Changes
- Added conditional `headers` function for Next.js + auth templates
- Forwards server headers using `next/headers` on server-side
- Client-side detection prevents hydration issues
- Fixed code formatting

### Template Logic
```handlebars
{{#if auth}}
  {{#if (includes frontend "next")}}
    headers: async () => {
      if (typeof window !== "undefined") return {}
      const { headers } = await import("next/headers")
      return Object.fromEntries(await headers())
    },
  {{/if}}
{{/if}}
```

Reference: https://orpc.unnoq.com/docs/adapters/next#client

### Impact
- ✅ Fixes SSR auth issues in Next.js projects
- ✅ No breaking changes
- ✅ Only applies to Next.js + auth combinations
- ✅ Backward compatible

**Type**: `fix` | **Scope**: `orpc` | **Breaking**: `No`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Next.js frontends now automatically include incoming request headers in server-side RPC calls. This improves authentication/session continuity, localization, and compatibility with header-dependent middleware. Client-side behavior remains unchanged.
  * Works transparently with no additional configuration, enabling more reliable SSR and edge runtime integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->