### PR TITLE
Update compatibility date in wrangler.jsonc.hbs

### DIFF
--- a/apps/cli/templates/deploy/wrangler/web/react/tanstack-start/wrangler.jsonc.hbs
+++ b/apps/cli/templates/deploy/wrangler/web/react/tanstack-start/wrangler.jsonc.hbs
@@ -2,7 +2,7 @@
     "$schema": "./node_modules/wrangler/config-schema.json",
     "name": "{{projectName}}",
     "main": "@tanstack/react-start/server-entry",
-    "compatibility_date": "2025-07-05",
+    "compatibility_date": "2025-09-15",
     "compatibility_flags": ["nodejs_compat"],
     "assets": {
       "directory": ".output/public",


### PR DESCRIPTION
Fixes an assertion error in tanstack-start with cloudflare

I was getting the following error on a fresh install:

```
  VITE v7.1.12  ready in 1495 ms

  ➜  Local:   http://localhost:3001/
  ➜  Network: use --host to expose
  ➜  Debug:   http://localhost:3001/__debug
  ➜  press h + enter to show help
  
  
AssertionError [ERR_ASSERTION]: Unexpected error: no match for module: node:http.
    at Object.unsafeModuleFallbackService (file:///Users/chris/src/neighbor/rebase/zone/node_modules/@cloudflare/vite-plugin/dist/index.js:8607:5)
    at #handleLoopback (/Users/chris/src/neighbor/rebase/zone/node_modules/miniflare/dist/src/index.js:61545:48)
    at Server.emit (node:events:519:35)
    at Server.emit (node:domain:489:12)
    at parserOnIncoming (node:_http_server:1153:12)
    at HTTPParser.parserOnHeadersComplete (node:_http_common:117:17)
Fallback service failed to fetch module; payload = AssertionError [ERR_ASSERTION]: Unexpected error: no match for module: node:http.
    at Object.unsafeModuleFallbackService (file:///Users/chris/src/neighbor/rebase/zone/node_modules/@cloudflare/vite-plugin/dist/index.js:8607:5)
    at #handleLoopback (/Users/chris/src/neighbor/rebase/zone/node_modules/miniflare/dist/src/index.js:61545:48)
    at Server.emit (node:events:519:35)
    at Server.emit (node:domain:489:12)
    at parserOnIncoming (node:_http_server:1153:12)
    at HTTPParser.parserOnHeadersComplete (node:_http_common:117:17); spec = /?specifier=node%3Ahttp&referrer=&rawSpecifier=node%3Ahttp
```

Updating the wrangler compatibility date fixes this error because it now includes node:http.

<img width="784" height="1506" alt="Zen Browser-2025-10-31 at 13 14 42@2x" src="https://github.com/user-attachments/assets/f6d35851-86c7-41e3-8c36-489c4b0b6533" />
