### PR TITLE
fix(web): keep stack builder URL updates shallow

### DIFF
--- a/apps/web/src/lib/stack-url-state.client.ts
+++ b/apps/web/src/lib/stack-url-state.client.ts
@@ -54,7 +54,9 @@ export const stackParsers = {
 
 export const stackQueryStatesOptions = {
   history: "replace" as const,
-  shallow: false,
+  // The stack builder state is fully client-driven on /new, so URL updates
+  // should stay shallow instead of forcing a server navigation.
+  shallow: true,
   urlKeys: stackUrlKeys,
   clearOnDefault: true,
 };


### PR DESCRIPTION
## Summary
- keep the `/new` stack builder query-state updates shallow so client-side selections don't trigger a blocking server navigation
- fix the prod issue where shared builder URLs could get stuck and ignore user changes

## Repro
This URL was getting stuck in production and would not let the backend selection change:
- `https://www.better-t-stack.dev/new?fe-w=next&be=self-next&rt=none&api=orpc&orm=prisma&au=none&add=biome,skills,turborepo`

## Root Cause
The builder is fully client-driven on `/new`, but its `nuqs` query-state config was using `shallow: false`. In production that forced a server navigation on every URL update, which left the UI stuck on the original query params instead of applying the local selection change.

## Verification
- `bun run build`
- `bun run check`
- verified in a local production run that clicking `No Backend` on the repro URL updates the URL to `be=none` and updates the CLI command accordingly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced URL state update behavior in the stack builder for more efficient navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->