### PR TITLE
chore(cli): update better-auth

### DIFF
--- a/apps/cli/src/constants.ts
+++ b/apps/cli/src/constants.ts
@@ -42,8 +42,8 @@ export const DEFAULT_CONFIG = getDefaultConfig();
 export const dependencyVersionMap = {
   typescript: "^5",
 
-  "better-auth": "1.4.5",
-  "@better-auth/expo": "1.4.5",
+  "better-auth": "^1.4.7",
+  "@better-auth/expo": "^1.4.7",
 
   "@clerk/nextjs": "^6.31.5",
   "@clerk/clerk-react": "^5.45.0",


### PR DESCRIPTION
This pull request updates the version constraints for the `better-auth` and `@better-auth/expo` dependencies in the `dependencyVersionMap` to allow for more recent versions.

Dependency version updates:

* Updated `better-auth` and `@better-auth/expo` dependency versions from `1.4.5` to `^1.4.7` in `apps/cli/src/constants.ts`, allowing compatibility with patch and minor releases above `1.4.7`.

This fixes the issue #721 