### PR TITLE
fix(template): use correct heroui-native path in monorepo setups

### DIFF
--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -22302,11 +22302,15 @@ export function useAppTheme() {
 }
 
 `],
-  ["frontend/native/uniwind/global.css", `@import "tailwindcss";
+  ["frontend/native/uniwind/global.css.hbs", `@import "tailwindcss";
 @import "uniwind";
 @import "heroui-native/styles";
 
+{{#if (includes addons "turborepo")}}
+@source '../../node_modules/heroui-native/lib';
+{{else}}
 @source './node_modules/heroui-native/lib';
+{{/if}}
 `],
   ["frontend/native/uniwind/metro.config.js.hbs", `const { getDefaultConfig } = require("expo/metro-config");
 const { withUniwindConfig } = require("uniwind/metro");

--- a/packages/template-generator/templates/frontend/native/uniwind/global.css.hbs
+++ b/packages/template-generator/templates/frontend/native/uniwind/global.css.hbs
@@ -2,4 +2,8 @@
 @import "uniwind";
 @import "heroui-native/styles";
 
+{{#if (includes addons "turborepo")}}
+@source '../../node_modules/heroui-native/lib';
+{{else}}
 @source './node_modules/heroui-native/lib';
+{{/if}}


### PR DESCRIPTION
## Summary

- In turborepo monorepos, bun hoists `heroui-native` to the root `node_modules`, so `@source './node_modules/heroui-native/lib'` in `global.css` doesn't resolve — HeroUI classes silently go missing
- Converted `global.css` to a Handlebars template (`.hbs`) that conditionally uses `../../node_modules/heroui-native/lib` when the turborepo addon is enabled, and keeps the original `./node_modules/heroui-native/lib` for non-monorepo setups

Fixes #810

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated template configuration to dynamically resolve paths based on project setup and available add-ons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->