### PR TITLE
fix(template-generator): gate app scripts by generated workspaces

### DIFF
--- a/packages/template-generator/src/post-process/package-configs.ts
+++ b/packages/template-generator/src/post-process/package-configs.ts
@@ -67,7 +67,22 @@ function updateRootPackageJson(vfs: VirtualFileSystem, config: ProjectConfig): v
   pkgJson.workspaces = workspaces;
 
   const scripts = pkgJson.scripts;
-  const { projectName, packageManager, backend, database, orm, dbSetup, addons } = config;
+  const { projectName, packageManager, backend, database, orm, dbSetup, addons, frontend } = config;
+  const hasWebApp = frontend.some((item) =>
+    [
+      "tanstack-router",
+      "react-router",
+      "tanstack-start",
+      "next",
+      "nuxt",
+      "svelte",
+      "solid",
+      "astro",
+    ].includes(item),
+  );
+  const hasNativeApp = frontend.some((item) =>
+    ["native-bare", "native-uniwind", "native-unistyles"].includes(item),
+  );
 
   const backendPackageName = backend === "convex" ? `@${projectName}/backend` : "server";
   const dbPackageName = `@${projectName}/db`;
@@ -83,8 +98,14 @@ function updateRootPackageJson(vfs: VirtualFileSystem, config: ProjectConfig): v
   scripts.dev = pmConfig.dev;
   scripts.build = pmConfig.build;
   scripts["check-types"] = pmConfig.checkTypes;
-  scripts["dev:native"] = pmConfig.filter("native", "dev");
-  scripts["dev:web"] = pmConfig.filter("web", "dev");
+
+  if (hasNativeApp) {
+    scripts["dev:native"] = pmConfig.filter("native", "dev");
+  }
+
+  if (hasWebApp) {
+    scripts["dev:web"] = pmConfig.filter("web", "dev");
+  }
 
   if (addons.includes("opentui")) {
     scripts["dev:tui"] = pmConfig.filter("tui", "dev");

--- a/packages/template-generator/src/processors/readme-generator.ts
+++ b/packages/template-generator/src/processors/readme-generator.ts
@@ -481,15 +481,27 @@ function generateScriptsList(
   config: ProjectConfig,
   hasNative: boolean,
 ): string {
-  const { database, addons, backend, dbSetup } = config;
+  const { database, addons, backend, dbSetup, frontend } = config;
   const isConvex = backend === "convex";
   const isBackendSelf = backend === "self";
+  const hasWeb = frontend.some((f) =>
+    [
+      "tanstack-router",
+      "react-router",
+      "tanstack-start",
+      "next",
+      "nuxt",
+      "svelte",
+      "solid",
+      "astro",
+    ].includes(f),
+  );
   const dbSupport = getDbScriptSupport(config);
 
   let scripts = `- \`${packageManagerRunCmd} dev\`: Start all applications in development mode
 - \`${packageManagerRunCmd} build\`: Build all applications`;
 
-  if (!isBackendSelf) {
+  if (hasWeb) {
     scripts += `\n- \`${packageManagerRunCmd} dev:web\`: Start only the web application`;
   }
 


### PR DESCRIPTION
## Summary
- only add `dev:web` when `apps/web` is generated
- only add `dev:native` when `apps/native` is generated
- align generated README script docs with the actual generated app surfaces

## Verification
- `cd packages/template-generator && bun run build`
- `bun run build:cli`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * The template generator now adds development scripts for web and native only when corresponding frontends are detected, producing cleaner, more accurate project configurations and avoiding unnecessary dev commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->