### PR TITLE
fix(cli): remove tailwind add flag from starlight scaffold

### DIFF
--- a/apps/cli/src/helpers/addons/starlight-setup.ts
+++ b/apps/cli/src/helpers/addons/starlight-setup.ts
@@ -28,8 +28,6 @@ export async function setupStarlight(
     "starlight",
     "--yes",
     "--no-install",
-    "--add",
-    "tailwind",
     "--no-git",
     "--skip-houston",
   ];


### PR DESCRIPTION
## Summary
- remove the `--add tailwind` arguments from the Starlight addon scaffold command
- keep the Starlight scaffold on the current `create-astro` no-install path

## Verification
- pre-commit `bun check`
- local smoke run: `bun run apps/cli/src/cli.ts create tmp-starlight-pr-<timestamp> --template none --frontend tanstack-router --backend hono --runtime bun --database sqlite --orm drizzle --auth none --api trpc --examples none --addons starlight --db-setup none --web-deploy none --server-deploy none --package-manager bun --no-install --no-git`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed automatic Tailwind CSS inclusion from Starlight documentation setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->