### PR TITLE
Fix#564: Update sponsors command to handle new API response format

### DIFF
--- a/apps/cli/src/utils/sponsors.ts
+++ b/apps/cli/src/utils/sponsors.ts
@@ -1,4 +1,5 @@
 import { log, outro, spinner } from "@clack/prompts";
+import { consola } from "consola";
 import pc from "picocolors";
 
 type SponsorSummary = {
@@ -37,7 +38,8 @@ type SponsorEntry = {
 	backers: Sponsor[];
 };
 
-export const SPONSORS_JSON_URL = "https://sponsors.amanv.dev/sponsors.json";
+export const SPONSORS_JSON_URL =
+	"https://sponsors.better-t-stack.dev/sponsors.json";
 
 export async function fetchSponsors(
 	url: string = SPONSORS_JSON_URL,
@@ -68,11 +70,7 @@ export function displaySponsors(sponsors: SponsorEntry) {
 		return;
 	}
 
-	// Show only special sponsors - because terminal has limited space
-	listSponsors(sponsors.specialSponsors);
-	// listSponsors(sponsors.sponsors);
-	// listSponsors(sponsors.pastSponsors);
-	// listSponsors(sponsors.backers);
+	displaySponsorsBox(sponsors);
 
 	if (total_sponsors - sponsors.specialSponsors.length > 0) {
 		log.message(
@@ -88,24 +86,31 @@ export function displaySponsors(sponsors: SponsorEntry) {
 	);
 }
 
-function listSponsors(sponsors: Sponsor[]) {
-	if (sponsors.length === 0) {
+function displaySponsorsBox(sponsors: SponsorEntry) {
+	if (sponsors.specialSponsors.length === 0) {
 		return;
 	}
 
-	log.message("Sponsors:");
-	sponsors.forEach((sponsor: Sponsor, idx: number) => {
-		const displayName = sponsor.name ?? sponsor.githubId;
-		const tier = sponsor.tierName ? ` (${sponsor.tierName})` : "";
+	let output = `${pc.bold(pc.cyan("-> Special Sponsors"))}\n\n`;
 
-		log.step(`${idx + 1}. ${pc.green(displayName)}${pc.yellow(tier)}`);
-		log.message(
-			`   ${pc.dim("GitHub:")} https://github.com/${sponsor.githubId}`,
-		);
+	sponsors.specialSponsors.forEach((sponsor: Sponsor, idx: number) => {
+		const displayName = sponsor.name ?? sponsor.githubId;
+		const tier = sponsor.tierName
+			? ` ${pc.yellow(`(${sponsor.tierName})`)}`
+			: "";
+
+		output += `${pc.green(`• ${displayName}`)}${tier}\n`;
+		output += `  ${pc.dim("GitHub:")} https://github.com/${sponsor.githubId}\n`;
 
 		const website = sponsor.websiteUrl ?? sponsor.githubUrl;
 		if (website) {
-			log.message(`   ${pc.dim("Website:")} ${website}`);
+			output += `  ${pc.dim("Website:")} ${website}\n`;
+		}
+
+		if (idx < sponsors.specialSponsors.length - 1) {
+			output += "\n";
 		}
 	});
+
+	consola.box(output);
 }

--- a/apps/cli/src/utils/sponsors.ts
+++ b/apps/cli/src/utils/sponsors.ts
@@ -16,12 +16,12 @@ type SponsorSummary = {
 };
 
 type Sponsor = {
-	name: string;
+	name?: string;
 	githubId: string;
 	avatarUrl: string;
-	websiteUrl: string;
+	websiteUrl?: string;
 	githubUrl: string;
-	tierName: string;
+	tierName?: string;
 	sinceWhen: string;
 	transactionCount: number;
 	totalProcessedAmount?: number;

--- a/apps/cli/src/utils/sponsors.ts
+++ b/apps/cli/src/utils/sponsors.ts
@@ -1,25 +1,47 @@
 import { log, outro, spinner } from "@clack/prompts";
 import pc from "picocolors";
 
-export interface SponsorEntry {
-	readonly sponsor: {
-		readonly login: string;
-		readonly name?: string | null;
-		readonly avatarUrl?: string | null;
-		readonly websiteUrl?: string | null;
-		readonly linkUrl?: string | null;
-		readonly type?: string;
+type SponsorSummary = {
+	total_sponsors: number;
+	total_lifetime_amount: number;
+	total_current_monthly: number;
+	special_sponsors: number;
+	current_sponsors: number;
+	past_sponsors: number;
+	backers: number;
+	top_sponsor?: {
+		name: string;
+		amount: number;
 	};
-	readonly isOneTime: boolean;
-	readonly monthlyDollars?: number;
-	readonly tierName?: string;
-}
+};
+
+type Sponsor = {
+	name: string;
+	githubId: string;
+	avatarUrl: string;
+	websiteUrl: string;
+	githubUrl: string;
+	tierName: string;
+	sinceWhen: string;
+	transactionCount: number;
+	totalProcessedAmount?: number;
+	formattedAmount?: string;
+};
+
+type SponsorEntry = {
+	generated_at: string;
+	summary: SponsorSummary;
+	specialSponsors: Sponsor[];
+	sponsors: Sponsor[];
+	pastSponsors: Sponsor[];
+	backers: Sponsor[];
+};
 
 export const SPONSORS_JSON_URL = "https://sponsors.amanv.dev/sponsors.json";
 
 export async function fetchSponsors(
 	url: string = SPONSORS_JSON_URL,
-): Promise<SponsorEntry[]> {
+): Promise<SponsorEntry> {
 	const s = spinner();
 	s.start("Fetching sponsors…");
 
@@ -29,13 +51,14 @@ export async function fetchSponsors(
 		throw new Error(`Failed to fetch sponsors: ${response.statusText}`);
 	}
 
-	const sponsors = (await response.json()) as SponsorEntry[];
+	const sponsors = (await response.json()) as SponsorEntry;
 	s.stop("Sponsors fetched successfully!");
 	return sponsors;
 }
 
-export function displaySponsors(sponsors: SponsorEntry[]) {
-	if (sponsors.length === 0) {
+export function displaySponsors(sponsors: SponsorEntry) {
+	const { total_sponsors } = sponsors.summary;
+	if (total_sponsors === 0) {
 		log.info("No sponsors found. You can be the first one! ✨");
 		outro(
 			pc.cyan(
@@ -45,24 +68,44 @@ export function displaySponsors(sponsors: SponsorEntry[]) {
 		return;
 	}
 
-	sponsors.forEach((entry: SponsorEntry, idx: number) => {
-		const sponsor = entry.sponsor;
-		const displayName = sponsor.name ?? sponsor.login;
-		const tier = entry.tierName ? ` (${entry.tierName})` : "";
+	// Show only special sponsors - because terminal has limited space
+	listSponsors(sponsors.specialSponsors);
+	// listSponsors(sponsors.sponsors);
+	// listSponsors(sponsors.pastSponsors);
+	// listSponsors(sponsors.backers);
 
-		log.step(`${idx + 1}. ${pc.green(displayName)}${pc.yellow(tier)}`);
-		log.message(`   ${pc.dim("GitHub:")} https://github.com/${sponsor.login}`);
-
-		const website = sponsor.websiteUrl ?? sponsor.linkUrl;
-		if (website) {
-			log.message(`   ${pc.dim("Website:")} ${website}`);
-		}
-	});
-
-	log.message("");
+	if (total_sponsors - sponsors.specialSponsors.length > 0) {
+		log.message(
+			pc.blue(
+				`+${total_sponsors - sponsors.specialSponsors.length} more amazing sponsors.\n`,
+			),
+		);
+	}
 	outro(
 		pc.magenta(
 			"Visit https://github.com/sponsors/AmanVarshney01 to become a sponsor.",
 		),
 	);
+}
+
+function listSponsors(sponsors: Sponsor[]) {
+	if (sponsors.length === 0) {
+		return;
+	}
+
+	log.message("Sponsors:");
+	sponsors.forEach((sponsor: Sponsor, idx: number) => {
+		const displayName = sponsor.name ?? sponsor.githubId;
+		const tier = sponsor.tierName ? ` (${sponsor.tierName})` : "";
+
+		log.step(`${idx + 1}. ${pc.green(displayName)}${pc.yellow(tier)}`);
+		log.message(
+			`   ${pc.dim("GitHub:")} https://github.com/${sponsor.githubId}`,
+		);
+
+		const website = sponsor.websiteUrl ?? sponsor.githubUrl;
+		if (website) {
+			log.message(`   ${pc.dim("Website:")} ${website}`);
+		}
+	});
 }


### PR DESCRIPTION
This PR fixes issue #564 a critical bug in the sponsors command caused by a change in the response structure of the API at https://sponsors.amanv.dev/sponsors.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Highlights featured/special sponsors first and shows a “N more sponsors” count.
  * Clearer empty state with a direct link to become a sponsor when none exist.
  * Link handling improved: prefers sponsor website, falls back to GitHub profile.
  * More consistent sponsor details shown (name, tier) and streamlined sponsor listing/rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->