### PR TITLE
fix(web): Use Input component in stack builder

### DIFF
--- a/apps/web/src/app/(home)/new/_components/stack-builder/index.tsx
+++ b/apps/web/src/app/(home)/new/_components/stack-builder/index.tsx
@@ -8,6 +8,7 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
@@ -86,21 +87,22 @@ export function StackBuilder() {
         <div className="hidden h-full flex-1 grid-cols-[24rem_minmax(0,1fr)] overflow-hidden border-border sm:grid">
           <aside className="flex min-h-0 flex-col overflow-hidden border-border/50 border-r bg-fd-background">
             <ScrollArea className="min-h-0 flex-1">
-              <div className="p-3">
-                <div className="overflow-hidden rounded-2xl bg-fd-background/80 ring-1 ring-border/35">
-                  <section className="space-y-2 border-border/20 border-b px-3 py-3">
+              <div className="p-2">
+                <div className="overflow-hidden rounded-2xl bg-fd-background/80">
+                  <section className="space-y-2 border-b border-border/20 px-3 py-3">
                     <label className="flex flex-col">
                       <span className="mb-1 font-mono text-[11px] text-muted-foreground uppercase tracking-wide">
                         Project Name
                       </span>
-                      <input
+                      <Input
                         type="text"
                         value={stack.projectName || ""}
                         onChange={(event) => {
                           setStack({ projectName: event.target.value });
                         }}
+                        aria-invalid={!!projectNameError}
                         className={cn(
-                          "builder-focus-ring w-full rounded-lg border bg-background/80 px-2.5 py-1.5 font-mono text-sm focus:outline-none",
+                          "builder-focus-ring w-full rounded-lg px-2.5 py-1.5 font-mono text-sm focus:outline-none",
                           projectNameError
                             ? "border-destructive bg-destructive/10 text-destructive-foreground"
                             : "border-border/60 focus:border-primary",
@@ -149,10 +151,9 @@ export function StackBuilder() {
                       }}
                       aria-label="Copy CLI command"
                       title="Click to copy command"
-                      className="builder-focus-ring cursor-pointer rounded-lg bg-background/75 px-2.5 py-2"
+                      className="builder-focus-ring cursor-pointer rounded-lg bg-muted/20 px-2.5 py-2"
                     >
                       <div className="flex items-start gap-2">
-                        <span className="select-none text-chart-4">$</span>
                         <code className="block break-all font-mono text-muted-foreground text-xs">
                           {command}
                         </code>
@@ -193,8 +194,8 @@ export function StackBuilder() {
               </div>
             </ScrollArea>
 
-            <div className="border-border/35 border-t bg-fd-background/95 p-3">
-              <div className="rounded-2xl bg-fd-background/80 p-3 ring-1 ring-border/35">
+            <div className="border-border/35 border-t bg-fd-background/95 p-2">
+              <div className="rounded-2xl bg-fd-background/80 p-2">
                 <ActionButtons
                   onReset={resetStack}
                   onRandom={getRandomStack}
@@ -271,7 +272,7 @@ export function StackBuilder() {
             {viewMode === "command" ? (
               <div ref={scrollAreaRef} className="h-full">
                 <ScrollArea className="h-full overflow-hidden scroll-smooth">
-                  <main className="p-3 sm:p-4">
+                  <main className="p-2 sm:p-4">
                     <TechCategories
                       mode="desktop"
                       stack={stack}
@@ -296,18 +297,19 @@ export function StackBuilder() {
           {mobileTab === "build" && (
             <div className="flex min-h-0 flex-1 flex-col">
               <ScrollArea className="h-full overflow-hidden scroll-smooth">
-                <main className="p-3 pb-6">
-                  <div className="mb-4 space-y-2 rounded-xl bg-muted/10 p-3">
+                <main className="p-2 pb-6">
+                  <div className="mb-4 space-y-2 rounded-xl bg-muted/10 p-2">
                     <label className="flex flex-col">
                       <span className="mb-1 font-mono text-[11px] text-muted-foreground uppercase tracking-wide">
                         Project Name
                       </span>
-                      <input
+                      <Input
                         type="text"
                         value={stack.projectName || ""}
                         onChange={(event) => {
                           setStack({ projectName: event.target.value });
                         }}
+                        aria-invalid={!!projectNameError}
                         className={cn(
                           "builder-focus-ring w-full rounded-lg border bg-background/75 px-2.5 py-1.5 font-mono text-sm focus:outline-none",
                           projectNameError
@@ -377,8 +379,8 @@ export function StackBuilder() {
                 </main>
               </ScrollArea>
 
-              <div className="border-border/35 border-t bg-fd-background/95 p-3 backdrop-blur-sm">
-                <div className="rounded-xl bg-fd-background/80 p-3 ring-1 ring-border/35">
+              <div className="border-border/35 border-t bg-fd-background/95 p-2 backdrop-blur-sm">
+                <div className="rounded-xl bg-fd-background/80 p-2">
                   <ActionButtons
                     onReset={resetStack}
                     onRandom={getRandomStack}

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -1,0 +1,20 @@
+import { Input as InputPrimitive } from "@base-ui/react/input";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <InputPrimitive
+      type={type}
+      data-slot="input"
+      className={cn(
+        "dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 disabled:bg-input/50 dark:disabled:bg-input/80 h-8 rounded-none border bg-transparent px-2.5 py-1 text-xs transition-colors file:h-6 file:text-xs file:font-medium focus-visible:ring-1 aria-invalid:ring-1 md:text-xs file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Input };


### PR DESCRIPTION
## Summary
Replaces native `<input>` elements in the stack builder with the shared `Input` component.

## Changes
- **Add** `Input` component (`apps/web/src/components/ui/input.tsx`) wrapping `@base-ui/react/input`
- **Replace** Project Name inputs in desktop and mobile views with `Input`
- **Add** `aria-invalid` for error state accessibility

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced improved form input component with enhanced accessibility features.

* **Improvements**
  * Added error state indicators on form inputs for better user feedback.
  * Updated copy-to-clipboard button to display state feedback (e.g., "Copied").
  * Refined spacing and padding across UI panels for consistency.
  * Enhanced mobile and responsive layout adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->