### PR TITLE
fix(cli): exclude prisma generated file from VCS

### DIFF
--- a/apps/cli/templates/base/_gitignore
+++ b/apps/cli/templates/base/_gitignore
@@ -39,6 +39,9 @@ lerna-debug.log*
 # Better-T-Stack
 .alchemy
 
+# Prisma
+**/prisma/generated
+
 # Testing
 coverage
 .nyc_output


### PR DESCRIPTION
Close #642 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Git ignore configuration to exclude generated Prisma files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->