### PR TITLE
fix(cli): remove BetterAuthOptions generic type from better-auth temp…

### DIFF
--- a/apps/cli/templates/auth/better-auth/server/base/src/index.ts.hbs
+++ b/apps/cli/templates/auth/better-auth/server/base/src/index.ts.hbs
@@ -1,5 +1,5 @@
 {{#if (eq orm "prisma")}}
-import { betterAuth, type BetterAuthOptions } from "better-auth";
+import { betterAuth } from "better-auth";
 import { prismaAdapter } from "better-auth/adapters/prisma";
 {{#if (eq payments "polar")}}
 import { polar, checkout, portal } from "@polar-sh/better-auth";
@@ -7,7 +7,7 @@ import { polarClient } from "./lib/payments";
 {{/if}}
 import prisma from "@{{projectName}}/db";
 
-export const auth = betterAuth<BetterAuthOptions>({
+export const auth = betterAuth({
   database: prismaAdapter(prisma, {
     {{#if (eq database "postgres")}}provider: "postgresql",{{/if}}
     {{#if (eq database "sqlite")}}provider: "sqlite",{{/if}}
@@ -59,7 +59,7 @@ export const auth = betterAuth<BetterAuthOptions>({
 
 {{#if (eq orm "drizzle")}}
 {{#if (or (eq runtime "bun") (eq runtime "node") (eq runtime "none"))}}
-import { betterAuth, type BetterAuthOptions } from "better-auth";
+import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 {{#if (eq payments "polar")}}
 import { polar, checkout, portal } from "@polar-sh/better-auth";
@@ -68,7 +68,7 @@ import { polarClient } from "./lib/payments";
 import { db } from "@{{projectName}}/db";
 import * as schema from "@{{projectName}}/db/schema/auth";
 
-export const auth = betterAuth<BetterAuthOptions>({
+export const auth = betterAuth({
   database: drizzleAdapter(db, {
     {{#if (eq database "postgres")}}provider: "pg",{{/if}}
     {{#if (eq database "sqlite")}}provider: "sqlite",{{/if}}
@@ -119,7 +119,7 @@ export const auth = betterAuth<BetterAuthOptions>({
 {{/if}}
 
 {{#if (eq runtime "workers")}}
-import { betterAuth, type BetterAuthOptions } from "better-auth";
+import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 {{#if (eq payments "polar")}}
 import { polar, checkout, portal } from "@polar-sh/better-auth";
@@ -129,7 +129,7 @@ import { db } from "@{{projectName}}/db";
 import * as schema from "@{{projectName}}/db/schema/auth";
 import { env } from "cloudflare:workers";
 
-export const auth = betterAuth<BetterAuthOptions>({
+export const auth = betterAuth({
   database: drizzleAdapter(db, {
     {{#if (eq database "postgres")}}provider: "pg",{{/if}}
     {{#if (eq database "sqlite")}}provider: "sqlite",{{/if}}
@@ -194,7 +194,7 @@ export const auth = betterAuth<BetterAuthOptions>({
 {{/if}}
 
 {{#if (eq orm "mongoose")}}
-import { betterAuth, type BetterAuthOptions } from "better-auth";
+import { betterAuth } from "better-auth";
 import { mongodbAdapter } from "better-auth/adapters/mongodb";
 {{#if (eq payments "polar")}}
 import { polar, checkout, portal } from "@polar-sh/better-auth";
@@ -202,7 +202,7 @@ import { polarClient } from "./lib/payments";
 {{/if}}
 import { client } from "@{{projectName}}/db";
 
-export const auth = betterAuth<BetterAuthOptions>({
+export const auth = betterAuth({
   database: mongodbAdapter(client),
   trustedOrigins: [
     process.env.CORS_ORIGIN || "",
@@ -248,13 +248,13 @@ export const auth = betterAuth<BetterAuthOptions>({
 {{/if}}
 
 {{#if (eq orm "none")}}
-import { betterAuth, type BetterAuthOptions } from "better-auth";
+import { betterAuth } from "better-auth";
 {{#if (eq payments "polar")}}
 import { polar, checkout, portal } from "@polar-sh/better-auth";
 import { polarClient } from "./lib/payments";
 {{/if}}
 
-export const auth = betterAuth<BetterAuthOptions>({
+export const auth = betterAuth({
   database: "", // Invalid configuration
   trustedOrigins: [
     process.env.CORS_ORIGIN || "",


### PR DESCRIPTION
Prior to this commit, any plugins added to the betterauth setup would not have inference and would just break builds. This commit removes the generic type and fixes betterauth's plugins/extensions inferences.

Before the fix:
The `admin()` plugin has a few additional methods you can use such as `api.auth.userHasPermission()`, but it is not seen / inferred here.
<img width="412" height="215" alt="image" src="https://github.com/user-attachments/assets/0007cc54-28c4-4bab-85d0-68694538210a" />
<img width="727" height="138" alt="image" src="https://github.com/user-attachments/assets/29bc4f8d-fb97-415a-95ec-befaaf0cbd07" />


After the fix:
All the methods that the plugin provides are now available / inferred properly.
<img width="419" height="234" alt="image" src="https://github.com/user-attachments/assets/2b4625fd-8d30-4014-aa11-c630d05348bf" />
<img width="386" height="138" alt="image" src="https://github.com/user-attachments/assets/7f9fc4a3-a344-4101-95dc-8a3a539fe4e6" />

Note:
- This is using the latest versions of better-auth (v1.4.3) and better-t-stack (v3.6.5)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified authentication initialization templates across all supported database systems (Prisma, Drizzle, MongoDB, Workers) and runtime environments. Generated authentication setup code now features cleaner, more straightforward signatures that are easier to understand and maintain while preserving all existing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->