### PR TITLE
fix(ci): harden npm release publishing

### DIFF
--- a/.github/workflows/pr-preview.yaml
+++ b/.github/workflows/pr-preview.yaml
@@ -30,6 +30,7 @@ jobs:
         with:
           node-version-file: package.json
           check-latest: true
+          registry-url: https://registry.npmjs.org
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -40,6 +41,11 @@ jobs:
         run: bun install --frozen-lockfile
         env:
           BTS_TELEMETRY: 0
+
+      - name: Verify NPM auth
+        run: npm whoami
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Generate Preview Version
         id: version
@@ -67,9 +73,9 @@ jobs:
         run: cd packages/types && bun run build
 
       - name: Publish types to NPM
-        run: cd packages/types && bun publish --access public --tag ${{ steps.version.outputs.tag }}
+        run: cd packages/types && npm publish --access public --provenance --tag ${{ steps.version.outputs.tag }}
         env:
-          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           BTS_TELEMETRY: 0
 
       - name: Update template-generator package version and types dependency
@@ -81,9 +87,9 @@ jobs:
         run: cd packages/template-generator && bun run build
 
       - name: Publish template-generator to NPM
-        run: cd packages/template-generator && bun publish --access public --tag ${{ steps.version.outputs.tag }}
+        run: cd packages/template-generator && npm publish --access public --provenance --tag ${{ steps.version.outputs.tag }}
         env:
-          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           BTS_TELEMETRY: 0
 
       - name: Update CLI package version and dependencies
@@ -102,15 +108,15 @@ jobs:
           BTS_TELEMETRY: 0
 
       - name: Publish CLI to NPM
-        run: cd apps/cli && bun publish --access public --tag ${{ steps.version.outputs.tag }}
+        run: cd apps/cli && npm publish --access public --provenance --tag ${{ steps.version.outputs.tag }}
         env:
-          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           BTS_TELEMETRY: 0
 
       - name: Publish create-bts to NPM
-        run: cd packages/create-bts && bun publish --access public --tag ${{ steps.version.outputs.tag }}
+        run: cd packages/create-bts && npm publish --access public --provenance --tag ${{ steps.version.outputs.tag }}
         env:
-          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           BTS_TELEMETRY: 0
 
       - name: Find existing preview comment

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,7 @@ jobs:
         with:
           node-version-file: package.json
           check-latest: true
+          registry-url: https://registry.npmjs.org
 
       - name: Extract version from commit message
         id: version
@@ -59,19 +60,6 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Create and push tag
-        if: steps.check-version.outputs.exists == 'false'
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          git config --local user.email "amanvarshney.work@gmail.com"
-          git config --local user.name "Aman Varshney"
-          if ! git rev-parse "v$VERSION" >/dev/null 2>&1; then
-            git tag -a "v$VERSION" -m "Release v$VERSION"
-            git push --tags
-          else
-            echo "Tag v$VERSION already exists, skipping"
-          fi
-
       - name: Setup Bun
         if: steps.check-version.outputs.exists == 'false'
         uses: oven-sh/setup-bun@v2
@@ -82,17 +70,11 @@ jobs:
         if: steps.check-version.outputs.exists == 'false'
         run: bun install --frozen-lockfile
 
-      - name: Create GitHub Release
+      - name: Verify NPM auth
         if: steps.check-version.outputs.exists == 'false'
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          if ! gh release view "v$VERSION" >/dev/null 2>&1; then
-            bunx changelogithub
-          else
-            echo "Release v$VERSION already exists, skipping"
-          fi
+        run: npm whoami
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Update types package version
         if: steps.check-version.outputs.exists == 'false'
@@ -107,9 +89,9 @@ jobs:
 
       - name: Publish types to NPM
         if: steps.check-version.outputs.exists == 'false'
-        run: cd packages/types && bun publish --access public
+        run: cd packages/types && npm publish --access public --provenance
         env:
-          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           BTS_TELEMETRY: 1
           CONVEX_INGEST_URL: ${{ secrets.CONVEX_INGEST_URL }}
 
@@ -126,9 +108,9 @@ jobs:
 
       - name: Publish template-generator to NPM
         if: steps.check-version.outputs.exists == 'false'
-        run: cd packages/template-generator && bun publish --access public
+        run: cd packages/template-generator && npm publish --access public --provenance
         env:
-          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           BTS_TELEMETRY: 1
           CONVEX_INGEST_URL: ${{ secrets.CONVEX_INGEST_URL }}
 
@@ -155,19 +137,44 @@ jobs:
 
       - name: Publish CLI to NPM
         if: steps.check-version.outputs.exists == 'false'
-        run: cd apps/cli && bun publish --access public
+        run: cd apps/cli && npm publish --access public --provenance
         env:
-          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           BTS_TELEMETRY: 1
           CONVEX_INGEST_URL: ${{ secrets.CONVEX_INGEST_URL }}
 
       - name: Publish create-bts alias to NPM
         if: steps.check-version.outputs.exists == 'false'
-        run: cd packages/create-bts && bun publish --access public
+        run: cd packages/create-bts && npm publish --access public --provenance
         env:
-          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           BTS_TELEMETRY: 1
           CONVEX_INGEST_URL: ${{ secrets.CONVEX_INGEST_URL }}
+
+      - name: Create and push tag
+        if: steps.check-version.outputs.exists == 'false'
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          git config --local user.email "amanvarshney.work@gmail.com"
+          git config --local user.name "Aman Varshney"
+          if ! git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            git tag -a "v$VERSION" -m "Release v$VERSION"
+            git push --tags
+          else
+            echo "Tag v$VERSION already exists, skipping"
+          fi
+
+      - name: Create GitHub Release
+        if: steps.check-version.outputs.exists == 'false'
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          if ! gh release view "v$VERSION" >/dev/null 2>&1; then
+            bunx changelogithub
+          else
+            echo "Release v$VERSION already exists, skipping"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Release Summary
         if: steps.check-version.outputs.exists == 'false'


### PR DESCRIPTION
## Summary
- switch release and preview publishing from `bun publish` to `npm publish`
- verify npm authentication explicitly before attempting any publish steps
- move tag and GitHub release creation until after all npm publishes succeed

## Why
The current release workflow created `v3.25.1` and a GitHub release even though package publishing failed at `@better-t-stack/types`. This change makes the failure mode clearer and prevents broken releases from being tagged as successful.

## Verification
- inspected failed `v3.25.1` release logs
- verified npm registry currently only has scoped packages published through `3.24.0`
- reviewed both `.github/workflows/release.yaml` and `.github/workflows/pr-preview.yaml` end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated package publishing workflow to use npm publish with provenance support.
  * Enhanced NPM authentication verification in deployment processes.
  * Reorganized release workflow steps for improved consistency and execution order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->