### PR TITLE
fix(cli): better auth api routes are not found

### DIFF
--- a/apps/cli/templates/backend/server/hono/src/index.ts.hbs
+++ b/apps/cli/templates/backend/server/hono/src/index.ts.hbs
@@ -54,7 +54,7 @@ app.use(
 );
 
 {{#if (eq auth "better-auth")}}
-app.on(["POST", "GET"], "/api/auth/**", (c) => auth.handler(c.req.raw));
+app.on(["POST", "GET"], "/api/auth/*", (c) => auth.handler(c.req.raw));
 {{/if}}
 
 {{#if (eq api "orpc")}}


### PR DESCRIPTION
After updating some packages to the latest version, Hono didn't serve the api routes for Better Auth anymore. Raising 404's.

This was also fixed in the better auth docs a while ago: https://github.com/better-auth/better-auth/pull/1317

Removing the extra asterisk fixes the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Adjusted authentication route matching to a single-segment wildcard under /api/auth, improving consistency of which endpoints are handled.

- Chores
  - Updated backend server template to reflect the new auth route pattern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->