### PR TITLE
fix(cli): per-query invalidate on error in QueryClient

### DIFF
--- a/apps/cli/templates/api/orpc/web/react/base/src/utils/orpc.ts.hbs
+++ b/apps/cli/templates/api/orpc/web/react/base/src/utils/orpc.ts.hbs
@@ -15,13 +15,11 @@ import type { AppRouterClient } from "@{{projectName}}/api/routers/index";
 
 export const queryClient = new QueryClient({
   queryCache: new QueryCache({
-    onError: (error) => {
+    onError: (error, query) => {
       toast.error(`Error: ${error.message}`, {
         action: {
           label: "retry",
-          onClick: () => {
-            queryClient.invalidateQueries();
-          },
+          onClick: query.invalidate,
         },
       });
     },

--- a/apps/cli/templates/api/trpc/web/react/base/src/utils/trpc.ts.hbs
+++ b/apps/cli/templates/api/trpc/web/react/base/src/utils/trpc.ts.hbs
@@ -7,13 +7,11 @@ import { toast } from 'sonner';
 
 export const queryClient = new QueryClient({
   queryCache: new QueryCache({
-    onError: (error) => {
+    onError: (error, query) => {
       toast.error(error.message, {
         action: {
           label: "retry",
-          onClick: () => {
-            queryClient.invalidateQueries();
-          },
+          onClick: query.invalidate,
         },
       });
     },
@@ -63,13 +61,11 @@ import { toast } from "sonner";
 
 export const queryClient = new QueryClient({
   queryCache: new QueryCache({
-    onError: (error) => {
+    onError: (error, query) => {
       toast.error(error.message, {
         action: {
           label: "retry",
-          onClick: () => {
-            queryClient.invalidateQueries();
-          },
+          onClick: query.invalidate,
         },
       });
     },

--- a/apps/cli/templates/frontend/react/tanstack-start/src/router.tsx.hbs
+++ b/apps/cli/templates/frontend/react/tanstack-start/src/router.tsx.hbs
@@ -68,13 +68,11 @@ export function getRouter() {
   {{#if (eq api "trpc")}}
 export const queryClient = new QueryClient({
   queryCache: new QueryCache({
-    onError: (error) => {
+    onError: (error, query) => {
       toast.error(error.message, {
         action: {
           label: "retry",
-          onClick: () => {
-            queryClient.invalidateQueries();
-          },
+          onClick: query.invalidate,
         },
       });
     },


### PR DESCRIPTION
It's better to invalidate only the failed query on error instead of all queries. This PR updates the global error handler to retry just the specific query.

issue https://github.com/AmanVarshney01/create-better-t-stack/issues/726

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error recovery with more efficient, targeted query cache invalidation during retry operations across API and frontend templates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->