### PR TITLE
fix(cli): update db template gitignore patterns

### DIFF
--- a/apps/cli/templates/db/base/_gitignore
+++ b/apps/cli/templates/db/base/_gitignore
@@ -5,6 +5,7 @@ node_modules
 out
 dist
 *.tgz
+/prisma/generated
 
 # code coverage
 coverage


### PR DESCRIPTION
Updates the database template .gitignore to properly handle Prisma's generated files, especially for the new prisma-client generator which outputs to custom directories.

### Problem
The current gitignore pattern /prisma/generated only covers the default Prisma generated directory, but:
The new prisma-client generator (GA since v6.16.0) requires a custom output path and generates code anywhere in the codebase
The generated directory includes both TypeScript client code and the query engine binary
Including the query engine in version control causes compatibility issues across different machines and platforms
As per Prisma's official documentation, generated directories should be excluded from version control

### Changes
Updated gitignore pattern from /prisma/generated to more flexible pattern(s) that cover:
Traditional /prisma/generated directory
Custom output paths commonly used with new prisma-client generator
Generated Prisma Client files in common locations like src/generated/prisma


### References
Prisma Docs: https://www.prisma.io/docs/orm/prisma-schema/overview/generators#3-exclude-the-generated-directory-from-version-control
Related: https://x.com/ShantanuJumde/status/1969382080795820262


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the database template's version control configuration to exclude generated artifacts from the repository, reducing unnecessary files in version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->