### PR TITLE
fix(cli): align Cloudflare env and auth plugins

### DIFF
--- a/apps/cli/test/api.test.ts
+++ b/apps/cli/test/api.test.ts
@@ -2,29 +2,8 @@ import { describe, expect, it } from "bun:test";
 
 import { createVirtual } from "../src/index";
 import type { API, Backend, Database, Examples, Frontend, ORM, Runtime } from "../src/types";
+import { collectFiles } from "./setup";
 import { expectError, expectSuccess, runTRPCTest, type TestConfig } from "./test-utils";
-
-function collectFiles(
-  node:
-    | { type: "file"; path: string; content: string }
-    | { type: "directory"; path: string; children: unknown[] },
-  rootPath: string,
-  files = new Map<string, string>(),
-) {
-  if (node.type === "file") {
-    const relativePath = node.path.startsWith(`${rootPath}/`)
-      ? node.path.slice(rootPath.length + 1)
-      : node.path;
-    files.set(relativePath, node.content);
-    return files;
-  }
-
-  for (const child of node.children as Parameters<typeof collectFiles>[0][]) {
-    collectFiles(child, rootPath, files);
-  }
-
-  return files;
-}
 
 describe("API Configurations", () => {
   describe("tRPC API", () => {

--- a/apps/cli/test/auth.test.ts
+++ b/apps/cli/test/auth.test.ts
@@ -80,6 +80,72 @@ describe("Authentication Configurations", () => {
       expectSuccess(result);
     });
 
+    it("should add nextCookies plugin for Next.js self backend", async () => {
+      const result = await runTRPCTest({
+        projectName: "better-auth-next-self-plugins",
+        auth: "better-auth",
+        backend: "self",
+        runtime: "none",
+        database: "postgres",
+        orm: "drizzle",
+        api: "trpc",
+        frontend: ["next"],
+        addons: ["turborepo"],
+        examples: ["none"],
+        dbSetup: "none",
+        webDeploy: "cloudflare",
+        serverDeploy: "none",
+        install: false,
+      });
+
+      expectSuccess(result);
+      if (!result.projectDir) {
+        throw new Error("Expected projectDir to be defined");
+      }
+
+      const authFile = await fs.readFile(
+        path.join(result.projectDir, "packages/auth/src/index.ts"),
+        "utf8",
+      );
+
+      expect(authFile).toContain('import { nextCookies } from "better-auth/next-js";');
+      expect(authFile).toContain("nextCookies()");
+    });
+
+    it("should add tanstackStartCookies plugin for TanStack Start self backend", async () => {
+      const result = await runTRPCTest({
+        projectName: "better-auth-tanstack-start-self-plugins",
+        auth: "better-auth",
+        backend: "self",
+        runtime: "none",
+        database: "postgres",
+        orm: "drizzle",
+        api: "trpc",
+        frontend: ["tanstack-start"],
+        addons: ["turborepo"],
+        examples: ["none"],
+        dbSetup: "none",
+        webDeploy: "none",
+        serverDeploy: "none",
+        install: false,
+      });
+
+      expectSuccess(result);
+      if (!result.projectDir) {
+        throw new Error("Expected projectDir to be defined");
+      }
+
+      const authFile = await fs.readFile(
+        path.join(result.projectDir, "packages/auth/src/index.ts"),
+        "utf8",
+      );
+
+      expect(authFile).toContain(
+        'import { tanstackStartCookies } from "better-auth/tanstack-start";',
+      );
+      expect(authFile).toContain("tanstackStartCookies()");
+    });
+
     it("should fail with better-auth + no database (non-convex)", async () => {
       const result = await runTRPCTest({
         projectName: "better-auth-no-db-fail",

--- a/apps/cli/test/clerk-matrix.test.ts
+++ b/apps/cli/test/clerk-matrix.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 
 import { createVirtual } from "../src/index";
 import { validateConfigCompatibility } from "../src/validation";
+import { collectFiles } from "./setup";
 
 const standardBackends = [
   { backend: "hono", runtime: "bun" },
@@ -41,28 +42,6 @@ function buildFrontendCombos(
   }
 
   return combos;
-}
-
-function collectFiles(
-  node:
-    | { type: "file"; path: string; content: string }
-    | { type: "directory"; path: string; children: unknown[] },
-  rootPath: string,
-  files = new Map<string, string>(),
-) {
-  if (node.type === "file") {
-    const relativePath = node.path.startsWith(`${rootPath}/`)
-      ? node.path.slice(rootPath.length + 1)
-      : node.path;
-    files.set(relativePath, node.content);
-    return files;
-  }
-
-  for (const child of node.children as Parameters<typeof collectFiles>[0][]) {
-    collectFiles(child, rootPath, files);
-  }
-
-  return files;
 }
 
 function expectedContextImport(backend: string) {

--- a/apps/cli/test/cloudflare-db-clients.test.ts
+++ b/apps/cli/test/cloudflare-db-clients.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from "bun:test";
+
+import { createVirtual } from "../src/index";
+import { collectFiles } from "./setup";
+
+describe("Cloudflare DB client generation", () => {
+  it("uses request-scoped db/auth factories for Workers templates", async () => {
+    const result = await createVirtual({
+      projectName: "workers-request-scoped-db",
+      frontend: ["tanstack-router"],
+      backend: "hono",
+      runtime: "workers",
+      database: "sqlite",
+      orm: "drizzle",
+      auth: "better-auth",
+      addons: ["none"],
+      examples: ["todo"],
+      dbSetup: "turso",
+      webDeploy: "none",
+      serverDeploy: "cloudflare",
+      install: false,
+      git: false,
+      packageManager: "bun",
+      payments: "none",
+      api: "trpc",
+    });
+
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    const files = collectFiles(result.value.root, result.value.root.path);
+    const dbFile = files.get("packages/db/src/index.ts");
+    const authFile = files.get("packages/auth/src/index.ts");
+    const envFile = files.get("packages/env/src/server.ts");
+    const serverFile = files.get("apps/server/src/index.ts");
+    const contextFile = files.get("packages/api/src/context.ts");
+    const todoRouterFile = files.get("packages/api/src/routers/todo.ts");
+
+    expect(dbFile).toContain("export function createDb()");
+    expect(dbFile).not.toContain("export const db = createDb();");
+    expect(authFile).toContain("export function createAuth()");
+    expect(authFile).not.toContain("export const auth = createAuth();");
+    expect(envFile).toContain('export { env } from "cloudflare:workers";');
+    expect(serverFile).toContain("createAuth().handler(c.req.raw)");
+    expect(contextFile).toContain("createAuth().api.getSession");
+    expect(todoRouterFile).toContain("const db = createDb();");
+  });
+
+  it("uses request-scoped db/auth factories for Next on Cloudflare", async () => {
+    const result = await createVirtual({
+      projectName: "next-cloudflare-request-scoped-db",
+      frontend: ["next"],
+      backend: "self",
+      runtime: "none",
+      database: "postgres",
+      orm: "prisma",
+      auth: "better-auth",
+      addons: ["none"],
+      examples: ["todo"],
+      dbSetup: "none",
+      webDeploy: "cloudflare",
+      serverDeploy: "none",
+      install: false,
+      git: false,
+      packageManager: "bun",
+      payments: "none",
+      api: "trpc",
+    });
+
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    const files = collectFiles(result.value.root, result.value.root.path);
+    const dbFile = files.get("packages/db/src/index.ts");
+    const authFile = files.get("packages/auth/src/index.ts");
+    const envFile = files.get("packages/env/src/server.ts");
+    const envPackageFile = files.get("packages/env/package.json");
+    const routeFile = files.get("apps/web/src/app/api/auth/[...all]/route.ts");
+    const dashboardFile = files.get("apps/web/src/app/dashboard/page.tsx");
+    const contextFile = files.get("packages/api/src/context.ts");
+
+    expect(dbFile).toContain("export function createPrismaClient()");
+    expect(dbFile).not.toContain("export default prisma;");
+    expect(authFile).toContain("const prisma = createPrismaClient();");
+    expect(authFile).not.toContain("export const auth = createAuth();");
+    expect(envFile).toContain('import { getCloudflareContext } from "@opennextjs/cloudflare";');
+    expect(envFile).toContain("function resolveEnvValue(key: string)");
+    expect(envFile).toContain("export async function getEnvAsync()");
+    expect(envFile).toContain("getCloudflareContext({ async: true })");
+    expect(envFile).toContain("export const env = createEnvProxy(resolveEnvValue);");
+    expect(envFile).not.toContain('export { env } from "cloudflare:workers";');
+    expect(envPackageFile).toContain('"@opennextjs/cloudflare"');
+    expect(dbFile).toContain("maxUses: 1");
+    expect(routeFile).toContain("toNextJsHandler(createAuth()).GET(request)");
+    expect(routeFile).toContain("toNextJsHandler(createAuth()).POST(request)");
+    expect(dashboardFile).toContain("createAuth().api.getSession");
+    expect(dashboardFile).not.toContain('import { authClient } from "@/lib/auth-client";');
+    expect(contextFile).toContain("createAuth().api.getSession");
+  });
+
+  it("uses maxUses=1 for Cloudflare-targeted Postgres pools", async () => {
+    const result = await createVirtual({
+      projectName: "workers-postgres-pool-config",
+      frontend: ["tanstack-router"],
+      backend: "hono",
+      runtime: "workers",
+      database: "postgres",
+      orm: "drizzle",
+      auth: "better-auth",
+      addons: ["none"],
+      examples: ["none"],
+      dbSetup: "none",
+      webDeploy: "none",
+      serverDeploy: "cloudflare",
+      install: false,
+      git: false,
+      packageManager: "bun",
+      payments: "none",
+      api: "trpc",
+    });
+
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    const files = collectFiles(result.value.root, result.value.root.path);
+    const dbFile = files.get("packages/db/src/index.ts");
+
+    expect(dbFile).toContain('import { Pool } from "pg";');
+    expect(dbFile).toContain("maxUses: 1");
+    expect(dbFile).toContain("return drizzle({ client: pool, schema });");
+  });
+
+  it("keeps Better Auth MongoDB templates factory-only for Cloudflare Next deployments", async () => {
+    const result = await createVirtual({
+      projectName: "next-cloudflare-mongodb-auth",
+      frontend: ["next"],
+      backend: "self",
+      runtime: "none",
+      database: "mongodb",
+      orm: "mongoose",
+      auth: "better-auth",
+      addons: ["none"],
+      examples: ["none"],
+      dbSetup: "mongodb-atlas",
+      webDeploy: "cloudflare",
+      serverDeploy: "none",
+      install: false,
+      git: false,
+      packageManager: "bun",
+      payments: "none",
+      api: "trpc",
+    });
+
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    const files = collectFiles(result.value.root, result.value.root.path);
+    const authFile = files.get("packages/auth/src/index.ts");
+    const routeFile = files.get("apps/web/src/app/api/auth/[...all]/route.ts");
+
+    expect(authFile).toContain("export function createAuth()");
+    expect(authFile).not.toContain("export const auth = createAuth();");
+    expect(routeFile).toContain("toNextJsHandler(createAuth()).GET(request)");
+  });
+
+  it("keeps singleton exports for non-Cloudflare runtimes", async () => {
+    const result = await createVirtual({
+      projectName: "bun-singleton-db",
+      frontend: ["tanstack-router"],
+      backend: "hono",
+      runtime: "bun",
+      database: "sqlite",
+      orm: "drizzle",
+      auth: "better-auth",
+      addons: ["none"],
+      examples: ["todo"],
+      dbSetup: "none",
+      webDeploy: "none",
+      serverDeploy: "none",
+      install: false,
+      git: false,
+      packageManager: "bun",
+      payments: "none",
+      api: "trpc",
+    });
+
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    const files = collectFiles(result.value.root, result.value.root.path);
+    const dbFile = files.get("packages/db/src/index.ts");
+    const authFile = files.get("packages/auth/src/index.ts");
+    const serverFile = files.get("apps/server/src/index.ts");
+
+    expect(dbFile).toContain("export const db = createDb();");
+    expect(authFile).toContain("export const auth = createAuth();");
+    expect(serverFile).toContain("auth.handler(c.req.raw)");
+  });
+
+  it("keeps singleton auth handlers for Next outside Cloudflare", async () => {
+    const result = await createVirtual({
+      projectName: "next-singleton-auth",
+      frontend: ["next"],
+      backend: "self",
+      runtime: "none",
+      database: "postgres",
+      orm: "prisma",
+      auth: "better-auth",
+      addons: ["none"],
+      examples: ["todo"],
+      dbSetup: "none",
+      webDeploy: "none",
+      serverDeploy: "none",
+      install: false,
+      git: false,
+      packageManager: "bun",
+      payments: "none",
+      api: "trpc",
+    });
+
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    const files = collectFiles(result.value.root, result.value.root.path);
+    const authFile = files.get("packages/auth/src/index.ts");
+    const routeFile = files.get("apps/web/src/app/api/auth/[...all]/route.ts");
+
+    expect(authFile).toContain("export const auth = createAuth();");
+    expect(routeFile).toContain("export const { GET, POST } = toNextJsHandler(auth);");
+    expect(routeFile).not.toContain("createAuth()");
+  });
+});

--- a/apps/cli/test/readme.test.ts
+++ b/apps/cli/test/readme.test.ts
@@ -1,28 +1,7 @@
 import { describe, expect, it } from "bun:test";
 
 import { createVirtual } from "../src/index";
-
-function collectFiles(
-  node:
-    | { type: "file"; path: string; content: string }
-    | { type: "directory"; path: string; children: unknown[] },
-  rootPath: string,
-  files = new Map<string, string>(),
-) {
-  if (node.type === "file") {
-    const relativePath = node.path.startsWith(`${rootPath}/`)
-      ? node.path.slice(rootPath.length + 1)
-      : node.path;
-    files.set(relativePath, node.content);
-    return files;
-  }
-
-  for (const child of node.children as Parameters<typeof collectFiles>[0][]) {
-    collectFiles(child, rootPath, files);
-  }
-
-  return files;
-}
+import { collectFiles } from "./setup";
 
 async function generateReadme(config: Parameters<typeof createVirtual>[0]): Promise<string> {
   const result = await createVirtual({

--- a/apps/cli/test/setup.ts
+++ b/apps/cli/test/setup.ts
@@ -4,12 +4,46 @@ import { join } from "node:path";
 
 export const SMOKE_DIR = join(import.meta.dir, "..", ".smoke");
 
+type VirtualFileNode = {
+  type: "file";
+  path: string;
+  content: string;
+};
+
+type VirtualDirectoryNode = {
+  type: "directory";
+  path: string;
+  children: VirtualNode[];
+};
+
+export type VirtualNode = VirtualFileNode | VirtualDirectoryNode;
+
 export async function ensureSmokeDirectory() {
   await mkdir(SMOKE_DIR, { recursive: true });
 }
 
 export async function cleanupSmokeDirectory() {
   await rm(SMOKE_DIR, { recursive: true, force: true });
+}
+
+export function collectFiles(
+  node: VirtualNode,
+  rootPath: string,
+  files = new Map<string, string>(),
+) {
+  if (node.type === "file") {
+    const relativePath = node.path.startsWith(`${rootPath}/`)
+      ? node.path.slice(rootPath.length + 1)
+      : node.path;
+    files.set(relativePath, node.content);
+    return files;
+  }
+
+  for (const child of node.children) {
+    collectFiles(child, rootPath, files);
+  }
+
+  return files;
 }
 
 // Global setup - runs once before all tests

--- a/packages/template-generator/src/processors/auth-plugins.ts
+++ b/packages/template-generator/src/processors/auth-plugins.ts
@@ -1,5 +1,5 @@
 import type { ProjectConfig } from "@better-t-stack/types";
-import { Project, SyntaxKind } from "ts-morph";
+import { Node, Project, SyntaxKind } from "ts-morph";
 
 import type { VirtualFileSystem } from "../core/virtual-fs";
 
@@ -68,10 +68,14 @@ export function processAuthPlugins(vfs: VirtualFileSystem, config: ProjectConfig
     }
   });
 
-  // Add plugins to betterAuth config
+  // Add plugins to the generated betterAuth config, regardless of whether the
+  // file exports a singleton `auth` or wraps the config in `createAuth()`.
   const betterAuthCall = sourceFile
-    .getVariableDeclaration("auth")
-    ?.getInitializerIfKind(SyntaxKind.CallExpression);
+    .getDescendantsOfKind(SyntaxKind.CallExpression)
+    .find((callExpression) => {
+      const expression = callExpression.getExpression();
+      return Node.isIdentifier(expression) && expression.getText() === "betterAuth";
+    });
 
   if (betterAuthCall) {
     const configObject = betterAuthCall

--- a/packages/template-generator/src/processors/env-deps.ts
+++ b/packages/template-generator/src/processors/env-deps.ts
@@ -7,7 +7,7 @@ export function processEnvDeps(vfs: VirtualFileSystem, config: ProjectConfig): v
   const envPath = "packages/env/package.json";
   if (!vfs.exists(envPath)) return;
 
-  const { frontend, backend, runtime } = config;
+  const { frontend, backend, runtime, webDeploy } = config;
   const deps: AvailableDependencies[] = ["zod"];
   const hasNative = frontend.some((value) =>
     ["native-bare", "native-uniwind", "native-unistyles"].includes(value),
@@ -29,6 +29,10 @@ export function processEnvDeps(vfs: VirtualFileSystem, config: ProjectConfig): v
   const needsServerEnv = backend !== "convex" && backend !== "none" && runtime !== "workers";
   if (needsServerEnv && !deps.includes("@t3-oss/env-core")) {
     deps.push("@t3-oss/env-core");
+  }
+
+  if (backend === "self" && webDeploy === "cloudflare" && hasNextJs) {
+    deps.push("@opennextjs/cloudflare");
   }
 
   addPackageDependency({ vfs, packagePath: envPath, dependencies: deps });

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -697,12 +697,16 @@ async function authenticateClerkRequest(request: Request): Promise<ClerkContextA
 {{#if (and (eq backend 'self') (includes frontend "next"))}}
 import type { NextRequest } from "next/server";
 {{#if (eq auth "better-auth")}}
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createAuth } from "@{{projectName}}/auth";
+{{else}}
 import { auth } from "@{{projectName}}/auth";
+{{/if}}
 {{/if}}
 
 export async function createContext(req: NextRequest){{#if (eq auth "clerk")}}: Promise<ClerkRequestContext>{{/if}} {
 {{#if (eq auth "better-auth")}}
-	const session = await auth.api.getSession({
+	const session = await {{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}createAuth(){{else}}auth{{/if}}.api.getSession({
 		headers: req.headers,
 	});
 	return {
@@ -725,12 +729,16 @@ export async function createContext(req: NextRequest){{#if (eq auth "clerk")}}: 
 
 {{else if (and (eq backend 'self') (includes frontend "tanstack-start"))}}
 {{#if (eq auth "better-auth")}}
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createAuth } from "@{{projectName}}/auth";
+{{else}}
 import { auth } from "@{{projectName}}/auth";
+{{/if}}
 {{/if}}
 
 export async function createContext({ req }: { req: Request }){{#if (eq auth "clerk")}}: Promise<ClerkRequestContext>{{/if}} {
 {{#if (eq auth "better-auth")}}
-	const session = await auth.api.getSession({
+	const session = await {{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}createAuth(){{else}}auth{{/if}}.api.getSession({
 		headers: req.headers,
 	});
 	return {
@@ -753,7 +761,11 @@ export async function createContext({ req }: { req: Request }){{#if (eq auth "cl
 
 {{else if (and (eq backend 'self') (includes frontend "nuxt"))}}
 {{#if (eq auth "better-auth")}}
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createAuth } from "@{{projectName}}/auth";
+{{else}}
 import { auth } from "@{{projectName}}/auth";
+{{/if}}
 {{/if}}
 
 export type CreateContextOptions = {
@@ -762,7 +774,7 @@ export type CreateContextOptions = {
 
 export async function createContext({ headers }: CreateContextOptions) {
 {{#if (eq auth "better-auth")}}
-	const session = await auth.api.getSession({ headers });
+	const session = await {{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}createAuth(){{else}}auth{{/if}}.api.getSession({ headers });
 	return {
 		auth: null,
 		session,
@@ -777,7 +789,11 @@ export async function createContext({ headers }: CreateContextOptions) {
 
 {{else if (and (eq backend 'self') (includes frontend "astro"))}}
 {{#if (eq auth "better-auth")}}
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createAuth } from "@{{projectName}}/auth";
+{{else}}
 import { auth } from "@{{projectName}}/auth";
+{{/if}}
 {{/if}}
 
 export type CreateContextOptions = {
@@ -786,7 +802,7 @@ export type CreateContextOptions = {
 
 export async function createContext({ headers }: CreateContextOptions) {
 {{#if (eq auth "better-auth")}}
-	const session = await auth.api.getSession({ headers });
+	const session = await {{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}createAuth(){{else}}auth{{/if}}.api.getSession({ headers });
 	return {
 		auth: null,
 		session,
@@ -802,7 +818,11 @@ export async function createContext({ headers }: CreateContextOptions) {
 {{else if (eq backend 'hono')}}
 import type { Context as HonoContext } from "hono";
 {{#if (eq auth "better-auth")}}
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createAuth } from "@{{projectName}}/auth";
+{{else}}
 import { auth } from "@{{projectName}}/auth";
+{{/if}}
 {{/if}}
 
 export type CreateContextOptions = {
@@ -811,7 +831,7 @@ export type CreateContextOptions = {
 
 export async function createContext({ context }: CreateContextOptions){{#if (eq auth "clerk")}}: Promise<ClerkRequestContext>{{/if}} {
 {{#if (eq auth "better-auth")}}
-	const session = await auth.api.getSession({
+	const session = await {{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}createAuth(){{else}}auth{{/if}}.api.getSession({
 		headers: context.req.raw.headers,
 	});
 	return {
@@ -1545,12 +1565,16 @@ async function authenticateClerkRequest(request: Request): Promise<ClerkContextA
 {{#if (and (eq backend 'self') (includes frontend "next"))}}
 import type { NextRequest } from "next/server";
 {{#if (eq auth "better-auth")}}
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createAuth } from "@{{projectName}}/auth";
+{{else}}
 import { auth } from "@{{projectName}}/auth";
+{{/if}}
 {{/if}}
 
 export async function createContext(req: NextRequest){{#if (eq auth "clerk")}}: Promise<ClerkRequestContext>{{/if}} {
 {{#if (eq auth "better-auth")}}
-	const session = await auth.api.getSession({
+	const session = await {{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}createAuth(){{else}}auth{{/if}}.api.getSession({
 		headers: req.headers,
 	});
 	return {
@@ -1573,12 +1597,16 @@ export async function createContext(req: NextRequest){{#if (eq auth "clerk")}}: 
 
 {{else if (and (eq backend 'self') (includes frontend "tanstack-start"))}}
 {{#if (eq auth "better-auth")}}
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createAuth } from "@{{projectName}}/auth";
+{{else}}
 import { auth } from "@{{projectName}}/auth";
+{{/if}}
 {{/if}}
 
 export async function createContext({ req }: { req: Request }){{#if (eq auth "clerk")}}: Promise<ClerkRequestContext>{{/if}} {
 {{#if (eq auth "better-auth")}}
-	const session = await auth.api.getSession({
+	const session = await {{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}createAuth(){{else}}auth{{/if}}.api.getSession({
 		headers: req.headers,
 	});
 	return {
@@ -1602,7 +1630,11 @@ export async function createContext({ req }: { req: Request }){{#if (eq auth "cl
 {{else if (eq backend 'hono')}}
 import type { Context as HonoContext } from "hono";
 {{#if (eq auth "better-auth")}}
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createAuth } from "@{{projectName}}/auth";
+{{else}}
 import { auth } from "@{{projectName}}/auth";
+{{/if}}
 {{/if}}
 
 export type CreateContextOptions = {
@@ -1611,7 +1643,7 @@ export type CreateContextOptions = {
 
 export async function createContext({ context }: CreateContextOptions){{#if (eq auth "clerk")}}: Promise<ClerkRequestContext>{{/if}} {
 {{#if (eq auth "better-auth")}}
-	const session = await auth.api.getSession({
+	const session = await {{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}createAuth(){{else}}auth{{/if}}.api.getSession({
 		headers: context.req.raw.headers,
 	});
 	return {
@@ -5008,10 +5040,17 @@ declare namespace App {
   }
 }
 `],
-  ["auth/better-auth/fullstack/astro/src/middleware.ts.hbs", `import { auth } from "@{{projectName}}/auth";
+  ["auth/better-auth/fullstack/astro/src/middleware.ts.hbs", `{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createAuth } from "@{{projectName}}/auth";
+{{else}}
+import { auth } from "@{{projectName}}/auth";
+{{/if}}
 import { defineMiddleware } from "astro:middleware";
 
 export const onRequest = defineMiddleware(async (context, next) => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+  const auth = createAuth();
+{{/if}}
   const isAuthed = await auth.api.getSession({
     headers: context.request.headers,
   });
@@ -5027,34 +5066,72 @@ export const onRequest = defineMiddleware(async (context, next) => {
   return next();
 });
 `],
-  ["auth/better-auth/fullstack/astro/src/pages/api/auth/[...all].ts.hbs", `import { auth } from "@{{projectName}}/auth";
+  ["auth/better-auth/fullstack/astro/src/pages/api/auth/[...all].ts.hbs", `{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createAuth } from "@{{projectName}}/auth";
+{{else}}
+import { auth } from "@{{projectName}}/auth";
+{{/if}}
 import type { APIRoute } from "astro";
 
 export const ALL: APIRoute = async (ctx) => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+  const auth = createAuth();
+{{/if}}
   return auth.handler(ctx.request);
 };
 `],
-  ["auth/better-auth/fullstack/next/src/app/api/auth/[...all]/route.ts.hbs", `import { auth } from "@{{projectName}}/auth";
+  ["auth/better-auth/fullstack/next/src/app/api/auth/[...all]/route.ts.hbs", `{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createAuth } from "@{{projectName}}/auth";
+{{else}}
+import { auth } from "@{{projectName}}/auth";
+{{/if}}
 import { toNextJsHandler } from "better-auth/next-js";
 
-export const { GET, POST } = toNextJsHandler(auth.handler);
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+export async function GET(request: Request) {
+	return toNextJsHandler(createAuth()).GET(request);
+}
+
+export async function POST(request: Request) {
+	return toNextJsHandler(createAuth()).POST(request);
+}
+{{else}}
+export const { GET, POST } = toNextJsHandler(auth);
+{{/if}}
 `],
-  ["auth/better-auth/fullstack/nuxt/server/api/auth/[...all].ts.hbs", `import { auth } from "@{{projectName}}/auth";
+  ["auth/better-auth/fullstack/nuxt/server/api/auth/[...all].ts.hbs", `{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createAuth } from "@{{projectName}}/auth";
+{{else}}
+import { auth } from "@{{projectName}}/auth";
+{{/if}}
 
 export default defineEventHandler((event) => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+  const auth = createAuth();
+{{/if}}
   return auth.handler(toWebRequest(event));
 });
 `],
-  ["auth/better-auth/fullstack/tanstack-start/src/routes/api/auth/$.ts.hbs", `import { auth } from '@{{projectName}}/auth'
+  ["auth/better-auth/fullstack/tanstack-start/src/routes/api/auth/$.ts.hbs", `{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createAuth } from '@{{projectName}}/auth'
+{{else}}
+import { auth } from '@{{projectName}}/auth'
+{{/if}}
 import { createFileRoute } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/api/auth/$')({
   server: {
     handlers: {
       GET: ({ request }) => {
+        {{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+        const auth = createAuth()
+        {{/if}}
         return auth.handler(request)
       },
       POST: ({ request }) => {
+        {{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+        const auth = createAuth()
+        {{/if}}
         return auth.handler(request)
       },
     },
@@ -6974,67 +7051,75 @@ import { env } from "@{{projectName}}/env/server";
 import { polar, checkout, portal } from "@polar-sh/better-auth";
 import { polarClient } from "./lib/payments";
 {{/if}}
-import prisma from "@{{projectName}}/db";
+import { createPrismaClient } from "@{{projectName}}/db";
 
-export const auth = betterAuth({
-	database: prismaAdapter(prisma, {
+export function createAuth() {
+	const prisma = createPrismaClient();
+
+	return betterAuth({
+		database: prismaAdapter(prisma, {
 {{#if (eq database "postgres")}}provider: "postgresql",{{/if}}
 {{#if (eq database "sqlite")}}provider: "sqlite",{{/if}}
 {{#if (eq database "mysql")}}provider: "mysql",{{/if}}
 {{#if (eq database "mongodb")}}provider: "mongodb",{{/if}}
-	}),
-
-	trustedOrigins: [
-		env.CORS_ORIGIN,
-{{#if (or (includes frontend "native-bare") (includes frontend "native-uniwind") (includes frontend "native-unistyles"))}}
-		"{{projectName}}://",
-		...(env.NODE_ENV === "development"
-			? [
-				"exp://",
-				"exp://**",
-				"exp://192.168.*.*:*/**",
-				"http://localhost:8081",
-			]
-			: []),
-{{/if}}
-	],
-	emailAndPassword: {
-		enabled: true,
-	},
-	secret: env.BETTER_AUTH_SECRET,
-	baseURL: env.BETTER_AUTH_URL,
-{{#if (ne backend "self")}}
-	advanced: {
-		defaultCookieAttributes: {
-			sameSite: "none",
-			secure: true,
-			httpOnly: true,
-		},
-	},
-{{/if}}
-	plugins: [
-{{#if (eq payments "polar")}}
-		polar({
-			client: polarClient,
-			createCustomerOnSignUp: true,
-			enableCustomerPortal: true,
-			use: [
-				checkout({
-					products: [
-						{
-							productId: "your-product-id",
-							slug: "pro",
-						},
-					],
-					successUrl: env.POLAR_SUCCESS_URL,
-					authenticatedUsersOnly: true,
-				}),
-				portal(),
-			],
 		}),
+
+		trustedOrigins: [
+			env.CORS_ORIGIN,
+{{#if (or (includes frontend "native-bare") (includes frontend "native-uniwind") (includes frontend "native-unistyles"))}}
+			"{{projectName}}://",
+			...(env.NODE_ENV === "development"
+				? [
+					"exp://",
+					"exp://**",
+					"exp://192.168.*.*:*/**",
+					"http://localhost:8081",
+				]
+				: []),
 {{/if}}
-	],
-});
+		],
+		emailAndPassword: {
+			enabled: true,
+		},
+		secret: env.BETTER_AUTH_SECRET,
+		baseURL: env.BETTER_AUTH_URL,
+{{#if (ne backend "self")}}
+		advanced: {
+			defaultCookieAttributes: {
+				sameSite: "none",
+				secure: true,
+				httpOnly: true,
+			},
+		},
+{{/if}}
+		plugins: [
+{{#if (eq payments "polar")}}
+			polar({
+				client: polarClient,
+				createCustomerOnSignUp: true,
+				enableCustomerPortal: true,
+				use: [
+					checkout({
+						products: [
+							{
+								productId: "your-product-id",
+								slug: "pro",
+							},
+						],
+						successUrl: env.POLAR_SUCCESS_URL,
+						authenticatedUsersOnly: true,
+					}),
+					portal(),
+				],
+			}),
+{{/if}}
+		],
+	});
+}
+
+{{#if (and (ne runtime "workers") (ne serverDeploy "cloudflare") (or (ne backend "self") (ne webDeploy "cloudflare")))}}
+export const auth = createAuth();
+{{/if}}
 {{/if}}
 
 {{#if (eq orm "drizzle")}}
@@ -7046,68 +7131,76 @@ import { env } from "@{{projectName}}/env/server";
 import { polar, checkout, portal } from "@polar-sh/better-auth";
 import { polarClient } from "./lib/payments";
 {{/if}}
-import { db } from "@{{projectName}}/db";
+import { createDb } from "@{{projectName}}/db";
 import * as schema from "@{{projectName}}/db/schema/auth";
 
 
-export const auth = betterAuth({
-	database: drizzleAdapter(db, {
+export function createAuth() {
+	const db = createDb();
+
+	return betterAuth({
+		database: drizzleAdapter(db, {
 {{#if (eq database "postgres")}}provider: "pg",{{/if}}
 {{#if (eq database "sqlite")}}provider: "sqlite",{{/if}}
 {{#if (eq database "mysql")}}provider: "mysql",{{/if}}
-		schema: schema,
-	}),
-	trustedOrigins: [
-		env.CORS_ORIGIN,
-{{#if (or (includes frontend "native-bare") (includes frontend "native-uniwind") (includes frontend "native-unistyles"))}}
-		"{{projectName}}://",
-		...(env.NODE_ENV === "development"
-			? [
-				"exp://",
-				"exp://**",
-				"exp://192.168.*.*:*/**",
-				"http://localhost:8081",
-			]
-			: []),
-{{/if}}
-	],
-	emailAndPassword: {
-		enabled: true,
-	},
-	secret: env.BETTER_AUTH_SECRET,
-	baseURL: env.BETTER_AUTH_URL,
-{{#if (ne backend "self")}}
-	advanced: {
-		defaultCookieAttributes: {
-			sameSite: "none",
-			secure: true,
-			httpOnly: true,
-		},
-	},
-{{/if}}
-	plugins: [
-{{#if (eq payments "polar")}}
-		polar({
-			client: polarClient,
-			createCustomerOnSignUp: true,
-			enableCustomerPortal: true,
-			use: [
-				checkout({
-					products: [
-						{
-							productId: "your-product-id",
-							slug: "pro",
-						},
-					],
-					successUrl: env.POLAR_SUCCESS_URL,
-					authenticatedUsersOnly: true,
-				}),
-				portal(),
-			],
+			schema: schema,
 		}),
+		trustedOrigins: [
+			env.CORS_ORIGIN,
+{{#if (or (includes frontend "native-bare") (includes frontend "native-uniwind") (includes frontend "native-unistyles"))}}
+			"{{projectName}}://",
+			...(env.NODE_ENV === "development"
+				? [
+					"exp://",
+					"exp://**",
+					"exp://192.168.*.*:*/**",
+					"http://localhost:8081",
+				]
+				: []),
 {{/if}}
-	],
-});
+		],
+		emailAndPassword: {
+			enabled: true,
+		},
+		secret: env.BETTER_AUTH_SECRET,
+		baseURL: env.BETTER_AUTH_URL,
+{{#if (ne backend "self")}}
+		advanced: {
+			defaultCookieAttributes: {
+				sameSite: "none",
+				secure: true,
+				httpOnly: true,
+			},
+		},
+{{/if}}
+		plugins: [
+{{#if (eq payments "polar")}}
+			polar({
+				client: polarClient,
+				createCustomerOnSignUp: true,
+				enableCustomerPortal: true,
+				use: [
+					checkout({
+						products: [
+							{
+								productId: "your-product-id",
+								slug: "pro",
+							},
+						],
+						successUrl: env.POLAR_SUCCESS_URL,
+						authenticatedUsersOnly: true,
+					}),
+					portal(),
+				],
+			}),
+{{/if}}
+		],
+	});
+}
+
+{{#if (and (ne runtime "workers") (ne serverDeploy "cloudflare") (or (ne backend "self") (ne webDeploy "cloudflare")))}}
+export const auth = createAuth();
+{{/if}}
 {{/if}}
 
 {{#if (eq runtime "workers")}}
@@ -7118,79 +7211,83 @@ import { env } from "@{{projectName}}/env/server";
 import { polar, checkout, portal } from "@polar-sh/better-auth";
 import { polarClient } from "./lib/payments";
 {{/if}}
-import { db } from "@{{projectName}}/db";
+import { createDb } from "@{{projectName}}/db";
 import * as schema from "@{{projectName}}/db/schema/auth";
 
 
-export const auth = betterAuth({
-	database: drizzleAdapter(db, {
+export function createAuth() {
+	const db = createDb();
+
+	return betterAuth({
+		database: drizzleAdapter(db, {
 {{#if (eq database "postgres")}}provider: "pg",{{/if}}
 {{#if (eq database "sqlite")}}provider: "sqlite",{{/if}}
 {{#if (eq database "mysql")}}provider: "mysql",{{/if}}
-		schema: schema,
-	}),
-	trustedOrigins: [
-		env.CORS_ORIGIN,
-{{#if (or (includes frontend "native-bare") (includes frontend "native-uniwind") (includes frontend "native-unistyles"))}}
-		"{{projectName}}://",
-		...(env.NODE_ENV === "development"
-			? [
-				"exp://",
-				"exp://**",
-				"exp://192.168.*.*:*/**",
-				"http://localhost:8081",
-			]
-			: []),
-{{/if}}
-	],
-	emailAndPassword: {
-		enabled: true,
-	},
-	// uncomment cookieCache setting when ready to deploy to Cloudflare using *.workers.dev domains
-	// session: {
-	//   cookieCache: {
-	//     enabled: true,
-	//     maxAge: 60,
-	//   },
-	// },
-	secret: env.BETTER_AUTH_SECRET,
-	baseURL: env.BETTER_AUTH_URL,
-	advanced: {
-		defaultCookieAttributes: {
-			sameSite: "none",
-			secure: true,
-			httpOnly: true,
-		},
-		// uncomment crossSubDomainCookies setting when ready to deploy and replace <your-workers-subdomain> with your actual workers subdomain
-		// https://developers.cloudflare.com/workers/wrangler/configuration/#workersdev
-		// crossSubDomainCookies: {
-		//   enabled: true,
-		//   domain: "<your-workers-subdomain>",
-		// },
-	},
-{{#if (eq payments "polar")}}
-	plugins: [
-		polar({
-			client: polarClient,
-			createCustomerOnSignUp: true,
-			enableCustomerPortal: true,
-			use: [
-				checkout({
-					products: [
-						{
-							productId: "your-product-id",
-							slug: "pro",
-						},
-					],
-					successUrl: env.POLAR_SUCCESS_URL,
-					authenticatedUsersOnly: true,
-				}),
-				portal(),
-			],
+			schema: schema,
 		}),
-	],
+		trustedOrigins: [
+			env.CORS_ORIGIN,
+{{#if (or (includes frontend "native-bare") (includes frontend "native-uniwind") (includes frontend "native-unistyles"))}}
+			"{{projectName}}://",
+			...(env.NODE_ENV === "development"
+				? [
+					"exp://",
+					"exp://**",
+					"exp://192.168.*.*:*/**",
+					"http://localhost:8081",
+				]
+				: []),
 {{/if}}
-});
+		],
+		emailAndPassword: {
+			enabled: true,
+		},
+		// uncomment cookieCache setting when ready to deploy to Cloudflare using *.workers.dev domains
+		// session: {
+		//   cookieCache: {
+		//     enabled: true,
+		//     maxAge: 60,
+		//   },
+		// },
+		secret: env.BETTER_AUTH_SECRET,
+		baseURL: env.BETTER_AUTH_URL,
+		advanced: {
+			defaultCookieAttributes: {
+				sameSite: "none",
+				secure: true,
+				httpOnly: true,
+			},
+			// uncomment crossSubDomainCookies setting when ready to deploy and replace <your-workers-subdomain> with your actual workers subdomain
+			// https://developers.cloudflare.com/workers/wrangler/configuration/#workersdev
+			// crossSubDomainCookies: {
+			//   enabled: true,
+			//   domain: "<your-workers-subdomain>",
+			// },
+		},
+{{#if (eq payments "polar")}}
+		plugins: [
+			polar({
+				client: polarClient,
+				createCustomerOnSignUp: true,
+				enableCustomerPortal: true,
+				use: [
+					checkout({
+						products: [
+							{
+								productId: "your-product-id",
+								slug: "pro",
+							},
+						],
+						successUrl: env.POLAR_SUCCESS_URL,
+						authenticatedUsersOnly: true,
+					}),
+					portal(),
+				],
+			}),
+		],
+{{/if}}
+	});
+}
 {{/if}}
 {{/if}}
 
@@ -7204,59 +7301,65 @@ import { polarClient } from "./lib/payments";
 {{/if}}
 import { client } from "@{{projectName}}/db";
 
-export const auth = betterAuth({
-	database: mongodbAdapter(client),
-	trustedOrigins: [
-		env.CORS_ORIGIN,
+export function createAuth() {
+	return betterAuth({
+		database: mongodbAdapter(client),
+		trustedOrigins: [
+			env.CORS_ORIGIN,
 {{#if (or (includes frontend "native-bare") (includes frontend "native-uniwind") (includes frontend "native-unistyles"))}}
-		"{{projectName}}://",
-		...(env.NODE_ENV === "development"
-			? [
-				"exp://",
-				"exp://**",
-				"exp://192.168.*.*:*/**",
-				"http://localhost:8081",
-			]
-			: []),
+			"{{projectName}}://",
+			...(env.NODE_ENV === "development"
+				? [
+					"exp://",
+					"exp://**",
+					"exp://192.168.*.*:*/**",
+					"http://localhost:8081",
+				]
+				: []),
 {{/if}}
-	],
-	emailAndPassword: {
-		enabled: true,
-	},
-	secret: env.BETTER_AUTH_SECRET,
-	baseURL: env.BETTER_AUTH_URL,
-{{#if (ne backend "self")}}
-	advanced: {
-		defaultCookieAttributes: {
-			sameSite: "none",
-			secure: true,
-			httpOnly: true,
+		],
+		emailAndPassword: {
+			enabled: true,
 		},
-	},
+		secret: env.BETTER_AUTH_SECRET,
+		baseURL: env.BETTER_AUTH_URL,
+{{#if (ne backend "self")}}
+		advanced: {
+			defaultCookieAttributes: {
+				sameSite: "none",
+				secure: true,
+				httpOnly: true,
+			},
+		},
 {{/if}}
 {{#if (eq payments "polar")}}
-	plugins: [
-		polar({
-			client: polarClient,
-			createCustomerOnSignUp: true,
-			enableCustomerPortal: true,
-			use: [
-				checkout({
-					products: [
-						{
-							productId: "your-product-id",
-							slug: "pro",
-						},
-					],
-					successUrl: env.POLAR_SUCCESS_URL,
-					authenticatedUsersOnly: true,
-				}),
-				portal(),
-			],
-		}),
-	],
+		plugins: [
+			polar({
+				client: polarClient,
+				createCustomerOnSignUp: true,
+				enableCustomerPortal: true,
+				use: [
+					checkout({
+						products: [
+							{
+								productId: "your-product-id",
+								slug: "pro",
+							},
+						],
+						successUrl: env.POLAR_SUCCESS_URL,
+						authenticatedUsersOnly: true,
+					}),
+					portal(),
+				],
+			}),
+		],
 {{/if}}
-});
+	});
+}
+
+{{#if (and (ne runtime "workers") (ne serverDeploy "cloudflare") (or (ne backend "self") (ne webDeploy "cloudflare")))}}
+export const auth = createAuth();
+{{/if}}
 {{/if}}
 
 {{#if (eq orm "none")}}
@@ -7268,59 +7371,65 @@ import { polarClient } from "./lib/payments";
 {{/if}}
 
 
-export const auth = betterAuth({
-	database: "", // Invalid configuration
-	trustedOrigins: [
-		env.CORS_ORIGIN,
+export function createAuth() {
+	return betterAuth({
+		database: "", // Invalid configuration
+		trustedOrigins: [
+			env.CORS_ORIGIN,
 {{#if (or (includes frontend "native-bare") (includes frontend "native-uniwind") (includes frontend "native-unistyles"))}}
-		"{{projectName}}://",
-		...(env.NODE_ENV === "development"
-			? [
-				"exp://",
-				"exp://**",
-				"exp://192.168.*.*:*/**",
-				"http://localhost:8081",
-			]
-			: []),
+			"{{projectName}}://",
+			...(env.NODE_ENV === "development"
+				? [
+					"exp://",
+					"exp://**",
+					"exp://192.168.*.*:*/**",
+					"http://localhost:8081",
+				]
+				: []),
 {{/if}}
-	],
-	emailAndPassword: {
-		enabled: true,
-	},
-	secret: env.BETTER_AUTH_SECRET,
-	baseURL: env.BETTER_AUTH_URL,
-{{#if (ne backend "self")}}
-	advanced: {
-		defaultCookieAttributes: {
-			sameSite: "none",
-			secure: true,
-			httpOnly: true,
+		],
+		emailAndPassword: {
+			enabled: true,
 		},
-	},
+		secret: env.BETTER_AUTH_SECRET,
+		baseURL: env.BETTER_AUTH_URL,
+{{#if (ne backend "self")}}
+		advanced: {
+			defaultCookieAttributes: {
+				sameSite: "none",
+				secure: true,
+				httpOnly: true,
+			},
+		},
 {{/if}}
 {{#if (eq payments "polar")}}
-	plugins: [
-		polar({
-			client: polarClient,
-			createCustomerOnSignUp: true,
-			enableCustomerPortal: true,
-			use: [
-				checkout({
-					products: [
-						{
-							productId: "your-product-id",
-							slug: "pro",
-						},
-					],
-					successUrl: env.POLAR_SUCCESS_URL,
-					authenticatedUsersOnly: true,
-				}),
-				portal(),
-			],
-		}),
-	],
+		plugins: [
+			polar({
+				client: polarClient,
+				createCustomerOnSignUp: true,
+				enableCustomerPortal: true,
+				use: [
+					checkout({
+						products: [
+							{
+								productId: "your-product-id",
+								slug: "pro",
+							},
+						],
+						successUrl: env.POLAR_SUCCESS_URL,
+						authenticatedUsersOnly: true,
+					}),
+					portal(),
+				],
+			}),
+		],
 {{/if}}
-});
+	});
+}
+
+{{#if (and (ne runtime "workers") (ne serverDeploy "cloudflare") (or (ne backend "self") (ne webDeploy "cloudflare")))}}
+export const auth = createAuth();
+{{/if}}
 {{/if}}
 `],
   ["auth/better-auth/server/base/tsconfig.json.hbs", `{
@@ -8797,13 +8906,19 @@ export default function Dashboard({
 import Dashboard from "./dashboard";
 import { headers } from "next/headers";
 {{#if (eq backend "self")}}
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createAuth } from "@{{projectName}}/auth";
+{{else}}
 import { auth } from "@{{projectName}}/auth";
 {{/if}}
+{{/if}}
+{{#if (or (ne backend "self") (eq payments "polar"))}}
 import { authClient } from "@/lib/auth-client";
+{{/if}}
 
 export default async function DashboardPage() {
 	{{#if (eq backend "self")}}
-	const session = await auth.api.getSession({
+	const session = await {{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}createAuth(){{else}}auth{{/if}}.api.getSession({
 		headers: await headers(),
 	});
 	{{else}}
@@ -10487,12 +10602,16 @@ export const getUser = createServerFn({ method: "GET" }).middleware([authMiddlew
     return context.session
 })`],
   ["auth/better-auth/web/react/tanstack-start/src/middleware/auth.ts.hbs", `{{#if (eq backend "self")}}
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createAuth } from "@{{projectName}}/auth";
+{{else}}
 import { auth } from "@{{projectName}}/auth";
+{{/if}}
 import { createMiddleware } from "@tanstack/react-start";
 
 
 export const authMiddleware = createMiddleware().server(async ({ next, request }) => {
-    const session = await auth.api.getSession({
+    const session = await {{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}createAuth(){{else}}auth{{/if}}.api.getSession({
         headers: request.headers,
     })
     return next({
@@ -13695,7 +13814,11 @@ import { createContext } from "@{{projectName}}/api/context";
 import { appRouter } from "@{{projectName}}/api/routers/index";
 {{/if}}
 {{#if (eq auth "better-auth")}}
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createAuth } from "@{{projectName}}/auth";
+{{else}}
 import { auth } from "@{{projectName}}/auth";
+{{/if}}
 {{/if}}
 import { Hono } from "hono";
 import { cors } from "hono/cors";
@@ -13729,7 +13852,16 @@ app.use(
 );
 
 {{#if (eq auth "better-auth")}}
-app.on(["POST", "GET"], "/api/auth/*", (c) => auth.handler(c.req.raw));
+app.on(
+	["POST", "GET"],
+	"/api/auth/*",
+	(c) =>
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+		createAuth().handler(c.req.raw)
+{{else}}
+		auth.handler(c.req.raw)
+{{/if}}
+);
 {{/if}}
 
 {{#if (eq api "orpc")}}
@@ -14084,23 +14216,31 @@ import * as schema from "./schema";
 {{#if (eq dbSetup "planetscale")}}
 import { drizzle } from "drizzle-orm/planetscale-serverless";
 
-export const db = drizzle({
-	connection: {
-		host: env.DATABASE_HOST,
-		username: env.DATABASE_USERNAME,
-		password: env.DATABASE_PASSWORD,
-	},
-	schema,
-});
+export function createDb() {
+	return drizzle({
+		connection: {
+			host: env.DATABASE_HOST,
+			username: env.DATABASE_USERNAME,
+			password: env.DATABASE_PASSWORD,
+		},
+		schema,
+	});
+}
 {{else}}
 import { drizzle } from "drizzle-orm/mysql2";
 
-export const db = drizzle({
-	connection: {
-		uri: env.DATABASE_URL,
-	},
-	schema,
-});
+export function createDb() {
+	return drizzle({
+		connection: {
+			uri: env.DATABASE_URL,
+		},
+		schema,
+	});
+}
+{{/if}}
+
+{{#if (and (ne serverDeploy "cloudflare") (or (ne backend "self") (ne webDeploy "cloudflare")))}}
+export const db = createDb();
 {{/if}}
 {{/if}}
 
@@ -14111,24 +14251,28 @@ import * as schema from "./schema";
 import { drizzle } from "drizzle-orm/planetscale-serverless";
 import { env } from "@{{projectName}}/env/server";
 
-export const db = drizzle({
-	connection: {
-		host: env.DATABASE_HOST,
-		username: env.DATABASE_USERNAME,
-		password: env.DATABASE_PASSWORD,
-	},
-	schema,
-});
+export function createDb() {
+	return drizzle({
+		connection: {
+			host: env.DATABASE_HOST,
+			username: env.DATABASE_USERNAME,
+			password: env.DATABASE_PASSWORD,
+		},
+		schema,
+	});
+}
 {{else}}
 import { drizzle } from "drizzle-orm/mysql2";
 import { env } from "@{{projectName}}/env/server";
 
-export const db = drizzle({
-	connection: {
-		uri: env.DATABASE_URL,
-	},
-	schema,
-});
+export function createDb() {
+	return drizzle({
+		connection: {
+			uri: env.DATABASE_URL,
+		},
+		schema,
+	});
+}
 {{/if}}
 {{/if}}
 `],
@@ -14160,12 +14304,32 @@ import * as schema from "./schema";
 import { neon } from '@neondatabase/serverless';
 import { drizzle } from 'drizzle-orm/neon-http';
 
-const sql = neon(env.DATABASE_URL);
-export const db = drizzle(sql, { schema });
+export function createDb() {
+	const sql = neon(env.DATABASE_URL);
+	return drizzle(sql, { schema });
+}
 {{else}}
 import { drizzle } from "drizzle-orm/node-postgres";
+{{#if (and (eq backend "self") (eq webDeploy "cloudflare"))}}
+import { Pool } from "pg";
+{{/if}}
 
-export const db = drizzle(env.DATABASE_URL, { schema });
+export function createDb() {
+{{#if (and (eq backend "self") (eq webDeploy "cloudflare"))}}
+	const pool = new Pool({
+		connectionString: env.DATABASE_URL,
+		maxUses: 1,
+	});
+
+	return drizzle({ client: pool, schema });
+{{else}}
+	return drizzle(env.DATABASE_URL, { schema });
+{{/if}}
+}
+{{/if}}
+
+{{#if (and (ne serverDeploy "cloudflare") (or (ne backend "self") (ne webDeploy "cloudflare")))}}
+export const db = createDb();
 {{/if}}
 {{/if}}
 
@@ -14177,15 +14341,26 @@ import { neon } from '@neondatabase/serverless';
 import { drizzle } from 'drizzle-orm/neon-http';
 import { env } from "@{{projectName}}/env/server";
 
-const sql = neon(env.DATABASE_URL || "");
-export const db = drizzle(sql, { schema });
+export function createDb() {
+	const sql = neon(env.DATABASE_URL || "");
+	return drizzle(sql, { schema });
+}
 {{else}}
 import { drizzle } from "drizzle-orm/node-postgres";
 import { env } from "@{{projectName}}/env/server";
+import { Pool } from "pg";
 
-export const db = drizzle(env.DATABASE_URL || "", { schema });
+export function createDb() {
+	const pool = new Pool({
+		connectionString: env.DATABASE_URL || "",
+		maxUses: 1,
+	});
+
+	return drizzle({ client: pool, schema });
+}
 {{/if}}
-{{/if}}`],
+{{/if}}
+`],
   ["db/drizzle/sqlite/drizzle.config.ts.hbs", `import { defineConfig } from "drizzle-kit";
 import dotenv from "dotenv";
 
@@ -14221,14 +14396,20 @@ import * as schema from "./schema";
 import { drizzle } from "drizzle-orm/libsql";
 import { createClient } from "@libsql/client";
 
-const client = createClient({
-	url: env.DATABASE_URL,
+export function createDb() {
+	const client = createClient({
+		url: env.DATABASE_URL,
 {{#if (eq dbSetup "turso")}}
-	authToken: env.DATABASE_AUTH_TOKEN,
+		authToken: env.DATABASE_AUTH_TOKEN,
 {{/if}}
-});
+	});
 
-export const db = drizzle({ client, schema });
+	return drizzle({ client, schema });
+}
+
+{{#if (and (ne serverDeploy "cloudflare") (or (ne backend "self") (ne webDeploy "cloudflare")))}}
+export const db = createDb();
+{{/if}}
 {{/if}}
 
 {{#if (eq runtime "workers")}}
@@ -14238,20 +14419,24 @@ import * as schema from "./schema";
 import { drizzle } from "drizzle-orm/d1";
 import { env } from "@{{projectName}}/env/server";
 
-export const db = drizzle(env.DB, { schema });
+export function createDb() {
+	return drizzle(env.DB, { schema });
+}
 {{else}}
 import { drizzle } from "drizzle-orm/libsql";
 import { env } from "@{{projectName}}/env/server";
 import { createClient } from "@libsql/client";
 
-const client = createClient({
-	url: env.DATABASE_URL || "",
+export function createDb() {
+	const client = createClient({
+		url: env.DATABASE_URL || "",
 {{#if (eq dbSetup "turso")}}
-	authToken: env.DATABASE_AUTH_TOKEN,
+		authToken: env.DATABASE_AUTH_TOKEN,
 {{/if}}
-});
+	});
 
-export const db = drizzle({ client, schema });
+	return drizzle({ client, schema });
+}
 {{/if}}
 {{/if}}
 `],
@@ -14360,26 +14545,28 @@ import { env } from "@{{projectName}}/env/server";
 {{#if (eq dbSetup "planetscale")}}
 import { PrismaPlanetScale } from "@prisma/adapter-planetscale";
 
-const adapter = new PrismaPlanetScale({ url: env.DATABASE_URL });
-const prisma = new PrismaClient({ adapter });
+export function createPrismaClient() {
+	const adapter = new PrismaPlanetScale({ url: env.DATABASE_URL });
+	return new PrismaClient({ adapter });
+}
 {{else}}
 import { PrismaMariaDb } from "@prisma/adapter-mariadb";
 
-const databaseUrl: string = env.DATABASE_URL;
-const url: URL = new URL(databaseUrl);
-const connectionConfig = {
-	host: url.hostname,
-	port: parseInt(url.port || "3306"),
-	user: url.username,
-	password: url.password,
-	database: url.pathname.slice(1),
-};
+export function createPrismaClient() {
+	const databaseUrl: string = env.DATABASE_URL;
+	const url: URL = new URL(databaseUrl);
+	const connectionConfig = {
+		host: url.hostname,
+		port: parseInt(url.port || "3306"),
+		user: url.username,
+		password: url.password,
+		database: url.pathname.slice(1),
+	};
 
-const adapter = new PrismaMariaDb(connectionConfig);
-const prisma = new PrismaClient({ adapter });
+	const adapter = new PrismaMariaDb(connectionConfig);
+	return new PrismaClient({ adapter });
+}
 {{/if}}
-
-export default prisma;
 {{else}}
 import { PrismaClient } from "../prisma/generated/client";
 import { env } from "@{{projectName}}/env/server";
@@ -14387,27 +14574,35 @@ import { env } from "@{{projectName}}/env/server";
 {{#if (eq dbSetup "planetscale")}}
 import { PrismaPlanetScale } from "@prisma/adapter-planetscale";
 
-const adapter = new PrismaPlanetScale({ url: env.DATABASE_URL });
-const prisma = new PrismaClient({ adapter });
+export function createPrismaClient() {
+	const adapter = new PrismaPlanetScale({ url: env.DATABASE_URL });
+	return new PrismaClient({ adapter });
+}
 {{else}}
 import { PrismaMariaDb } from "@prisma/adapter-mariadb";
 
-const databaseUrl: string = env.DATABASE_URL;
-const url: URL = new URL(databaseUrl);
-const connectionConfig = {
-	host: url.hostname,
-	port: parseInt(url.port || "3306"),
-	user: url.username,
-	password: url.password,
-	database: url.pathname.slice(1),
-};
+export function createPrismaClient() {
+	const databaseUrl: string = env.DATABASE_URL;
+	const url: URL = new URL(databaseUrl);
+	const connectionConfig = {
+		host: url.hostname,
+		port: parseInt(url.port || "3306"),
+		user: url.username,
+		password: url.password,
+		database: url.pathname.slice(1),
+	};
 
-const adapter = new PrismaMariaDb(connectionConfig);
-const prisma = new PrismaClient({ adapter });
+	const adapter = new PrismaMariaDb(connectionConfig);
+	return new PrismaClient({ adapter });
+}
 {{/if}}
 
+{{#if (and (ne serverDeploy "cloudflare") (or (ne backend "self") (ne webDeploy "cloudflare")))}}
+const prisma = createPrismaClient();
 export default prisma;
-{{/if}}`],
+{{/if}}
+{{/if}}
+`],
   ["db/prisma/postgres/prisma.config.ts.hbs", `import path from "node:path";
 import { defineConfig, env } from 'prisma/config'
 import dotenv from 'dotenv'
@@ -14461,61 +14656,86 @@ import { neonConfig } from "@neondatabase/serverless";
 
 neonConfig.poolQueryViaFetch = true;
 
-const prisma = new PrismaClient({
-	adapter: new PrismaNeon({
-		connectionString: env.DATABASE_URL,
-	}),
-});
+export function createPrismaClient() {
+	return new PrismaClient({
+		adapter: new PrismaNeon({
+			connectionString: env.DATABASE_URL,
+		}),
+	});
+}
 
 {{else if (eq dbSetup "prisma-postgres")}}
 import { PrismaPg } from "@prisma/adapter-pg";
 
-const adapter = new PrismaPg({
-	connectionString: env.DATABASE_URL,
-});
+export function createPrismaClient() {
+	const adapter = new PrismaPg({
+		connectionString: env.DATABASE_URL,
+		maxUses: 1,
+	});
 
-const prisma = new PrismaClient({ adapter });
+	return new PrismaClient({ adapter });
+}
 
 {{else}}
 import { PrismaPg } from "@prisma/adapter-pg";
 
-const adapter = new PrismaPg({ connectionString: env.DATABASE_URL });
-const prisma = new PrismaClient({ adapter });
+export function createPrismaClient() {
+	const adapter = new PrismaPg({
+		connectionString: env.DATABASE_URL,
+		maxUses: 1,
+	});
+	return new PrismaClient({ adapter });
+}
 
 {{/if}}
-
-export default prisma;
 {{else}}
 import { PrismaClient } from "../prisma/generated/client";
 import { env } from "@{{projectName}}/env/server";
 {{#if (eq dbSetup "neon")}}
 import { PrismaNeon } from "@prisma/adapter-neon";
 
-const adapter = new PrismaNeon({
-	connectionString: env.DATABASE_URL,
-});
+export function createPrismaClient() {
+	const adapter = new PrismaNeon({
+		connectionString: env.DATABASE_URL,
+	});
 
-const prisma = new PrismaClient({ adapter });
+	return new PrismaClient({ adapter });
+}
 
 {{else if (eq dbSetup "prisma-postgres")}}
 import { PrismaPg } from "@prisma/adapter-pg";
 
-const adapter = new PrismaPg({
-	connectionString: env.DATABASE_URL,
-});
+export function createPrismaClient() {
+	const adapter = new PrismaPg({
+		connectionString: env.DATABASE_URL,
+{{#if (and (eq backend "self") (eq webDeploy "cloudflare"))}}
+		maxUses: 1,
+{{/if}}
+	});
 
-const prisma = new PrismaClient({ adapter });
+	return new PrismaClient({ adapter });
+}
 
 {{else}}
 import { PrismaPg } from "@prisma/adapter-pg";
 
-const adapter = new PrismaPg({ connectionString: env.DATABASE_URL });
-const prisma = new PrismaClient({ adapter });
+export function createPrismaClient() {
+	const adapter = new PrismaPg({
+		connectionString: env.DATABASE_URL,
+{{#if (and (eq backend "self") (eq webDeploy "cloudflare"))}}
+		maxUses: 1,
+{{/if}}
+	});
+	return new PrismaClient({ adapter });
+}
 
 {{/if}}
-
+{{#if (and (ne serverDeploy "cloudflare") (or (ne backend "self") (ne webDeploy "cloudflare")))}}
+const prisma = createPrismaClient();
 export default prisma;
-{{/if}}`],
+{{/if}}
+{{/if}}
+`],
   ["db/prisma/sqlite/prisma.config.ts.hbs", `import path from "node:path";
 import { defineConfig, env } from "prisma/config";
 import dotenv from "dotenv";
@@ -14566,25 +14786,36 @@ datasource db {
 import { PrismaD1 } from "@prisma/adapter-d1";
 import { env } from "@{{projectName}}/env/server";
 
-const adapter = new PrismaD1(env.DB);
-const prisma = new PrismaClient({ adapter });
+export function createPrismaClient() {
+	const adapter = new PrismaD1(env.DB);
+	return new PrismaClient({ adapter });
+}
 
+{{#if (and (ne runtime "workers") (ne serverDeploy "cloudflare") (or (ne backend "self") (ne webDeploy "cloudflare")))}}
+const prisma = createPrismaClient();
 export default prisma;
+{{/if}}
 {{else}}
 import { PrismaLibSql } from "@prisma/adapter-libsql";
 import { env } from "@{{projectName}}/env/server";
 
-const adapter = new PrismaLibSql({
-	url: env.DATABASE_URL,
+export function createPrismaClient() {
+	const adapter = new PrismaLibSql({
+		url: env.DATABASE_URL,
 {{#if (eq dbSetup "turso")}}
-	authToken: env.DATABASE_AUTH_TOKEN || "",
+		authToken: env.DATABASE_AUTH_TOKEN || "",
 {{/if}}
-});
+	});
 
-const prisma = new PrismaClient({ adapter });
+	return new PrismaClient({ adapter });
+}
 
+{{#if (and (ne runtime "workers") (ne serverDeploy "cloudflare") (or (ne backend "self") (ne webDeploy "cloudflare")))}}
+const prisma = createPrismaClient();
 export default prisma;
-{{/if}}`],
+{{/if}}
+{{/if}}
+`],
   ["examples/ai/convex/packages/backend/convex/agent.ts.hbs", `import { Agent } from "@convex-dev/agent";
 import { google } from "@ai-sdk/google";
 import { components } from "./_generated/api";
@@ -18770,18 +19001,28 @@ export default function TodosScreen() {
   ["examples/todo/server/drizzle/base/src/routers/todo.ts.hbs", `{{#if (eq api "orpc")}}
 import { eq } from "drizzle-orm";
 import z from "zod";
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createDb } from "@{{projectName}}/db";
+{{else}}
 import { db } from "@{{projectName}}/db";
+{{/if}}
 import { todo } from "@{{projectName}}/db/schema/todo";
 import { publicProcedure } from "../index";
 
 export const todoRouter = {
   getAll: publicProcedure.handler(async () => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+    const db = createDb();
+{{/if}}
     return await db.select().from(todo);
   }),
 
   create: publicProcedure
     .input(z.object({ text: z.string().min(1) }))
     .handler(async ({ input }) => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+      const db = createDb();
+{{/if}}
       return await db
         .insert(todo)
         .values({
@@ -18792,6 +19033,9 @@ export const todoRouter = {
   toggle: publicProcedure
     .input(z.object({ id: z.number(), completed: z.boolean() }))
     .handler(async ({ input }) => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+      const db = createDb();
+{{/if}}
       return await db
         .update(todo)
         .set({ completed: input.completed })
@@ -18801,6 +19045,9 @@ export const todoRouter = {
   delete: publicProcedure
     .input(z.object({ id: z.number() }))
     .handler(async ({ input }) => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+      const db = createDb();
+{{/if}}
       return await db.delete(todo).where(eq(todo.id, input.id));
     }),
 };
@@ -18811,16 +19058,26 @@ import z from "zod";
 import { router, publicProcedure } from "../index";
 import { todo } from "@{{projectName}}/db/schema/todo";
 import { eq } from "drizzle-orm";
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createDb } from "@{{projectName}}/db";
+{{else}}
 import { db } from "@{{projectName}}/db";
+{{/if}}
 
 export const todoRouter = router({
   getAll: publicProcedure.query(async () => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+    const db = createDb();
+{{/if}}
     return await db.select().from(todo);
   }),
 
   create: publicProcedure
     .input(z.object({ text: z.string().min(1) }))
     .mutation(async ({ input }) => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+      const db = createDb();
+{{/if}}
       return await db.insert(todo).values({
         text: input.text,
       });
@@ -18829,6 +19086,9 @@ export const todoRouter = router({
   toggle: publicProcedure
     .input(z.object({ id: z.number(), completed: z.boolean() }))
     .mutation(async ({ input }) => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+      const db = createDb();
+{{/if}}
       return await db
         .update(todo)
         .set({ completed: input.completed })
@@ -18838,6 +19098,9 @@ export const todoRouter = router({
   delete: publicProcedure
     .input(z.object({ id: z.number() }))
     .mutation(async ({ input }) => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+      const db = createDb();
+{{/if}}
       return await db.delete(todo).where(eq(todo.id, input.id));
     }),
 });
@@ -18961,11 +19224,18 @@ export { Todo };
 `],
   ["examples/todo/server/prisma/base/src/routers/todo.ts.hbs", `{{#if (eq api "orpc")}}
 import z from "zod";
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createPrismaClient } from "@{{projectName}}/db";
+{{else}}
 import prisma from "@{{projectName}}/db";
+{{/if}}
 import { publicProcedure } from "../index";
 
 export const todoRouter = {
   getAll: publicProcedure.handler(async () => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+    const prisma = createPrismaClient();
+{{/if}}
     return await prisma.todo.findMany({
       orderBy: {
         id: "asc",
@@ -18976,6 +19246,9 @@ export const todoRouter = {
   create: publicProcedure
     .input(z.object({ text: z.string().min(1) }))
     .handler(async ({ input }) => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+      const prisma = createPrismaClient();
+{{/if}}
       return await prisma.todo.create({
         data: {
           text: input.text,
@@ -18990,6 +19263,9 @@ export const todoRouter = {
     .input(z.object({ id: z.number(), completed: z.boolean() }))
     {{/if}}
     .handler(async ({ input }) => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+      const prisma = createPrismaClient();
+{{/if}}
       return await prisma.todo.update({
         where: { id: input.id },
         data: { completed: input.completed },
@@ -19003,6 +19279,9 @@ export const todoRouter = {
     .input(z.object({ id: z.number() }))
     {{/if}}
     .handler(async ({ input }) => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+      const prisma = createPrismaClient();
+{{/if}}
       return await prisma.todo.delete({
         where: { id: input.id },
       });
@@ -19013,11 +19292,18 @@ export const todoRouter = {
 {{#if (eq api "trpc")}}
 import { TRPCError } from "@trpc/server";
 import z from "zod";
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createPrismaClient } from "@{{projectName}}/db";
+{{else}}
 import prisma from "@{{projectName}}/db";
+{{/if}}
 import { publicProcedure, router } from "../index";
 
 export const todoRouter = router({
   getAll: publicProcedure.query(async () => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+    const prisma = createPrismaClient();
+{{/if}}
     return await prisma.todo.findMany({
       orderBy: {
         id: "asc"
@@ -19028,6 +19314,9 @@ export const todoRouter = router({
   create: publicProcedure
     .input(z.object({ text: z.string().min(1) }))
     .mutation(async ({ input }) => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+      const prisma = createPrismaClient();
+{{/if}}
       return await prisma.todo.create({
         data: {
           text: input.text,
@@ -19042,6 +19331,9 @@ export const todoRouter = router({
     .input(z.object({ id: z.number(), completed: z.boolean() }))
     {{/if}}
     .mutation(async ({ input }) => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+      const prisma = createPrismaClient();
+{{/if}}
       try {
         return await prisma.todo.update({
           where: { id: input.id },
@@ -19062,6 +19354,9 @@ export const todoRouter = router({
     .input(z.object({ id: z.number() }))
     {{/if}}
     .mutation(async ({ input }) => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+      const prisma = createPrismaClient();
+{{/if}}
       try {
         return await prisma.todo.delete({
           where: { id: input.id },
@@ -27787,7 +28082,67 @@ export const env = createEnv({
 	emptyStringAsUndefined: true,
 });
 `],
-  ["packages/env/src/server.ts.hbs", `{{#if (or (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+  ["packages/env/src/server.ts.hbs", `{{#if (eq serverDeploy "cloudflare")}}
+/// <reference path="../env.d.ts" />
+// For Cloudflare Workers, env is accessed via cloudflare:workers module
+// Types are defined in env.d.ts based on your alchemy.run.ts bindings
+export { env } from "cloudflare:workers";
+{{else if (and (eq backend "self") (eq webDeploy "cloudflare") (includes frontend "next"))}}
+/// <reference path="../env.d.ts" />
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+
+function getNodeEnvValue(key: string) {
+	return process.env[key];
+}
+
+function getCloudflareEnvSync() {
+	try {
+		return getCloudflareContext().env as Env;
+	} catch {
+		return undefined;
+	}
+}
+
+function createEnvProxy(getValue: (key: string) => string | undefined) {
+	return new Proxy({} as Env, {
+		get(_target, prop) {
+			if (typeof prop !== "string") {
+				return undefined;
+			}
+
+			return getValue(prop);
+		},
+	});
+}
+
+function resolveEnvValue(key: string) {
+	const nodeValue = getNodeEnvValue(key);
+	if (nodeValue !== undefined) {
+		return nodeValue;
+	}
+
+	return getCloudflareEnvSync()?.[key as keyof Env];
+}
+
+// Next.js local dev runs in Node.js, where env vars are exposed on process.env.
+// In the Cloudflare runtime, fall back to OpenNext's Cloudflare context bindings.
+// For static routes (ISR/SSG), use getEnvAsync() so OpenNext can resolve bindings
+// with the async Cloudflare context API.
+export async function getEnvAsync() {
+	const cloudflareEnv = (await getCloudflareContext({ async: true })).env as Env;
+
+	return createEnvProxy((key) => {
+		const nodeValue = getNodeEnvValue(key);
+		if (nodeValue !== undefined) {
+			return nodeValue;
+		}
+
+		return cloudflareEnv[key as keyof Env];
+	});
+}
+
+export const env = createEnvProxy(resolveEnvValue);
+{{else if (and (eq backend "self") (eq webDeploy "cloudflare"))}}
 /// <reference path="../env.d.ts" />
 // For Cloudflare Workers, env is accessed via cloudflare:workers module
 // Types are defined in env.d.ts based on your alchemy.run.ts bindings

--- a/packages/template-generator/src/utils/add-deps.ts
+++ b/packages/template-generator/src/utils/add-deps.ts
@@ -139,16 +139,16 @@ export const dependencyVersionMap = {
   "@tanstack/solid-query-devtools": "^5.87.4",
   "@tanstack/solid-router-devtools": "^1.131.44",
 
-  wrangler: "^4.54.0",
+  wrangler: "^4.77.0",
   "@cloudflare/vite-plugin": "^1.17.1",
-  "@opennextjs/cloudflare": "^1.14.6",
+  "@opennextjs/cloudflare": "^1.17.3",
   "nitro-cloudflare-dev": "^0.2.2",
   "@sveltejs/adapter-cloudflare": "^7.2.4",
   "@cloudflare/workers-types": "^4.20251213.0",
   "@astrojs/cloudflare": "^13.0.1",
   "@astrojs/node": "^10.0.0-beta.9",
 
-  alchemy: "^0.87.0",
+  alchemy: "^0.90.0",
 
   dotenv: "^17.2.2",
   tsdown: "^0.16.5",

--- a/packages/template-generator/templates/api/orpc/server/src/context.ts.hbs
+++ b/packages/template-generator/templates/api/orpc/server/src/context.ts.hbs
@@ -33,12 +33,16 @@ async function authenticateClerkRequest(request: Request): Promise<ClerkContextA
 {{#if (and (eq backend 'self') (includes frontend "next"))}}
 import type { NextRequest } from "next/server";
 {{#if (eq auth "better-auth")}}
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createAuth } from "@{{projectName}}/auth";
+{{else}}
 import { auth } from "@{{projectName}}/auth";
+{{/if}}
 {{/if}}
 
 export async function createContext(req: NextRequest){{#if (eq auth "clerk")}}: Promise<ClerkRequestContext>{{/if}} {
 {{#if (eq auth "better-auth")}}
-	const session = await auth.api.getSession({
+	const session = await {{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}createAuth(){{else}}auth{{/if}}.api.getSession({
 		headers: req.headers,
 	});
 	return {
@@ -61,12 +65,16 @@ export async function createContext(req: NextRequest){{#if (eq auth "clerk")}}: 
 
 {{else if (and (eq backend 'self') (includes frontend "tanstack-start"))}}
 {{#if (eq auth "better-auth")}}
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createAuth } from "@{{projectName}}/auth";
+{{else}}
 import { auth } from "@{{projectName}}/auth";
+{{/if}}
 {{/if}}
 
 export async function createContext({ req }: { req: Request }){{#if (eq auth "clerk")}}: Promise<ClerkRequestContext>{{/if}} {
 {{#if (eq auth "better-auth")}}
-	const session = await auth.api.getSession({
+	const session = await {{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}createAuth(){{else}}auth{{/if}}.api.getSession({
 		headers: req.headers,
 	});
 	return {
@@ -89,7 +97,11 @@ export async function createContext({ req }: { req: Request }){{#if (eq auth "cl
 
 {{else if (and (eq backend 'self') (includes frontend "nuxt"))}}
 {{#if (eq auth "better-auth")}}
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createAuth } from "@{{projectName}}/auth";
+{{else}}
 import { auth } from "@{{projectName}}/auth";
+{{/if}}
 {{/if}}
 
 export type CreateContextOptions = {
@@ -98,7 +110,7 @@ export type CreateContextOptions = {
 
 export async function createContext({ headers }: CreateContextOptions) {
 {{#if (eq auth "better-auth")}}
-	const session = await auth.api.getSession({ headers });
+	const session = await {{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}createAuth(){{else}}auth{{/if}}.api.getSession({ headers });
 	return {
 		auth: null,
 		session,
@@ -113,7 +125,11 @@ export async function createContext({ headers }: CreateContextOptions) {
 
 {{else if (and (eq backend 'self') (includes frontend "astro"))}}
 {{#if (eq auth "better-auth")}}
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createAuth } from "@{{projectName}}/auth";
+{{else}}
 import { auth } from "@{{projectName}}/auth";
+{{/if}}
 {{/if}}
 
 export type CreateContextOptions = {
@@ -122,7 +138,7 @@ export type CreateContextOptions = {
 
 export async function createContext({ headers }: CreateContextOptions) {
 {{#if (eq auth "better-auth")}}
-	const session = await auth.api.getSession({ headers });
+	const session = await {{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}createAuth(){{else}}auth{{/if}}.api.getSession({ headers });
 	return {
 		auth: null,
 		session,
@@ -138,7 +154,11 @@ export async function createContext({ headers }: CreateContextOptions) {
 {{else if (eq backend 'hono')}}
 import type { Context as HonoContext } from "hono";
 {{#if (eq auth "better-auth")}}
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createAuth } from "@{{projectName}}/auth";
+{{else}}
 import { auth } from "@{{projectName}}/auth";
+{{/if}}
 {{/if}}
 
 export type CreateContextOptions = {
@@ -147,7 +167,7 @@ export type CreateContextOptions = {
 
 export async function createContext({ context }: CreateContextOptions){{#if (eq auth "clerk")}}: Promise<ClerkRequestContext>{{/if}} {
 {{#if (eq auth "better-auth")}}
-	const session = await auth.api.getSession({
+	const session = await {{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}createAuth(){{else}}auth{{/if}}.api.getSession({
 		headers: context.req.raw.headers,
 	});
 	return {

--- a/packages/template-generator/templates/api/trpc/server/src/context.ts.hbs
+++ b/packages/template-generator/templates/api/trpc/server/src/context.ts.hbs
@@ -33,12 +33,16 @@ async function authenticateClerkRequest(request: Request): Promise<ClerkContextA
 {{#if (and (eq backend 'self') (includes frontend "next"))}}
 import type { NextRequest } from "next/server";
 {{#if (eq auth "better-auth")}}
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createAuth } from "@{{projectName}}/auth";
+{{else}}
 import { auth } from "@{{projectName}}/auth";
+{{/if}}
 {{/if}}
 
 export async function createContext(req: NextRequest){{#if (eq auth "clerk")}}: Promise<ClerkRequestContext>{{/if}} {
 {{#if (eq auth "better-auth")}}
-	const session = await auth.api.getSession({
+	const session = await {{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}createAuth(){{else}}auth{{/if}}.api.getSession({
 		headers: req.headers,
 	});
 	return {
@@ -61,12 +65,16 @@ export async function createContext(req: NextRequest){{#if (eq auth "clerk")}}: 
 
 {{else if (and (eq backend 'self') (includes frontend "tanstack-start"))}}
 {{#if (eq auth "better-auth")}}
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createAuth } from "@{{projectName}}/auth";
+{{else}}
 import { auth } from "@{{projectName}}/auth";
+{{/if}}
 {{/if}}
 
 export async function createContext({ req }: { req: Request }){{#if (eq auth "clerk")}}: Promise<ClerkRequestContext>{{/if}} {
 {{#if (eq auth "better-auth")}}
-	const session = await auth.api.getSession({
+	const session = await {{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}createAuth(){{else}}auth{{/if}}.api.getSession({
 		headers: req.headers,
 	});
 	return {
@@ -90,7 +98,11 @@ export async function createContext({ req }: { req: Request }){{#if (eq auth "cl
 {{else if (eq backend 'hono')}}
 import type { Context as HonoContext } from "hono";
 {{#if (eq auth "better-auth")}}
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createAuth } from "@{{projectName}}/auth";
+{{else}}
 import { auth } from "@{{projectName}}/auth";
+{{/if}}
 {{/if}}
 
 export type CreateContextOptions = {
@@ -99,7 +111,7 @@ export type CreateContextOptions = {
 
 export async function createContext({ context }: CreateContextOptions){{#if (eq auth "clerk")}}: Promise<ClerkRequestContext>{{/if}} {
 {{#if (eq auth "better-auth")}}
-	const session = await auth.api.getSession({
+	const session = await {{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}createAuth(){{else}}auth{{/if}}.api.getSession({
 		headers: context.req.raw.headers,
 	});
 	return {

--- a/packages/template-generator/templates/auth/better-auth/fullstack/astro/src/middleware.ts.hbs
+++ b/packages/template-generator/templates/auth/better-auth/fullstack/astro/src/middleware.ts.hbs
@@ -1,7 +1,14 @@
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createAuth } from "@{{projectName}}/auth";
+{{else}}
 import { auth } from "@{{projectName}}/auth";
+{{/if}}
 import { defineMiddleware } from "astro:middleware";
 
 export const onRequest = defineMiddleware(async (context, next) => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+  const auth = createAuth();
+{{/if}}
   const isAuthed = await auth.api.getSession({
     headers: context.request.headers,
   });

--- a/packages/template-generator/templates/auth/better-auth/fullstack/astro/src/pages/api/auth/[...all].ts.hbs
+++ b/packages/template-generator/templates/auth/better-auth/fullstack/astro/src/pages/api/auth/[...all].ts.hbs
@@ -1,6 +1,13 @@
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createAuth } from "@{{projectName}}/auth";
+{{else}}
 import { auth } from "@{{projectName}}/auth";
+{{/if}}
 import type { APIRoute } from "astro";
 
 export const ALL: APIRoute = async (ctx) => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+  const auth = createAuth();
+{{/if}}
   return auth.handler(ctx.request);
 };

--- a/packages/template-generator/templates/auth/better-auth/fullstack/next/src/app/api/auth/[...all]/route.ts.hbs
+++ b/packages/template-generator/templates/auth/better-auth/fullstack/next/src/app/api/auth/[...all]/route.ts.hbs
@@ -1,4 +1,18 @@
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createAuth } from "@{{projectName}}/auth";
+{{else}}
 import { auth } from "@{{projectName}}/auth";
+{{/if}}
 import { toNextJsHandler } from "better-auth/next-js";
 
-export const { GET, POST } = toNextJsHandler(auth.handler);
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+export async function GET(request: Request) {
+	return toNextJsHandler(createAuth()).GET(request);
+}
+
+export async function POST(request: Request) {
+	return toNextJsHandler(createAuth()).POST(request);
+}
+{{else}}
+export const { GET, POST } = toNextJsHandler(auth);
+{{/if}}

--- a/packages/template-generator/templates/auth/better-auth/fullstack/nuxt/server/api/auth/[...all].ts.hbs
+++ b/packages/template-generator/templates/auth/better-auth/fullstack/nuxt/server/api/auth/[...all].ts.hbs
@@ -1,5 +1,12 @@
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createAuth } from "@{{projectName}}/auth";
+{{else}}
 import { auth } from "@{{projectName}}/auth";
+{{/if}}
 
 export default defineEventHandler((event) => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+  const auth = createAuth();
+{{/if}}
   return auth.handler(toWebRequest(event));
 });

--- a/packages/template-generator/templates/auth/better-auth/fullstack/tanstack-start/src/routes/api/auth/$.ts.hbs
+++ b/packages/template-generator/templates/auth/better-auth/fullstack/tanstack-start/src/routes/api/auth/$.ts.hbs
@@ -1,13 +1,23 @@
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createAuth } from '@{{projectName}}/auth'
+{{else}}
 import { auth } from '@{{projectName}}/auth'
+{{/if}}
 import { createFileRoute } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/api/auth/$')({
   server: {
     handlers: {
       GET: ({ request }) => {
+        {{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+        const auth = createAuth()
+        {{/if}}
         return auth.handler(request)
       },
       POST: ({ request }) => {
+        {{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+        const auth = createAuth()
+        {{/if}}
         return auth.handler(request)
       },
     },

--- a/packages/template-generator/templates/auth/better-auth/server/base/src/index.ts.hbs
+++ b/packages/template-generator/templates/auth/better-auth/server/base/src/index.ts.hbs
@@ -6,67 +6,75 @@ import { env } from "@{{projectName}}/env/server";
 import { polar, checkout, portal } from "@polar-sh/better-auth";
 import { polarClient } from "./lib/payments";
 {{/if}}
-import prisma from "@{{projectName}}/db";
+import { createPrismaClient } from "@{{projectName}}/db";
 
-export const auth = betterAuth({
-	database: prismaAdapter(prisma, {
+export function createAuth() {
+	const prisma = createPrismaClient();
+
+	return betterAuth({
+		database: prismaAdapter(prisma, {
 {{#if (eq database "postgres")}}provider: "postgresql",{{/if}}
 {{#if (eq database "sqlite")}}provider: "sqlite",{{/if}}
 {{#if (eq database "mysql")}}provider: "mysql",{{/if}}
 {{#if (eq database "mongodb")}}provider: "mongodb",{{/if}}
-	}),
-
-	trustedOrigins: [
-		env.CORS_ORIGIN,
-{{#if (or (includes frontend "native-bare") (includes frontend "native-uniwind") (includes frontend "native-unistyles"))}}
-		"{{projectName}}://",
-		...(env.NODE_ENV === "development"
-			? [
-				"exp://",
-				"exp://**",
-				"exp://192.168.*.*:*/**",
-				"http://localhost:8081",
-			]
-			: []),
-{{/if}}
-	],
-	emailAndPassword: {
-		enabled: true,
-	},
-	secret: env.BETTER_AUTH_SECRET,
-	baseURL: env.BETTER_AUTH_URL,
-{{#if (ne backend "self")}}
-	advanced: {
-		defaultCookieAttributes: {
-			sameSite: "none",
-			secure: true,
-			httpOnly: true,
-		},
-	},
-{{/if}}
-	plugins: [
-{{#if (eq payments "polar")}}
-		polar({
-			client: polarClient,
-			createCustomerOnSignUp: true,
-			enableCustomerPortal: true,
-			use: [
-				checkout({
-					products: [
-						{
-							productId: "your-product-id",
-							slug: "pro",
-						},
-					],
-					successUrl: env.POLAR_SUCCESS_URL,
-					authenticatedUsersOnly: true,
-				}),
-				portal(),
-			],
 		}),
+
+		trustedOrigins: [
+			env.CORS_ORIGIN,
+{{#if (or (includes frontend "native-bare") (includes frontend "native-uniwind") (includes frontend "native-unistyles"))}}
+			"{{projectName}}://",
+			...(env.NODE_ENV === "development"
+				? [
+					"exp://",
+					"exp://**",
+					"exp://192.168.*.*:*/**",
+					"http://localhost:8081",
+				]
+				: []),
 {{/if}}
-	],
-});
+		],
+		emailAndPassword: {
+			enabled: true,
+		},
+		secret: env.BETTER_AUTH_SECRET,
+		baseURL: env.BETTER_AUTH_URL,
+{{#if (ne backend "self")}}
+		advanced: {
+			defaultCookieAttributes: {
+				sameSite: "none",
+				secure: true,
+				httpOnly: true,
+			},
+		},
+{{/if}}
+		plugins: [
+{{#if (eq payments "polar")}}
+			polar({
+				client: polarClient,
+				createCustomerOnSignUp: true,
+				enableCustomerPortal: true,
+				use: [
+					checkout({
+						products: [
+							{
+								productId: "your-product-id",
+								slug: "pro",
+							},
+						],
+						successUrl: env.POLAR_SUCCESS_URL,
+						authenticatedUsersOnly: true,
+					}),
+					portal(),
+				],
+			}),
+{{/if}}
+		],
+	});
+}
+
+{{#if (and (ne runtime "workers") (ne serverDeploy "cloudflare") (or (ne backend "self") (ne webDeploy "cloudflare")))}}
+export const auth = createAuth();
+{{/if}}
 {{/if}}
 
 {{#if (eq orm "drizzle")}}
@@ -78,68 +86,76 @@ import { env } from "@{{projectName}}/env/server";
 import { polar, checkout, portal } from "@polar-sh/better-auth";
 import { polarClient } from "./lib/payments";
 {{/if}}
-import { db } from "@{{projectName}}/db";
+import { createDb } from "@{{projectName}}/db";
 import * as schema from "@{{projectName}}/db/schema/auth";
 
 
-export const auth = betterAuth({
-	database: drizzleAdapter(db, {
+export function createAuth() {
+	const db = createDb();
+
+	return betterAuth({
+		database: drizzleAdapter(db, {
 {{#if (eq database "postgres")}}provider: "pg",{{/if}}
 {{#if (eq database "sqlite")}}provider: "sqlite",{{/if}}
 {{#if (eq database "mysql")}}provider: "mysql",{{/if}}
-		schema: schema,
-	}),
-	trustedOrigins: [
-		env.CORS_ORIGIN,
-{{#if (or (includes frontend "native-bare") (includes frontend "native-uniwind") (includes frontend "native-unistyles"))}}
-		"{{projectName}}://",
-		...(env.NODE_ENV === "development"
-			? [
-				"exp://",
-				"exp://**",
-				"exp://192.168.*.*:*/**",
-				"http://localhost:8081",
-			]
-			: []),
-{{/if}}
-	],
-	emailAndPassword: {
-		enabled: true,
-	},
-	secret: env.BETTER_AUTH_SECRET,
-	baseURL: env.BETTER_AUTH_URL,
-{{#if (ne backend "self")}}
-	advanced: {
-		defaultCookieAttributes: {
-			sameSite: "none",
-			secure: true,
-			httpOnly: true,
-		},
-	},
-{{/if}}
-	plugins: [
-{{#if (eq payments "polar")}}
-		polar({
-			client: polarClient,
-			createCustomerOnSignUp: true,
-			enableCustomerPortal: true,
-			use: [
-				checkout({
-					products: [
-						{
-							productId: "your-product-id",
-							slug: "pro",
-						},
-					],
-					successUrl: env.POLAR_SUCCESS_URL,
-					authenticatedUsersOnly: true,
-				}),
-				portal(),
-			],
+			schema: schema,
 		}),
+		trustedOrigins: [
+			env.CORS_ORIGIN,
+{{#if (or (includes frontend "native-bare") (includes frontend "native-uniwind") (includes frontend "native-unistyles"))}}
+			"{{projectName}}://",
+			...(env.NODE_ENV === "development"
+				? [
+					"exp://",
+					"exp://**",
+					"exp://192.168.*.*:*/**",
+					"http://localhost:8081",
+				]
+				: []),
 {{/if}}
-	],
-});
+		],
+		emailAndPassword: {
+			enabled: true,
+		},
+		secret: env.BETTER_AUTH_SECRET,
+		baseURL: env.BETTER_AUTH_URL,
+{{#if (ne backend "self")}}
+		advanced: {
+			defaultCookieAttributes: {
+				sameSite: "none",
+				secure: true,
+				httpOnly: true,
+			},
+		},
+{{/if}}
+		plugins: [
+{{#if (eq payments "polar")}}
+			polar({
+				client: polarClient,
+				createCustomerOnSignUp: true,
+				enableCustomerPortal: true,
+				use: [
+					checkout({
+						products: [
+							{
+								productId: "your-product-id",
+								slug: "pro",
+							},
+						],
+						successUrl: env.POLAR_SUCCESS_URL,
+						authenticatedUsersOnly: true,
+					}),
+					portal(),
+				],
+			}),
+{{/if}}
+		],
+	});
+}
+
+{{#if (and (ne runtime "workers") (ne serverDeploy "cloudflare") (or (ne backend "self") (ne webDeploy "cloudflare")))}}
+export const auth = createAuth();
+{{/if}}
 {{/if}}
 
 {{#if (eq runtime "workers")}}
@@ -150,79 +166,83 @@ import { env } from "@{{projectName}}/env/server";
 import { polar, checkout, portal } from "@polar-sh/better-auth";
 import { polarClient } from "./lib/payments";
 {{/if}}
-import { db } from "@{{projectName}}/db";
+import { createDb } from "@{{projectName}}/db";
 import * as schema from "@{{projectName}}/db/schema/auth";
 
 
-export const auth = betterAuth({
-	database: drizzleAdapter(db, {
+export function createAuth() {
+	const db = createDb();
+
+	return betterAuth({
+		database: drizzleAdapter(db, {
 {{#if (eq database "postgres")}}provider: "pg",{{/if}}
 {{#if (eq database "sqlite")}}provider: "sqlite",{{/if}}
 {{#if (eq database "mysql")}}provider: "mysql",{{/if}}
-		schema: schema,
-	}),
-	trustedOrigins: [
-		env.CORS_ORIGIN,
-{{#if (or (includes frontend "native-bare") (includes frontend "native-uniwind") (includes frontend "native-unistyles"))}}
-		"{{projectName}}://",
-		...(env.NODE_ENV === "development"
-			? [
-				"exp://",
-				"exp://**",
-				"exp://192.168.*.*:*/**",
-				"http://localhost:8081",
-			]
-			: []),
-{{/if}}
-	],
-	emailAndPassword: {
-		enabled: true,
-	},
-	// uncomment cookieCache setting when ready to deploy to Cloudflare using *.workers.dev domains
-	// session: {
-	//   cookieCache: {
-	//     enabled: true,
-	//     maxAge: 60,
-	//   },
-	// },
-	secret: env.BETTER_AUTH_SECRET,
-	baseURL: env.BETTER_AUTH_URL,
-	advanced: {
-		defaultCookieAttributes: {
-			sameSite: "none",
-			secure: true,
-			httpOnly: true,
-		},
-		// uncomment crossSubDomainCookies setting when ready to deploy and replace <your-workers-subdomain> with your actual workers subdomain
-		// https://developers.cloudflare.com/workers/wrangler/configuration/#workersdev
-		// crossSubDomainCookies: {
-		//   enabled: true,
-		//   domain: "<your-workers-subdomain>",
-		// },
-	},
-{{#if (eq payments "polar")}}
-	plugins: [
-		polar({
-			client: polarClient,
-			createCustomerOnSignUp: true,
-			enableCustomerPortal: true,
-			use: [
-				checkout({
-					products: [
-						{
-							productId: "your-product-id",
-							slug: "pro",
-						},
-					],
-					successUrl: env.POLAR_SUCCESS_URL,
-					authenticatedUsersOnly: true,
-				}),
-				portal(),
-			],
+			schema: schema,
 		}),
-	],
+		trustedOrigins: [
+			env.CORS_ORIGIN,
+{{#if (or (includes frontend "native-bare") (includes frontend "native-uniwind") (includes frontend "native-unistyles"))}}
+			"{{projectName}}://",
+			...(env.NODE_ENV === "development"
+				? [
+					"exp://",
+					"exp://**",
+					"exp://192.168.*.*:*/**",
+					"http://localhost:8081",
+				]
+				: []),
 {{/if}}
-});
+		],
+		emailAndPassword: {
+			enabled: true,
+		},
+		// uncomment cookieCache setting when ready to deploy to Cloudflare using *.workers.dev domains
+		// session: {
+		//   cookieCache: {
+		//     enabled: true,
+		//     maxAge: 60,
+		//   },
+		// },
+		secret: env.BETTER_AUTH_SECRET,
+		baseURL: env.BETTER_AUTH_URL,
+		advanced: {
+			defaultCookieAttributes: {
+				sameSite: "none",
+				secure: true,
+				httpOnly: true,
+			},
+			// uncomment crossSubDomainCookies setting when ready to deploy and replace <your-workers-subdomain> with your actual workers subdomain
+			// https://developers.cloudflare.com/workers/wrangler/configuration/#workersdev
+			// crossSubDomainCookies: {
+			//   enabled: true,
+			//   domain: "<your-workers-subdomain>",
+			// },
+		},
+{{#if (eq payments "polar")}}
+		plugins: [
+			polar({
+				client: polarClient,
+				createCustomerOnSignUp: true,
+				enableCustomerPortal: true,
+				use: [
+					checkout({
+						products: [
+							{
+								productId: "your-product-id",
+								slug: "pro",
+							},
+						],
+						successUrl: env.POLAR_SUCCESS_URL,
+						authenticatedUsersOnly: true,
+					}),
+					portal(),
+				],
+			}),
+		],
+{{/if}}
+	});
+}
 {{/if}}
 {{/if}}
 
@@ -236,59 +256,65 @@ import { polarClient } from "./lib/payments";
 {{/if}}
 import { client } from "@{{projectName}}/db";
 
-export const auth = betterAuth({
-	database: mongodbAdapter(client),
-	trustedOrigins: [
-		env.CORS_ORIGIN,
+export function createAuth() {
+	return betterAuth({
+		database: mongodbAdapter(client),
+		trustedOrigins: [
+			env.CORS_ORIGIN,
 {{#if (or (includes frontend "native-bare") (includes frontend "native-uniwind") (includes frontend "native-unistyles"))}}
-		"{{projectName}}://",
-		...(env.NODE_ENV === "development"
-			? [
-				"exp://",
-				"exp://**",
-				"exp://192.168.*.*:*/**",
-				"http://localhost:8081",
-			]
-			: []),
+			"{{projectName}}://",
+			...(env.NODE_ENV === "development"
+				? [
+					"exp://",
+					"exp://**",
+					"exp://192.168.*.*:*/**",
+					"http://localhost:8081",
+				]
+				: []),
 {{/if}}
-	],
-	emailAndPassword: {
-		enabled: true,
-	},
-	secret: env.BETTER_AUTH_SECRET,
-	baseURL: env.BETTER_AUTH_URL,
-{{#if (ne backend "self")}}
-	advanced: {
-		defaultCookieAttributes: {
-			sameSite: "none",
-			secure: true,
-			httpOnly: true,
+		],
+		emailAndPassword: {
+			enabled: true,
 		},
-	},
+		secret: env.BETTER_AUTH_SECRET,
+		baseURL: env.BETTER_AUTH_URL,
+{{#if (ne backend "self")}}
+		advanced: {
+			defaultCookieAttributes: {
+				sameSite: "none",
+				secure: true,
+				httpOnly: true,
+			},
+		},
 {{/if}}
 {{#if (eq payments "polar")}}
-	plugins: [
-		polar({
-			client: polarClient,
-			createCustomerOnSignUp: true,
-			enableCustomerPortal: true,
-			use: [
-				checkout({
-					products: [
-						{
-							productId: "your-product-id",
-							slug: "pro",
-						},
-					],
-					successUrl: env.POLAR_SUCCESS_URL,
-					authenticatedUsersOnly: true,
-				}),
-				portal(),
-			],
-		}),
-	],
+		plugins: [
+			polar({
+				client: polarClient,
+				createCustomerOnSignUp: true,
+				enableCustomerPortal: true,
+				use: [
+					checkout({
+						products: [
+							{
+								productId: "your-product-id",
+								slug: "pro",
+							},
+						],
+						successUrl: env.POLAR_SUCCESS_URL,
+						authenticatedUsersOnly: true,
+					}),
+					portal(),
+				],
+			}),
+		],
 {{/if}}
-});
+	});
+}
+
+{{#if (and (ne runtime "workers") (ne serverDeploy "cloudflare") (or (ne backend "self") (ne webDeploy "cloudflare")))}}
+export const auth = createAuth();
+{{/if}}
 {{/if}}
 
 {{#if (eq orm "none")}}
@@ -300,57 +326,63 @@ import { polarClient } from "./lib/payments";
 {{/if}}
 
 
-export const auth = betterAuth({
-	database: "", // Invalid configuration
-	trustedOrigins: [
-		env.CORS_ORIGIN,
+export function createAuth() {
+	return betterAuth({
+		database: "", // Invalid configuration
+		trustedOrigins: [
+			env.CORS_ORIGIN,
 {{#if (or (includes frontend "native-bare") (includes frontend "native-uniwind") (includes frontend "native-unistyles"))}}
-		"{{projectName}}://",
-		...(env.NODE_ENV === "development"
-			? [
-				"exp://",
-				"exp://**",
-				"exp://192.168.*.*:*/**",
-				"http://localhost:8081",
-			]
-			: []),
+			"{{projectName}}://",
+			...(env.NODE_ENV === "development"
+				? [
+					"exp://",
+					"exp://**",
+					"exp://192.168.*.*:*/**",
+					"http://localhost:8081",
+				]
+				: []),
 {{/if}}
-	],
-	emailAndPassword: {
-		enabled: true,
-	},
-	secret: env.BETTER_AUTH_SECRET,
-	baseURL: env.BETTER_AUTH_URL,
-{{#if (ne backend "self")}}
-	advanced: {
-		defaultCookieAttributes: {
-			sameSite: "none",
-			secure: true,
-			httpOnly: true,
+		],
+		emailAndPassword: {
+			enabled: true,
 		},
-	},
+		secret: env.BETTER_AUTH_SECRET,
+		baseURL: env.BETTER_AUTH_URL,
+{{#if (ne backend "self")}}
+		advanced: {
+			defaultCookieAttributes: {
+				sameSite: "none",
+				secure: true,
+				httpOnly: true,
+			},
+		},
 {{/if}}
 {{#if (eq payments "polar")}}
-	plugins: [
-		polar({
-			client: polarClient,
-			createCustomerOnSignUp: true,
-			enableCustomerPortal: true,
-			use: [
-				checkout({
-					products: [
-						{
-							productId: "your-product-id",
-							slug: "pro",
-						},
-					],
-					successUrl: env.POLAR_SUCCESS_URL,
-					authenticatedUsersOnly: true,
-				}),
-				portal(),
-			],
-		}),
-	],
+		plugins: [
+			polar({
+				client: polarClient,
+				createCustomerOnSignUp: true,
+				enableCustomerPortal: true,
+				use: [
+					checkout({
+						products: [
+							{
+								productId: "your-product-id",
+								slug: "pro",
+							},
+						],
+						successUrl: env.POLAR_SUCCESS_URL,
+						authenticatedUsersOnly: true,
+					}),
+					portal(),
+				],
+			}),
+		],
 {{/if}}
-});
+	});
+}
+
+{{#if (and (ne runtime "workers") (ne serverDeploy "cloudflare") (or (ne backend "self") (ne webDeploy "cloudflare")))}}
+export const auth = createAuth();
+{{/if}}
 {{/if}}

--- a/packages/template-generator/templates/auth/better-auth/web/react/next/src/app/dashboard/page.tsx.hbs
+++ b/packages/template-generator/templates/auth/better-auth/web/react/next/src/app/dashboard/page.tsx.hbs
@@ -2,13 +2,19 @@ import { redirect } from "next/navigation";
 import Dashboard from "./dashboard";
 import { headers } from "next/headers";
 {{#if (eq backend "self")}}
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createAuth } from "@{{projectName}}/auth";
+{{else}}
 import { auth } from "@{{projectName}}/auth";
 {{/if}}
+{{/if}}
+{{#if (or (ne backend "self") (eq payments "polar"))}}
 import { authClient } from "@/lib/auth-client";
+{{/if}}
 
 export default async function DashboardPage() {
 	{{#if (eq backend "self")}}
-	const session = await auth.api.getSession({
+	const session = await {{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}createAuth(){{else}}auth{{/if}}.api.getSession({
 		headers: await headers(),
 	});
 	{{else}}

--- a/packages/template-generator/templates/auth/better-auth/web/react/tanstack-start/src/middleware/auth.ts.hbs
+++ b/packages/template-generator/templates/auth/better-auth/web/react/tanstack-start/src/middleware/auth.ts.hbs
@@ -1,10 +1,14 @@
 {{#if (eq backend "self")}}
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createAuth } from "@{{projectName}}/auth";
+{{else}}
 import { auth } from "@{{projectName}}/auth";
+{{/if}}
 import { createMiddleware } from "@tanstack/react-start";
 
 
 export const authMiddleware = createMiddleware().server(async ({ next, request }) => {
-    const session = await auth.api.getSession({
+    const session = await {{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}createAuth(){{else}}auth{{/if}}.api.getSession({
         headers: request.headers,
     })
     return next({

--- a/packages/template-generator/templates/backend/server/hono/src/index.ts.hbs
+++ b/packages/template-generator/templates/backend/server/hono/src/index.ts.hbs
@@ -14,7 +14,11 @@ import { createContext } from "@{{projectName}}/api/context";
 import { appRouter } from "@{{projectName}}/api/routers/index";
 {{/if}}
 {{#if (eq auth "better-auth")}}
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createAuth } from "@{{projectName}}/auth";
+{{else}}
 import { auth } from "@{{projectName}}/auth";
+{{/if}}
 {{/if}}
 import { Hono } from "hono";
 import { cors } from "hono/cors";
@@ -48,7 +52,16 @@ app.use(
 );
 
 {{#if (eq auth "better-auth")}}
-app.on(["POST", "GET"], "/api/auth/*", (c) => auth.handler(c.req.raw));
+app.on(
+	["POST", "GET"],
+	"/api/auth/*",
+	(c) =>
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+		createAuth().handler(c.req.raw)
+{{else}}
+		auth.handler(c.req.raw)
+{{/if}}
+);
 {{/if}}
 
 {{#if (eq api "orpc")}}

--- a/packages/template-generator/templates/db/drizzle/mysql/src/index.ts.hbs
+++ b/packages/template-generator/templates/db/drizzle/mysql/src/index.ts.hbs
@@ -5,23 +5,31 @@ import * as schema from "./schema";
 {{#if (eq dbSetup "planetscale")}}
 import { drizzle } from "drizzle-orm/planetscale-serverless";
 
-export const db = drizzle({
-	connection: {
-		host: env.DATABASE_HOST,
-		username: env.DATABASE_USERNAME,
-		password: env.DATABASE_PASSWORD,
-	},
-	schema,
-});
+export function createDb() {
+	return drizzle({
+		connection: {
+			host: env.DATABASE_HOST,
+			username: env.DATABASE_USERNAME,
+			password: env.DATABASE_PASSWORD,
+		},
+		schema,
+	});
+}
 {{else}}
 import { drizzle } from "drizzle-orm/mysql2";
 
-export const db = drizzle({
-	connection: {
-		uri: env.DATABASE_URL,
-	},
-	schema,
-});
+export function createDb() {
+	return drizzle({
+		connection: {
+			uri: env.DATABASE_URL,
+		},
+		schema,
+	});
+}
+{{/if}}
+
+{{#if (and (ne serverDeploy "cloudflare") (or (ne backend "self") (ne webDeploy "cloudflare")))}}
+export const db = createDb();
 {{/if}}
 {{/if}}
 
@@ -32,23 +40,27 @@ import * as schema from "./schema";
 import { drizzle } from "drizzle-orm/planetscale-serverless";
 import { env } from "@{{projectName}}/env/server";
 
-export const db = drizzle({
-	connection: {
-		host: env.DATABASE_HOST,
-		username: env.DATABASE_USERNAME,
-		password: env.DATABASE_PASSWORD,
-	},
-	schema,
-});
+export function createDb() {
+	return drizzle({
+		connection: {
+			host: env.DATABASE_HOST,
+			username: env.DATABASE_USERNAME,
+			password: env.DATABASE_PASSWORD,
+		},
+		schema,
+	});
+}
 {{else}}
 import { drizzle } from "drizzle-orm/mysql2";
 import { env } from "@{{projectName}}/env/server";
 
-export const db = drizzle({
-	connection: {
-		uri: env.DATABASE_URL,
-	},
-	schema,
-});
+export function createDb() {
+	return drizzle({
+		connection: {
+			uri: env.DATABASE_URL,
+		},
+		schema,
+	});
+}
 {{/if}}
 {{/if}}

--- a/packages/template-generator/templates/db/drizzle/postgres/src/index.ts.hbs
+++ b/packages/template-generator/templates/db/drizzle/postgres/src/index.ts.hbs
@@ -6,12 +6,32 @@ import * as schema from "./schema";
 import { neon } from '@neondatabase/serverless';
 import { drizzle } from 'drizzle-orm/neon-http';
 
-const sql = neon(env.DATABASE_URL);
-export const db = drizzle(sql, { schema });
+export function createDb() {
+	const sql = neon(env.DATABASE_URL);
+	return drizzle(sql, { schema });
+}
 {{else}}
 import { drizzle } from "drizzle-orm/node-postgres";
+{{#if (and (eq backend "self") (eq webDeploy "cloudflare"))}}
+import { Pool } from "pg";
+{{/if}}
 
-export const db = drizzle(env.DATABASE_URL, { schema });
+export function createDb() {
+{{#if (and (eq backend "self") (eq webDeploy "cloudflare"))}}
+	const pool = new Pool({
+		connectionString: env.DATABASE_URL,
+		maxUses: 1,
+	});
+
+	return drizzle({ client: pool, schema });
+{{else}}
+	return drizzle(env.DATABASE_URL, { schema });
+{{/if}}
+}
+{{/if}}
+
+{{#if (and (ne serverDeploy "cloudflare") (or (ne backend "self") (ne webDeploy "cloudflare")))}}
+export const db = createDb();
 {{/if}}
 {{/if}}
 
@@ -23,12 +43,22 @@ import { neon } from '@neondatabase/serverless';
 import { drizzle } from 'drizzle-orm/neon-http';
 import { env } from "@{{projectName}}/env/server";
 
-const sql = neon(env.DATABASE_URL || "");
-export const db = drizzle(sql, { schema });
+export function createDb() {
+	const sql = neon(env.DATABASE_URL || "");
+	return drizzle(sql, { schema });
+}
 {{else}}
 import { drizzle } from "drizzle-orm/node-postgres";
 import { env } from "@{{projectName}}/env/server";
+import { Pool } from "pg";
 
-export const db = drizzle(env.DATABASE_URL || "", { schema });
+export function createDb() {
+	const pool = new Pool({
+		connectionString: env.DATABASE_URL || "",
+		maxUses: 1,
+	});
+
+	return drizzle({ client: pool, schema });
+}
 {{/if}}
 {{/if}}

--- a/packages/template-generator/templates/db/drizzle/sqlite/src/index.ts.hbs
+++ b/packages/template-generator/templates/db/drizzle/sqlite/src/index.ts.hbs
@@ -4,14 +4,20 @@ import * as schema from "./schema";
 import { drizzle } from "drizzle-orm/libsql";
 import { createClient } from "@libsql/client";
 
-const client = createClient({
-	url: env.DATABASE_URL,
+export function createDb() {
+	const client = createClient({
+		url: env.DATABASE_URL,
 {{#if (eq dbSetup "turso")}}
-	authToken: env.DATABASE_AUTH_TOKEN,
+		authToken: env.DATABASE_AUTH_TOKEN,
 {{/if}}
-});
+	});
 
-export const db = drizzle({ client, schema });
+	return drizzle({ client, schema });
+}
+
+{{#if (and (ne serverDeploy "cloudflare") (or (ne backend "self") (ne webDeploy "cloudflare")))}}
+export const db = createDb();
+{{/if}}
 {{/if}}
 
 {{#if (eq runtime "workers")}}
@@ -21,19 +27,23 @@ import * as schema from "./schema";
 import { drizzle } from "drizzle-orm/d1";
 import { env } from "@{{projectName}}/env/server";
 
-export const db = drizzle(env.DB, { schema });
+export function createDb() {
+	return drizzle(env.DB, { schema });
+}
 {{else}}
 import { drizzle } from "drizzle-orm/libsql";
 import { env } from "@{{projectName}}/env/server";
 import { createClient } from "@libsql/client";
 
-const client = createClient({
-	url: env.DATABASE_URL || "",
+export function createDb() {
+	const client = createClient({
+		url: env.DATABASE_URL || "",
 {{#if (eq dbSetup "turso")}}
-	authToken: env.DATABASE_AUTH_TOKEN,
+		authToken: env.DATABASE_AUTH_TOKEN,
 {{/if}}
-});
+	});
 
-export const db = drizzle({ client, schema });
+	return drizzle({ client, schema });
+}
 {{/if}}
 {{/if}}

--- a/packages/template-generator/templates/db/prisma/mysql/src/index.ts.hbs
+++ b/packages/template-generator/templates/db/prisma/mysql/src/index.ts.hbs
@@ -5,26 +5,28 @@ import { env } from "@{{projectName}}/env/server";
 {{#if (eq dbSetup "planetscale")}}
 import { PrismaPlanetScale } from "@prisma/adapter-planetscale";
 
-const adapter = new PrismaPlanetScale({ url: env.DATABASE_URL });
-const prisma = new PrismaClient({ adapter });
+export function createPrismaClient() {
+	const adapter = new PrismaPlanetScale({ url: env.DATABASE_URL });
+	return new PrismaClient({ adapter });
+}
 {{else}}
 import { PrismaMariaDb } from "@prisma/adapter-mariadb";
 
-const databaseUrl: string = env.DATABASE_URL;
-const url: URL = new URL(databaseUrl);
-const connectionConfig = {
-	host: url.hostname,
-	port: parseInt(url.port || "3306"),
-	user: url.username,
-	password: url.password,
-	database: url.pathname.slice(1),
-};
+export function createPrismaClient() {
+	const databaseUrl: string = env.DATABASE_URL;
+	const url: URL = new URL(databaseUrl);
+	const connectionConfig = {
+		host: url.hostname,
+		port: parseInt(url.port || "3306"),
+		user: url.username,
+		password: url.password,
+		database: url.pathname.slice(1),
+	};
 
-const adapter = new PrismaMariaDb(connectionConfig);
-const prisma = new PrismaClient({ adapter });
+	const adapter = new PrismaMariaDb(connectionConfig);
+	return new PrismaClient({ adapter });
+}
 {{/if}}
-
-export default prisma;
 {{else}}
 import { PrismaClient } from "../prisma/generated/client";
 import { env } from "@{{projectName}}/env/server";
@@ -32,24 +34,31 @@ import { env } from "@{{projectName}}/env/server";
 {{#if (eq dbSetup "planetscale")}}
 import { PrismaPlanetScale } from "@prisma/adapter-planetscale";
 
-const adapter = new PrismaPlanetScale({ url: env.DATABASE_URL });
-const prisma = new PrismaClient({ adapter });
+export function createPrismaClient() {
+	const adapter = new PrismaPlanetScale({ url: env.DATABASE_URL });
+	return new PrismaClient({ adapter });
+}
 {{else}}
 import { PrismaMariaDb } from "@prisma/adapter-mariadb";
 
-const databaseUrl: string = env.DATABASE_URL;
-const url: URL = new URL(databaseUrl);
-const connectionConfig = {
-	host: url.hostname,
-	port: parseInt(url.port || "3306"),
-	user: url.username,
-	password: url.password,
-	database: url.pathname.slice(1),
-};
+export function createPrismaClient() {
+	const databaseUrl: string = env.DATABASE_URL;
+	const url: URL = new URL(databaseUrl);
+	const connectionConfig = {
+		host: url.hostname,
+		port: parseInt(url.port || "3306"),
+		user: url.username,
+		password: url.password,
+		database: url.pathname.slice(1),
+	};
 
-const adapter = new PrismaMariaDb(connectionConfig);
-const prisma = new PrismaClient({ adapter });
+	const adapter = new PrismaMariaDb(connectionConfig);
+	return new PrismaClient({ adapter });
+}
 {{/if}}
 
+{{#if (and (ne serverDeploy "cloudflare") (or (ne backend "self") (ne webDeploy "cloudflare")))}}
+const prisma = createPrismaClient();
 export default prisma;
+{{/if}}
 {{/if}}

--- a/packages/template-generator/templates/db/prisma/postgres/src/index.ts.hbs
+++ b/packages/template-generator/templates/db/prisma/postgres/src/index.ts.hbs
@@ -7,58 +7,82 @@ import { neonConfig } from "@neondatabase/serverless";
 
 neonConfig.poolQueryViaFetch = true;
 
-const prisma = new PrismaClient({
-	adapter: new PrismaNeon({
-		connectionString: env.DATABASE_URL,
-	}),
-});
+export function createPrismaClient() {
+	return new PrismaClient({
+		adapter: new PrismaNeon({
+			connectionString: env.DATABASE_URL,
+		}),
+	});
+}
 
 {{else if (eq dbSetup "prisma-postgres")}}
 import { PrismaPg } from "@prisma/adapter-pg";
 
-const adapter = new PrismaPg({
-	connectionString: env.DATABASE_URL,
-});
+export function createPrismaClient() {
+	const adapter = new PrismaPg({
+		connectionString: env.DATABASE_URL,
+		maxUses: 1,
+	});
 
-const prisma = new PrismaClient({ adapter });
+	return new PrismaClient({ adapter });
+}
 
 {{else}}
 import { PrismaPg } from "@prisma/adapter-pg";
 
-const adapter = new PrismaPg({ connectionString: env.DATABASE_URL });
-const prisma = new PrismaClient({ adapter });
+export function createPrismaClient() {
+	const adapter = new PrismaPg({
+		connectionString: env.DATABASE_URL,
+		maxUses: 1,
+	});
+	return new PrismaClient({ adapter });
+}
 
 {{/if}}
-
-export default prisma;
 {{else}}
 import { PrismaClient } from "../prisma/generated/client";
 import { env } from "@{{projectName}}/env/server";
 {{#if (eq dbSetup "neon")}}
 import { PrismaNeon } from "@prisma/adapter-neon";
 
-const adapter = new PrismaNeon({
-	connectionString: env.DATABASE_URL,
-});
+export function createPrismaClient() {
+	const adapter = new PrismaNeon({
+		connectionString: env.DATABASE_URL,
+	});
 
-const prisma = new PrismaClient({ adapter });
+	return new PrismaClient({ adapter });
+}
 
 {{else if (eq dbSetup "prisma-postgres")}}
 import { PrismaPg } from "@prisma/adapter-pg";
 
-const adapter = new PrismaPg({
-	connectionString: env.DATABASE_URL,
-});
+export function createPrismaClient() {
+	const adapter = new PrismaPg({
+		connectionString: env.DATABASE_URL,
+{{#if (and (eq backend "self") (eq webDeploy "cloudflare"))}}
+		maxUses: 1,
+{{/if}}
+	});
 
-const prisma = new PrismaClient({ adapter });
+	return new PrismaClient({ adapter });
+}
 
 {{else}}
 import { PrismaPg } from "@prisma/adapter-pg";
 
-const adapter = new PrismaPg({ connectionString: env.DATABASE_URL });
-const prisma = new PrismaClient({ adapter });
+export function createPrismaClient() {
+	const adapter = new PrismaPg({
+		connectionString: env.DATABASE_URL,
+{{#if (and (eq backend "self") (eq webDeploy "cloudflare"))}}
+		maxUses: 1,
+{{/if}}
+	});
+	return new PrismaClient({ adapter });
+}
 
 {{/if}}
-
+{{#if (and (ne serverDeploy "cloudflare") (or (ne backend "self") (ne webDeploy "cloudflare")))}}
+const prisma = createPrismaClient();
 export default prisma;
+{{/if}}
 {{/if}}

--- a/packages/template-generator/templates/db/prisma/sqlite/src/index.ts.hbs
+++ b/packages/template-generator/templates/db/prisma/sqlite/src/index.ts.hbs
@@ -4,22 +4,32 @@ import { PrismaClient } from "../prisma/generated/client";
 import { PrismaD1 } from "@prisma/adapter-d1";
 import { env } from "@{{projectName}}/env/server";
 
-const adapter = new PrismaD1(env.DB);
-const prisma = new PrismaClient({ adapter });
+export function createPrismaClient() {
+	const adapter = new PrismaD1(env.DB);
+	return new PrismaClient({ adapter });
+}
 
+{{#if (and (ne runtime "workers") (ne serverDeploy "cloudflare") (or (ne backend "self") (ne webDeploy "cloudflare")))}}
+const prisma = createPrismaClient();
 export default prisma;
+{{/if}}
 {{else}}
 import { PrismaLibSql } from "@prisma/adapter-libsql";
 import { env } from "@{{projectName}}/env/server";
 
-const adapter = new PrismaLibSql({
-	url: env.DATABASE_URL,
+export function createPrismaClient() {
+	const adapter = new PrismaLibSql({
+		url: env.DATABASE_URL,
 {{#if (eq dbSetup "turso")}}
-	authToken: env.DATABASE_AUTH_TOKEN || "",
+		authToken: env.DATABASE_AUTH_TOKEN || "",
 {{/if}}
-});
+	});
 
-const prisma = new PrismaClient({ adapter });
+	return new PrismaClient({ adapter });
+}
 
+{{#if (and (ne runtime "workers") (ne serverDeploy "cloudflare") (or (ne backend "self") (ne webDeploy "cloudflare")))}}
+const prisma = createPrismaClient();
 export default prisma;
+{{/if}}
 {{/if}}

--- a/packages/template-generator/templates/examples/todo/server/drizzle/base/src/routers/todo.ts.hbs
+++ b/packages/template-generator/templates/examples/todo/server/drizzle/base/src/routers/todo.ts.hbs
@@ -1,18 +1,28 @@
 {{#if (eq api "orpc")}}
 import { eq } from "drizzle-orm";
 import z from "zod";
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createDb } from "@{{projectName}}/db";
+{{else}}
 import { db } from "@{{projectName}}/db";
+{{/if}}
 import { todo } from "@{{projectName}}/db/schema/todo";
 import { publicProcedure } from "../index";
 
 export const todoRouter = {
   getAll: publicProcedure.handler(async () => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+    const db = createDb();
+{{/if}}
     return await db.select().from(todo);
   }),
 
   create: publicProcedure
     .input(z.object({ text: z.string().min(1) }))
     .handler(async ({ input }) => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+      const db = createDb();
+{{/if}}
       return await db
         .insert(todo)
         .values({
@@ -23,6 +33,9 @@ export const todoRouter = {
   toggle: publicProcedure
     .input(z.object({ id: z.number(), completed: z.boolean() }))
     .handler(async ({ input }) => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+      const db = createDb();
+{{/if}}
       return await db
         .update(todo)
         .set({ completed: input.completed })
@@ -32,6 +45,9 @@ export const todoRouter = {
   delete: publicProcedure
     .input(z.object({ id: z.number() }))
     .handler(async ({ input }) => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+      const db = createDb();
+{{/if}}
       return await db.delete(todo).where(eq(todo.id, input.id));
     }),
 };
@@ -42,16 +58,26 @@ import z from "zod";
 import { router, publicProcedure } from "../index";
 import { todo } from "@{{projectName}}/db/schema/todo";
 import { eq } from "drizzle-orm";
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createDb } from "@{{projectName}}/db";
+{{else}}
 import { db } from "@{{projectName}}/db";
+{{/if}}
 
 export const todoRouter = router({
   getAll: publicProcedure.query(async () => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+    const db = createDb();
+{{/if}}
     return await db.select().from(todo);
   }),
 
   create: publicProcedure
     .input(z.object({ text: z.string().min(1) }))
     .mutation(async ({ input }) => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+      const db = createDb();
+{{/if}}
       return await db.insert(todo).values({
         text: input.text,
       });
@@ -60,6 +86,9 @@ export const todoRouter = router({
   toggle: publicProcedure
     .input(z.object({ id: z.number(), completed: z.boolean() }))
     .mutation(async ({ input }) => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+      const db = createDb();
+{{/if}}
       return await db
         .update(todo)
         .set({ completed: input.completed })
@@ -69,6 +98,9 @@ export const todoRouter = router({
   delete: publicProcedure
     .input(z.object({ id: z.number() }))
     .mutation(async ({ input }) => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+      const db = createDb();
+{{/if}}
       return await db.delete(todo).where(eq(todo.id, input.id));
     }),
 });

--- a/packages/template-generator/templates/examples/todo/server/prisma/base/src/routers/todo.ts.hbs
+++ b/packages/template-generator/templates/examples/todo/server/prisma/base/src/routers/todo.ts.hbs
@@ -1,10 +1,17 @@
 {{#if (eq api "orpc")}}
 import z from "zod";
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createPrismaClient } from "@{{projectName}}/db";
+{{else}}
 import prisma from "@{{projectName}}/db";
+{{/if}}
 import { publicProcedure } from "../index";
 
 export const todoRouter = {
   getAll: publicProcedure.handler(async () => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+    const prisma = createPrismaClient();
+{{/if}}
     return await prisma.todo.findMany({
       orderBy: {
         id: "asc",
@@ -15,6 +22,9 @@ export const todoRouter = {
   create: publicProcedure
     .input(z.object({ text: z.string().min(1) }))
     .handler(async ({ input }) => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+      const prisma = createPrismaClient();
+{{/if}}
       return await prisma.todo.create({
         data: {
           text: input.text,
@@ -29,6 +39,9 @@ export const todoRouter = {
     .input(z.object({ id: z.number(), completed: z.boolean() }))
     {{/if}}
     .handler(async ({ input }) => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+      const prisma = createPrismaClient();
+{{/if}}
       return await prisma.todo.update({
         where: { id: input.id },
         data: { completed: input.completed },
@@ -42,6 +55,9 @@ export const todoRouter = {
     .input(z.object({ id: z.number() }))
     {{/if}}
     .handler(async ({ input }) => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+      const prisma = createPrismaClient();
+{{/if}}
       return await prisma.todo.delete({
         where: { id: input.id },
       });
@@ -52,11 +68,18 @@ export const todoRouter = {
 {{#if (eq api "trpc")}}
 import { TRPCError } from "@trpc/server";
 import z from "zod";
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+import { createPrismaClient } from "@{{projectName}}/db";
+{{else}}
 import prisma from "@{{projectName}}/db";
+{{/if}}
 import { publicProcedure, router } from "../index";
 
 export const todoRouter = router({
   getAll: publicProcedure.query(async () => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+    const prisma = createPrismaClient();
+{{/if}}
     return await prisma.todo.findMany({
       orderBy: {
         id: "asc"
@@ -67,6 +90,9 @@ export const todoRouter = router({
   create: publicProcedure
     .input(z.object({ text: z.string().min(1) }))
     .mutation(async ({ input }) => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+      const prisma = createPrismaClient();
+{{/if}}
       return await prisma.todo.create({
         data: {
           text: input.text,
@@ -81,6 +107,9 @@ export const todoRouter = router({
     .input(z.object({ id: z.number(), completed: z.boolean() }))
     {{/if}}
     .mutation(async ({ input }) => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+      const prisma = createPrismaClient();
+{{/if}}
       try {
         return await prisma.todo.update({
           where: { id: input.id },
@@ -101,6 +130,9 @@ export const todoRouter = router({
     .input(z.object({ id: z.number() }))
     {{/if}}
     .mutation(async ({ input }) => {
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+      const prisma = createPrismaClient();
+{{/if}}
       try {
         return await prisma.todo.delete({
           where: { id: input.id },

--- a/packages/template-generator/templates/packages/env/src/server.ts.hbs
+++ b/packages/template-generator/templates/packages/env/src/server.ts.hbs
@@ -1,4 +1,64 @@
-{{#if (or (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}
+{{#if (eq serverDeploy "cloudflare")}}
+/// <reference path="../env.d.ts" />
+// For Cloudflare Workers, env is accessed via cloudflare:workers module
+// Types are defined in env.d.ts based on your alchemy.run.ts bindings
+export { env } from "cloudflare:workers";
+{{else if (and (eq backend "self") (eq webDeploy "cloudflare") (includes frontend "next"))}}
+/// <reference path="../env.d.ts" />
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+
+function getNodeEnvValue(key: string) {
+	return process.env[key];
+}
+
+function getCloudflareEnvSync() {
+	try {
+		return getCloudflareContext().env as Env;
+	} catch {
+		return undefined;
+	}
+}
+
+function createEnvProxy(getValue: (key: string) => string | undefined) {
+	return new Proxy({} as Env, {
+		get(_target, prop) {
+			if (typeof prop !== "string") {
+				return undefined;
+			}
+
+			return getValue(prop);
+		},
+	});
+}
+
+function resolveEnvValue(key: string) {
+	const nodeValue = getNodeEnvValue(key);
+	if (nodeValue !== undefined) {
+		return nodeValue;
+	}
+
+	return getCloudflareEnvSync()?.[key as keyof Env];
+}
+
+// Next.js local dev runs in Node.js, where env vars are exposed on process.env.
+// In the Cloudflare runtime, fall back to OpenNext's Cloudflare context bindings.
+// For static routes (ISR/SSG), use getEnvAsync() so OpenNext can resolve bindings
+// with the async Cloudflare context API.
+export async function getEnvAsync() {
+	const cloudflareEnv = (await getCloudflareContext({ async: true })).env as Env;
+
+	return createEnvProxy((key) => {
+		const nodeValue = getNodeEnvValue(key);
+		if (nodeValue !== undefined) {
+			return nodeValue;
+		}
+
+		return cloudflareEnv[key as keyof Env];
+	});
+}
+
+export const env = createEnvProxy(resolveEnvValue);
+{{else if (and (eq backend "self") (eq webDeploy "cloudflare"))}}
 /// <reference path="../env.d.ts" />
 // For Cloudflare Workers, env is accessed via cloudflare:workers module
 // Types are defined in env.d.ts based on your alchemy.run.ts bindings


### PR DESCRIPTION
## Summary
- fix Workers-family templates to keep DB and auth clients request-scoped while preserving singleton exports for non-Cloudflare targets
- fix `Next + self + Cloudflare` generated env packages so local `next dev` reads from `process.env` and Cloudflare runtime reads from OpenNext's Cloudflare context
- restore Better Auth plugin injection for generated `createAuth()` templates and add regression coverage for Next and TanStack Start
- add the `@opennextjs/cloudflare` env package dependency in the correct package and bump the default `@opennextjs/cloudflare`, `alchemy`, and `wrangler` versions

## Testing
- `cd packages/template-generator && bun run build`
- `bun test apps/cli/test/auth.test.ts`
- `bun test apps/cli/test/cloudflare-db-clients.test.ts`
- `bun run check`

## Issues
- Fixes #935


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Templates now emit per-request factory helpers for DB and auth in Cloudflare/Workers targets to improve serverless isolation.

* **Improvements**
  * Conditional template wiring and server env resolution updated for Cloudflare+Next and related runtimes.
  * Generated routes/middleware now prefer per-request instances in affected deployments.

* **Tests**
  * Added integration tests covering Better‑Auth wiring and Cloudflare DB client scenarios.
  * Shared virtual filesystem helper added for tests.

* **Dependencies**
  * Version pins updated for wrangler, @opennextjs/cloudflare, and alchemy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->