### PR TITLE
feat(cli): add Clerk and Expo MCP recommendations

### DIFF
--- a/apps/cli/src/helpers/addons/mcp-setup.ts
+++ b/apps/cli/src/helpers/addons/mcp-setup.ts
@@ -55,6 +55,14 @@ function hasReactBasedFrontend(frontend: ProjectConfig["frontend"]): boolean {
   );
 }
 
+function hasNativeFrontend(frontend: ProjectConfig["frontend"]): boolean {
+  return (
+    frontend.includes("native-bare") ||
+    frontend.includes("native-uniwind") ||
+    frontend.includes("native-unistyles")
+  );
+}
+
 function getRecommendedMcpServers(config: ProjectConfig): McpServerDef[] {
   const servers: McpServerDef[] = [];
 
@@ -174,6 +182,24 @@ function getRecommendedMcpServers(config: ProjectConfig): McpServerDef[] {
       label: "Better Auth",
       name: "better-auth",
       target: "https://mcp.inkeep.com/better-auth/mcp",
+    });
+  }
+
+  if (config.auth === "clerk") {
+    servers.push({
+      key: "clerk",
+      label: "Clerk",
+      name: "clerk",
+      target: "https://mcp.clerk.com/mcp",
+    });
+  }
+
+  if (hasNativeFrontend(config.frontend)) {
+    servers.push({
+      key: "expo",
+      label: "Expo",
+      name: "expo-mcp",
+      target: "https://mcp.expo.dev/mcp",
     });
   }
 


### PR DESCRIPTION
## Summary
- add Clerk MCP recommendation when auth is set to Clerk
- add Expo MCP recommendation when any native frontend is selected
- keep curated MCP selection locked and conditional by stack

## Changes
- updated `apps/cli/src/helpers/addons/mcp-setup.ts`
  - added `hasNativeFrontend()` helper
  - added Clerk MCP (`https://mcp.clerk.com/mcp`)
  - added Expo MCP (`https://mcp.expo.dev/mcp`)

## Validation
- `bun test` in `apps/cli`
- `bun run build` at repo root


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced MCP server recommendations: Clerk MCP server is now recommended for projects using Clerk authentication, and Expo MCP server is recommended for native app projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->