### PR TITLE
feat(web): add nx in stack builder

### DIFF
--- a/apps/web/src/app/(home)/new/_components/stack-builder/use-stack-builder.ts
+++ b/apps/web/src/app/(home)/new/_components/stack-builder/use-stack-builder.ts
@@ -247,6 +247,15 @@ export function useStackBuilder() {
               ? nextArray.filter((id) => id !== techId)
               : [...nextArray, techId];
 
+            if (catKey === "addons" && !isSelected) {
+              if (techId === "nx") {
+                nextArray = nextArray.filter((id) => id !== "turborepo");
+              }
+              if (techId === "turborepo") {
+                nextArray = nextArray.filter((id) => id !== "nx");
+              }
+            }
+
             if (nextArray.length > 1) {
               nextArray = nextArray.filter((id) => id !== "none");
             }

--- a/apps/web/src/app/(home)/new/_components/tech-icon.tsx
+++ b/apps/web/src/app/(home)/new/_components/tech-icon.tsx
@@ -28,6 +28,7 @@ export function TechIcon({
       icon.includes("express") ||
       icon.includes("clerk") ||
       icon.includes("planetscale") ||
+      icon.includes("nx") ||
       icon.includes("polar") ||
       icon.includes("astro"))
   ) {

--- a/apps/web/src/app/(home)/new/_components/utils.ts
+++ b/apps/web/src/app/(home)/new/_components/utils.ts
@@ -993,6 +993,12 @@ export const getDisabledReason = (
     if (optionId === "tauri" && !hasTauriCompatibleFrontend(currentStack.webFrontend)) {
       return "Tauri requires TanStack Router, React Router, Nuxt, Svelte, Solid, or Next.js";
     }
+    if (optionId === "nx" && currentStack.addons.includes("turborepo")) {
+      return "Nx and Turborepo cannot be used together";
+    }
+    if (optionId === "turborepo" && currentStack.addons.includes("nx")) {
+      return "Nx and Turborepo cannot be used together";
+    }
   }
 
   // ============================================

--- a/apps/web/src/components/ui/tech-badge.tsx
+++ b/apps/web/src/components/ui/tech-badge.tsx
@@ -64,6 +64,7 @@ function TechIcon({ icon, name, className }: { icon: string; name: string; class
       icon.includes("express") ||
       icon.includes("clerk") ||
       icon.includes("planetscale") ||
+      icon.includes("nx") ||
       icon.includes("polar") ||
       icon.includes("astro"))
   ) {

--- a/apps/web/src/lib/constant.ts
+++ b/apps/web/src/lib/constant.ts
@@ -563,6 +563,14 @@ export const TECH_OPTIONS: Record<
       default: true,
     },
     {
+      id: "nx",
+      name: "Nx",
+      description: "Smart monorepo build system and task runner",
+      icon: `${ICON_BASE_URL}/nx.svg`,
+      color: "from-cyan-500 to-cyan-700",
+      default: false,
+    },
+    {
       id: "ruler",
       name: "Ruler",
       description: "Centralize your AI rules",

--- a/apps/web/src/lib/stack-utils.ts
+++ b/apps/web/src/lib/stack-utils.ts
@@ -113,6 +113,7 @@ export function generateStackCommand(stack: StackState) {
                 "lefthook",
                 "husky",
                 "turborepo",
+                "nx",
                 "ultracite",
                 "fumadocs",
                 "oxlint",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Nx as an available addon option in the stack builder
  * Implemented mutual exclusion between Nx and Turborepo—selecting one automatically removes the other from your stack configuration

* **Styling & UI**
  * Enhanced icon and badge rendering for Nx addon with proper light-theme variants and color categorization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->