### PR TITLE
fix(analytics): correct monthly trends and aggregation inputs

### DIFF
--- a/apps/web/content/docs/analytics.mdx
+++ b/apps/web/content/docs/analytics.mdx
@@ -30,6 +30,7 @@ Add `export BTS_TELEMETRY_DISABLED=1` to your shell profile to make it permanent
 ## Where to view analytics
 
 - Charts: [`/analytics`](/analytics)
+- Shared website analytics: [Umami dashboard](https://umami.amanv.cloud/share/pHvqHleyOl9PBfaK) (self-hosted on a Hostinger VPS)
 - Raw JSON snapshot: `https://r2.better-t-stack.dev/analytics-data.json`
 - CSV export: `https://r2.better-t-stack.dev/export.csv`
 

--- a/apps/web/src/app/(home)/_components/stats-section.tsx
+++ b/apps/web/src/app/(home)/_components/stats-section.tsx
@@ -8,7 +8,7 @@ import Link from "next/link";
 
 export default function StatsSection() {
   const stats = useQuery(api.analytics.getStats, {});
-  const dailyStats = useQuery(api.analytics.getDailyStats, {});
+  const dailyStats = useQuery(api.analytics.getDailyStats, { days: 30 });
   const githubRepo = useQuery(api.stats.getGithubRepo, {
     name: "AmanVarshney01/create-better-t-stack",
   });

--- a/apps/web/src/app/(home)/analytics/_components/analytics-header.tsx
+++ b/apps/web/src/app/(home)/analytics/_components/analytics-header.tsx
@@ -118,6 +118,21 @@ export function AnalyticsHeader({
               </Link>
             </span>
           </div>
+          <div className="flex items-start gap-2">
+            <span className="mt-0.5 shrink-0 text-primary">&gt;</span>
+            <span>
+              Website analytics dashboard:{" "}
+              <Link
+                href="https://umami.amanv.cloud/share/pHvqHleyOl9PBfaK"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-accent underline underline-offset-2 hover:text-primary"
+              >
+                Umami
+              </Link>{" "}
+              - self-hosted on a Hostinger VPS
+            </span>
+          </div>
         </div>
 
         <div className="mt-4 rounded-lg bg-muted/25 p-3 text-xs">

--- a/apps/web/src/app/(home)/analytics/_components/timeline-charts.tsx
+++ b/apps/web/src/app/(home)/analytics/_components/timeline-charts.tsx
@@ -51,12 +51,18 @@ const areaChartConfig = {
 } satisfies ChartConfig;
 
 const barChartConfig = {
-  count: { label: "Projects", color: "var(--chart-2)" },
+  totalProjects: { label: "Total Projects", color: "var(--chart-2)" },
 } satisfies ChartConfig;
 
 const hourlyChartConfig = {
   count: { label: "Projects", color: "var(--chart-3)" },
 } satisfies ChartConfig;
+
+function formatMonthLabel(monthKey: string, pattern: string): string {
+  const parsedMonth = parseISO(`${monthKey}-01`);
+  if (Number.isNaN(parsedMonth.getTime())) return monthKey;
+  return format(parsedMonth, pattern);
+}
 
 export function TimelineSection({ data }: { data: AggregatedAnalyticsData }) {
   const { timeSeries, monthlyTimeSeries, platformDistribution, hourlyDistribution } = data;
@@ -70,7 +76,10 @@ export function TimelineSection({ data }: { data: AggregatedAnalyticsData }) {
       </div>
 
       <div className="grid gap-6 lg:grid-cols-2">
-        <ChartCard title="daily_projects.chart" description="Project creations over time">
+        <ChartCard
+          title="daily_projects.chart"
+          description="Project creations over the last 30 days"
+        >
           <ChartContainer
             config={areaChartConfig}
             className="aspect-auto h-[280px] w-full min-h-[200px]"
@@ -109,7 +118,7 @@ export function TimelineSection({ data }: { data: AggregatedAnalyticsData }) {
           </ChartContainer>
         </ChartCard>
 
-        <ChartCard title="monthly_trends.bar" description="Monthly project volume">
+        <ChartCard title="monthly_trends.bar" description="Total projects created in each month">
           <ChartContainer
             config={barChartConfig}
             className="aspect-auto h-[280px] w-full min-h-[200px]"
@@ -121,11 +130,18 @@ export function TimelineSection({ data }: { data: AggregatedAnalyticsData }) {
                 tickLine={false}
                 axisLine={false}
                 tickMargin={10}
-                tickFormatter={(val) => val.slice(5)}
+                tickFormatter={(val) => formatMonthLabel(String(val), "MMM yy")}
               />
               <YAxis tickLine={false} axisLine={false} />
-              <ChartTooltip content={<ChartTooltipContent hideIndicator />} />
-              <Bar dataKey="count" fill="var(--chart-2)" radius={4} />
+              <ChartTooltip
+                content={
+                  <ChartTooltipContent
+                    labelFormatter={(value) => formatMonthLabel(String(value), "MMMM yyyy")}
+                    hideIndicator
+                  />
+                }
+              />
+              <Bar dataKey="totalProjects" fill="var(--chart-2)" radius={4} />
             </BarChart>
           </ChartContainer>
         </ChartCard>

--- a/apps/web/src/app/(home)/analytics/_components/types.ts
+++ b/apps/web/src/app/(home)/analytics/_components/types.ts
@@ -3,7 +3,7 @@ import type { ChartConfig } from "@/components/ui/chart";
 export type Distribution = Array<{ name: string; value: number }>;
 export type VersionDistribution = Array<{ version: string; count: number }>;
 export type TimeSeriesData = Array<{ date: string; count: number }>;
-export type MonthlyData = Array<{ month: string; count: number }>;
+export type MonthlyData = Array<{ month: string; totalProjects: number }>;
 export type HourlyData = Array<{ hour: string; count: number }>;
 
 export type AggregatedAnalyticsData = {

--- a/apps/web/src/app/(home)/analytics/page.tsx
+++ b/apps/web/src/app/(home)/analytics/page.tsx
@@ -30,11 +30,17 @@ export const metadata: Metadata = {
 };
 
 export default async function Analytics() {
-  const [preloadedStats, preloadedDailyStats] = await Promise.all([
+  const [preloadedStats, preloadedDailyStats, preloadedMonthlyStats] = await Promise.all([
     preloadQuery(api.analytics.getStats, {}),
-    preloadQuery(api.analytics.getDailyStats, {}),
+    preloadQuery(api.analytics.getDailyStats, { days: 30 }),
+    preloadQuery(api.analytics.getMonthlyStats, {}),
   ]);
+
   return (
-    <AnalyticsClient preloadedStats={preloadedStats} preloadedDailyStats={preloadedDailyStats} />
+    <AnalyticsClient
+      preloadedStats={preloadedStats}
+      preloadedDailyStats={preloadedDailyStats}
+      preloadedMonthlyStats={preloadedMonthlyStats}
+    />
   );
 }


### PR DESCRIPTION
## Summary
- add `getMonthlyStats` Convex query to aggregate full-history monthly totals from daily analytics
- keep dashboard daily charts explicitly scoped to the latest 30 days for predictable payload size
- wire analytics page/client to consume preloaded monthly aggregates and use that range for avg/day
- update monthly chart field mapping/labels and add the shared Umami dashboard link in docs and analytics header

## Verification
- bun run build:web

## Deploy order
1. deploy Convex backend first (`bun run deploy:convex`)
2. deploy web app second (`bun run deploy:web`)
