### PR TITLE
fix: wrangler deploy commands

### DIFF
--- a/apps/cli/src/helpers/core/post-installation.ts
+++ b/apps/cli/src/helpers/core/post-installation.ts
@@ -453,12 +453,12 @@ function getWranglerDeployInstructions(
 	if (webDeploy === "wrangler") {
 		const deployPath = backend === "self" ? "apps/web" : "apps/web";
 		instructions.push(
-			`${pc.bold("Deploy web to Cloudflare Workers:")}\n${pc.cyan("•")} Deploy: ${`cd ${deployPath} && ${runCmd} run deploy`}`,
+			`${pc.bold("Deploy web to Cloudflare Workers:")}\n${pc.cyan("•")} Deploy: ${`cd ${deployPath} && ${runCmd} deploy`}`,
 		);
 	}
 	if (serverDeploy === "wrangler" && backend !== "self") {
 		instructions.push(
-			`${pc.bold("Deploy server to Cloudflare Workers:")}\n${pc.cyan("•")} Deploy: ${`cd apps/server && ${runCmd} run deploy`}`,
+			`${pc.bold("Deploy server to Cloudflare Workers:")}\n${pc.cyan("•")} Deploy: ${`cd apps/server && ${runCmd} deploy`}`,
 		);
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated deployment command format in deployment instructions to use direct deploy commands instead of the run-prefix variant for both web and server deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->