### PR TITLE
fix: remove neonConfig WebSocket override for Bun+Docker compatibility

### DIFF
--- a/packages/template-generator/src/processors/db-deps.ts
+++ b/packages/template-generator/src/processors/db-deps.ts
@@ -61,8 +61,7 @@ function processPrismaDeps(
     deps.push(dbSetup === "d1" ? "@prisma/adapter-d1" : "@prisma/adapter-libsql");
   } else if (database === "postgres") {
     if (dbSetup === "neon") {
-      deps.push("@prisma/adapter-neon", "@neondatabase/serverless", "ws");
-      devDeps.push("@types/ws");
+      deps.push("@prisma/adapter-neon", "@neondatabase/serverless");
     } else if (dbSetup === "prisma-postgres") {
       deps.push("@prisma/adapter-pg", "pg");
       devDeps.push("@types/pg");
@@ -112,8 +111,7 @@ function processDrizzleDeps(
     const devDeps: AvailableDependencies[] = ["drizzle-kit"];
 
     if (dbSetup === "neon") {
-      deps.push("@neondatabase/serverless", "ws");
-      devDeps.push("@types/ws");
+      deps.push("@neondatabase/serverless");
     } else {
       deps.push("pg");
       devDeps.push("@types/pg");

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -11249,14 +11249,8 @@ import { env } from "@{{projectName}}/env/server";
 import * as schema from "./schema";
 
 {{#if (eq dbSetup "neon")}}
-import { neon, neonConfig } from '@neondatabase/serverless';
+import { neon } from '@neondatabase/serverless';
 import { drizzle } from 'drizzle-orm/neon-http';
-import ws from "ws";
-
-neonConfig.webSocketConstructor = ws;
-
-// To work in edge environments (Cloudflare Workers, Vercel Edge, etc.), enable querying over fetch
-// neonConfig.poolQueryViaFetch = true
 
 const sql = neon(env.DATABASE_URL);
 export const db = drizzle(sql, { schema });
@@ -11271,13 +11265,9 @@ export const db = drizzle(env.DATABASE_URL, { schema });
 import * as schema from "./schema";
 
 {{#if (eq dbSetup "neon")}}
-import { neon, neonConfig } from '@neondatabase/serverless';
+import { neon } from '@neondatabase/serverless';
 import { drizzle } from 'drizzle-orm/neon-http';
 import { env } from "@{{projectName}}/env/server";
-import ws from "ws";
-
-neonConfig.webSocketConstructor = ws;
-neonConfig.poolQueryViaFetch = true;
 
 const sql = neon(env.DATABASE_URL || "");
 export const db = drizzle(sql, { schema });
@@ -11592,11 +11582,6 @@ import { PrismaClient } from "../prisma/generated/client";
 import { env } from "@{{projectName}}/env/server";
 {{#if (eq dbSetup "neon")}}
 import { PrismaNeon } from "@prisma/adapter-neon";
-import { neonConfig } from "@neondatabase/serverless";
-import ws from "ws";
-
-neonConfig.webSocketConstructor = ws;
-neonConfig.poolQueryViaFetch = true;
 
 const adapter = new PrismaNeon({
 	connectionString: env.DATABASE_URL,

--- a/packages/template-generator/templates/db/drizzle/postgres/src/index.ts.hbs
+++ b/packages/template-generator/templates/db/drizzle/postgres/src/index.ts.hbs
@@ -3,14 +3,8 @@ import { env } from "@{{projectName}}/env/server";
 import * as schema from "./schema";
 
 {{#if (eq dbSetup "neon")}}
-import { neon, neonConfig } from '@neondatabase/serverless';
+import { neon } from '@neondatabase/serverless';
 import { drizzle } from 'drizzle-orm/neon-http';
-import ws from "ws";
-
-neonConfig.webSocketConstructor = ws;
-
-// To work in edge environments (Cloudflare Workers, Vercel Edge, etc.), enable querying over fetch
-// neonConfig.poolQueryViaFetch = true
 
 const sql = neon(env.DATABASE_URL);
 export const db = drizzle(sql, { schema });
@@ -25,13 +19,9 @@ export const db = drizzle(env.DATABASE_URL, { schema });
 import * as schema from "./schema";
 
 {{#if (eq dbSetup "neon")}}
-import { neon, neonConfig } from '@neondatabase/serverless';
+import { neon } from '@neondatabase/serverless';
 import { drizzle } from 'drizzle-orm/neon-http';
 import { env } from "@{{projectName}}/env/server";
-import ws from "ws";
-
-neonConfig.webSocketConstructor = ws;
-neonConfig.poolQueryViaFetch = true;
 
 const sql = neon(env.DATABASE_URL || "");
 export const db = drizzle(sql, { schema });

--- a/packages/template-generator/templates/db/prisma/postgres/src/index.ts.hbs
+++ b/packages/template-generator/templates/db/prisma/postgres/src/index.ts.hbs
@@ -36,11 +36,6 @@ import { PrismaClient } from "../prisma/generated/client";
 import { env } from "@{{projectName}}/env/server";
 {{#if (eq dbSetup "neon")}}
 import { PrismaNeon } from "@prisma/adapter-neon";
-import { neonConfig } from "@neondatabase/serverless";
-import ws from "ws";
-
-neonConfig.webSocketConstructor = ws;
-neonConfig.poolQueryViaFetch = true;
 
 const adapter = new PrismaNeon({
 	connectionString: env.DATABASE_URL,


### PR DESCRIPTION
## Summary

Addresses #879 - Bun runtime + Prisma Neon adapter: WebSocket constructor override causes production failure in Docker.

## Problem

Using `neonConfig.webSocketConstructor = ws` (Node's ws library) in a Bun environment caused `Unexpected server response: 101` in Docker. Forcing Node's ws implementation inside Bun runtime caused protocol upgrade mismatches in containerized environments.

## Solution

- **Drizzle**: Remove all neonConfig. Use Neon HTTP driver (`neon-http`) with `neon()` + `drizzle()` only - uses fetch by default, no WebSocket required.
- **Prisma (Node/Bun)**: Remove neonConfig entirely. Use PrismaNeon adapter without config - driver auto-detects runtime.
- **Prisma (Workers)**: Keep `poolQueryViaFetch = true` for edge runtime.
- **Dependencies**: Remove `ws` and `@types/ws` from Neon setup (both Prisma and Drizzle).

Aligns with official [Neon Drizzle docs](https://neon.tech/docs/drizzle) and [Neon Prisma docs](https://neon.tech/docs/prisma).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed WebSocket support and the "ws" package dependency from Neon PostgreSQL database configurations in both Prisma and Drizzle ORM template generation
  * Eliminated WebSocket constructor assignments and edge-fetch pool query optimization configurations from Neon adapter initialization
  * Simplified database template initialization by using Neon serverless adapter in its default configuration without explicit overrides

<!-- end of auto-generated comment: release notes by coderabbit.ai -->