### PR TITLE
chore: drop event field and clean charts

### DIFF
--- a/apps/cli/src/utils/analytics.ts
+++ b/apps/cli/src/utils/analytics.ts
@@ -30,7 +30,6 @@ export async function trackProjectCreation(config: ProjectConfig, disableAnalyti
 
   try {
     await sendConvexEvent({
-      event: "project_created",
       ...safeConfig,
       cli_version: getLatestCLIVersion(),
       node_version: typeof process !== "undefined" ? process.version : "",

--- a/apps/web/src/app/(home)/analytics/_components/analytics-page.tsx
+++ b/apps/web/src/app/(home)/analytics/_components/analytics-page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Loader2 } from "lucide-react";
 import Footer from "../../_components/footer";
 import { AnalyticsHeader } from "./analytics-header";
 import { DevToolsSection } from "./dev-environment-charts";
@@ -13,6 +14,7 @@ export default function AnalyticsPage({
   range,
   onRangeChange,
   legacy,
+  isLoading,
 }: {
   data: AggregatedAnalyticsData;
   range: "all" | "30d" | "7d" | "1d";
@@ -23,6 +25,7 @@ export default function AnalyticsPage({
     lastUpdatedIso: string;
     source: string;
   };
+  isLoading?: boolean;
 }) {
   return (
     <div className="mx-auto min-h-svh">
@@ -33,7 +36,7 @@ export default function AnalyticsPage({
           legacy={legacy}
         />
 
-        <RangeSelector value={range} onChange={onRangeChange} />
+        <RangeSelector value={range} onChange={onRangeChange} isLoading={isLoading} />
 
         <MetricsCards data={data} />
 
@@ -51,9 +54,11 @@ export default function AnalyticsPage({
 function RangeSelector({
   value,
   onChange,
+  isLoading,
 }: {
   value: "all" | "30d" | "7d" | "1d";
   onChange: (val: "all" | "30d" | "7d" | "1d") => void;
+  isLoading?: boolean;
 }) {
   const options: Array<{ value: "all" | "30d" | "7d" | "1d"; label: string }> = [
     { value: "all", label: "All time" },
@@ -63,7 +68,7 @@ function RangeSelector({
   ];
 
   return (
-    <div className="flex flex-wrap items-center gap-2">
+    <div className="flex flex-wrap items-center gap-3">
       <span className="text-muted-foreground text-sm">Range:</span>
       <div className="flex flex-wrap gap-2">
         {options.map((opt) => (
@@ -71,7 +76,8 @@ function RangeSelector({
             key={opt.value}
             type="button"
             onClick={() => onChange(opt.value)}
-            className={`rounded border px-3 py-1 text-sm transition-colors ${
+            disabled={isLoading}
+            className={`rounded border px-3 py-1 text-sm transition-colors disabled:opacity-50 ${
               value === opt.value
                 ? "border-primary bg-primary/10 text-primary"
                 : "border-border text-foreground hover:bg-muted/60"
@@ -81,6 +87,7 @@ function RangeSelector({
           </button>
         ))}
       </div>
+      {isLoading && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />}
     </div>
   );
 }

--- a/apps/web/src/app/(home)/analytics/_components/stack-configuration-charts.tsx
+++ b/apps/web/src/app/(home)/analytics/_components/stack-configuration-charts.tsx
@@ -1,13 +1,28 @@
-import { Bar, BarChart, CartesianGrid, Cell, Pie, PieChart, XAxis, YAxis } from "recharts";
-import {
-  ChartContainer,
-  ChartLegend,
-  ChartLegendContent,
-  ChartTooltip,
-  ChartTooltipContent,
-} from "@/components/ui/chart";
+import { Bar, BarChart, CartesianGrid, Cell, Pie, PieChart, Tooltip, XAxis, YAxis } from "recharts";
+import { ChartContainer, ChartLegend, ChartLegendContent } from "@/components/ui/chart";
 import type { AggregatedAnalyticsData, Distribution } from "./types";
-import { chartConfig, getColor } from "./types";
+import { chartConfig, getColor, truncateLabel } from "./types";
+
+function CustomYAxisTick({
+  x,
+  y,
+  payload,
+  maxChars = 11,
+}: {
+  x: number;
+  y: number;
+  payload: { value: string };
+  maxChars?: number;
+}) {
+  const label = truncateLabel(String(payload.value), maxChars);
+  return (
+    <g transform={`translate(${x},${y})`}>
+      <text x={-4} y={0} dy={4} textAnchor="end" fill="hsl(var(--muted-foreground))" fontSize={11}>
+        {label}
+      </text>
+    </g>
+  );
+}
 
 function ChartCard({
   title,
@@ -32,22 +47,39 @@ function ChartCard({
   );
 }
 
+function CustomTooltip({
+  active,
+  payload,
+}: {
+  active?: boolean;
+  payload?: Array<{ value: number; payload: { name: string } }>;
+}) {
+  if (!active || !payload?.length) return null;
+  const item = payload[0];
+  return (
+    <div className="rounded border border-border/50 bg-background px-3 py-2 text-xs shadow-lg">
+      <p className="font-medium">{item.payload.name}</p>
+      <p className="text-muted-foreground">{item.value.toLocaleString()} projects</p>
+    </div>
+  );
+}
+
 function BarChartComponent({ data, height = 280 }: { data: Distribution; height?: number }) {
   return (
     <ChartContainer config={chartConfig} style={{ height }} className="w-full">
-      <BarChart data={data} layout="vertical" margin={{ left: 0 }}>
-        <CartesianGrid horizontal={false} className="stroke-border" />
-        <XAxis type="number" tickLine={false} axisLine={false} className="text-xs" />
+      <BarChart data={data} layout="vertical" margin={{ left: 4, right: 12, top: 4, bottom: 4 }}>
+        <CartesianGrid horizontal={false} className="stroke-border/40" />
+        <XAxis type="number" tickLine={false} axisLine={false} tick={{ fontSize: 10 }} />
         <YAxis
           dataKey="name"
           type="category"
           tickLine={false}
           axisLine={false}
-          width={100}
-          className="text-xs"
+          width={85}
+          tick={(props) => <CustomYAxisTick {...props} maxChars={11} />}
         />
-        <ChartTooltip content={<ChartTooltipContent />} />
-        <Bar dataKey="value" radius={4}>
+        <Tooltip content={<CustomTooltip />} cursor={{ fill: "hsl(var(--muted))", opacity: 0.3 }} />
+        <Bar dataKey="value" radius={3}>
           {data.map((entry, i) => (
             <Cell key={entry.name} fill={getColor(i)} />
           ))}
@@ -58,24 +90,44 @@ function BarChartComponent({ data, height = 280 }: { data: Distribution; height?
 }
 
 function PieChartComponent({ data }: { data: Distribution }) {
+  const total = data.reduce((sum, d) => sum + d.value, 0);
+
   return (
     <ChartContainer config={chartConfig} className="h-[280px] w-full">
       <PieChart>
-        <ChartTooltip content={<ChartTooltipContent nameKey="name" />} />
+        <Tooltip
+          content={({ active, payload }) => {
+            if (!active || !payload?.length) return null;
+            const item = payload[0].payload as { name: string; value: number };
+            const percent = ((item.value / total) * 100).toFixed(1);
+            return (
+              <div className="rounded border border-border/50 bg-background px-3 py-2 text-xs shadow-lg">
+                <p className="font-medium">{item.name}</p>
+                <p className="text-muted-foreground">
+                  {item.value.toLocaleString()} ({percent}%)
+                </p>
+              </div>
+            );
+          }}
+        />
         <Pie
           data={data}
           cx="50%"
-          cy="50%"
-          outerRadius={80}
+          cy="45%"
+          outerRadius={65}
+          innerRadius={35}
           dataKey="value"
-          label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}
-          labelLine={false}
+          paddingAngle={2}
         >
           {data.map((entry, i) => (
             <Cell key={entry.name} fill={getColor(i)} />
           ))}
         </Pie>
-        <ChartLegend content={<ChartLegendContent />} />
+        <ChartLegend
+          content={<ChartLegendContent nameKey="name" />}
+          formatter={(value) => truncateLabel(String(value), 10)}
+          wrapperStyle={{ fontSize: 11 }}
+        />
       </PieChart>
     </ChartContainer>
   );

--- a/apps/web/src/app/(home)/analytics/_components/types.ts
+++ b/apps/web/src/app/(home)/analytics/_components/types.ts
@@ -52,14 +52,23 @@ export const chartConfig = {
 } satisfies ChartConfig;
 
 export const CHART_COLORS = [
-  "hsl(var(--chart-1))",
-  "hsl(var(--chart-2))",
-  "hsl(var(--chart-3))",
-  "hsl(var(--chart-4))",
-  "hsl(var(--chart-5))",
-  "hsl(var(--muted-foreground))",
+  "hsl(142 76% 36%)",
+  "hsl(221 83% 53%)",
+  "hsl(262 83% 58%)",
+  "hsl(24 95% 53%)",
+  "hsl(47 96% 53%)",
+  "hsl(339 90% 51%)",
+  "hsl(173 80% 40%)",
+  "hsl(291 64% 42%)",
+  "hsl(210 40% 50%)",
+  "hsl(0 72% 51%)",
 ];
 
 export function getColor(index: number) {
   return CHART_COLORS[index % CHART_COLORS.length];
+}
+
+export function truncateLabel(label: string, maxLength = 16) {
+  if (label.length <= maxLength) return label;
+  return `${label.slice(0, maxLength - 1)}...`;
 }

--- a/bun.lock
+++ b/bun.lock
@@ -118,6 +118,7 @@
       "name": "@better-t-stack/backend",
       "version": "1.0.0",
       "dependencies": {
+        "@convex-dev/crons": "^0.2.0",
         "@erquhart/convex-oss-stats": "^0.8.1",
         "convex": "^1.28.2",
         "convex-helpers": "^0.1.104",
@@ -183,6 +184,8 @@
     "@clack/core": ["@clack/core@0.5.0", "", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow=="],
 
     "@clack/prompts": ["@clack/prompts@0.11.0", "", { "dependencies": { "@clack/core": "0.5.0", "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw=="],
+
+    "@convex-dev/crons": ["@convex-dev/crons@0.2.0", "", { "dependencies": { "cron-parser": "^4.9.0" }, "peerDependencies": { "convex": "^1.24.8" } }, "sha512-JowF/DDPl8FuhXml2/0jmEa6uIKr/UK1UwP+FdbPt2BRVxACRX4CNlzDQEtHbO2p2FVKiJh4zEg8p5/YM27PEA=="],
 
     "@emnapi/core": ["@emnapi/core@1.7.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg=="],
 
@@ -1080,6 +1083,8 @@
 
     "create-bts": ["create-bts@workspace:packages/create-bts"],
 
+    "cron-parser": ["cron-parser@4.9.0", "", { "dependencies": { "luxon": "^3.2.1" } }, "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q=="],
+
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
@@ -1629,6 +1634,8 @@
     "lru-cache": ["lru-cache@11.2.4", "", {}, "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg=="],
 
     "lucide-react": ["lucide-react@0.555.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-D8FvHUGbxWBRQM90NZeIyhAvkFfsh3u9ekrMvJ30Z6gnpBHS6HC6ldLg7tL45hwiIz/u66eKDtdA23gwwGsAHA=="],
+
+    "luxon": ["luxon@3.7.2", "", {}, "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 	"engines": {
 		"node": ">=20"
 	},
-	"packageManager": "bun@1.3.1",
+	"packageManager": "bun@1.3.4",
 	"workspaces": [
 		"apps/*",
 		"packages/*"

--- a/packages/backend/convex/http.ts
+++ b/packages/backend/convex/http.ts
@@ -10,7 +10,7 @@ http.route({
   method: "POST",
   handler: httpAction(async (ctx, req) => {
     const body = await req.json();
-    if (!body || typeof body.event !== "string") {
+    if (!body) {
       return new Response("Bad Request", { status: 400 });
     }
 
@@ -18,7 +18,6 @@ http.route({
     if (ingest) {
       try {
         await ctx.runMutation(ingest, {
-          event: body.event,
           database: body.database,
           orm: body.orm,
           backend: body.backend,
@@ -40,7 +39,7 @@ http.route({
           platform: body.platform,
         });
       } catch (error) {
-        console.error("Failed to ingest analytics event:", error);
+        console.error("Failed to ingest analytics:", error);
         return new Response("Internal Server Error", { status: 500 });
       }
     }

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -23,7 +23,6 @@ export default defineSchema({
   }),
 
   analyticsEvents: defineTable({
-    event: v.string(),
     database: v.optional(v.string()),
     orm: v.optional(v.string()),
     backend: v.optional(v.string()),
@@ -43,7 +42,7 @@ export default defineSchema({
     cli_version: v.optional(v.string()),
     node_version: v.optional(v.string()),
     platform: v.optional(v.string()),
-  }).index("by_event", ["event"]),
+  }),
 
   analyticsStats: defineTable({
     totalProjects: v.number(),
@@ -67,6 +66,9 @@ export default defineSchema({
     install: distributionValidator,
     nodeVersion: distributionValidator,
     cliVersion: distributionValidator,
+    hourlyDistribution: v.optional(distributionValidator),
+    stackCombinations: v.optional(distributionValidator),
+    dbOrmCombinations: v.optional(distributionValidator),
   }),
 
   analyticsDailyStats: defineTable({

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -14,6 +14,7 @@
 		"typescript": "^5.9.3"
 	},
 	"dependencies": {
+		"@convex-dev/crons": "^0.2.0",
 		"@erquhart/convex-oss-stats": "^0.8.1",
 		"convex": "^1.28.2",
 		"convex-helpers": "^0.1.104"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Drops the `event` field from analytics and adds new hourly/stack/db-orm metrics with revamped charts, improved range loading UX, and updated queries/APIs.
> 
> - **Backend**:
>   - Remove `event` from `analyticsEvents` schema, API args, and queries; delete `by_event` index.
>   - Add computed metrics: `hourlyDistribution`, `stackCombinations`, `dbOrmCombinations`; update `ingestEvent`, `backfillStats`, `getStats`.
>   - Refactor `getAllEvents` to accept only ranged values and stream until cutoff; HTTP ingest no longer requires `event`.
>   - Dependency: add `@convex-dev/crons`.
> - **CLI**:
>   - Stop sending `event` in telemetry payloads.
> - **Web**:
>   - Client: default range to `all`, add `isLoading` state, use ranged events; build and surface new distributions.
>   - Charts: add hourly activity and popular backend+frontend and DB+ORM bars; replace tooltips/legends/ticks, tweak margins, use donut pies; update color palette.
>   - UI: disable range buttons while loading and show spinner.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb80e1fca2598f3286f74bf92400aac9efb31f9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loading indicator to analytics page during data retrieval
  * Introduced new analytics metrics for hourly distribution, popular stack combinations, and database/ORM combinations
  * Enhanced chart visualizations with improved tooltips, custom tick rendering, and label truncation
  * Changed default analytics time range to all-time view

* **Chores**
  * Updated package manager to bun@1.3.4

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->