### PR TITLE
chore(cli): Remove custom srvx version for Clerk TanStack Start

### DIFF
--- a/packages/template-generator/src/processors/auth-deps.ts
+++ b/packages/template-generator/src/processors/auth-deps.ts
@@ -43,7 +43,7 @@ function processConvexAuthDeps(vfs: VirtualFileSystem, config: ProjectConfig): v
         addPackageDependency({
           vfs,
           packagePath: webPath,
-          dependencies: ["@clerk/tanstack-react-start", "srvx"],
+          dependencies: ["@clerk/tanstack-react-start"],
         });
       } else if (hasViteReact) {
         addPackageDependency({ vfs, packagePath: webPath, dependencies: ["@clerk/clerk-react"] });

--- a/packages/template-generator/src/utils/add-deps.ts
+++ b/packages/template-generator/src/utils/add-deps.ts
@@ -150,7 +150,6 @@ export const dependencyVersionMap = {
   "@t3-oss/env-core": "^0.13.1",
   "@t3-oss/env-nextjs": "^0.13.1",
   "@t3-oss/env-nuxt": "^0.13.1",
-  srvx: "0.8.15",
 
   "@polar-sh/better-auth": "^1.6.4",
   "@polar-sh/sdk": "^0.42.2",


### PR DESCRIPTION
`srvx` was pinned in this PR to resolve upstream issues https://github.com/AmanVarshney01/create-better-t-stack/pull/647

This is now fixed and safe to remove

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed automatic inclusion of the srvx dependency when generating projects with Clerk authentication and TanStack Start.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->