### PR TITLE
fix: Replace 'claude' with 'windsurf' in ultracite hooks selection to match the hooks provided by ultracite docs and avoid errors

### DIFF
--- a/apps/cli/src/helpers/addons/ultracite-setup.ts
+++ b/apps/cli/src/helpers/addons/ultracite-setup.ts
@@ -30,7 +30,7 @@ type UltraciteAgent =
   | "goose"
   | "roo-code";
 
-type UltraciteHook = "cursor" | "claude";
+type UltraciteHook = "cursor" | "windsurf";
 
 const EDITORS = {
   vscode: {
@@ -102,8 +102,8 @@ const HOOKS = {
   cursor: {
     label: "Cursor",
   },
-  claude: {
-    label: "Claude",
+  windsurf: {
+    label: "Windsurf",
   },
 } as const;
 


### PR DESCRIPTION
Hey there,

I got an error when I ran the following command due to ultracite not supporting "claude" hooks.

Reference showing they only support Cursor & Windsurf hooks:  https://docs.ultracite.ai/hooks

**Command I ran:**

```bash
bun create better-t-stack@latest my-app --frontend tanstack-start --backend convex --runtime none --api none --auth clerk --payments none --database none --orm none --db-setup none --package-manager bun --git --web-deploy cloudflare --server-deploy none --install --addons biome turborepo ultracite --examples ai
```

**This is the error I got:**

```
◐  Running Ultracite init command.│
■  Failed to set up Ultracite
Command failed with exit code 1: bunx 'ultracite@latest' init --pm bun --frameworks react --editors vscode --agents codex claude --hooks claude --skip-install

Resolving dependencies
Resolved, downloaded and extracted [2]
Saved lockfile
✖ Invalid option: expected one of "cursor"|"windsurf" → at hooks[0]
```

**Full log:**

```
┌  Creating a new Better-T-Stack project
│
●  Using these pre-selected options:
│
│  Frontend: tanstack-start
│  Backend: convex
│  Runtime: none
│  API: none
│  Database: none
│  ORM: none
│  Auth: clerk
│  Payments: none
│  Addons: biome, turborepo, ultracite
│  Examples: ai
│  Git Init: Yes
│  Package Manager: bun
│  Install Dependencies: Yes
│  Database Setup: none
│  Web Deployment: cloudflare
│  Server Deployment: none
│
│
│
●  Setting up Ultracite...
│
◇  Choose editors
│  VSCode / Cursor / Windsurf
│
◇  Choose agents
│  2 items selected
│
◇  Choose hooks
│  1 items selected
│
◐  Running Ultracite init command.│
■  Failed to set up Ultracite
Command failed with exit code 1: bunx 'ultracite@latest' init --pm bun --frameworks react --editors vscode --agents codex claude --hooks claude --skip-install

Resolving dependencies
Resolved, downloaded and extracted [2]
Saved lockfile
✖ Invalid option: expected one of "cursor"|"windsurf" → at hooks[0]

Usage: ultracite init [options]

Initialize Ultracite in the current directory

Options:
  --pm [string]               Package manager to use (choices: "npm", "pnpm",
                              "bun", "yarn", "deno")
  --linter [string]           Linter / formatter to use (choices: "biome",
                              "eslint", "oxlint")
  --editors [values...]       Type: string Editors to configure array (choices:
                              "vscode", "cursor", "windsurf", "antigravity",
                              "kiro", "trae", "void", "zed")
  --agents [values...]        Type: string Agents to enable array (choices:
                              "claude", "codex", "jules", "copilot", "cline",
                              "amp", "aider", "firebase-studio", "open-hands",
                              "gemini", "junie", "augmentcode", "kilo-code",
                              "goose", "roo-code", "warp", "droid", "opencode",
                              "crush", "qwen", "amazon-q-cli", "firebender")
  --hooks [values...]         Type: string Hooks to enable array (choices:
                              "cursor", "windsurf")
  --frameworks [values...]    Type: string Frameworks being used array (choices:
                              "react", "next", "solid", "vue", "svelte", "qwik",
                              "remix", "angular", "astro")
  --integrations [values...]  Type: string Additional integrations to enable
                              array (choices: "husky", "lefthook",
                              "lint-staged", "pre-commit")
  --migrate [values...]       Type: string Migration tools to remove (e.g.,
                              eslint, prettier). Removes dependencies, config
                              files, and editor settings. array (choices:
                              "eslint", "prettier")
  --type-aware [boolean]      enable type-aware linting (oxlint only, installs
                              oxlint-tsgolint)
  --skip-install [boolean]    Skip installing dependencies (default: false)
  --quiet [boolean]           Suppress all interactive prompts and visual
                              output. Automatically enabled in CI environments.
                              (default: true)
  -h, --help                  display help for command
◓  Running Ultracite init command.│
◆  Project template successfully scaffolded!
```

