### PR TITLE
[Experimental] web: migrate apps/web to Vague theme

### DIFF
--- a/apps/web/public/favicon/favicon.svg
+++ b/apps/web/public/favicon/favicon.svg
@@ -1,20 +1,20 @@
 <svg width="96" height="96" viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg">
   <style>
     :root {
-      --logo-bg: #f5eeff;
-      --logo-stroke: #b79aff;
-      --logo-dot-1: #8839ef;
-      --logo-dot-2: #cba6f7;
-      --logo-glyph: #8839ef;
+      --logo-bg: #f3f2f7;
+      --logo-stroke: #c9c8d4;
+      --logo-dot-1: #6e94b2;
+      --logo-dot-2: #bb9dbd;
+      --logo-glyph: #6e94b2;
     }
 
     @media (prefers-color-scheme: dark) {
       :root {
-        --logo-bg: #181825;
-        --logo-stroke: #6c7086;
-        --logo-dot-1: #cba6f7;
-        --logo-dot-2: #b4befe;
-        --logo-glyph: #cba6f7;
+        --logo-bg: #202022;
+        --logo-stroke: #333738;
+        --logo-dot-1: #9bb4bc;
+        --logo-dot-2: #bb9dbd;
+        --logo-glyph: #9bb4bc;
       }
     }
   </style>

--- a/apps/web/public/favicon/site.webmanifest
+++ b/apps/web/public/favicon/site.webmanifest
@@ -15,7 +15,7 @@
       "purpose": "maskable"
     }
   ],
-  "theme_color": "#ffffff",
-  "background_color": "#ffffff",
+  "theme_color": "#9bb4bc",
+  "background_color": "#141415",
   "display": "standalone"
 }

--- a/apps/web/public/logo-dark.svg
+++ b/apps/web/public/logo-dark.svg
@@ -1,5 +1,5 @@
 <svg width="96" height="96" viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect x="8" y="8" width="80" height="80" rx="16" fill="#181825" stroke="#6C7086" stroke-width="3"/>
+  <rect x="8" y="8" width="80" height="80" rx="16" fill="#202022" stroke="#333738" stroke-width="3"/>
   <text
     x="48"
     y="50"
@@ -8,7 +8,7 @@
     font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, monospace"
     font-size="34"
     font-weight="700"
-    fill="#CBA6F7"
+    fill="#9BB4BC"
   >
     $_
   </text>

--- a/apps/web/public/logo-light.svg
+++ b/apps/web/public/logo-light.svg
@@ -1,5 +1,5 @@
 <svg width="96" height="96" viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect x="8" y="8" width="80" height="80" rx="16" fill="#F5EEFF" stroke="#B79AFF" stroke-width="3"/>
+  <rect x="8" y="8" width="80" height="80" rx="16" fill="#F3F2F7" stroke="#C9C8D4" stroke-width="3"/>
   <text
     x="48"
     y="50"
@@ -8,7 +8,7 @@
     font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, monospace"
     font-size="34"
     font-weight="700"
-    fill="#8839EF"
+    fill="#6E94B2"
   >
     $_
   </text>

--- a/apps/web/public/logo.svg
+++ b/apps/web/public/logo.svg
@@ -1,20 +1,20 @@
 <svg width="96" height="96" viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg">
   <style>
     :root {
-      --logo-bg: #f5eeff;
-      --logo-stroke: #b79aff;
-      --logo-dot-1: #8839ef;
-      --logo-dot-2: #cba6f7;
-      --logo-glyph: #8839ef;
+      --logo-bg: #f3f2f7;
+      --logo-stroke: #c9c8d4;
+      --logo-dot-1: #6e94b2;
+      --logo-dot-2: #bb9dbd;
+      --logo-glyph: #6e94b2;
     }
 
     @media (prefers-color-scheme: dark) {
       :root {
-        --logo-bg: #181825;
-        --logo-stroke: #6c7086;
-        --logo-dot-1: #cba6f7;
-        --logo-dot-2: #b4befe;
-        --logo-glyph: #cba6f7;
+        --logo-bg: #202022;
+        --logo-stroke: #333738;
+        --logo-dot-1: #9bb4bc;
+        --logo-dot-2: #bb9dbd;
+        --logo-glyph: #9bb4bc;
       }
     }
   </style>

--- a/apps/web/src/app/(home)/analytics/_components/analytics-header.tsx
+++ b/apps/web/src/app/(home)/analytics/_components/analytics-header.tsx
@@ -33,12 +33,12 @@ export function AnalyticsHeader({
         </div>
       </div>
 
-      <div className="rounded-xl bg-gradient-to-br from-primary/12 via-fd-background to-fd-background/90 p-4 ring-1 ring-border/40 sm:p-5">
+      <div className="rounded-xl p-4 ring-1 ring-border/40 sm:p-5">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex items-center gap-2">
             <span className="text-primary">$</span>
             <span className="text-muted-foreground">status:</span>
-            <span className="text-green-500">online</span>
+            <span className="text-chart-4">online</span>
           </div>
           {formattedDate && (
             <div className="flex items-center gap-2 text-muted-foreground text-xs">

--- a/apps/web/src/app/(home)/new/_components/code-viewer.tsx
+++ b/apps/web/src/app/(home)/new/_components/code-viewer.tsx
@@ -97,8 +97,8 @@ export const CodeViewer = memo(function CodeViewer({
               <CodeBlockContent
                 language={item.language as BundledLanguage}
                 themes={{
-                  light: "catppuccin-latte",
-                  dark: "catppuccin-mocha",
+                  light: "vitesse-light",
+                  dark: "vesper",
                 }}
                 className="bg-fd-background"
               >

--- a/apps/web/src/app/(home)/new/_components/stack-builder/selected-stack-badges.tsx
+++ b/apps/web/src/app/(home)/new/_components/stack-builder/selected-stack-badges.tsx
@@ -120,7 +120,7 @@ export function SelectedStackBadges({ stack, onRemove }: SelectedStackBadgesProp
                       />
                     )}
                     {tech.name}
-                    <span className="rounded-full p-0.5 hover:bg-black/10 dark:hover:bg-white/10">
+                    <span className="rounded-full p-0.5 hover:bg-muted">
                       <X className="h-2.5 w-2.5" />
                     </span>
                   </button>

--- a/apps/web/src/app/(home)/stack/_components/stack-display.tsx
+++ b/apps/web/src/app/(home)/stack/_components/stack-display.tsx
@@ -185,7 +185,7 @@ export function StackDisplay({ stackState }: StackDisplayProps) {
             <span
               className={
                 copied
-                  ? "flex items-center gap-1 rounded border border-green-500/20 bg-green-500/10 px-2 py-1 font-mono text-green-600 text-xs transition-colors dark:text-green-400"
+                  ? "flex items-center gap-1 rounded border border-[color-mix(in_srgb,var(--chart-4)_35%,transparent)] bg-[color-mix(in_srgb,var(--chart-4)_16%,transparent)] px-2 py-1 font-mono text-[var(--chart-4)] text-xs transition-colors"
                   : "flex items-center gap-1 rounded border border-border px-2 py-1 font-mono text-xs transition-colors"
               }
             >

--- a/apps/web/src/app/global.css
+++ b/apps/web/src/app/global.css
@@ -1,5 +1,5 @@
 @import "tailwindcss";
-@import "fumadocs-ui/css/neutral.css";
+@import "fumadocs-ui/css/shadcn.css";
 @import "fumadocs-ui/css/preset.css";
 @import "tw-animate-css";
 
@@ -160,98 +160,105 @@
 }
 
 :root {
-  --color-fd-primary: #8839ef;
-  --color-fd-primary-foreground: #ffffff;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.44 0.04 279.33);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.44 0.04 279.33);
-  --popover: oklch(0.86 0.01 268.48);
-  --popover-foreground: oklch(0.44 0.04 279.33);
-  --primary: #8839ef;
-  --primary-foreground: #ffffff;
-  --secondary: oklch(0.86 0.01 268.48);
-  --secondary-foreground: oklch(0.44 0.04 279.33);
-  --muted: oklch(0.91 0.01 264.51);
-  --muted-foreground: oklch(0.55 0.03 279.08);
-  --accent: #9353d3;
-  --accent-foreground: #ffffff;
-  --destructive: #d20f39;
-  --border: oklch(0.81 0.02 271.2);
-  --input: oklch(0.86 0.01 268.48);
-  --ring: #8839ef;
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.93 0.01 264.52);
-  --sidebar-foreground: oklch(0.44 0.04 279.33);
-  --sidebar-primary: #8839ef;
-  --sidebar-primary-foreground: #ffffff;
-  --sidebar-accent: #9353d3;
-  --sidebar-accent-foreground: #ffffff;
-  --sidebar-border: oklch(0.81 0.02 271.2);
-  --sidebar-ring: #8839ef;
-  --destructive-foreground: oklch(1 0 0);
+  --color-fd-overlay: color-mix(in srgb, #141415 50%, transparent);
+  --background: #f3f2f7;
+  --foreground: #252530;
+  --card: #fafafe;
+  --card-foreground: #252530;
+  --popover: #f9f8fd;
+  --popover-foreground: #252530;
+  --primary: #6e94b2;
+  --primary-foreground: #f8f9ff;
+  --secondary: #e2e1ea;
+  --secondary-foreground: #323246;
+  --muted: #dcdae7;
+  --muted-foreground: #606079;
+  --accent: #e2e1ea;
+  --accent-foreground: #5f7e9a;
+  --destructive: #d8647e;
+  --border: #c9c8d4;
+  --input: #ebeaf2;
+  --ring: #7e98e8;
+  --chart-1: #6e94b2;
+  --chart-2: #c48282;
+  --chart-3: #e0a363;
+  --chart-4: #7fa563;
+  --chart-5: #bb9dbd;
+  --sidebar: #efeef5;
+  --sidebar-foreground: #252530;
+  --sidebar-primary: #6e94b2;
+  --sidebar-primary-foreground: #f8f9ff;
+  --sidebar-accent: #dedce8;
+  --sidebar-accent-foreground: #252530;
+  --sidebar-border: #c9c8d4;
+  --sidebar-ring: #7e98e8;
+  --destructive-foreground: #f8f9ff;
   --radius: 0.35rem;
-  --shadow-color: hsl(240 30% 25%);
-  --shadow-opacity: 0.12;
+  --shadow-color: #252530;
+  --shadow-opacity: 0.14;
   --shadow-blur: 6px;
   --shadow-spread: 0px;
   --shadow-offset-x: 0px;
   --shadow-offset-y: 4px;
   --letter-spacing: 0em;
   --spacing: 0.25rem;
-  --shadow-2xs: 0px 4px 6px 0px hsl(240 30% 25% / 0.06);
-  --shadow-xs: 0px 4px 6px 0px hsl(240 30% 25% / 0.06);
-  --shadow-sm: 0px 4px 6px 0px hsl(240 30% 25% / 0.12), 0px 1px 2px -1px hsl(240 30% 25% / 0.12);
-  --shadow: 0px 4px 6px 0px hsl(240 30% 25% / 0.12), 0px 1px 2px -1px hsl(240 30% 25% / 0.12);
-  --shadow-md: 0px 4px 6px 0px hsl(240 30% 25% / 0.12), 0px 2px 4px -1px hsl(240 30% 25% / 0.12);
-  --shadow-lg: 0px 4px 6px 0px hsl(240 30% 25% / 0.12), 0px 4px 6px -1px hsl(240 30% 25% / 0.12);
-  --shadow-xl: 0px 4px 6px 0px hsl(240 30% 25% / 0.12), 0px 8px 10px -1px hsl(240 30% 25% / 0.12);
-  --shadow-2xl: 0px 4px 6px 0px hsl(240 30% 25% / 0.3);
+  --shadow-2xs: 0px 4px 6px 0px color-mix(in srgb, #252530 10%, transparent);
+  --shadow-xs: 0px 4px 6px 0px color-mix(in srgb, #252530 10%, transparent);
+  --shadow-sm:
+    0px 4px 6px 0px color-mix(in srgb, #252530 16%, transparent),
+    0px 1px 2px -1px color-mix(in srgb, #252530 14%, transparent);
+  --shadow:
+    0px 4px 6px 0px color-mix(in srgb, #252530 16%, transparent),
+    0px 1px 2px -1px color-mix(in srgb, #252530 14%, transparent);
+  --shadow-md:
+    0px 4px 6px 0px color-mix(in srgb, #252530 16%, transparent),
+    0px 2px 4px -1px color-mix(in srgb, #252530 14%, transparent);
+  --shadow-lg:
+    0px 4px 6px 0px color-mix(in srgb, #252530 16%, transparent),
+    0px 4px 6px -1px color-mix(in srgb, #252530 14%, transparent);
+  --shadow-xl:
+    0px 4px 6px 0px color-mix(in srgb, #252530 16%, transparent),
+    0px 8px 10px -1px color-mix(in srgb, #252530 14%, transparent);
+  --shadow-2xl: 0px 4px 6px 0px color-mix(in srgb, #252530 32%, transparent);
   --tracking-normal: 0em;
 }
 
 .dark {
-  --color-fd-primary: #cba6f7;
-  --color-fd-primary-foreground: #11111b;
-  --color-fd-background: #0d0d0d;
-  --background: #11111b;
-  --foreground: #cdd6f4;
-  --card: #11111b;
-  --card-foreground: #cdd6f4;
-  --popover: #181825;
-  --popover-foreground: #cdd6f4;
-  --primary: #cba6f7;
-  --primary-foreground: #11111b;
-  --secondary: #313244;
-  --secondary-foreground: #cdd6f4;
-  --muted: #313244;
-  --muted-foreground: #a6adc8;
-  --accent: #b4befe;
-  --accent-foreground: #11111b;
-  --destructive: #f38ba8;
-  --border: #45475a;
-  --input: #313244;
-  --ring: #cba6f7;
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: #11111b;
-  --sidebar-foreground: #cdd6f4;
-  --sidebar-primary: #cba6f7;
-  --sidebar-primary-foreground: #11111b;
-  --sidebar-accent: #b4befe;
-  --sidebar-accent-foreground: #11111b;
-  --sidebar-border: #45475a;
-  --sidebar-ring: #cba6f7;
-  --destructive-foreground: #11111b;
+  --color-fd-overlay: color-mix(in srgb, #050506 60%, transparent);
+  --background: #141415;
+  --foreground: #cdcdcd;
+  --card: #202022;
+  --card-foreground: #cdcdcd;
+  --popover: #202022;
+  --popover-foreground: #cdcdcd;
+  --primary: #9bb4bc;
+  --primary-foreground: #141415;
+  --secondary: #252530;
+  --secondary-foreground: #c3c3d5;
+  --muted: #252530;
+  --muted-foreground: #8d8da3;
+  --accent: #2d2d39;
+  --accent-foreground: #9bb4bc;
+  --destructive: #d8647e;
+  --border: #333738;
+  --input: #202022;
+  --ring: #7e98e8;
+  --chart-1: #9bb4bc;
+  --chart-2: #c48282;
+  --chart-3: #e8b589;
+  --chart-4: #7fa563;
+  --chart-5: #6e94b2;
+  --sidebar: #141415;
+  --sidebar-foreground: #cdcdcd;
+  --sidebar-primary: #9bb4bc;
+  --sidebar-primary-foreground: #141415;
+  --sidebar-accent: #252530;
+  --sidebar-accent-foreground: #cdcdcd;
+  --sidebar-border: #333738;
+  --sidebar-ring: #7e98e8;
+  --destructive-foreground: #141415;
   --radius: 0.35rem;
-  --shadow-color: hsl(240 30% 5%);
+  --shadow-color: #080809;
   --shadow-opacity: 0.25;
   --shadow-blur: 8px;
   --shadow-spread: 0px;
@@ -259,25 +266,36 @@
   --shadow-offset-y: 4px;
   --letter-spacing: 0em;
   --spacing: 0.25rem;
-  --shadow-2xs: 0px 2px 4px 0px hsl(240 30% 5% / 0.15);
-  --shadow-xs: 0px 2px 4px 0px hsl(240 30% 5% / 0.15);
-  --shadow-sm: 0px 4px 8px 0px hsl(240 30% 5% / 0.2), 0px 1px 2px -1px hsl(240 30% 5% / 0.15);
-  --shadow: 0px 4px 8px 0px hsl(240 30% 5% / 0.2), 0px 1px 2px -1px hsl(240 30% 5% / 0.15);
-  --shadow-md: 0px 6px 12px 0px hsl(240 30% 5% / 0.25), 0px 2px 4px -1px hsl(240 30% 5% / 0.2);
-  --shadow-lg: 0px 8px 16px 0px hsl(240 30% 5% / 0.3), 0px 4px 6px -1px hsl(240 30% 5% / 0.25);
-  --shadow-xl: 0px 12px 24px 0px hsl(240 30% 5% / 0.35), 0px 8px 10px -1px hsl(240 30% 5% / 0.3);
-  --shadow-2xl: 0px 16px 32px 0px hsl(240 30% 5% / 0.4);
+  --shadow-2xs: 0px 2px 4px 0px color-mix(in srgb, #080809 16%, transparent);
+  --shadow-xs: 0px 2px 4px 0px color-mix(in srgb, #080809 16%, transparent);
+  --shadow-sm:
+    0px 4px 8px 0px color-mix(in srgb, #080809 22%, transparent),
+    0px 1px 2px -1px color-mix(in srgb, #080809 16%, transparent);
+  --shadow:
+    0px 4px 8px 0px color-mix(in srgb, #080809 22%, transparent),
+    0px 1px 2px -1px color-mix(in srgb, #080809 16%, transparent);
+  --shadow-md:
+    0px 6px 12px 0px color-mix(in srgb, #080809 28%, transparent),
+    0px 2px 4px -1px color-mix(in srgb, #080809 22%, transparent);
+  --shadow-lg:
+    0px 8px 16px 0px color-mix(in srgb, #080809 34%, transparent),
+    0px 4px 6px -1px color-mix(in srgb, #080809 28%, transparent);
+  --shadow-xl:
+    0px 12px 24px 0px color-mix(in srgb, #080809 38%, transparent),
+    0px 8px 10px -1px color-mix(in srgb, #080809 32%, transparent);
+  --shadow-2xl: 0px 16px 32px 0px color-mix(in srgb, #080809 44%, transparent);
 }
 
-/* @layer base {
-	* {
-		@apply border-border outline-ring/50;
-	}
-	body {
-		@apply text-foreground;
-		letter-spacing: var(--tracking-normal);
-	}
-} */
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+
+  body {
+    @apply bg-background text-foreground;
+    letter-spacing: var(--tracking-normal);
+  }
+}
 
 .terminal-cursor {
   animation: blink 1s infinite;
@@ -321,15 +339,15 @@
     0deg,
     transparent,
     transparent 2px,
-    rgba(255, 255, 255, 0.03) 2px,
-    rgba(255, 255, 255, 0.03) 4px
+    color-mix(in srgb, var(--foreground) 6%, transparent) 2px,
+    color-mix(in srgb, var(--foreground) 6%, transparent) 4px
   );
   pointer-events: none;
 }
 
 .terminal-block-hover:hover {
   border-color: var(--primary);
-  box-shadow: 0 0 10px rgba(136, 57, 239, 0.3);
+  box-shadow: 0 0 10px color-mix(in srgb, var(--ring) 30%, transparent);
   transform: translateY(-1px);
 }
 
@@ -392,25 +410,25 @@
 .recharts-cartesian-axis-tick-value {
   font-size: 0.75rem;
   font-weight: 500;
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
 }
 
 .recharts-cartesian-axis-line {
-  stroke: hsl(var(--border));
+  stroke: var(--border);
   stroke-width: 1;
 }
 
 .recharts-cartesian-grid-horizontal line,
 .recharts-cartesian-grid-vertical line {
-  stroke: hsl(var(--border));
+  stroke: var(--border);
   stroke-width: 1;
   stroke-dasharray: 3 3;
   opacity: 0.5;
 }
 
 .recharts-tooltip-wrapper {
-  background: hsl(var(--popover));
-  border: 1px solid hsl(var(--border));
+  background: var(--popover);
+  border: 1px solid var(--border);
   border-radius: var(--radius);
   box-shadow: var(--shadow-lg);
   padding: 0.5rem;
@@ -419,20 +437,20 @@
 }
 
 .recharts-tooltip-item {
-  color: hsl(var(--foreground));
+  color: var(--foreground);
 }
 
 .recharts-legend-item-text {
   font-family: var(--font-mono);
   font-size: 0.75rem;
-  color: hsl(var(--foreground));
+  color: var(--foreground);
 }
 
 .recharts-pie-label {
   font-family: var(--font-mono);
   font-size: 0.75rem;
   font-weight: 500;
-  color: hsl(var(--foreground));
+  color: var(--foreground);
 }
 
 .recharts-bar-rectangle {
@@ -467,35 +485,35 @@
 
 /* Terminal-style chart headers */
 .chart-header {
-  border-bottom: 1px solid hsl(var(--border));
+  border-bottom: 1px solid var(--border);
   padding: 0.75rem 1rem;
-  background: hsl(var(--card));
+  background: var(--card);
 }
 
 .chart-header-title {
   font-family: var(--font-mono);
   font-size: 0.875rem;
   font-weight: 600;
-  color: hsl(var(--foreground));
+  color: var(--foreground);
 }
 
 .chart-header-description {
   font-size: 0.75rem;
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
   margin-top: 0.25rem;
 }
 
 /* Chart hover effects */
 .chart-card {
   transition: all 0.2s ease;
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: var(--radius);
   overflow: hidden;
 }
 
 .chart-card:hover {
-  border-color: hsl(var(--primary));
-  box-shadow: 0 0 0 1px hsl(var(--primary) / 0.1);
+  border-color: var(--primary);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--primary) 20%, transparent);
 }
 
 /* Chart loading state */
@@ -504,7 +522,7 @@
   align-items: center;
   justify-content: center;
   height: 300px;
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
   font-family: var(--font-mono);
   font-size: 0.875rem;
 }
@@ -515,7 +533,7 @@
   align-items: center;
   justify-content: center;
   height: 300px;
-  color: hsl(var(--destructive));
+  color: var(--destructive);
   font-family: var(--font-mono);
   font-size: 0.875rem;
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -125,8 +125,8 @@ export default function Layout({ children }: { children: ReactNode }) {
             },
           }}
           theme={{
-            enableSystem: true,
-            defaultTheme: "system",
+            enableSystem: false,
+            defaultTheme: "dark",
           }}
         >
           <Providers>{children}</Providers>

--- a/apps/web/src/app/manifest.ts
+++ b/apps/web/src/app/manifest.ts
@@ -10,8 +10,8 @@ export default function manifest(): MetadataRoute.Manifest {
       "A modern CLI tool for scaffolding end-to-end type-safe TypeScript projects with best practices and customizable configurations",
     start_url: "/new",
     display: "standalone",
-    background_color: "#ffffff",
-    theme_color: "#000000",
+    background_color: "#141415",
+    theme_color: "#9bb4bc",
     icons: [
       {
         src: "/favicon/web-app-manifest-192x192.png",

--- a/apps/web/src/app/og/docs/[...slug]/route.tsx
+++ b/apps/web/src/app/og/docs/[...slug]/route.tsx
@@ -17,7 +17,7 @@ export async function GET(_req: Request, { params }: RouteContext<"/og/docs/[...
         width: "100%",
         display: "flex",
         flexDirection: "column",
-        background: "#0a0a0a",
+        background: "#101012",
         fontFamily: "system-ui, sans-serif",
         position: "relative",
       }}
@@ -28,10 +28,10 @@ export async function GET(_req: Request, { params }: RouteContext<"/og/docs/[...
           flexDirection: "column",
           margin: "40px",
           flex: 1,
-          border: "1px solid #313244",
+          border: "1px solid #333738",
           borderRadius: "8px",
           overflow: "hidden",
-          background: "#11111b",
+          background: "#141415",
         }}
       >
         <div
@@ -39,8 +39,8 @@ export async function GET(_req: Request, { params }: RouteContext<"/og/docs/[...
             display: "flex",
             alignItems: "center",
             padding: "14px 20px",
-            background: "#181825",
-            borderBottom: "1px solid #313244",
+            background: "#202022",
+            borderBottom: "1px solid #333738",
             gap: "8px",
           }}
         >
@@ -50,7 +50,7 @@ export async function GET(_req: Request, { params }: RouteContext<"/og/docs/[...
                 width: "12px",
                 height: "12px",
                 borderRadius: "50%",
-                background: "#f38ba8",
+                background: "#d8647e",
                 display: "flex",
               }}
             />
@@ -59,7 +59,7 @@ export async function GET(_req: Request, { params }: RouteContext<"/og/docs/[...
                 width: "12px",
                 height: "12px",
                 borderRadius: "50%",
-                background: "#f9e2af",
+                background: "#f3be7c",
                 display: "flex",
               }}
             />
@@ -68,7 +68,7 @@ export async function GET(_req: Request, { params }: RouteContext<"/og/docs/[...
                 width: "12px",
                 height: "12px",
                 borderRadius: "50%",
-                background: "#a6e3a1",
+                background: "#7fa563",
                 display: "flex",
               }}
             />
@@ -77,7 +77,7 @@ export async function GET(_req: Request, { params }: RouteContext<"/og/docs/[...
             style={{
               flex: 1,
               textAlign: "center",
-              color: "#585b70",
+              color: "#606079",
               fontSize: "14px",
               fontFamily: "monospace",
               display: "flex",
@@ -102,7 +102,7 @@ export async function GET(_req: Request, { params }: RouteContext<"/og/docs/[...
             style={{
               fontSize: "56px",
               fontWeight: 700,
-              color: "#cdd6f4",
+              color: "#cdcdcd",
               lineHeight: 1.15,
               letterSpacing: "-0.025em",
               display: "flex",
@@ -116,7 +116,7 @@ export async function GET(_req: Request, { params }: RouteContext<"/og/docs/[...
             <div
               style={{
                 fontSize: "24px",
-                color: "#6c7086",
+                color: "#8d8da3",
                 lineHeight: 1.5,
                 display: "flex",
                 flexWrap: "wrap",
@@ -133,14 +133,14 @@ export async function GET(_req: Request, { params }: RouteContext<"/og/docs/[...
             justifyContent: "space-between",
             alignItems: "center",
             padding: "16px 56px",
-            borderTop: "1px solid #313244",
-            background: "#181825",
+            borderTop: "1px solid #333738",
+            background: "#202022",
           }}
         >
           <div style={{ display: "flex", alignItems: "center", gap: "10px" }}>
             <span
               style={{
-                color: "#cba6f7",
+                color: "#9bb4bc",
                 fontSize: "18px",
                 fontWeight: 600,
                 display: "flex",
@@ -148,12 +148,12 @@ export async function GET(_req: Request, { params }: RouteContext<"/og/docs/[...
             >
               Better-T Stack
             </span>
-            <span style={{ color: "#313244", fontSize: "18px", display: "flex" }}>/</span>
-            <span style={{ color: "#585b70", fontSize: "16px", display: "flex" }}>docs</span>
+            <span style={{ color: "#333738", fontSize: "18px", display: "flex" }}>/</span>
+            <span style={{ color: "#606079", fontSize: "16px", display: "flex" }}>docs</span>
           </div>
           <div
             style={{
-              color: "#45475a",
+              color: "#8d8da3",
               fontSize: "14px",
               fontFamily: "monospace",
               display: "flex",

--- a/apps/web/src/components/ui/file-tree.tsx
+++ b/apps/web/src/components/ui/file-tree.tsx
@@ -147,7 +147,7 @@ function TreeIndicator({ className, ...props }: React.HTMLAttributes<HTMLDivElem
     <div
       dir={direction}
       className={cn(
-        "bg-muted absolute left-1.5 h-full w-px rounded-md py-3 duration-300 ease-in-out hover:bg-slate-300 rtl:right-1.5",
+        "bg-muted absolute left-1.5 h-full w-px rounded-md py-3 duration-300 ease-in-out hover:bg-border rtl:right-1.5",
         className,
       )}
       {...props}

--- a/apps/web/src/components/ui/kibo-ui/code-block/index.tsx
+++ b/apps/web/src/components/ui/kibo-ui/code-block/index.tsx
@@ -201,14 +201,13 @@ const darkModeClassNames = cn(
 );
 
 const lineHighlightClassNames = cn(
-  "[&_.line.highlighted]:bg-blue-50",
-  "[&_.line.highlighted]:after:bg-blue-500",
+  "[&_.line.highlighted]:bg-accent/35",
+  "[&_.line.highlighted]:after:bg-ring",
   "[&_.line.highlighted]:after:absolute",
   "[&_.line.highlighted]:after:left-0",
   "[&_.line.highlighted]:after:top-0",
   "[&_.line.highlighted]:after:bottom-0",
   "[&_.line.highlighted]:after:w-0.5",
-  "dark:[&_.line.highlighted]:!bg-blue-500/10",
 );
 
 const lineDiffClassNames = cn(
@@ -217,12 +216,10 @@ const lineDiffClassNames = cn(
   "[&_.line.diff]:after:top-0",
   "[&_.line.diff]:after:bottom-0",
   "[&_.line.diff]:after:w-0.5",
-  "[&_.line.diff.add]:bg-emerald-50",
-  "[&_.line.diff.add]:after:bg-emerald-500",
-  "[&_.line.diff.remove]:bg-rose-50",
-  "[&_.line.diff.remove]:after:bg-rose-500",
-  "dark:[&_.line.diff.add]:!bg-emerald-500/10",
-  "dark:[&_.line.diff.remove]:!bg-rose-500/10",
+  "[&_.line.diff.add]:bg-primary/12",
+  "[&_.line.diff.add]:after:bg-primary",
+  "[&_.line.diff.remove]:bg-destructive/15",
+  "[&_.line.diff.remove]:after:bg-destructive",
 );
 
 const lineFocusedClassNames = cn(
@@ -230,10 +227,7 @@ const lineFocusedClassNames = cn(
   "[&_code:has(.focused)_.line.focused]:blur-none",
 );
 
-const wordHighlightClassNames = cn(
-  "[&_.highlighted-word]:bg-blue-50",
-  "dark:[&_.highlighted-word]:!bg-blue-500/10",
-);
+const wordHighlightClassNames = cn("[&_.highlighted-word]:bg-accent/35");
 
 const codeBlockClassName = cn(
   "mt-0 bg-background text-sm",
@@ -257,8 +251,8 @@ const highlight = (
   codeToHtml(html, {
     lang: language ?? "typescript",
     themes: themes ?? {
-      light: "github-light",
-      dark: "github-dark-default",
+      light: "vitesse-light",
+      dark: "vesper",
     },
     transformers: [
       transformerNotationDiff({

--- a/apps/web/src/components/ui/share-dialog.tsx
+++ b/apps/web/src/components/ui/share-dialog.tsx
@@ -115,8 +115,8 @@ export function ShareDialog({ children, stackUrl, stackState }: ShareDialogProps
           width: 128,
           margin: 2,
           color: {
-            dark: isDark ? "#cdd6f4" : "#11111b",
-            light: isDark ? "#11111b" : "#ffffff",
+            dark: isDark ? "#cdcdcd" : "#252530",
+            light: isDark ? "#141415" : "#f3f2f7",
           },
         });
         setQrCodeDataUrl(dataUrl);
@@ -239,7 +239,7 @@ export function ShareDialog({ children, stackUrl, stackState }: ShareDialogProps
                   className={cn(
                     "flex items-center gap-2 rounded border px-3 py-2 font-mono text-xs transition-all",
                     copied
-                      ? "border-green-500/20 bg-green-500/10 text-green-600 dark:text-green-400"
+                      ? "border-[color-mix(in_srgb,var(--chart-4)_35%,transparent)] bg-[color-mix(in_srgb,var(--chart-4)_16%,transparent)] text-[var(--chart-4)]"
                       : "border-border bg-fd-background text-muted-foreground hover:border-muted-foreground/30 hover:bg-muted hover:text-foreground",
                   )}
                 >


### PR DESCRIPTION
## Summary
- migrate `apps/web` design tokens to an experimental Vague-inspired palette
- update Fumadocs/shadcn color bridging so header/nav/docs use the same token system
- retheme code viewer and code block highlights to match the new palette
- update web manifest, logo/favicon SVG colors, and docs OG image palette
- fix hover contrast issues in Fumadocs header interactions

## Experimental Notice
This PR is **experimental** and intended for visual QA and iteration before a final theme lock-in.

## Validation
- `bun check`
- `bun run build` (from `apps/web`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated application theme color system with a new color palette and design tokens
  * Refreshed syntax highlighting themes across code components
  * Updated web app manifest colors to reflect new branding
  * Enhanced visual consistency across UI components with updated hover states and interactive elements
  * Changed default theme configuration to dark mode

<!-- end of auto-generated comment: release notes by coderabbit.ai -->