### PR TITLE
feat(cli): add ultracite skills source

### DIFF
--- a/apps/cli/src/helpers/addons/skills-setup.ts
+++ b/apps/cli/src/helpers/addons/skills-setup.ts
@@ -71,6 +71,9 @@ const SKILL_SOURCES = {
   "msmps/opentui-skill": {
     label: "OpenTUI Platform",
   },
+  "haydenbleasel/ultracite": {
+    label: "Ultracite",
+  },
 } satisfies Record<string, SkillSource>;
 
 type SourceKey = keyof typeof SKILL_SOURCES;
@@ -189,6 +192,10 @@ function getRecommendedSourceKeys(config: ProjectConfig): SourceKey[] {
     sources.push("msmps/opentui-skill");
   }
 
+  if (addons.includes("ultracite")) {
+    sources.push("haydenbleasel/ultracite");
+  }
+
   return sources;
 }
 
@@ -268,6 +275,7 @@ const CURATED_SKILLS_BY_SOURCE: Record<SourceKey, (config: ProjectConfig) => str
     "convex-security-check",
   ],
   "msmps/opentui-skill": () => ["opentui"],
+  "haydenbleasel/ultracite": () => ["ultracite"],
 };
 
 function getCuratedSkillNamesForSourceKey(sourceKey: SourceKey, config: ProjectConfig): string[] {


### PR DESCRIPTION
## Summary
- add haydenbleasel/ultracite to curated skill sources
- recommend this source when the ultracite addon is selected
- map the curated ultracite skill for installation

## Verification
- bunx oxlint apps/cli/src/helpers/addons/skills-setup.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ultracite as a new skill source option, allowing users to access and utilize Ultracite-based skills
  * Enabled Ultracite recommendations that automatically appear when the Ultracite addon is active
  * Integrated curated Ultracite skills collection into the system for seamless skill discovery and management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->