### PR TITLE
fix(cli): add missing agents for ruler setup

### DIFF
--- a/apps/cli/src/helpers/addons/ruler-setup.ts
+++ b/apps/cli/src/helpers/addons/ruler-setup.ts
@@ -46,6 +46,16 @@ export async function setupRuler(config: ProjectConfig) {
 			crush: { label: "Crush" },
 			zed: { label: "Zed" },
 			qwen: { label: "Qwen" },
+			amazonqcli: {label: "Amazon Q CLI"},
+			augmentcode: {label: "AugmentCode"},
+			firebender: {label: "Firebender"},
+			goose: {label: "Goose"},
+			jules: {label: "Jules"},
+			kiro: {label: "Kiro"},
+			openhands: {label: "Open Hands"},
+			roo: {label: "RooCode"},
+			trae: {label: "Trae AI"},
+			warp: {label: "Warp"},
 		} as const;
 
 		const selectedEditors = await autocompleteMultiselect({


### PR DESCRIPTION
Close #625.

Please review and provide suggestions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded editor selection with ten new AI editors: AmazonQ CLI, Augment Code, Firebender, Goose, Jules, Kiro, OpenHands, Roo, Trae, and Warp, available in the editor setup prompt.
  * Users can now choose these editors in the multi-select when configuring editor integrations in the CLI.
  * No changes to existing options; all previous editors remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->