### PR TITLE
fix(cli): use simple RPCLink for tanstack-start with separate backends

### DIFF
--- a/apps/cli/templates/api/orpc/web/react/base/src/utils/orpc.ts.hbs
+++ b/apps/cli/templates/api/orpc/web/react/base/src/utils/orpc.ts.hbs
@@ -3,15 +3,16 @@ import { RPCLink } from "@orpc/client/fetch";
 import { createTanstackQueryUtils } from "@orpc/tanstack-query";
 import { QueryCache, QueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-{{#if (includes frontend "tanstack-start")}}
+{{#if (and (includes frontend "tanstack-start") (eq backend "self"))}}
 import { createRouterClient } from "@orpc/server";
 import type { RouterClient } from "@orpc/server";
 import { createIsomorphicFn } from "@tanstack/react-start";
 import { appRouter } from "@{{projectName}}/api/routers/index";
 import { createContext } from "@{{projectName}}/api/context";
-{{#unless (eq backend "self")}}
+{{else if (includes frontend "tanstack-start")}}
+import type { RouterClient } from "@orpc/server";
+import { appRouter } from "@{{projectName}}/api/routers/index";
 import { env } from "@{{projectName}}/env/web";
-{{/unless}}
 {{else}}
 import type { AppRouterClient } from "@{{projectName}}/api/routers/index";
 {{#unless (eq backend "self")}}
@@ -32,30 +33,18 @@ export const queryClient = new QueryClient({
 	}),
 });
 
-{{#if (includes frontend "tanstack-start")}}
+{{#if (and (includes frontend "tanstack-start") (eq backend "self"))}}
 const getORPCClient = createIsomorphicFn()
 	.server(() =>
 		createRouterClient(appRouter, {
 			context: async ({ req }) => {
-{{#if (eq backend "self")}}
 				return createContext({ req });
-{{else if (eq backend "hono")}}
-				return createContext({ context: req });
-{{else if (eq backend "elysia")}}
-				return createContext({ context: req });
-{{else if (eq backend "express")}}
-				return createContext({ req });
-{{else if (eq backend "fastify")}}
-				return createContext(req.headers);
-{{else}}
-				return createContext();
-{{/if}}
 			},
 		}),
 	)
 	.client((): RouterClient<typeof appRouter> => {
 			const link = new RPCLink({
-			url: {{#if (eq backend "self")}}`${window.location.origin}/api/rpc`{{else}}`${env.VITE_SERVER_URL}/rpc`{{/if}},
+			url: `${window.location.origin}/api/rpc`,
 {{#if (eq auth "better-auth")}}
 			fetch(url, options) {
 				return fetch(url, {
@@ -68,6 +57,24 @@ const getORPCClient = createIsomorphicFn()
 
 		return createORPCClient(link);
 	});
+
+export const client: RouterClient<typeof appRouter> = getORPCClient();
+{{else if (includes frontend "tanstack-start")}}
+const link = new RPCLink({
+	url: `${env.VITE_SERVER_URL}/rpc`,
+{{#if (eq auth "better-auth")}}
+	fetch(url, options) {
+		return fetch(url, {
+			...options,
+			credentials: "include",
+		});
+	},
+{{/if}}
+});
+
+const getORPCClient = () => {
+	return createORPCClient(link) as RouterClient<typeof appRouter>;
+};
 
 export const client: RouterClient<typeof appRouter> = getORPCClient();
 {{else}}
@@ -103,3 +110,4 @@ export const client: AppRouterClient = createORPCClient(link)
 {{/if}}
 
 export const orpc = createTanstackQueryUtils(client)
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined RPC client configuration and initialization for improved consistency.
  * Standardized API client exports and URL construction across different backend configurations.
  * Reorganized conditional logic for clearer handling of framework-specific client setup paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->