### PR TITLE
chore(native): update metro config for nativewind

### DIFF
--- a/apps/cli/templates/frontend/native/nativewind/metro.config.js
+++ b/apps/cli/templates/frontend/native/nativewind/metro.config.js
@@ -5,43 +5,15 @@ const { withNativeWind } = require("nativewind/metro");
 const path = require("node:path");
 
 const config = withTurborepoManagedCache(
-  withMonorepoPaths(
-    withNativeWind(getDefaultConfig(__dirname), {
-      input: "./global.css",
-      configPath: "./tailwind.config.js",
-    }),
-  ),
+  withNativeWind(getDefaultConfig(__dirname), {
+    input: "./global.css",
+    configPath: "./tailwind.config.js",
+  }),
 );
 
 config.resolver.unstable_enablePackageExports = true;
 
-config.resolver.disableHierarchicalLookup = true;
-
 module.exports = config;
-
-/**
- * Add the monorepo paths to the Metro config.
- * This allows Metro to resolve modules from the monorepo.
- *
- * @see https://docs.expo.dev/guides/monorepos/#modify-the-metro-config
- * @param {import('expo/metro-config').MetroConfig} config
- * @returns {import('expo/metro-config').MetroConfig}
- */
-function withMonorepoPaths(config) {
-  const projectRoot = __dirname;
-  const workspaceRoot = path.resolve(projectRoot, "../..");
-
-  // #1 - Watch all files in the monorepo
-  config.watchFolders = [workspaceRoot];
-
-  // #2 - Resolve modules within the project's `node_modules` first, then all monorepo modules
-  config.resolver.nodeModulesPaths = [
-    path.resolve(projectRoot, "node_modules"),
-    path.resolve(workspaceRoot, "node_modules"),
-  ];
-
-  return config;
-}
 
 /**
  * Move the Metro cache to the `.cache/metro` folder.


### PR DESCRIPTION
see
https://github.com/expo/expo/pull/39384

  Changes

  - Removed the deprecated withMonorepoPaths configuration wrapper that was causing compatibility issues
  - Removed disableHierarchicalLookup setting which is no longer needed with the latest Metro version
  - Simplified the Metro config to use only withTurborepoManagedCache and withNativeWind wrappers

  Why this change is needed

  The previous configuration included manual monorepo path resolution that is now handled automatically by Expo's default Metro configuration. The
  disableHierarchicalLookup option was also causing module resolution issues in certain monorepo setups.

  Testing

  - Tested with a fresh project generated using the CLI template
  - Verified that NativeWind styles are properly applied
  - Confirmed module resolution works correctly in monorepo environment

  Related Issues

  - Fixes compatibility issues mentioned in expo/expo#39384


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Refactor
  - Simplified Metro configuration for NativeWind to reduce complexity and improve maintainability.

- Bug Fixes
  - Improved module resolution reliability, reducing path-related issues across different project setups.

- Chores
  - Streamlined template initialization while keeping cache optimizations intact for consistent performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->