### PR TITLE
fix(cli): explicitly reference env vars in native template for Metro inlining

### DIFF
--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -27783,7 +27783,19 @@ export const env = createEnv({
 		EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY: z.string().min(1),
 {{/if}}
 	},
-	runtimeEnv: process.env,
+	runtimeEnv: {
+{{#if (eq backend "convex")}}
+		EXPO_PUBLIC_CONVEX_URL: process.env.EXPO_PUBLIC_CONVEX_URL,
+{{#if (eq auth "better-auth")}}
+		EXPO_PUBLIC_CONVEX_SITE_URL: process.env.EXPO_PUBLIC_CONVEX_SITE_URL,
+{{/if}}
+{{else}}
+		EXPO_PUBLIC_SERVER_URL: process.env.EXPO_PUBLIC_SERVER_URL,
+{{/if}}
+{{#if (eq auth "clerk")}}
+		EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY: process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY,
+{{/if}}
+	},
 	emptyStringAsUndefined: true,
 });
 `],

--- a/packages/template-generator/templates/packages/env/src/native.ts.hbs
+++ b/packages/template-generator/templates/packages/env/src/native.ts.hbs
@@ -16,6 +16,18 @@ export const env = createEnv({
 		EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY: z.string().min(1),
 {{/if}}
 	},
-	runtimeEnv: process.env,
+	runtimeEnv: {
+{{#if (eq backend "convex")}}
+		EXPO_PUBLIC_CONVEX_URL: process.env.EXPO_PUBLIC_CONVEX_URL,
+{{#if (eq auth "better-auth")}}
+		EXPO_PUBLIC_CONVEX_SITE_URL: process.env.EXPO_PUBLIC_CONVEX_SITE_URL,
+{{/if}}
+{{else}}
+		EXPO_PUBLIC_SERVER_URL: process.env.EXPO_PUBLIC_SERVER_URL,
+{{/if}}
+{{#if (eq auth "clerk")}}
+		EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY: process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY,
+{{/if}}
+	},
 	emptyStringAsUndefined: true,
 });


### PR DESCRIPTION
## Summary

- Replaces `runtimeEnv: process.env` with explicit per-variable references (`process.env.EXPO_PUBLIC_*`) in the native env template so Metro can inline them during production Hermes bytecode bundling
- Without this, `process.env` resolves to an empty object in production iOS builds, causing Zod validation to throw and crash the app on startup

## Details

Metro's transform for `EXPO_PUBLIC_*` environment variables only works on **individual property accesses** like `process.env.EXPO_PUBLIC_SERVER_URL` — it performs AST-level replacement. Passing `process.env` as a whole object to `runtimeEnv` results in an empty object in production Hermes bytecode bundles. This works in development because Metro dev server handles `process.env` differently.

## Test plan

- [ ] Generate a project with each native env combination (convex, non-convex, clerk, better-auth) and verify the `native.ts` output has explicit env var references
- [ ] Build a production iOS release and confirm env vars are correctly inlined

Fixes #987

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated environment variable configuration for generated project templates. Environment variables are now selectively included based on your selected backend (Convex or standard server) and authentication method (Clerk or Better Auth). This ensures only required variables are available at runtime, improving both security and project efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->