### PR TITLE
fix(cli): sqlite without turso doesn't need db:local, added missing task db:local in turbo.json

### DIFF
--- a/apps/cli/src/helpers/core/create-readme.ts
+++ b/apps/cli/src/helpers/core/create-readme.ts
@@ -127,7 +127,7 @@ ${generateProjectStructure(projectName, frontend, backend, addons, isConvex, api
 
 ## Available Scripts
 
-${generateScriptsList(packageManagerRunCmd, database, orm, auth, hasNative, addons, backend)}
+${generateScriptsList(packageManagerRunCmd, database, orm, auth, hasNative, addons, backend, options.dbSetup)}
 `;
 }
 
@@ -488,7 +488,6 @@ function generateDatabaseSetup(
 
   const isBackendSelf = backend === "self";
   const envPath = isBackendSelf ? "apps/web/.env" : "apps/server/.env";
-  const dbLocalPath = "packages/db";
 
   let setup = "## Database Setup\n\n";
 
@@ -497,15 +496,13 @@ function generateDatabaseSetup(
       orm === "drizzle" ? " with Drizzle ORM" : orm === "prisma" ? " with Prisma" : ` with ${orm}`
     }.
 
-1. Start the local SQLite database:
+ 1. Start the local SQLite database (optional):
 ${
   dbSetup === "d1"
     ? "D1 local development and migrations are handled automatically by Alchemy during dev and deploy."
-    : dbSetup === "turso"
-      ? `\`\`\`bash
-cd ${dbLocalPath} && ${packageManagerRunCmd} db:local
+    : `\`\`\`bash
+${packageManagerRunCmd} db:local
 \`\`\``
-      : "SQLite local database are created automatically by the ORM."
 }
 
 2. Update your \`.env\` file in the \`${isBackendSelf ? "apps/web" : "apps/server"}\` directory with the appropriate connection details if needed.
@@ -566,6 +563,7 @@ function generateScriptsList(
   hasNative: boolean,
   addons: Addons[],
   backend: string,
+  dbSetup?: DatabaseSetup,
 ) {
   const isConvex = backend === "convex";
   const isBackendNone = backend === "none";
@@ -600,9 +598,9 @@ function generateScriptsList(
 - \`${packageManagerRunCmd} db:push\`: Push schema changes to database
 - \`${packageManagerRunCmd} db:studio\`: Open database studio UI`;
 
-    if (database === "sqlite" && orm === "drizzle") {
+    if (database === "sqlite" && dbSetup !== "d1") {
       scripts += `
-- \`cd packages/db && ${packageManagerRunCmd} db:local\`: Start the local SQLite database`;
+- \`${packageManagerRunCmd} db:local\`: Start the local SQLite database`;
     }
   }
 

--- a/apps/cli/src/helpers/core/post-installation.ts
+++ b/apps/cli/src/helpers/core/post-installation.ts
@@ -100,13 +100,9 @@ export async function displayPostInstallInstructions(
     output += `${pc.cyan(`${stepCounter++}.`)} ${packageManager} install\n`;
   }
 
-  if (
-    database === "sqlite" &&
-    dbSetup === "none" &&
-    (serverDeploy === "alchemy" || webDeploy === "alchemy")
-  ) {
+  if (database === "sqlite" && dbSetup !== "d1") {
     output += `${pc.cyan(`${stepCounter++}.`)} ${runCmd} db:local\n${pc.dim(
-      "   (starts local SQLite server for Workers compatibility)",
+      "   (optional - starts local SQLite database)",
     )}\n`;
   }
 

--- a/apps/cli/src/helpers/core/project-config.ts
+++ b/apps/cli/src/helpers/core/project-config.ts
@@ -81,7 +81,7 @@ async function updateRootPackageJson(projectDir: string, options: ProjectConfig)
     }
   }
 
-  if (database === "sqlite" && orm !== "none" && dbSetup === "turso") {
+  if (database === "sqlite" && dbSetup !== "d1") {
     scripts["db:local"] = pmConfig.filter(dbPackageName, "db:local");
   }
 
@@ -187,7 +187,7 @@ async function updateDbPackageJson(projectDir: string, options: ProjectConfig) {
   const isD1Alchemy = dbSetup === "d1" && serverDeploy === "alchemy";
 
   if (database !== "none") {
-    if (database === "sqlite" && orm !== "none" && dbSetup === "turso") {
+    if (database === "sqlite" && dbSetup !== "d1") {
       scripts["db:local"] = "turso dev --db-file local.db";
     }
 

--- a/apps/cli/templates/addons/turborepo/turbo.json.hbs
+++ b/apps/cli/templates/addons/turborepo/turbo.json.hbs
@@ -55,9 +55,8 @@
 		"db:down": {
 			"cache": false,
 			"persistent": true
-		}
-		{{/if}}
-		{{#if (eq dbSetup "turso")}},
+		}{{/if}}
+		{{#if (and (eq database "sqlite") (ne dbSetup "d1"))}},
 		"db:local": {
 			"cache": false,
 			"persistent": true


### PR DESCRIPTION
ORM(Prisma and Drizzle) creates the local file automatically.

db:local is dependent on turso cli. So, I removed it when turso is not selected by user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now inserts a direct local DB command in generated setup instructions for SQLite projects when local DB setup is enabled, regardless of ORM choice.
  * Turborepo task templates include the local DB task for applicable SQLite setups.

* **Bug Fixes / Improvements**
  * Post-installation messaging marks starting the local SQLite DB as optional and clarifies the instruction wording.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **SQLite local DB flow updated**
> 
> - README: marks starting SQLite as optional; simplifies command to `db:local`; passes `dbSetup` to script generation
> - Scripts: adds `db:local` when `database=sqlite` and `dbSetup ≠ d1`; updates script text to run from root
> - Post-install: includes optional `db:local` step under the same condition
> - Turborepo template: adds `db:local` task for applicable SQLite setups
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ce40e747db5b3022603db13afed166a82aba29c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->