### PR TITLE
Use `status` instead of `error` 

### DIFF
--- a/apps/cli/templates/backend/server/elysia/src/index.ts.hbs
+++ b/apps/cli/templates/backend/server/elysia/src/index.ts.hbs
@@ -65,11 +65,11 @@ const app = new Elysia()
   )
   {{#if (eq auth "better-auth")}}
   .all("/api/auth/*", async (context) => {
-    const { request } = context;
+    const { request, status } = context;
     if (["POST", "GET"].includes(request.method)) {
       return auth.handler(request);
     }
-    context.error(405);
+    status('Method Not Allowed')
   })
   {{/if}}
 {{#if (eq api "orpc")}}


### PR DESCRIPTION
The “error” function has been removed in favor of “status.”

You can check it out here: https://github.com/elysiajs/elysia/releases/tag/1.4.0