### PR TITLE
Fix docker not finding compose plugin when using turborepo by adding --env-mode=loose

### DIFF
--- a/apps/cli/src/helpers/core/project-config.ts
+++ b/apps/cli/src/helpers/core/project-config.ts
@@ -91,10 +91,10 @@ async function updateRootPackageJson(projectDir: string, options: ProjectConfig)
       }
     }
     if (options.dbSetup === "docker") {
-      scripts["db:start"] = `turbo -F ${dbPackageName} db:start`;
-      scripts["db:watch"] = `turbo -F ${dbPackageName} db:watch`;
-      scripts["db:stop"] = `turbo -F ${dbPackageName} db:stop`;
-      scripts["db:down"] = `turbo -F ${dbPackageName} db:down`;
+      scripts["db:start"] = `turbo -F ${dbPackageName} --env-mode=loose db:start`;
+      scripts["db:watch"] = `turbo -F ${dbPackageName} --env-mode=loose db:watch`;
+      scripts["db:stop"] = `turbo -F ${dbPackageName} --env-mode=loose db:stop`;
+      scripts["db:down"] = `turbo -F ${dbPackageName} --env-mode=loose db:down`;
     }
   } else if (options.packageManager === "pnpm") {
     scripts.dev = devScript;


### PR DESCRIPTION
This fixes an issue when you are using both turborepo and docker compose where those commands will fail:
```
> docker compose up -d

unknown shorthand flag: 'd' in -d

Usage:  docker [OPTIONS] COMMAND [ARG...]

Run 'docker --help' for more information
 ELIFECYCLE  Command failed with exit code 125.
```
 
There is a closed issue in the turborepo repository proposing this fix.
See https://github.com/vercel/turborepo/issues/8653

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database management commands (start, watch, stop, down) to use an updated environment mode setting when Docker-based database setup is configured.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->