### PR TITLE
Add support for Ultracite hooks flag

### DIFF
--- a/apps/cli/src/helpers/addons/ultracite-setup.ts
+++ b/apps/cli/src/helpers/addons/ultracite-setup.ts
@@ -33,6 +33,8 @@ type UltraciteAgent =
 	| "goose"
 	| "roo-code";
 
+type UltraciteHook = "cursor" | "claude";
+
 const EDITORS = {
 	vscode: {
 		label: "VSCode / Cursor / Windsurf",
@@ -99,6 +101,15 @@ const AGENTS = {
 	},
 } as const;
 
+const HOOKS = {
+	cursor: {
+		label: "Cursor",
+	},
+	claude: {
+		label: "Claude",
+	},
+} as const;
+
 function getFrameworksFromFrontend(frontend: string[]): string[] {
 	const frameworkMap: Record<string, string> = {
 		"tanstack-router": "react",
@@ -151,6 +162,14 @@ export async function setupUltracite(config: ProjectConfig, hasHusky: boolean) {
 						})),
 						required: true,
 					}),
+				hooks: () =>
+					autocompleteMultiselect<UltraciteHook>({
+						message: "Choose hooks",
+						options: Object.entries(HOOKS).map(([key, hook]) => ({
+							value: key as UltraciteHook,
+							label: hook.label,
+						})),
+					}),
 			},
 			{
 				onCancel: () => {
@@ -161,7 +180,7 @@ export async function setupUltracite(config: ProjectConfig, hasHusky: boolean) {
 
 		const editors = result.editors as UltraciteEditor[];
 		const agents = result.agents as UltraciteAgent[];
-
+		const hooks = result.hooks as UltraciteHook[];
 		const frameworks = getFrameworksFromFrontend(frontend);
 
 		const ultraciteArgs = ["init", "--pm", packageManager];
@@ -176,6 +195,10 @@ export async function setupUltracite(config: ProjectConfig, hasHusky: boolean) {
 
 		if (agents.length > 0) {
 			ultraciteArgs.push("--agents", ...agents);
+		}
+
+		if (hooks.length > 0) {
+			ultraciteArgs.push("--hooks", ...hooks);
 		}
 
 		if (hasHusky) {


### PR DESCRIPTION
This pull request enhances the Ultracite setup flow in `apps/cli/src/helpers/addons/ultracite-setup.ts` by introducing support for selecting and passing "hooks" (such as Cursor and Claude) during initialization. The changes add a new prompt for hook selection and ensure that user choices are included in the Ultracite initialization arguments.

**New hook selection support:**

* Added a new type `UltraciteHook` and a `HOOKS` constant to define available hooks (`cursor`, `claude`) and their labels. [[1]](diffhunk://#diff-ed705d32997fc39380805dd4323bf2d21e57bfe1bee1abba957a59d50926e012R36-R37) [[2]](diffhunk://#diff-ed705d32997fc39380805dd4323bf2d21e57bfe1bee1abba957a59d50926e012R104-R112)
* Integrated a new autocomplete multiselect prompt for hooks in the setup flow, allowing users to choose one or more hooks interactively.
* Captured selected hooks from user input and included them in the Ultracite initialization arguments (`ultraciteArgs`) via the `--hooks` flag. [[1]](diffhunk://#diff-ed705d32997fc39380805dd4323bf2d21e57bfe1bee1abba957a59d50926e012L164-R183) [[2]](diffhunk://#diff-ed705d32997fc39380805dd4323bf2d21e57bfe1bee1abba957a59d50926e012R200-R203)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hook selection capability during Ultracite setup. Users can now choose between Cursor and Claude hooks, with selected options being automatically configured during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->