### PR TITLE
Add analytics seed data and fix chart display issues on mobile

### DIFF
--- a/apps/web/src/app/(home)/analytics/_components/dev-environment-charts.tsx
+++ b/apps/web/src/app/(home)/analytics/_components/dev-environment-charts.tsx
@@ -58,7 +58,7 @@ function VerticalBarChart({ data, height = 280 }: { data: Distribution; height?:
           tickMargin={10}
           tickFormatter={(value) => (value.length > 20 ? `${value.slice(0, 20)}…` : value)}
         />
-        <YAxis tickLine={false} axisLine={false} width={16} />
+        <YAxis tickLine={false} axisLine={false} />
         <ChartTooltip content={<ChartTooltipContent nameKey="name" />} />
         <Bar dataKey="value" radius={4}>
           {data.map((entry, index) => (
@@ -88,7 +88,7 @@ function VersionBarChart({ data, height = 280 }: { data: VersionDistribution; he
           tickMargin={10}
           tickFormatter={(value) => (value.length > 7 ? `${value.slice(0, 7)}…` : value)}
         />
-        <YAxis tickLine={false} axisLine={false} width={16} />
+        <YAxis tickLine={false} axisLine={false} />
         <ChartTooltip content={<ChartTooltipContent hideIndicator />} />
         <Bar dataKey="count" fill="var(--chart-5)" radius={4} />
       </BarChart>

--- a/apps/web/src/app/(home)/analytics/_components/stack-configuration-charts.tsx
+++ b/apps/web/src/app/(home)/analytics/_components/stack-configuration-charts.tsx
@@ -52,7 +52,7 @@ function BarChartComponent({ data, height = 280 }: { data: Distribution; height?
           tickMargin={10}
           tickFormatter={(value) => (value.length > 20 ? `${value.slice(0, 20)}…` : value)}
         />
-        <YAxis tickLine={false} axisLine={false} width={16} />
+        <YAxis tickLine={false} axisLine={false} />
         <ChartTooltip content={<ChartTooltipContent nameKey="name" />} />
         <Bar dataKey="value" radius={4}>
           {data.map((entry, index) => (

--- a/apps/web/src/app/(home)/analytics/_components/timeline-charts.tsx
+++ b/apps/web/src/app/(home)/analytics/_components/timeline-charts.tsx
@@ -85,7 +85,7 @@ export function TimelineSection({ data }: { data: AggregatedAnalyticsData }) {
                 tickFormatter={(val) => format(parseISO(val), "d")}
                 interval="preserveStartEnd"
               />
-              <YAxis tickLine={false} axisLine={false} width={16} />
+              <YAxis tickLine={false} axisLine={false} />
               <ChartTooltip
                 content={
                   <ChartTooltipContent
@@ -123,7 +123,7 @@ export function TimelineSection({ data }: { data: AggregatedAnalyticsData }) {
                 tickMargin={10}
                 tickFormatter={(val) => val.slice(5)}
               />
-              <YAxis tickLine={false} axisLine={false} width={16} />
+              <YAxis tickLine={false} axisLine={false} />
               <ChartTooltip content={<ChartTooltipContent hideIndicator />} />
               <Bar dataKey="count" fill="var(--chart-2)" radius={4} />
             </BarChart>
@@ -171,7 +171,7 @@ export function TimelineSection({ data }: { data: AggregatedAnalyticsData }) {
                 interval={3}
                 tickFormatter={(val) => val.replace(":00", "")}
               />
-              <YAxis tickLine={false} axisLine={false} width={16} />
+              <YAxis tickLine={false} axisLine={false} />
               <ChartTooltip
                 content={
                   <ChartTooltipContent labelFormatter={(value) => `${value} UTC`} hideIndicator />

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -12,7 +12,6 @@ import type * as analytics from "../analytics.js";
 import type * as healthCheck from "../healthCheck.js";
 import type * as hooks from "../hooks.js";
 import type * as http from "../http.js";
-import type * as seed from "../seed.js";
 import type * as showcase from "../showcase.js";
 import type * as stats from "../stats.js";
 import type * as testimonials from "../testimonials.js";
@@ -28,7 +27,6 @@ declare const fullApi: ApiFromModules<{
   healthCheck: typeof healthCheck;
   hooks: typeof hooks;
   http: typeof http;
-  seed: typeof seed;
   showcase: typeof showcase;
   stats: typeof stats;
   testimonials: typeof testimonials;


### PR DESCRIPTION
## Add analytics seed data and fix chart display issues on mobile

### Changes

#### 1. Add seed file for analytics data (`packages/backend/convex/seed.ts`)

Added a seed file to generate mock analytics data for development and testing purposes. The seed file:

- Generates realistic project creation events with randomized stack configurations
- Covers all supported options: databases, ORMs, backends, runtimes, frontends, addons, etc.
- Includes time-based distribution for testing timeline charts
- Provides `seedAnalytics` mutation for populating test data

#### 2. Fix chart overflow on mobile devices

**Problem**: Chart cards were overflowing vertically on smaller screens.

**Cause**: The `ChartContainer` component has `aspect-video` (16:9) in its base className, which conflicted with explicit `h-[280px]` heights on constrained mobile widths.

**Solution**: Added `aspect-auto` to all `ChartContainer` instances to override the base aspect ratio.

#### 3. Fix excessive left padding in charts

**Problem**: Large empty space on the left side of charts.

**Cause**: Recharts' `YAxis` component defaults to 60px width.

**Solution**: Set `width={16}` on all `YAxis` components.

### Files Changed

- `packages/backend/convex/seed.ts` (new)
- `apps/web/src/app/(home)/analytics/_components/timeline-charts.tsx`
- `apps/web/src/app/(home)/analytics/_components/stack-configuration-charts.tsx`
- `apps/web/src/app/(home)/analytics/_components/dev-environment-charts.tsx`

### Testing

- Verified seed data generates correctly
- Charts render properly on mobile viewports
- No y-axis overflow
- Reduced left padding improves chart visibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated responsive sizing properties for analytics chart components to improve display behavior across different screen dimensions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses chart overflow on small screens by overriding the base aspect ratio on analytics charts.
> 
> - Adds `aspect-auto` to all `ChartContainer` instances in `timeline-charts.tsx`, `stack-configuration-charts.tsx`, and `dev-environment-charts.tsx` so charts respect explicit heights and don’t vertically overflow on mobile
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0385e9346efa6e3c843836640899543268ff96c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->