### PR TITLE
feat: conditionally import Button based on payments provider

### DIFF
--- a/apps/cli/templates/auth/better-auth/web/react/next/src/app/dashboard/dashboard.tsx.hbs
+++ b/apps/cli/templates/auth/better-auth/web/react/next/src/app/dashboard/dashboard.tsx.hbs
@@ -1,5 +1,7 @@
 "use client";
+{{#if (eq payments "polar")}}
 import { Button } from "@/components/ui/button";
+{{/if}}
 import { authClient } from "@/lib/auth-client";
 {{#if (eq api "orpc")}}
 import { useQuery } from "@tanstack/react-query";

--- a/apps/cli/templates/auth/better-auth/web/react/react-router/src/routes/dashboard.tsx.hbs
+++ b/apps/cli/templates/auth/better-auth/web/react/react-router/src/routes/dashboard.tsx.hbs
@@ -1,4 +1,6 @@
+{{#if (eq payments "polar")}}
 import { Button } from "@/components/ui/button";
+{{/if}}
 import { authClient } from "@/lib/auth-client";
 {{#if (eq api "orpc")}}
 import { orpc } from "@/utils/orpc";

--- a/apps/cli/templates/auth/better-auth/web/react/tanstack-router/src/routes/dashboard.tsx.hbs
+++ b/apps/cli/templates/auth/better-auth/web/react/tanstack-router/src/routes/dashboard.tsx.hbs
@@ -1,4 +1,6 @@
+{{#if (eq payments "polar")}}
 import { Button } from "@/components/ui/button";
+{{/if}}
 import { authClient } from "@/lib/auth-client";
 {{#if (eq api "orpc")}}
 import { orpc } from "@/utils/orpc";


### PR DESCRIPTION
Otherwise the import is unused if polar is not selected as the Button is only used with Polar in this case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added subscription UI: displays plan, active subscription status, and a subscription management/checkout flow when the Polar payment option is enabled.
* **Chores**
  * Improved templates to conditionally load payment-related components based on payment-provider configuration across Next.js, React Router, and Tanstack Router.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->