### PR TITLE
fix: missing `/src` from README instructions

### DIFF
--- a/apps/cli/src/helpers/core/create-readme.ts
+++ b/apps/cli/src/helpers/core/create-readme.ts
@@ -674,7 +674,7 @@ SERVER_URL={your-production-server-domain}
 CORS_ORIGIN={your-production-web-domain}
 BETTER_AUTH_URL={your-production-server-domain}
 \`\`\`
-- In \`apps/server/lib/auth.ts\`, uncomment the \`session.cookieCache\` and \`advanced.crossSubDomainCookies\` sections and replace \`<your-workers-subdomain>\` with your actual workers subdomain. These settings are required to ensure cookies are transferred properly between your web and server domains.
+- In \`apps/server/src/lib/auth.ts\`, uncomment the \`session.cookieCache\` and \`advanced.crossSubDomainCookies\` sections and replace \`<your-workers-subdomain>\` with your actual workers subdomain. These settings are required to ensure cookies are transferred properly between your web and server domains.
 `;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the README content generated by the CLI to reference the correct authentication file location in the “Before Deploying to Cloudflare” section.
  * Improves clarity of deployment steps for frontend/server setup.
  * No behavioral changes to the CLI or app functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->