### PR TITLE
feat(cli): add openapi suppport in orpc

### DIFF
--- a/apps/cli/src/constants.ts
+++ b/apps/cli/src/constants.ts
@@ -112,6 +112,8 @@ export const dependencyVersionMap = {
 
 	"@orpc/server": "^1.8.6",
 	"@orpc/client": "^1.8.6",
+	"@orpc/openapi": "^1.8.6",
+	"@orpc/zod": "^1.8.6",
 	"@orpc/tanstack-query": "^1.8.6",
 
 	"@trpc/tanstack-react-query": "^11.5.0",

--- a/apps/cli/src/helpers/core/api-setup.ts
+++ b/apps/cli/src/helpers/core/api-setup.ts
@@ -54,7 +54,14 @@ function getApiDependencies(
 	> = {};
 
 	if (api === "orpc") {
-		deps.server = { dependencies: ["@orpc/server", "@orpc/client"] };
+		deps.server = {
+			dependencies: [
+				"@orpc/server",
+				"@orpc/client",
+				"@orpc/openapi",
+				"@orpc/zod",
+			],
+		};
 	} else if (api === "trpc") {
 		deps.server = { dependencies: ["@trpc/server", "@trpc/client"] };
 	}

--- a/apps/cli/src/helpers/core/post-installation.ts
+++ b/apps/cli/src/helpers/core/post-installation.ts
@@ -14,6 +14,7 @@ export async function displayPostInstallInstructions(
 	config: ProjectConfig & { depsInstalled: boolean },
 ) {
 	const {
+		api,
 		database,
 		relativePath,
 		packageManager,
@@ -158,6 +159,14 @@ export async function displayPostInstallInstructions(
 
 	if (!isConvex) {
 		output += `${pc.cyan("•")} Backend API: http://localhost:3000\n`;
+
+		if (api === "orpc") {
+			if (backend === "next") {
+				output += `${pc.cyan("•")} OpenAPI (Scalar UI): http://localhost:3000/rpc/api\n`;
+			} else {
+				output += `${pc.cyan("•")} OpenAPI (Scalar UI): http://localhost:3000/api\n`;
+			}
+		}
 	}
 
 	if (addons?.includes("starlight")) {

--- a/apps/cli/src/helpers/deployment/alchemy/alchemy-next-setup.ts
+++ b/apps/cli/src/helpers/deployment/alchemy/alchemy-next-setup.ts
@@ -25,7 +25,6 @@ export async function setupNextAlchemyDeploy(
 				...pkg.scripts,
 				deploy: "alchemy deploy",
 				destroy: "alchemy destroy",
-				dev: "alchemy dev",
 			};
 		}
 		await fs.writeJson(pkgPath, pkg, { spaces: 2 });

--- a/apps/cli/src/helpers/deployment/alchemy/alchemy-nuxt-setup.ts
+++ b/apps/cli/src/helpers/deployment/alchemy/alchemy-nuxt-setup.ts
@@ -26,7 +26,6 @@ export async function setupNuxtAlchemyDeploy(
 				...pkg.scripts,
 				deploy: "alchemy deploy",
 				destroy: "alchemy destroy",
-				dev: "alchemy dev",
 			};
 		}
 		await fs.writeJson(pkgPath, pkg, { spaces: 2 });

--- a/apps/cli/src/helpers/deployment/alchemy/alchemy-react-router-setup.ts
+++ b/apps/cli/src/helpers/deployment/alchemy/alchemy-react-router-setup.ts
@@ -25,7 +25,6 @@ export async function setupReactRouterAlchemyDeploy(
 				...pkg.scripts,
 				deploy: "alchemy deploy",
 				destroy: "alchemy destroy",
-				dev: "alchemy dev",
 			};
 		}
 		await fs.writeJson(pkgPath, pkg, { spaces: 2 });

--- a/apps/cli/src/helpers/deployment/alchemy/alchemy-solid-setup.ts
+++ b/apps/cli/src/helpers/deployment/alchemy/alchemy-solid-setup.ts
@@ -25,7 +25,6 @@ export async function setupSolidAlchemyDeploy(
 				...pkg.scripts,
 				deploy: "alchemy deploy",
 				destroy: "alchemy destroy",
-				dev: "alchemy dev",
 			};
 		}
 		await fs.writeJson(pkgPath, pkg, { spaces: 2 });

--- a/apps/cli/src/helpers/deployment/alchemy/alchemy-svelte-setup.ts
+++ b/apps/cli/src/helpers/deployment/alchemy/alchemy-svelte-setup.ts
@@ -26,7 +26,6 @@ export async function setupSvelteAlchemyDeploy(
 				...pkg.scripts,
 				deploy: "alchemy deploy",
 				destroy: "alchemy destroy",
-				dev: "alchemy dev",
 			};
 		}
 

--- a/apps/cli/src/helpers/deployment/alchemy/alchemy-tanstack-router-setup.ts
+++ b/apps/cli/src/helpers/deployment/alchemy/alchemy-tanstack-router-setup.ts
@@ -25,7 +25,6 @@ export async function setupTanStackRouterAlchemyDeploy(
 				...pkg.scripts,
 				deploy: "alchemy deploy",
 				destroy: "alchemy destroy",
-				dev: "alchemy dev",
 			};
 		}
 

--- a/apps/cli/src/helpers/deployment/alchemy/alchemy-tanstack-start-setup.ts
+++ b/apps/cli/src/helpers/deployment/alchemy/alchemy-tanstack-start-setup.ts
@@ -26,7 +26,6 @@ export async function setupTanStackStartAlchemyDeploy(
 				...pkg.scripts,
 				deploy: "alchemy deploy",
 				destroy: "alchemy destroy",
-				dev: "alchemy dev",
 			};
 		}
 

--- a/apps/cli/templates/api/orpc/server/next/src/app/rpc/[...all]/route.ts.hbs
+++ b/apps/cli/templates/api/orpc/server/next/src/app/rpc/[...all]/route.ts.hbs
@@ -6,13 +6,25 @@ import { OpenAPIHandler } from '@orpc/openapi/fetch'
 import { OpenAPIReferencePlugin } from '@orpc/openapi/plugins'
 import { ZodToJsonSchemaConverter } from '@orpc/zod/zod4'
 import { RPCHandler } from '@orpc/server/fetch'
+import { onError } from '@orpc/server'
 import { NextRequest } from 'next/server'
 
-const rpcHandler = new RPCHandler(appRouter)
+const rpcHandler = new RPCHandler(appRouter, {
+  interceptors: [
+    onError((error) => {
+      console.error(error)
+    }),
+  ],
+})
 const apiHandler = new OpenAPIHandler(appRouter, {
   plugins: [
     new OpenAPIReferencePlugin({
       schemaConverters: [new ZodToJsonSchemaConverter()],
+    }),
+  ],
+  interceptors: [
+    onError((error) => {
+      console.error(error)
     }),
   ],
 })

--- a/apps/cli/templates/api/orpc/server/next/src/app/rpc/[...all]/route.ts.hbs
+++ b/apps/cli/templates/api/orpc/server/next/src/app/rpc/[...all]/route.ts.hbs
@@ -2,18 +2,35 @@
 import { createContext } from '@/lib/context'
 {{/if}}
 import { appRouter } from '@/routers'
+import { OpenAPIHandler } from '@orpc/openapi/fetch'
+import { OpenAPIReferencePlugin } from '@orpc/openapi/plugins'
+import { ZodToJsonSchemaConverter } from '@orpc/zod/zod4'
 import { RPCHandler } from '@orpc/server/fetch'
 import { NextRequest } from 'next/server'
 
-const handler = new RPCHandler(appRouter)
+const rpcHandler = new RPCHandler(appRouter)
+const apiHandler = new OpenAPIHandler(appRouter, {
+  plugins: [
+    new OpenAPIReferencePlugin({
+      schemaConverters: [new ZodToJsonSchemaConverter()],
+    }),
+  ],
+})
 
 async function handleRequest(req: NextRequest) {
-  const { response } = await handler.handle(req, {
+  const rpcResult = await rpcHandler.handle(req, {
     prefix: '/rpc',
     context: {{#if (eq auth "better-auth")}}await createContext(req){{else}}{}{{/if}},
   })
+  if (rpcResult.response) return rpcResult.response
 
-  return response ?? new Response('Not found', { status: 404 })
+  const apiResult = await apiHandler.handle(req, {
+    prefix: '/rpc/api',
+    context: {{#if (eq auth "better-auth")}}await createContext(req){{else}}{}{{/if}},
+  })
+  if (apiResult.response) return apiResult.response
+
+  return new Response('Not found', { status: 404 })
 }
 
 export const GET = handleRequest

--- a/apps/cli/templates/backend/server/elysia/src/index.ts.hbs
+++ b/apps/cli/templates/backend/server/elysia/src/index.ts.hbs
@@ -14,6 +14,7 @@ import { OpenAPIHandler } from "@orpc/openapi/fetch";
 import { OpenAPIReferencePlugin } from "@orpc/openapi/plugins";
 import { ZodToJsonSchemaConverter } from "@orpc/zod/zod4";
 import { RPCHandler } from "@orpc/server/fetch";
+import { onError } from "@orpc/server";
 import { appRouter } from "./routers";
 import { createContext } from "./lib/context";
 {{/if}}
@@ -22,11 +23,22 @@ import { auth } from "./lib/auth";
 {{/if}}
 
 {{#if (eq api "orpc")}}
-const rpcHandler = new RPCHandler(appRouter);
+const rpcHandler = new RPCHandler(appRouter, {
+  interceptors: [
+    onError((error) => {
+      console.error(error);
+    }),
+  ],
+});
 const apiHandler = new OpenAPIHandler(appRouter, {
   plugins: [
     new OpenAPIReferencePlugin({
       schemaConverters: [new ZodToJsonSchemaConverter()],
+    }),
+  ],
+  interceptors: [
+    onError((error) => {
+      console.error(error);
     }),
   ],
 });

--- a/apps/cli/templates/backend/server/elysia/src/index.ts.hbs
+++ b/apps/cli/templates/backend/server/elysia/src/index.ts.hbs
@@ -10,6 +10,9 @@ import { appRouter } from "./routers/index";
 import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
 {{/if}}
 {{#if (eq api "orpc")}}
+import { OpenAPIHandler } from "@orpc/openapi/fetch";
+import { OpenAPIReferencePlugin } from "@orpc/openapi/plugins";
+import { ZodToJsonSchemaConverter } from "@orpc/zod/zod4";
 import { RPCHandler } from "@orpc/server/fetch";
 import { appRouter } from "./routers";
 import { createContext } from "./lib/context";
@@ -19,7 +22,14 @@ import { auth } from "./lib/auth";
 {{/if}}
 
 {{#if (eq api "orpc")}}
-const handler = new RPCHandler(appRouter);
+const rpcHandler = new RPCHandler(appRouter);
+const apiHandler = new OpenAPIHandler(appRouter, {
+  plugins: [
+    new OpenAPIReferencePlugin({
+      schemaConverters: [new ZodToJsonSchemaConverter()],
+    }),
+  ],
+});
 {{/if}}
 
 {{#if (eq runtime "node")}}
@@ -48,8 +58,15 @@ const app = new Elysia()
   {{/if}}
 {{#if (eq api "orpc")}}
   .all('/rpc*', async (context) => {
-    const { response } = await handler.handle(context.request, {
+    const { response } = await rpcHandler.handle(context.request, {
       prefix: '/rpc',
+      context: await createContext({ context })
+    })
+    return response ?? new Response('Not Found', { status: 404 })
+  })
+  .all('/api*', async (context) => {
+    const { response } = await apiHandler.handle(context.request, {
+      prefix: '/api',
       context: await createContext({ context })
     })
     return response ?? new Response('Not Found', { status: 404 })

--- a/apps/cli/templates/backend/server/express/src/index.ts.hbs
+++ b/apps/cli/templates/backend/server/express/src/index.ts.hbs
@@ -9,6 +9,7 @@ import { OpenAPIHandler } from "@orpc/openapi/node";
 import { OpenAPIReferencePlugin } from "@orpc/openapi/plugins";
 import { ZodToJsonSchemaConverter } from "@orpc/zod/zod4";
 import { RPCHandler } from "@orpc/server/node";
+import { onError } from "@orpc/server";
 import { appRouter } from "./routers";
 {{#if (eq auth "better-auth")}}
 import { createContext } from "./lib/context";
@@ -53,11 +54,22 @@ app.use(
 {{/if}}
 
 {{#if (eq api "orpc")}}
-const rpcHandler = new RPCHandler(appRouter);
+const rpcHandler = new RPCHandler(appRouter, {
+  interceptors: [
+    onError((error) => {
+      console.error(error);
+    }),
+  ],
+});
 const apiHandler = new OpenAPIHandler(appRouter, {
   plugins: [
     new OpenAPIReferencePlugin({
       schemaConverters: [new ZodToJsonSchemaConverter()],
+    }),
+  ],
+  interceptors: [
+    onError((error) => {
+      console.error(error);
     }),
   ],
 });

--- a/apps/cli/templates/backend/server/express/src/index.ts.hbs
+++ b/apps/cli/templates/backend/server/express/src/index.ts.hbs
@@ -5,6 +5,9 @@ import { createContext } from "./lib/context";
 import { appRouter } from "./routers/index";
 {{/if}}
 {{#if (eq api "orpc")}}
+import { OpenAPIHandler } from "@orpc/openapi/node";
+import { OpenAPIReferencePlugin } from "@orpc/openapi/plugins";
+import { ZodToJsonSchemaConverter } from "@orpc/zod/zod4";
 import { RPCHandler } from "@orpc/server/node";
 import { appRouter } from "./routers";
 {{#if (eq auth "better-auth")}}
@@ -50,9 +53,17 @@ app.use(
 {{/if}}
 
 {{#if (eq api "orpc")}}
-const handler = new RPCHandler(appRouter);
-app.use("/rpc{*path}", async (req, res, next) => {
-  const { matched } = await handler.handle(req, res, {
+const rpcHandler = new RPCHandler(appRouter);
+const apiHandler = new OpenAPIHandler(appRouter, {
+  plugins: [
+    new OpenAPIReferencePlugin({
+      schemaConverters: [new ZodToJsonSchemaConverter()],
+    }),
+  ],
+});
+
+app.use(async (req, res, next) => {
+  const rpcResult = await rpcHandler.handle(req, res, {
     prefix: "/rpc",
     {{#if (eq auth "better-auth")}}
     context: await createContext({ req }),
@@ -60,7 +71,18 @@ app.use("/rpc{*path}", async (req, res, next) => {
     context: {},
     {{/if}}
   });
-  if (matched) return;
+  if (rpcResult.matched) return;
+
+  const apiResult = await apiHandler.handle(req, res, {
+    prefix: "/api",
+    {{#if (eq auth "better-auth")}}
+    context: await createContext({ req }),
+    {{else}}
+    context: {},
+    {{/if}}
+  });
+  if (apiResult.matched) return;
+
   next();
 });
 {{/if}}

--- a/apps/cli/templates/backend/server/fastify/src/index.ts.hbs
+++ b/apps/cli/templates/backend/server/fastify/src/index.ts.hbs
@@ -14,6 +14,7 @@ import { OpenAPIReferencePlugin } from "@orpc/openapi/plugins";
 import { ZodToJsonSchemaConverter } from "@orpc/zod/zod4";
 import { RPCHandler } from "@orpc/server/node";
 import { CORSPlugin } from "@orpc/server/plugins";
+import { onError } from "@orpc/server";
 import { appRouter } from "./routers/index";
 import { createServer } from "node:http";
 {{#if (eq auth "better-auth")}}
@@ -51,12 +52,22 @@ const rpcHandler = new RPCHandler(appRouter, {
       allowHeaders: ["Content-Type", "Authorization"],
     }),
   ],
+  interceptors: [
+    onError((error) => {
+      console.error(error);
+    }),
+  ],
 });
 
 const apiHandler = new OpenAPIHandler(appRouter, {
   plugins: [
     new OpenAPIReferencePlugin({
       schemaConverters: [new ZodToJsonSchemaConverter()],
+    }),
+  ],
+  interceptors: [
+    onError((error) => {
+      console.error(error);
     }),
   ],
 });

--- a/apps/cli/templates/backend/server/fastify/src/index.ts.hbs
+++ b/apps/cli/templates/backend/server/fastify/src/index.ts.hbs
@@ -9,6 +9,9 @@ import { appRouter, type AppRouter } from "./routers/index";
 {{/if}}
 
 {{#if (eq api "orpc")}}
+import { OpenAPIHandler } from "@orpc/openapi/node";
+import { OpenAPIReferencePlugin } from "@orpc/openapi/plugins";
+import { ZodToJsonSchemaConverter } from "@orpc/zod/zod4";
 import { RPCHandler } from "@orpc/server/node";
 import { CORSPlugin } from "@orpc/server/plugins";
 import { appRouter } from "./routers/index";
@@ -40,7 +43,7 @@ const baseCorsConfig = {
 };
 
 {{#if (eq api "orpc")}}
-const handler = new RPCHandler(appRouter, {
+const rpcHandler = new RPCHandler(appRouter, {
   plugins: [
     new CORSPlugin({
       origin: process.env.CORS_ORIGIN,
@@ -50,16 +53,33 @@ const handler = new RPCHandler(appRouter, {
   ],
 });
 
+const apiHandler = new OpenAPIHandler(appRouter, {
+  plugins: [
+    new OpenAPIReferencePlugin({
+      schemaConverters: [new ZodToJsonSchemaConverter()],
+    }),
+  ],
+});
+
 const fastify = Fastify({
   logger: true,
   serverFactory: (fastifyHandler) => {
     const server = createServer(async (req, res) => {
-      const { matched } = await handler.handle(req, res, {
+      const { matched } = await rpcHandler.handle(req, res, {
         context: await createContext(req.headers),
         prefix: "/rpc",
       });
 
       if (matched) {
+        return;
+      }
+
+      const apiResult = await apiHandler.handle(req, res, {
+        context: await createContext(req.headers),
+        prefix: "/api",
+      });
+
+      if (apiResult.matched) {
         return;
       }
 

--- a/apps/cli/templates/backend/server/hono/src/index.ts.hbs
+++ b/apps/cli/templates/backend/server/hono/src/index.ts.hbs
@@ -9,6 +9,7 @@ import { OpenAPIHandler } from "@orpc/openapi/fetch";
 import { OpenAPIReferencePlugin } from "@orpc/openapi/plugins";
 import { ZodToJsonSchemaConverter } from "@orpc/zod/zod4";
 import { RPCHandler } from "@orpc/server/fetch";
+import { onError } from "@orpc/server";
 import { createContext } from "./lib/context";
 import { appRouter } from "./routers/index";
 {{/if}}
@@ -63,9 +64,20 @@ export const apiHandler = new OpenAPIHandler(appRouter, {
       schemaConverters: [new ZodToJsonSchemaConverter()],
     }),
   ],
+  interceptors: [
+    onError((error) => {
+      console.error(error);
+    }),
+  ],
 });
 
-export const rpcHandler = new RPCHandler(appRouter);
+export const rpcHandler = new RPCHandler(appRouter, {
+  interceptors: [
+    onError((error) => {
+      console.error(error);
+    }),
+  ],
+});
 
 app.use("/*", async (c, next) => {
   const context = await createContext({ context: c });

--- a/apps/cli/templates/backend/server/hono/src/index.ts.hbs
+++ b/apps/cli/templates/backend/server/hono/src/index.ts.hbs
@@ -5,6 +5,9 @@ import "dotenv/config";
 import { env } from "cloudflare:workers";
 {{/if}}
 {{#if (eq api "orpc")}}
+import { OpenAPIHandler } from "@orpc/openapi/fetch";
+import { OpenAPIReferencePlugin } from "@orpc/openapi/plugins";
+import { ZodToJsonSchemaConverter } from "@orpc/zod/zod4";
 import { RPCHandler } from "@orpc/server/fetch";
 import { createContext } from "./lib/context";
 import { appRouter } from "./routers/index";
@@ -54,17 +57,37 @@ app.on(["POST", "GET"], "/api/auth/**", (c) => auth.handler(c.req.raw));
 {{/if}}
 
 {{#if (eq api "orpc")}}
-const handler = new RPCHandler(appRouter);
-app.use("/rpc/*", async (c, next) => {
+export const apiHandler = new OpenAPIHandler(appRouter, {
+  plugins: [
+    new OpenAPIReferencePlugin({
+      schemaConverters: [new ZodToJsonSchemaConverter()],
+    }),
+  ],
+});
+
+export const rpcHandler = new RPCHandler(appRouter);
+
+app.use("/*", async (c, next) => {
   const context = await createContext({ context: c });
-  const { matched, response } = await handler.handle(c.req.raw, {
+
+  const rpcResult = await rpcHandler.handle(c.req.raw, {
     prefix: "/rpc",
     context: context,
   });
 
-  if (matched) {
-    return c.newResponse(response.body, response);
+  if (rpcResult.matched) {
+    return c.newResponse(rpcResult.response.body, rpcResult.response);
   }
+
+  const apiResult = await apiHandler.handle(c.req.raw, {
+    prefix: "/api",
+    context: context,
+  });
+
+  if (apiResult.matched) {
+    return c.newResponse(apiResult.response.body, apiResult.response);
+  }
+
   await next();
 });
 {{/if}}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - ORPC templates now expose OpenAPI-powered API docs/schemas across Next, Express, Fastify, Hono, and Elysia; Next.js RPC route supports GET/POST/PUT/PATCH/DELETE.

- Documentation
  - Post-install instructions for ORPC projects now include a link to the OpenAPI docs endpoint.

- Chores
  - Added OpenAPI-related ORPC dependencies.
  - Alchemy deployment setups no longer inject a “dev” script; only “deploy” and “destroy” are added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->