### PR TITLE
fix(cli): dynamically inject alchemy env.d.ts imports using ts-morph …

### DIFF
--- a/apps/cli/src/helpers/core/post-installation.ts
+++ b/apps/cli/src/helpers/core/post-installation.ts
@@ -266,13 +266,11 @@ async function getDatabaseInstructions(
 	if (dbSetup === "d1" && serverDeploy === "alchemy") {
 		if (orm === "drizzle") {
 			instructions.push(
-				`${pc.yellow(
-					"NOTE:",
-				)} D1 migrations are automatically handled by Alchemy`,
+				`${pc.cyan("•")} Generate migrations: ${`${runCmd} db:generate`}`,
 			);
 		} else if (orm === "prisma") {
 			instructions.push(
-				`${pc.cyan("•")} Generate migrations: ${`${runCmd} db:generate`}`,
+				`${pc.cyan("•")} Generate Prisma client: ${`${runCmd} db:generate`}`,
 			);
 			instructions.push(
 				`${pc.cyan("•")} Apply migrations: ${`${runCmd} db:migrate`}`,

--- a/apps/cli/src/helpers/core/template-manager.ts
+++ b/apps/cli/src/helpers/core/template-manager.ts
@@ -4,6 +4,7 @@ import { glob } from "tinyglobby";
 import { PKG_ROOT } from "../../constants";
 import type { ProjectConfig } from "../../types";
 import { processTemplate } from "../../utils/template-processor";
+import { setupEnvDtsImport } from "../deployment/alchemy/env-dts-setup";
 
 export async function processAndCopyFiles(
 	sourcePattern: string | string[],
@@ -1203,12 +1204,13 @@ export async function setupDeploymentTemplates(
 						serverAppDir,
 						context,
 					);
-					await processAndCopyFiles(
-						"env.d.ts.hbs",
-						alchemyTemplateSrc,
-						serverAppDir,
+					const envDtsPath = path.join(serverAppDir, "env.d.ts");
+					await processTemplate(
+						path.join(alchemyTemplateSrc, "env.d.ts.hbs"),
+						envDtsPath,
 						context,
 					);
+					await setupEnvDtsImport(envDtsPath, projectDir, context);
 
 					await addEnvDtsToPackages(projectDir, context, alchemyTemplateSrc);
 				}
@@ -1283,22 +1285,24 @@ async function addEnvDtsToPackages(
 	for (const packageName of packages) {
 		const packageDir = path.join(projectDir, packageName);
 		if (await fs.pathExists(packageDir)) {
-			await processAndCopyFiles(
-				"env.d.ts.hbs",
-				alchemyTemplateSrc,
-				packageDir,
+			const envDtsPath = path.join(packageDir, "env.d.ts");
+			await processTemplate(
+				path.join(alchemyTemplateSrc, "env.d.ts.hbs"),
+				envDtsPath,
 				context,
 			);
+			await setupEnvDtsImport(envDtsPath, projectDir, context);
 		}
 	}
 
 	const serverAppDir = path.join(projectDir, "apps/server");
 	if (await fs.pathExists(serverAppDir)) {
-		await processAndCopyFiles(
-			"env.d.ts.hbs",
-			alchemyTemplateSrc,
-			serverAppDir,
+		const envDtsPath = path.join(serverAppDir, "env.d.ts");
+		await processTemplate(
+			path.join(alchemyTemplateSrc, "env.d.ts.hbs"),
+			envDtsPath,
 			context,
 		);
+		await setupEnvDtsImport(envDtsPath, projectDir, context);
 	}
 }

--- a/apps/cli/src/helpers/deployment/alchemy/env-dts-setup.ts
+++ b/apps/cli/src/helpers/deployment/alchemy/env-dts-setup.ts
@@ -1,0 +1,84 @@
+import path from "node:path";
+import fs from "fs-extra";
+import { Project } from "ts-morph";
+import type { ProjectConfig } from "../../../types";
+
+const tsProject = new Project({
+	useInMemoryFileSystem: false,
+	skipAddingFilesFromTsConfig: true,
+});
+
+function determineImportPath(
+	envDtsPath: string,
+	projectDir: string,
+	config: ProjectConfig,
+): string {
+	const { webDeploy, serverDeploy, backend } = config;
+	const isBackendSelf = backend === "self";
+
+	let alchemyRunPath: string;
+
+	if (
+		webDeploy === "alchemy" &&
+		(serverDeploy === "alchemy" || isBackendSelf)
+	) {
+		// Both web and server are alchemy, or web + backend=self
+		if (isBackendSelf) {
+			alchemyRunPath = path.join(projectDir, "apps/web/alchemy.run.ts");
+		} else {
+			alchemyRunPath = path.join(projectDir, "alchemy.run.ts");
+		}
+	} else if (webDeploy === "alchemy") {
+		// Only web is alchemy
+		alchemyRunPath = path.join(projectDir, "apps/web/alchemy.run.ts");
+	} else if (serverDeploy === "alchemy") {
+		// Only server is alchemy
+		alchemyRunPath = path.join(projectDir, "apps/server/alchemy.run.ts");
+	} else {
+		// Should not happen, but fallback
+		alchemyRunPath = path.join(projectDir, "alchemy.run.ts");
+	}
+
+	// Calculate relative path from env.d.ts to alchemy.run.ts
+	const relativePath = path.relative(
+		path.dirname(envDtsPath),
+		alchemyRunPath.replace(/\.ts$/, ""),
+	);
+
+	// Normalize the path for imports (use forward slashes, handle relative paths)
+	const importPath = relativePath.startsWith(".")
+		? relativePath
+		: `./${relativePath}`;
+
+	return importPath.replace(/\\/g, "/");
+}
+
+export async function setupEnvDtsImport(
+	envDtsPath: string,
+	projectDir: string,
+	config: ProjectConfig,
+) {
+	if (!(await fs.pathExists(envDtsPath))) {
+		return;
+	}
+
+	const importPath = determineImportPath(envDtsPath, projectDir, config);
+
+	const sourceFile = tsProject.addSourceFileAtPath(envDtsPath);
+
+	const existingImports = sourceFile.getImportDeclarations();
+	const alreadyHasImport = existingImports.some(
+		(imp) =>
+			imp.getModuleSpecifierValue() === importPath &&
+			imp.getNamedImports().some((named) => named.getName() === "server"),
+	);
+
+	if (!alreadyHasImport) {
+		sourceFile.insertImportDeclaration(0, {
+			moduleSpecifier: importPath,
+			namedImports: [{ name: "server", isTypeOnly: true }],
+		});
+	}
+
+	await sourceFile.save();
+}

--- a/apps/cli/templates/deploy/alchemy/alchemy.run.ts.hbs
+++ b/apps/cli/templates/deploy/alchemy/alchemy.run.ts.hbs
@@ -21,7 +21,6 @@ import { Worker } from "alchemy/cloudflare";
 {{/if}}
 {{#if (and (or (eq serverDeploy "alchemy") (and (eq webDeploy "alchemy") (eq backend "self"))) (eq dbSetup "d1"))}}
 import { D1Database } from "alchemy/cloudflare";
-import { Exec } from "alchemy/os";
 {{/if}}
 import { config } from "dotenv";
 
@@ -36,11 +35,6 @@ config({ path: "./.env" });
 const app = await alchemy("{{projectName}}");
 
 {{#if (and (or (eq serverDeploy "alchemy") (and (eq webDeploy "alchemy") (eq backend "self"))) (eq dbSetup "d1"))}}
-await Exec("db-generate", {
-	{{#if (and (eq webDeploy "alchemy") (eq serverDeploy "alchemy"))}}cwd: "packages/db",{{/if}}
-	command: "{{packageManager}} run db:generate",
-});
-
 const db = await D1Database("database", {
 	{{#if (eq orm "prisma")}}
 	migrationsDir: "packages/db/prisma/migrations",

--- a/apps/cli/templates/deploy/alchemy/env.d.ts.hbs
+++ b/apps/cli/templates/deploy/alchemy/env.d.ts.hbs
@@ -1,12 +1,6 @@
 // This file infers types for the cloudflare:workers environment from your Alchemy Worker.
 // @see https://alchemy.run/concepts/bindings/#type-safe-bindings
 
-{{#if (eq webDeploy "alchemy")}}
-import type { server } from "../../alchemy.run";
-{{else}}
-import type { server } from "./alchemy.run";
-{{/if}}
-
 export type CloudflareEnv = typeof server.Env;
 
 declare global {


### PR DESCRIPTION
…and remove db:generate Exec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated installation guidance for D1 database migration setup with Drizzle ORM to prompt for explicit migration generation.
  * Refined Prisma ORM setup instructions to clarify the client generation step.
  * Enhanced environment type configuration handling during project deployment setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->