### PR TITLE
fix(cli): bump biome schema version to 2.2.6

### DIFF
--- a/apps/cli/templates/addons/biome/biome.json.hbs
+++ b/apps/cli/templates/addons/biome/biome.json.hbs
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.2.0/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.2.6/schema.json",
 	"vcs": {
 		"enabled": false,
 		"clientKind": "git",

--- a/apps/cli/templates/addons/ultracite/biome.json.hbs
+++ b/apps/cli/templates/addons/ultracite/biome.json.hbs
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.2.0/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.2.6/schema.json",
 	"files": {
 		"ignoreUnknown": false,
 		"includes": [


### PR DESCRIPTION
Close #644

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Biome configuration schema templates to version 2.2.6, ensuring compatibility with the latest schema specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->