### PR TITLE
fix(cli): use type-only import for AppRouter in tanstack-start with separate backend

### DIFF
--- a/apps/cli/templates/api/orpc/web/react/base/src/utils/orpc.ts.hbs
+++ b/apps/cli/templates/api/orpc/web/react/base/src/utils/orpc.ts.hbs
@@ -11,7 +11,7 @@ import { appRouter } from "@{{projectName}}/api/routers/index";
 import { createContext } from "@{{projectName}}/api/context";
 {{else if (includes frontend "tanstack-start")}}
 import type { RouterClient } from "@orpc/server";
-import { appRouter } from "@{{projectName}}/api/routers/index";
+import type { AppRouter } from "@{{projectName}}/api/routers/index";
 import { env } from "@{{projectName}}/env/web";
 {{else}}
 import type { AppRouterClient } from "@{{projectName}}/api/routers/index";
@@ -73,10 +73,10 @@ const link = new RPCLink({
 });
 
 const getORPCClient = () => {
-	return createORPCClient(link) as RouterClient<typeof appRouter>;
+	return createORPCClient(link) as RouterClient<AppRouter>;
 };
 
-export const client: RouterClient<typeof appRouter> = getORPCClient();
+export const client: RouterClient<AppRouter> = getORPCClient();
 {{else}}
 export const link = new RPCLink({
 {{#if (and (eq backend "self") (includes frontend "next"))}}


### PR DESCRIPTION
## Summary

- Changes `import { appRouter }` to `import type { AppRouter }` for tanstack-start with separate backend configuration
- Updates type references from `RouterClient<typeof appRouter>` to `RouterClient<AppRouter>`

## Problem

When using tanstack-start with a separate backend, the oRPC client template was importing `appRouter` as a runtime value. This caused the entire API module chain to be executed at import time:

```
apps/web/src/utils/orpc.ts
    └── import { appRouter } → packages/api/src/routers/index.ts
                                    └── packages/api/src/routers/todo.ts
                                            └── import { db } → packages/db/src/index.ts
                                                                    └── import { env } from "@project/env/server"
                                                                                └── VALIDATES SERVER ENV VARS ❌
```

Since server env vars (`DATABASE_URL`, `BETTER_AUTH_SECRET`, etc.) aren't available in the client-side web app, this caused validation errors on startup:

```
Invalid environment variables: [
  { path: ['DATABASE_URL'], message: 'Invalid input: expected string, received undefined' },
  { path: ['BETTER_AUTH_SECRET'], message: 'Invalid input: expected string, received undefined' },
  ...
]
```

## Solution

Type-only imports (`import type { ... }`) are erased at compile time and don't execute runtime code, avoiding the module chain execution.

This only affects the `tanstack-start + separate backend` case. The fullstack case (`backend: "self"`) correctly uses the runtime import since it needs `appRouter` for `createRouterClient()` and server env vars are available.

## Regression

Introduced in #768.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type declarations in API client configuration for enhanced type safety.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->