### PR TITLE
fix(template-generator): align Fastify oRPC server template with adapter docs

### DIFF
--- a/packages/template-generator/templates/backend/server/fastify/src/index.ts.hbs
+++ b/packages/template-generator/templates/backend/server/fastify/src/index.ts.hbs
@@ -9,17 +9,13 @@ import { appRouter, type AppRouter } from "@{{projectName}}/api/routers/index";
 {{/if}}
 
 {{#if (eq api "orpc")}}
-import { OpenAPIHandler } from "@orpc/openapi/node";
+import { OpenAPIHandler } from "@orpc/openapi/fastify";
 import { OpenAPIReferencePlugin } from "@orpc/openapi/plugins";
 import { ZodToJsonSchemaConverter } from "@orpc/zod/zod4";
-import { RPCHandler } from "@orpc/server/node";
-import { CORSPlugin } from "@orpc/server/plugins";
+import { RPCHandler } from "@orpc/server/fastify";
 import { onError } from "@orpc/server";
-import { appRouter } from "@{{projectName}}/api/routers/index";
-import { createServer } from "node:http";
-{{#if (eq auth "better-auth")}}
 import { createContext } from "@{{projectName}}/api/context";
-{{/if}}
+import { appRouter } from "@{{projectName}}/api/routers/index";
 {{/if}}
 
 {{#if (includes examples "ai")}}
@@ -46,13 +42,6 @@ const baseCorsConfig = {
 
 {{#if (eq api "orpc")}}
 const rpcHandler = new RPCHandler(appRouter, {
-	plugins: [
-		new CORSPlugin({
-			origin: env.CORS_ORIGIN,
-			credentials: true,
-			allowHeaders: ["Content-Type", "Authorization"],
-		}),
-	],
 	interceptors: [
 		onError((error) => {
 			console.error(error);
@@ -75,31 +64,6 @@ const apiHandler = new OpenAPIHandler(appRouter, {
 
 const fastify = Fastify({
 	logger: true,
-	serverFactory: (fastifyHandler) => {
-		const server = createServer(async (req, res) => {
-			const { matched } = await rpcHandler.handle(req, res, {
-				context: await createContext(req.headers),
-				prefix: "/rpc",
-			});
-
-			if (matched) {
-				return;
-			}
-
-			const apiResult = await apiHandler.handle(req, res, {
-				context: await createContext(req.headers),
-				prefix: "/api-reference",
-			});
-
-			if (apiResult.matched) {
-				return;
-			}
-
-			fastifyHandler(req, res);
-		});
-
-		return server;
-	},
 });
 {{else}}
 const fastify = Fastify({
@@ -108,6 +72,36 @@ const fastify = Fastify({
 {{/if}}
 
 fastify.register(fastifyCors, baseCorsConfig);
+
+{{#if (eq api "orpc")}}
+fastify.register(async (rpcApp) => {
+	rpcApp.addContentTypeParser("*", (_, payload, done) => {
+		done(null, payload);
+	});
+
+	rpcApp.all("/rpc/*", async (request, reply) => {
+		const { matched } = await rpcHandler.handle(request, reply, {
+			context: await createContext(request.headers),
+			prefix: "/rpc",
+		});
+
+		if (!matched) {
+			reply.status(404).send();
+		}
+	});
+
+	rpcApp.all("/api-reference/*", async (request, reply) => {
+		const { matched } = await apiHandler.handle(request, reply, {
+			context: await createContext(request.headers),
+			prefix: "/api-reference",
+		});
+
+		if (!matched) {
+			reply.status(404).send();
+		}
+	});
+});
+{{/if}}
 
 {{#if (eq auth "better-auth")}}
 fastify.route({


### PR DESCRIPTION
## Summary
- switch Fastify server template oRPC imports from Node adapters to Fastify adapters
- remove custom `serverFactory` proxying and mount oRPC handlers with `fastify.all(...)` routes
- add scoped `addContentTypeParser("*", ...)` for oRPC routes
- regenerate embedded templates output

## Verification
- `bun run generate-templates` (packages/template-generator)
- `bun run typecheck` (packages/template-generator)
- pre-commit hook ran `bun check` successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Generated Fastify servers now use Fastify-native adapters for oRPC integration, replacing Node/Express style setup.
  * Improved route handling for RPC and API reference endpoints with proper 404 fallback responses.

* **Refactor**
  * Simplified plugin configuration for oRPC integration in template-generated backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->