### PR TITLE
fix(cli): remove PORT env from express server

### DIFF
--- a/apps/cli/templates/backend/server/express/src/index.ts.hbs
+++ b/apps/cli/templates/backend/server/express/src/index.ts.hbs
@@ -116,7 +116,6 @@ app.get("/", (_req, res) => {
 	res.status(200).send("OK");
 });
 
-const port = env.PORT;
-app.listen(port, () => {
-	console.log(`Server is running on port ${port}`);
+app.listen(3000, () => {
+	console.log("Server is running on http://localhost:3000");
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Server now starts on a fixed port 3000 instead of using environment-based port configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->