### PR TITLE
Update Ultracite init

### DIFF
--- a/apps/cli/src/helpers/addons/ultracite-setup.ts
+++ b/apps/cli/src/helpers/addons/ultracite-setup.ts
@@ -115,7 +115,7 @@ export async function setupUltracite(config: ProjectConfig, hasHusky: boolean) {
 						})),
 						required: true,
 					}),
-				rules: () =>
+				agents: () =>
 					autocompleteMultiselect<UltraciteAgent>({
 						message: "Choose agents",
 						options: Object.entries(AGENTS).map(([key, agent]) => ({
@@ -133,7 +133,7 @@ export async function setupUltracite(config: ProjectConfig, hasHusky: boolean) {
 		);
 
 		const editors = result.editors as UltraciteEditor[];
-		const rules = result.rules as UltraciteAgent[];
+		const agents = result.agents as UltraciteAgent[];
 
 		const ultraciteArgs = ["init", "--pm", packageManager, "--frameworks", "react,next"];
 
@@ -141,8 +141,8 @@ export async function setupUltracite(config: ProjectConfig, hasHusky: boolean) {
 			ultraciteArgs.push("--editors", ...editors);
 		}
 
-		if (rules.length > 0) {
-			ultraciteArgs.push("--agents", ...rules);
+		if (agents.length > 0) {
+			ultraciteArgs.push("--agents", ...agents);
 		}
 
 		if (hasHusky) {


### PR DESCRIPTION
We changed `--rules` to `--agents` in v6.

Also introduced `--frameworks`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded selection of agent options for configuration
  * Framework selection added during initialization (React, Next.js)

* **Changes**
  * CLI terminology and prompts updated from "rules" to "agents"
  * Command syntax and argument flags updated to use agents and include frameworks
  * UI autocomplete and selection behavior adjusted for agents
<!-- end of auto-generated comment: release notes by coderabbit.ai -->