### PR TITLE
Change package command from 'neondb' to 'get-db' for neon database setup

### DIFF
--- a/apps/cli/src/helpers/database-providers/neon-setup.ts
+++ b/apps/cli/src/helpers/database-providers/neon-setup.ts
@@ -133,7 +133,7 @@ async function setupWithNeonDb(
 
 		const packageCmd = getPackageExecutionCommand(
 			packageManager,
-			"neondb@latest --yes",
+			"get-db@latest --yes",
 		);
 
 		await execa(packageCmd, {


### PR DESCRIPTION
The package "neondb' has been renamed to 'get-db'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CLI command used during Neon database initialization. All existing workflows and setup functionality remain unchanged, ensuring a consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->