### PR TITLE
fix: add turbo start task with passThroughEnv for deployment env injection

### DIFF
--- a/packages/template-generator/src/processors/turbo-generator.ts
+++ b/packages/template-generator/src/processors/turbo-generator.ts
@@ -14,6 +14,7 @@ interface TurboTask {
   outputs?: string[];
   cache?: boolean;
   persistent?: boolean;
+  passThroughEnv?: string[];
 }
 
 interface TurboConfig {
@@ -95,6 +96,12 @@ function getBaseTasks(frontend: string[]): Record<string, TurboTask> {
     dev: {
       cache: false,
       persistent: true,
+    },
+    start: {
+      dependsOn: ["build"],
+      cache: false,
+      persistent: true,
+      passThroughEnv: ["*"],
     },
   };
 }


### PR DESCRIPTION
## Summary

- Adds a `start` task to the generated `turbo.json` with `passThroughEnv: ["*"]`
- Adds `passThroughEnv` to the `TurboTask` interface

## Problem

Turborepo filters environment variables by default. When deploying with `turbo run start --filter=server` on Docker-based platforms (Dokploy, Railway, etc.), all server env vars are `undefined` at runtime because Turborepo doesn't forward them to the child process.

This causes immediate crashes with `@t3-oss/env-core` validation:

```
❌ Invalid environment variables: [
  { path: ["DATABASE_URL"], message: "Invalid input: expected string, received undefined" },
  { path: ["BETTER_AUTH_SECRET"], message: "Invalid input: expected string, received undefined" },
  ...
]
```

## Fix

The `start` task with `passThroughEnv: ["*"]` tells Turborepo to forward all environment variables to the server process, which is the expected behavior for production deployments.

## Test plan

- [ ] Verify generated `turbo.json` includes the `start` task with `passThroughEnv`
- [ ] Deploy a scaffolded project using `turbo run start --filter=server` and confirm env vars are available

Fixes #992

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced build task configuration to support environment variable forwarding.
  * Added a new `start` task to the build pipeline with proper dependency management, disabled caching, and persistent execution mode for reliable builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->