### PR TITLE
fix(web): use Convex connection status on analytics page

### DIFF
--- a/apps/web/src/app/(home)/analytics/_components/analytics-header.tsx
+++ b/apps/web/src/app/(home)/analytics/_components/analytics-header.tsx
@@ -2,9 +2,12 @@ import { format } from "date-fns";
 import { Terminal } from "lucide-react";
 import Link from "next/link";
 
+import { cn } from "@/lib/utils";
+
 export function AnalyticsHeader({
   lastUpdated,
   legacy,
+  connectionStatus,
 }: {
   lastUpdated: string | null;
   legacy: {
@@ -13,11 +16,34 @@ export function AnalyticsHeader({
     lastUpdatedIso: string;
     source: string;
   };
+  connectionStatus: "online" | "connecting" | "reconnecting" | "offline";
 }) {
   const formattedDate = lastUpdated
     ? format(new Date(lastUpdated), "MMM d, yyyy 'at' HH:mm")
     : null;
   const legacyDate = format(new Date(legacy.lastUpdatedIso), "MMM d, yyyy 'at' HH:mm");
+  const statusMeta = {
+    online: {
+      label: "online",
+      textClass: "text-primary",
+      dotClass: "bg-primary",
+    },
+    connecting: {
+      label: "connecting",
+      textClass: "text-muted-foreground",
+      dotClass: "bg-muted-foreground",
+    },
+    reconnecting: {
+      label: "reconnecting",
+      textClass: "text-accent",
+      dotClass: "bg-accent",
+    },
+    offline: {
+      label: "offline",
+      textClass: "text-destructive",
+      dotClass: "bg-destructive",
+    },
+  }[connectionStatus];
 
   return (
     <div className="mb-4 space-y-4">
@@ -38,7 +64,16 @@ export function AnalyticsHeader({
           <div className="flex items-center gap-2">
             <span className="text-primary">$</span>
             <span className="text-muted-foreground">status:</span>
-            <span className="text-green-500">online</span>
+            <span className={cn("inline-flex items-center gap-2", statusMeta.textClass)}>
+              <span
+                className={cn(
+                  "h-2 w-2 rounded-full",
+                  statusMeta.dotClass,
+                  connectionStatus !== "online" && "animate-pulse",
+                )}
+              />
+              {statusMeta.label}
+            </span>
           </div>
           {formattedDate && (
             <div className="flex items-center gap-2 text-muted-foreground text-xs">

--- a/apps/web/src/app/(home)/analytics/_components/analytics-page.tsx
+++ b/apps/web/src/app/(home)/analytics/_components/analytics-page.tsx
@@ -13,6 +13,7 @@ import { TimelineSection } from "./timeline-charts";
 export default function AnalyticsPage({
   data,
   legacy,
+  connectionStatus,
 }: {
   data: AggregatedAnalyticsData;
   legacy: {
@@ -21,11 +22,16 @@ export default function AnalyticsPage({
     lastUpdatedIso: string;
     source: string;
   };
+  connectionStatus: "online" | "connecting" | "reconnecting" | "offline";
 }) {
   return (
     <div className="mx-auto min-h-svh bg-fd-background">
       <div className="container mx-auto space-y-10 px-4 py-8 pt-16">
-        <AnalyticsHeader lastUpdated={data.lastUpdated} legacy={legacy} />
+        <AnalyticsHeader
+          lastUpdated={data.lastUpdated}
+          legacy={legacy}
+          connectionStatus={connectionStatus}
+        />
 
         <MetricsCards data={data} />
 

--- a/apps/web/src/app/(home)/analytics/analytics-client.tsx
+++ b/apps/web/src/app/(home)/analytics/analytics-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { api } from "@better-t-stack/backend/convex/_generated/api";
-import { type Preloaded, usePreloadedQuery } from "convex/react";
+import { type Preloaded, useConvexConnectionState, usePreloadedQuery } from "convex/react";
 
 import type { AggregatedAnalyticsData, Distribution } from "./_components/types";
 
@@ -35,6 +35,22 @@ type PrecomputedStats = {
 };
 
 type DailyStats = { date: string; count: number };
+type ConnectionStatus = "online" | "connecting" | "reconnecting" | "offline";
+
+function getConnectionStatus({
+  isWebSocketConnected,
+  hasEverConnected,
+  connectionRetries,
+}: {
+  isWebSocketConnected: boolean;
+  hasEverConnected: boolean;
+  connectionRetries: number;
+}): ConnectionStatus {
+  if (isWebSocketConnected) return "online";
+  if (hasEverConnected) return "reconnecting";
+  if (connectionRetries > 0) return "offline";
+  return "connecting";
+}
 
 function recordToDistribution(record: Record<string, number>): Distribution {
   return Object.entries(record)
@@ -149,6 +165,8 @@ export function AnalyticsClient({
 }) {
   const stats = usePreloadedQuery(preloadedStats);
   const dailyStats = usePreloadedQuery(preloadedDailyStats);
+  const connectionState = useConvexConnectionState();
+  const connectionStatus = getConnectionStatus(connectionState);
 
   const data = stats
     ? buildFromPrecomputed(stats, dailyStats)
@@ -199,5 +217,5 @@ export function AnalyticsClient({
     source: "PostHog (legacy, pre-Convex)",
   };
 
-  return <AnalyticsPage data={data} legacy={legacy} />;
+  return <AnalyticsPage data={data} legacy={legacy} connectionStatus={connectionStatus} />;
 }


### PR DESCRIPTION
Summary:\n- wire analytics status badge to real Convex connection state using the Convex connection hook\n- replace hardcoded online label with dynamic statuses: online, connecting, reconnecting, offline\n- align status colors with app theme tokens: primary, accent, muted-foreground, destructive\n\nValidation:\n- bunx tsc --noEmit -p apps/web/tsconfig.json\n- lefthook pre-commit (bun check)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a real-time connection status indicator to the analytics dashboard, displaying whether the app is online, connecting, reconnecting, or offline with a visual indicator and animated status dot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->