### PR TITLE
Add tailwindDirectives css parser config to biome config file

### DIFF
--- a/apps/cli/templates/addons/biome/biome.json.hbs
+++ b/apps/cli/templates/addons/biome/biome.json.hbs
@@ -66,6 +66,11 @@
 		"formatter": {
 			"quoteStyle": "double"
 		}
+	},
+	"css": {
+		"parser": {
+			"tailwindDirectives": true
+		}
 	}
 	{{#if (or (includes frontend "svelte") (includes frontend "nuxt"))}}
 	,


### PR DESCRIPTION
[Biome v2.3](https://biomejs.dev/internals/changelog/version/2-3-0/) introduced a tailwindDirectives option to the css parser that is required when using tailwind. Without this option enabled, you get a bunch of these errors when you run `bun check` for the first time.

```
apps/web/src/index.css:4:2 parse

  ✖ Tailwind-specific syntax is disabled.

    2 │ @import "tw-animate-css";
    3 │
  > 4 │ @custom-variant dark (&:where(.dark, .dark *));
      │  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    5 │
    6 │ @theme {

  ℹ Enable `tailwindDirectives` in the css parser options, or remove this if you are not using Tailwind CSS.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Biome configuration to enable Tailwind CSS directives parsing for improved CSS processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->