### PR TITLE
feat(cli): upgrade to nuxt 4.1

### DIFF
--- a/apps/cli/src/helpers/core/post-installation.ts
+++ b/apps/cli/src/helpers/core/post-installation.ts
@@ -236,7 +236,7 @@ async function getDatabaseInstructions(
 	database: Database,
 	orm?: ORM,
 	runCmd?: string,
-	_runtime?: Runtime,
+	runtime?: Runtime,
 	dbSetup?: DatabaseSetup,
 	serverDeploy?: string,
 ): Promise<string> {
@@ -252,12 +252,11 @@ async function getDatabaseInstructions(
 	}
 
 	if (serverDeploy === "wrangler" && dbSetup === "d1") {
-		if (orm === "prisma" && _runtime === "workers") {
+		if (orm === "prisma" && runtime === "workers") {
 			instructions.push(
-				`${pc.yellow(
+				`\n${pc.yellow(
 					"WARNING:",
-				)} Prisma + D1 on Workers with Wrangler has migration issues.
-	   Consider using Alchemy deploy instead of Wrangler for D1 projects.`,
+				)} Prisma + D1 on Workers with Wrangler has migration issues.\n   Consider using Alchemy deploy instead of Wrangler for D1 projects.\n`,
 			);
 		}
 		const packageManager = runCmd === "npm run" ? "npm" : runCmd || "npm";

--- a/apps/cli/src/helpers/deployment/alchemy/alchemy-nuxt-setup.ts
+++ b/apps/cli/src/helpers/deployment/alchemy/alchemy-nuxt-setup.ts
@@ -13,7 +13,7 @@ export async function setupNuxtAlchemyDeploy(
 	if (!(await fs.pathExists(webAppDir))) return;
 
 	await addPackageDependency({
-		devDependencies: ["alchemy", "nitro-cloudflare-dev", "dotenv"],
+		devDependencies: ["alchemy", "nitro-cloudflare-dev", "dotenv", "wrangler"],
 		projectDir: webAppDir,
 	});
 

--- a/apps/cli/templates/frontend/nuxt/app/app.config.ts.hbs
+++ b/apps/cli/templates/frontend/nuxt/app/app.config.ts.hbs
@@ -3,7 +3,7 @@ export default defineAppConfig({
   ui: {
     colors: {
       primary: 'emerald',
-      neutral: 'slate',
+      neutral: 'neutral',
     },
     button: {
       defaultVariants: {

--- a/apps/cli/templates/frontend/nuxt/nuxt.config.ts.hbs
+++ b/apps/cli/templates/frontend/nuxt/nuxt.config.ts.hbs
@@ -12,7 +12,7 @@ export default defineNuxtConfig({
   devServer: {
     port: 3001
   },
-  ssr: false,
+  ssr: true,
   {{#if (eq backend "convex")}}
   convex: {
     url: process.env.NUXT_PUBLIC_CONVEX_URL,

--- a/apps/cli/templates/frontend/nuxt/package.json.hbs
+++ b/apps/cli/templates/frontend/nuxt/package.json.hbs
@@ -10,12 +10,12 @@
     "postinstall": "nuxt prepare"
   },
   "dependencies": {
-    "@nuxt/ui": "3.3.0",
-    "nuxt": "^4.0.2",
-    "typescript": "^5.8.3",
-    "vue": "^3.5.18",
+    "@nuxt/ui": "3.3.3",
+    "nuxt": "^4.1.1",
+    "typescript": "^5.9.2",
+    "vue": "^3.5.21",
     "vue-router": "^4.5.1",
-    "zod": "^4.0.2"
+    "zod": "^4.1.5"
   },
   "devDependencies": {
     "tailwindcss": "^4.1.11",

--- a/apps/cli/templates/frontend/nuxt/tsconfig.json.hbs
+++ b/apps/cli/templates/frontend/nuxt/tsconfig.json.hbs
@@ -1,5 +1,6 @@
 {
   // https://nuxt.com/docs/guide/concepts/typescript
+  "files": [],
   "references": [
     {
       "path": "./.nuxt/tsconfig.app.json"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Server-side rendering is now enabled by default in generated Nuxt apps.

- Style
  - Updated UI neutral color palette for Nuxt templates (slate → neutral) for a more consistent look.
  - Improved formatting of CLI Prisma + D1 warning message for better readability.

- Chores
  - Updated Nuxt template dependencies: @nuxt/ui, nuxt, typescript, vue, and zod.
  - Added wrangler to devDependencies for Nuxt Alchemy deploy setup.
  - Nuxt tsconfig template now includes an empty "files" array.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->