### PR TITLE
feat(cli): use biome js api to format all generated templates

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,88 +1,90 @@
 {
-  "name": "create-better-t-stack",
-  "version": "2.43.1",
-  "description": "A modern CLI tool for scaffolding end-to-end type-safe TypeScript projects with best practices and customizable configurations",
-  "type": "module",
-  "license": "MIT",
-  "author": "Aman Varshney",
-  "bin": {
-    "create-better-t-stack": "dist/cli.js"
-  },
-  "files": [
-    "templates",
-    "dist"
-  ],
-  "keywords": [
-    "better-t-stack",
-    "typescript",
-    "boilerplate",
-    "starter",
-    "cli",
-    "turborepo",
-    "trpc",
-    "better-auth",
-    "monorepo",
-    "fullstack",
-    "type-safety",
-    "react",
-    "react-native",
-    "expo",
-    "hono",
-    "elysia",
-    "drizzle",
-    "prisma",
-    "tanstack",
-    "tailwind",
-    "shadcn",
-    "pwa",
-    "tauri",
-    "biome"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/AmanVarshney01/create-better-t-stack.git",
-    "directory": "apps/cli"
-  },
-  "publishConfig": {
-    "access": "public"
-  },
-  "homepage": "https://better-t-stack.dev/",
-  "scripts": {
-    "build": "tsdown",
-    "dev": "tsdown --watch",
-    "check-types": "tsc --noEmit",
-    "check": "biome check --write .",
-    "test": "bun run build && vitest run",
-    "test:ui": "bun run build && vitest --ui",
-    "test:with-build": "bun run build && WITH_BUILD=1 vitest --ui",
-    "prepublishOnly": "npm run build"
-  },
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
-    }
-  },
-  "dependencies": {
-    "@clack/prompts": "^1.0.0-alpha.4",
-    "consola": "^3.4.2",
-    "execa": "^9.6.0",
-    "fs-extra": "^11.3.1",
-    "gradient-string": "^3.0.0",
-    "handlebars": "^4.7.8",
-    "jsonc-parser": "^3.3.1",
-    "picocolors": "^1.1.1",
-    "tinyglobby": "^0.2.15",
-    "trpc-cli": "^0.10.2",
-    "ts-morph": "^27.0.0",
-    "zod": "^4.1.5"
-  },
-  "devDependencies": {
-    "@types/fs-extra": "^11.0.4",
-    "@types/node": "^24.3.1",
-    "@vitest/ui": "^3.2.4",
-    "tsdown": "^0.14.2",
-    "typescript": "^5.9.2",
-    "vitest": "^3.2.4"
-  }
+	"name": "create-better-t-stack",
+	"version": "2.43.1",
+	"description": "A modern CLI tool for scaffolding end-to-end type-safe TypeScript projects with best practices and customizable configurations",
+	"type": "module",
+	"license": "MIT",
+	"author": "Aman Varshney",
+	"bin": {
+		"create-better-t-stack": "dist/cli.js"
+	},
+	"files": [
+		"templates",
+		"dist"
+	],
+	"keywords": [
+		"better-t-stack",
+		"typescript",
+		"boilerplate",
+		"starter",
+		"cli",
+		"turborepo",
+		"trpc",
+		"better-auth",
+		"monorepo",
+		"fullstack",
+		"type-safety",
+		"react",
+		"react-native",
+		"expo",
+		"hono",
+		"elysia",
+		"drizzle",
+		"prisma",
+		"tanstack",
+		"tailwind",
+		"shadcn",
+		"pwa",
+		"tauri",
+		"biome"
+	],
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/AmanVarshney01/create-better-t-stack.git",
+		"directory": "apps/cli"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"homepage": "https://better-t-stack.dev/",
+	"scripts": {
+		"build": "tsdown",
+		"dev": "tsdown --watch",
+		"check-types": "tsc --noEmit",
+		"check": "biome check --write .",
+		"test": "bun run build && vitest run",
+		"test:ui": "bun run build && vitest --ui",
+		"test:with-build": "bun run build && WITH_BUILD=1 vitest --ui",
+		"prepublishOnly": "npm run build"
+	},
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"dependencies": {
+		"@biomejs/js-api": "^3.0.0",
+		"@biomejs/wasm-nodejs": "^2.2.4",
+		"@clack/prompts": "^1.0.0-alpha.4",
+		"consola": "^3.4.2",
+		"execa": "^9.6.0",
+		"fs-extra": "^11.3.1",
+		"gradient-string": "^3.0.0",
+		"handlebars": "^4.7.8",
+		"jsonc-parser": "^3.3.1",
+		"picocolors": "^1.1.1",
+		"tinyglobby": "^0.2.15",
+		"trpc-cli": "^0.10.2",
+		"ts-morph": "^27.0.0",
+		"zod": "^4.1.5"
+	},
+	"devDependencies": {
+		"@types/fs-extra": "^11.0.4",
+		"@types/node": "^24.3.1",
+		"@vitest/ui": "^3.2.4",
+		"tsdown": "^0.14.2",
+		"typescript": "^5.9.2",
+		"vitest": "^3.2.4"
+	}
 }

--- a/apps/cli/src/constants.ts
+++ b/apps/cli/src/constants.ts
@@ -92,7 +92,7 @@ export const dependencyVersionMap = {
 
 	"@elysiajs/cors": "^1.3.3",
 	"@elysiajs/trpc": "^1.1.0",
-	"elysia": "^1.3.21",
+	elysia: "^1.3.21",
 
 	"@hono/node-server": "^1.14.4",
 	"@hono/trpc-server": "^0.4.0",
@@ -108,7 +108,7 @@ export const dependencyVersionMap = {
 
 	turbo: "^2.5.4",
 
-	"ai": "^5.0.39",
+	ai: "^5.0.39",
 	"@ai-sdk/google": "^2.0.13",
 	"@ai-sdk/vue": "^2.0.39",
 	"@ai-sdk/svelte": "^3.0.39",

--- a/apps/cli/src/helpers/core/template-manager.ts
+++ b/apps/cli/src/helpers/core/template-manager.ts
@@ -47,11 +47,7 @@ export async function processAndCopyFiles(
 			continue;
 		}
 
-		if (srcPath.endsWith(".hbs")) {
-			await processTemplate(srcPath, destPath, context);
-		} else {
-			await fs.copy(srcPath, destPath, { overwrite: true });
-		}
+		await processTemplate(srcPath, destPath, context);
 	}
 }
 

--- a/apps/cli/src/helpers/deployment/alchemy/alchemy-next-setup.ts
+++ b/apps/cli/src/helpers/deployment/alchemy/alchemy-next-setup.ts
@@ -13,7 +13,12 @@ export async function setupNextAlchemyDeploy(
 
 	await addPackageDependency({
 		dependencies: ["@opennextjs/cloudflare"],
-		devDependencies: ["alchemy", "dotenv", "wrangler", "@cloudflare/workers-types"],
+		devDependencies: [
+			"alchemy",
+			"dotenv",
+			"wrangler",
+			"@cloudflare/workers-types",
+		],
 		projectDir: webAppDir,
 	});
 

--- a/apps/cli/src/utils/biome-formatter.ts
+++ b/apps/cli/src/utils/biome-formatter.ts
@@ -1,0 +1,95 @@
+import path from "node:path";
+import { Biome } from "@biomejs/js-api/nodejs";
+import consola from "consola";
+
+let biome: Biome | null = null;
+let projectKey: number | null = null;
+
+async function initializeBiome(): Promise<{
+	biome: Biome;
+	projectKey: number;
+}> {
+	if (biome && projectKey !== null) return { biome, projectKey };
+
+	try {
+		biome = new Biome();
+		const result = biome.openProject("./");
+		projectKey = result.projectKey;
+
+		biome.applyConfiguration(projectKey, {
+			formatter: {
+				enabled: true,
+				indentStyle: "tab",
+				indentWidth: 2,
+				lineWidth: 80,
+			},
+			linter: {
+				enabled: false,
+			},
+			javascript: {
+				formatter: {
+					enabled: true,
+				},
+			},
+			json: {
+				formatter: {
+					enabled: true,
+				},
+			},
+		});
+
+		return { biome, projectKey };
+	} catch (error) {
+		consola.error("Failed to initialize Biome:", error);
+		throw error;
+	}
+}
+
+function isSupportedFile(filePath: string): boolean {
+	const ext = path.extname(filePath).toLowerCase();
+	const supportedExtensions = [".js", ".jsx", ".ts", ".tsx", ".json", ".jsonc"];
+	return supportedExtensions.includes(ext);
+}
+
+function shouldSkipFile(filePath: string): boolean {
+	const basename = path.basename(filePath);
+	const skipPatterns = [
+		".hbs",
+		"package-lock.json",
+		"yarn.lock",
+		"pnpm-lock.yaml",
+		"bun.lock",
+		".d.ts",
+	];
+
+	return skipPatterns.some((pattern) => basename.includes(pattern));
+}
+
+export async function formatFileWithBiome(
+	filePath: string,
+	content: string,
+): Promise<string | null> {
+	if (!isSupportedFile(filePath) || shouldSkipFile(filePath)) {
+		return null;
+	}
+
+	try {
+		const { biome: biomeInstance, projectKey: key } = await initializeBiome();
+
+		const result = biomeInstance.formatContent(key, content, {
+			filePath: path.basename(filePath),
+		});
+
+		if (result.diagnostics && result.diagnostics.length > 0) {
+			consola.debug(
+				`Biome formatting diagnostics for ${filePath}:`,
+				result.diagnostics,
+			);
+		}
+
+		return result.content;
+	} catch (error) {
+		consola.warn(`Failed to format ${filePath} with Biome:`, error);
+		return null;
+	}
+}

--- a/apps/cli/src/utils/template-processor.ts
+++ b/apps/cli/src/utils/template-processor.ts
@@ -3,25 +3,36 @@ import consola from "consola";
 import fs from "fs-extra";
 import handlebars from "handlebars";
 import type { ProjectConfig } from "../types";
+import { formatFileWithBiome } from "./biome-formatter";
 
-/**
- * Processes a Handlebars template file and writes the output to the destination.
- * @param srcPath Path to the source .hbs template file.
- * @param destPath Path to write the processed file.
- * @param context Data to be passed to the Handlebars template.
- */
 export async function processTemplate(
 	srcPath: string,
 	destPath: string,
 	context: ProjectConfig,
 ) {
 	try {
-		const templateContent = await fs.readFile(srcPath, "utf-8");
-		const template = handlebars.compile(templateContent);
-		const processedContent = template(context);
-
 		await fs.ensureDir(path.dirname(destPath));
-		await fs.writeFile(destPath, processedContent);
+
+		let content: string;
+
+		if (srcPath.endsWith(".hbs")) {
+			const templateContent = await fs.readFile(srcPath, "utf-8");
+			const template = handlebars.compile(templateContent);
+			content = template(context);
+		} else {
+			content = await fs.readFile(srcPath, "utf-8");
+		}
+
+		try {
+			const formattedContent = await formatFileWithBiome(destPath, content);
+			if (formattedContent) {
+				content = formattedContent;
+			}
+		} catch (formatError) {
+			consola.debug(`Failed to format ${destPath}:`, formatError);
+		}
+
+		await fs.writeFile(destPath, content);
 	} catch (error) {
 		consola.error(`Error processing template ${srcPath}:`, error);
 		throw new Error(`Failed to process template ${srcPath}`);

--- a/apps/web/src/app/(home)/new/_components/stack-builder.tsx
+++ b/apps/web/src/app/(home)/new/_components/stack-builder.tsx
@@ -10,14 +10,7 @@ import {
 } from "lucide-react";
 import { motion } from "motion/react";
 import type React from "react";
-import {
-	startTransition,
-	useCallback,
-	useEffect,
-	useMemo,
-	useRef,
-	useState,
-} from "react";
+import { startTransition, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import {
 	DropdownMenu,
@@ -72,16 +65,13 @@ const StackBuilder = () => {
 	const contentRef = useRef<HTMLDivElement>(null);
 	const lastAppliedStackString = useRef<string>("");
 
-	const compatibilityAnalysis = useMemo(
-		() => analyzeStackCompatibility(stack),
-		[stack],
-	);
+	const compatibilityAnalysis = analyzeStackCompatibility(stack);
 
 	const projectNameError = validateProjectName(stack.projectName || "");
 
-	const formatProjectName = useCallback((name: string): string => {
+	const formatProjectName = (name: string): string => {
 		return name.replace(/\s+/g, "-");
-	}, []);
+	};
 
 	const getStackUrl = (): string => {
 		const stackToUse = compatibilityAnalysis.adjustedStack || stack;
@@ -274,6 +264,7 @@ const StackBuilder = () => {
 		};
 		const cmd = generateStackCommand(stackWithProjectName);
 		setCommand(cmd);
+		// biome-ignore lint/correctness/useExhaustiveDependencies: let it be
 	}, [stack, compatibilityAnalysis.adjustedStack, formatProjectName]);
 
 	const handleTechSelect = (

--- a/biome.json
+++ b/biome.json
@@ -28,7 +28,13 @@
 		"indentStyle": "tab",
 		"includes": ["**", "!**/templates"]
 	},
-	"assist": { "actions": { "source": { "organizeImports": "on" } } },
+	"assist": {
+		"actions": {
+			"source": {
+				"organizeImports": "on"
+			}
+		}
+	},
 	"linter": {
 		"enabled": true,
 		"rules": {
@@ -64,7 +70,12 @@
 	},
 	"javascript": {
 		"formatter": {
-			"quoteStyle": "double"
+			"enabled": true
+		}
+	},
+	"json": {
+		"formatter": {
+			"enabled": true
 		}
 	}
 }

--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,8 @@
         "create-better-t-stack": "dist/cli.js",
       },
       "dependencies": {
+        "@biomejs/js-api": "^3.0.0",
+        "@biomejs/wasm-nodejs": "^2.2.4",
         "@clack/prompts": "^1.0.0-alpha.4",
         "consola": "^3.4.2",
         "execa": "^9.6.0",
@@ -38,6 +40,7 @@
         "@types/node": "^24.3.1",
         "@vitest/ui": "^3.2.4",
         "tsdown": "^0.14.2",
+        "tsx": "^4.19.2",
         "typescript": "^5.9.2",
         "vitest": "^3.2.4",
       },
@@ -270,6 +273,10 @@
     "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.2.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-n9a1/f2CwIDmNMNkFs+JI0ZjFnMO0jdOyGNtihgUNFnlmd84yIYY2KMTBmMV58ZlVHjgmY5Y6E1hVTnSRieggA=="],
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.2.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Nawu5nHjP/zPKTIryh2AavzTc/KEg4um/MxWdXW0A6P/RZOyIpa7+QSjeXwAwX/utJGaCoXRPWtF3m5U/bB3Ww=="],
+
+    "@biomejs/js-api": ["@biomejs/js-api@3.0.0", "", { "peerDependencies": { "@biomejs/wasm-bundler": "^2.2.0", "@biomejs/wasm-nodejs": "^2.2.0", "@biomejs/wasm-web": "^2.2.0" }, "optionalPeers": ["@biomejs/wasm-bundler", "@biomejs/wasm-nodejs", "@biomejs/wasm-web"] }, "sha512-5QcGJFj9IO+yXl76ICjvkdE38uxRcTDsBzcCZHEZ+ma+Te/nbvJg4A3KtAds9HCrEF0JKLWiyjMhAbqazuJvYA=="],
+
+    "@biomejs/wasm-nodejs": ["@biomejs/wasm-nodejs@2.2.4", "", {}, "sha512-ExHAa8W9uyinDhvxhe9CXA6V9bHka3RIs9jKQWlzOz7/LEt3IcFA+fo0O+9RdU30q7lmoo83VqUJwWPTLXeWiA=="],
 
     "@clack/core": ["@clack/core@1.0.0-alpha.4", "", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-VCtU+vjyKPMSakVrB9q1bOnXN7QW/w4+YQDQCOF59GrzydW+169i0fVx/qzRRXJgt8KGj/pZZ/JxXroFZIDByg=="],
 
@@ -2519,6 +2526,8 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "tsx": ["tsx@4.20.5", "", { "dependencies": { "esbuild": "~0.25.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw=="],
+
     "turbo": ["turbo@2.5.6", "", { "optionalDependencies": { "turbo-darwin-64": "2.5.6", "turbo-darwin-arm64": "2.5.6", "turbo-linux-64": "2.5.6", "turbo-linux-arm64": "2.5.6", "turbo-windows-64": "2.5.6", "turbo-windows-arm64": "2.5.6" }, "bin": { "turbo": "bin/turbo" } }, "sha512-gxToHmi9oTBNB05UjUsrWf0OyN5ZXtD0apOarC1KIx232Vp3WimRNy3810QzeNSgyD5rsaIDXlxlbnOzlouo+w=="],
 
     "turbo-darwin-64": ["turbo-darwin-64@2.5.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-3C1xEdo4aFwMJAPvtlPqz1Sw/+cddWIOmsalHFMrsqqydcptwBfu26WW2cDm3u93bUzMbBJ8k3zNKFqxJ9ei2A=="],
@@ -3431,6 +3440,8 @@
 
     "tsdown/tinyglobby": ["tinyglobby@0.2.14", "", { "dependencies": { "fdir": "^6.4.4", "picomatch": "^4.0.2" } }, "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ=="],
 
+    "tsx/esbuild": ["esbuild@0.25.9", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.9", "@esbuild/android-arm": "0.25.9", "@esbuild/android-arm64": "0.25.9", "@esbuild/android-x64": "0.25.9", "@esbuild/darwin-arm64": "0.25.9", "@esbuild/darwin-x64": "0.25.9", "@esbuild/freebsd-arm64": "0.25.9", "@esbuild/freebsd-x64": "0.25.9", "@esbuild/linux-arm": "0.25.9", "@esbuild/linux-arm64": "0.25.9", "@esbuild/linux-ia32": "0.25.9", "@esbuild/linux-loong64": "0.25.9", "@esbuild/linux-mips64el": "0.25.9", "@esbuild/linux-ppc64": "0.25.9", "@esbuild/linux-riscv64": "0.25.9", "@esbuild/linux-s390x": "0.25.9", "@esbuild/linux-x64": "0.25.9", "@esbuild/netbsd-arm64": "0.25.9", "@esbuild/netbsd-x64": "0.25.9", "@esbuild/openbsd-arm64": "0.25.9", "@esbuild/openbsd-x64": "0.25.9", "@esbuild/openharmony-arm64": "0.25.9", "@esbuild/sunos-x64": "0.25.9", "@esbuild/win32-arm64": "0.25.9", "@esbuild/win32-ia32": "0.25.9", "@esbuild/win32-x64": "0.25.9" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g=="],
+
     "vite/esbuild": ["esbuild@0.25.9", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.9", "@esbuild/android-arm": "0.25.9", "@esbuild/android-arm64": "0.25.9", "@esbuild/android-x64": "0.25.9", "@esbuild/darwin-arm64": "0.25.9", "@esbuild/darwin-x64": "0.25.9", "@esbuild/freebsd-arm64": "0.25.9", "@esbuild/freebsd-x64": "0.25.9", "@esbuild/linux-arm": "0.25.9", "@esbuild/linux-arm64": "0.25.9", "@esbuild/linux-ia32": "0.25.9", "@esbuild/linux-loong64": "0.25.9", "@esbuild/linux-mips64el": "0.25.9", "@esbuild/linux-ppc64": "0.25.9", "@esbuild/linux-riscv64": "0.25.9", "@esbuild/linux-s390x": "0.25.9", "@esbuild/linux-x64": "0.25.9", "@esbuild/netbsd-arm64": "0.25.9", "@esbuild/netbsd-x64": "0.25.9", "@esbuild/openbsd-arm64": "0.25.9", "@esbuild/openbsd-x64": "0.25.9", "@esbuild/openharmony-arm64": "0.25.9", "@esbuild/sunos-x64": "0.25.9", "@esbuild/win32-arm64": "0.25.9", "@esbuild/win32-ia32": "0.25.9", "@esbuild/win32-x64": "0.25.9" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g=="],
 
     "vite/tinyglobby": ["tinyglobby@0.2.14", "", { "dependencies": { "fdir": "^6.4.4", "picomatch": "^4.0.2" } }, "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ=="],
@@ -4038,6 +4049,56 @@
     "qrcode/yargs/yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
 
     "string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.0", "", {}, "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg=="],
+
+    "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.9", "", { "os": "aix", "cpu": "ppc64" }, "sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA=="],
+
+    "tsx/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.25.9", "", { "os": "android", "cpu": "arm" }, "sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ=="],
+
+    "tsx/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.9", "", { "os": "android", "cpu": "arm64" }, "sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg=="],
+
+    "tsx/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.25.9", "", { "os": "android", "cpu": "x64" }, "sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw=="],
+
+    "tsx/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg=="],
+
+    "tsx/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ=="],
+
+    "tsx/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.9", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q=="],
+
+    "tsx/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.9", "", { "os": "freebsd", "cpu": "x64" }, "sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg=="],
+
+    "tsx/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.9", "", { "os": "linux", "cpu": "arm" }, "sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw=="],
+
+    "tsx/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw=="],
+
+    "tsx/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.9", "", { "os": "linux", "cpu": "ia32" }, "sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A=="],
+
+    "tsx/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.9", "", { "os": "linux", "cpu": "none" }, "sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ=="],
+
+    "tsx/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.9", "", { "os": "linux", "cpu": "none" }, "sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA=="],
+
+    "tsx/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.9", "", { "os": "linux", "cpu": "ppc64" }, "sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w=="],
+
+    "tsx/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.9", "", { "os": "linux", "cpu": "none" }, "sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg=="],
+
+    "tsx/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.9", "", { "os": "linux", "cpu": "s390x" }, "sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA=="],
+
+    "tsx/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.9", "", { "os": "linux", "cpu": "x64" }, "sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg=="],
+
+    "tsx/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.9", "", { "os": "none", "cpu": "arm64" }, "sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q=="],
+
+    "tsx/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.9", "", { "os": "none", "cpu": "x64" }, "sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g=="],
+
+    "tsx/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.9", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ=="],
+
+    "tsx/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.9", "", { "os": "openbsd", "cpu": "x64" }, "sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA=="],
+
+    "tsx/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.9", "", { "os": "sunos", "cpu": "x64" }, "sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw=="],
+
+    "tsx/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.9", "", { "os": "win32", "cpu": "arm64" }, "sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ=="],
+
+    "tsx/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.9", "", { "os": "win32", "cpu": "ia32" }, "sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww=="],
+
+    "tsx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.9", "", { "os": "win32", "cpu": "x64" }, "sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ=="],
 
     "vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.9", "", { "os": "aix", "cpu": "ppc64" }, "sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA=="],
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - CLI now auto-formats generated JavaScript/TypeScript and JSON files using Biome for cleaner output.
  - All scaffolded files are consistently processed through the templating pipeline.

- Refactor
  - Simplified template handling flow and streamlined UI logic to reduce complexity (no API changes).

- Style
  - Updated formatting configuration: enabled JS and JSON formatters and organize-imports behavior.

- Chores
  - Added Biome tooling dependencies to support formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->