### PR TITLE
Remove deprecated baseUrl parameter from tsconfig.json files

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,37 +1,36 @@
 {
-  "compilerOptions": {
-    "baseUrl": ".",
-    "target": "ESNext",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "react-jsx",
-    "incremental": true,
-    "paths": {
-      "fumadocs-mdx:collections/*": [".source/*"],
-      "@/*": ["./src/*"],
-      "@/public/*": ["./public/*"]
-    },
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ]
-  },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts",
-    ".next/dev/types/**/*.ts"
-  ],
-  "exclude": ["node_modules"]
+	"compilerOptions": {
+		"target": "ESNext",
+		"lib": ["dom", "dom.iterable", "esnext"],
+		"allowJs": true,
+		"skipLibCheck": true,
+		"strict": true,
+		"forceConsistentCasingInFileNames": true,
+		"noEmit": true,
+		"esModuleInterop": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"jsx": "react-jsx",
+		"incremental": true,
+		"paths": {
+			"fumadocs-mdx:collections/*": [".source/*"],
+			"@/*": ["./src/*"],
+			"@/public/*": ["./public/*"]
+		},
+		"plugins": [
+			{
+				"name": "next"
+			}
+		]
+	},
+	"include": [
+		"next-env.d.ts",
+		"**/*.ts",
+		"**/*.tsx",
+		".next/types/**/*.ts",
+		".next/dev/types/**/*.ts"
+	],
+	"exclude": ["node_modules"]
 }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,36 +1,36 @@
 {
-	"compilerOptions": {
-		"target": "ESNext",
-		"lib": ["dom", "dom.iterable", "esnext"],
-		"allowJs": true,
-		"skipLibCheck": true,
-		"strict": true,
-		"forceConsistentCasingInFileNames": true,
-		"noEmit": true,
-		"esModuleInterop": true,
-		"module": "esnext",
-		"moduleResolution": "bundler",
-		"resolveJsonModule": true,
-		"isolatedModules": true,
-		"jsx": "react-jsx",
-		"incremental": true,
-		"paths": {
-			"fumadocs-mdx:collections/*": [".source/*"],
-			"@/*": ["./src/*"],
-			"@/public/*": ["./public/*"]
-		},
-		"plugins": [
-			{
-				"name": "next"
-			}
-		]
-	},
-	"include": [
-		"next-env.d.ts",
-		"**/*.ts",
-		"**/*.tsx",
-		".next/types/**/*.ts",
-		".next/dev/types/**/*.ts"
-	],
-	"exclude": ["node_modules"]
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "paths": {
+      "fumadocs-mdx:collections/*": [".source/*"],
+      "@/*": ["./src/*"],
+      "@/public/*": ["./public/*"]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
 }

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -150,7 +150,7 @@ export default {
   "devDependencies": {
     "@types/bun": "^1.3.4",
     "concurrently": "^9.1.0",
-    "typescript": "^5"
+    "typescript": "^6"
   }
 }
 `],
@@ -25224,8 +25224,7 @@ initOpenNextCloudflareForDev();
     "@types/node": "^20",
     "@types/react": "^19.2.10",
     "@types/react-dom": "^19.2.3",
-    "tailwindcss": "^4.1.18",
-    "typescript": "^5"
+    "tailwindcss": "^4.1.18"
   }
 }
 `],
@@ -25633,7 +25632,6 @@ export function ThemeProvider({
     "@types/react-dom": "^19.2.3",
     "react-router-devtools": "^1.1.0",
     "tailwindcss": "^4.2.2",
-    "typescript": "^5.8.3",
     "vite": "^8.0.8",
     "vite-tsconfig-paths": "^6.1.1"
   }
@@ -28731,8 +28729,7 @@ await app.finalize();
   "devDependencies": {
     "@types/react": "^19.2.10",
     "@types/react-dom": "^19.2.3",
-    "tailwindcss": "^4.1.18",
-    "typescript": "^5.9.3"
+    "tailwindcss": "^4.1.18"
   },
   "scripts": {
     "check-types": "tsc --noEmit"

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -200,7 +200,6 @@ console.log("Electrobun desktop shell started.");
     "module": "ESNext",
     "moduleResolution": "bundler",
     "noEmit": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }
@@ -13317,8 +13316,7 @@ next-env.d.ts
   "compilerOptions": {
     "composite": true,
 		"outDir": "dist",
-		"baseUrl": ".",
-    "paths": {
+		"paths": {
       "@/*": ["./src/*"]
     },
     "jsx": "react-jsx"{{#if (eq backend "hono")}},
@@ -23907,7 +23905,6 @@ export const darkTheme = {
   "compilerOptions": {
     "strict": true,
     "jsx": "react-jsx",
-    "baseUrl": ".",
     "paths": {
       "@/*": ["*"]
     }
@@ -24867,7 +24864,6 @@ module.exports = uniwindConfig;
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./*"]
     }
@@ -25567,7 +25563,6 @@ export function ThemeProvider({
     "target": "ES2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
-    "baseUrl": ".",
     "skipLibCheck": true,
     "strict": true,
     "noEmit": true,
@@ -26111,7 +26106,6 @@ export default function Home() {
     "moduleResolution": "bundler",
     "jsx": "react-jsx",
     "rootDirs": [".", "./.react-router/types"],
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
       "@{{projectName}}/ui/*": ["../../packages/ui/src/*"]
@@ -26575,7 +26569,6 @@ function HomeComponent() {
     "skipLibCheck": true,
     "types": ["vite/client"],
     "rootDirs": ["."],
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
       "@{{projectName}}/ui/*": ["../../packages/ui/src/*"]
@@ -27164,7 +27157,6 @@ function HomeComponent() {
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
       "@{{projectName}}/ui/*": ["../../packages/ui/src/*"]
@@ -27656,7 +27648,6 @@ body {
     "noUncheckedSideEffectImports": true,
 
     "rootDirs": ["."],
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }
@@ -29466,7 +29457,6 @@ export function cn(...inputs: ClassValue[]) {
   ["packages/ui/tsconfig.json.hbs", `{
   "extends": "@{{projectName}}/config/tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "jsx": "react-jsx",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "paths": {

--- a/packages/template-generator/src/utils/add-deps.ts
+++ b/packages/template-generator/src/utils/add-deps.ts
@@ -12,7 +12,7 @@ type PackageJson = {
 };
 
 export const dependencyVersionMap = {
-  typescript: "^5",
+  typescript: "^6",
 
   "better-auth": "1.5.5",
   "@better-auth/expo": "1.5.5",

--- a/packages/template-generator/templates/addons/electrobun/apps/desktop/package.json.hbs
+++ b/packages/template-generator/templates/addons/electrobun/apps/desktop/package.json.hbs
@@ -9,6 +9,6 @@
   "devDependencies": {
     "@types/bun": "^1.3.4",
     "concurrently": "^9.1.0",
-    "typescript": "^5"
+    "typescript": "^6"
   }
 }

--- a/packages/template-generator/templates/addons/electrobun/apps/desktop/tsconfig.json.hbs
+++ b/packages/template-generator/templates/addons/electrobun/apps/desktop/tsconfig.json.hbs
@@ -6,7 +6,6 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "noEmit": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/packages/template-generator/templates/backend/server/base/tsconfig.json.hbs
+++ b/packages/template-generator/templates/backend/server/base/tsconfig.json.hbs
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "composite": true,
 		"outDir": "dist",
-		"baseUrl": ".",
-    "paths": {
+		"paths": {
       "@/*": ["./src/*"]
     },
     "jsx": "react-jsx"{{#if (eq backend "hono")}},

--- a/packages/template-generator/templates/frontend/native/unistyles/tsconfig.json.hbs
+++ b/packages/template-generator/templates/frontend/native/unistyles/tsconfig.json.hbs
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "strict": true,
     "jsx": "react-jsx",
-    "baseUrl": ".",
     "paths": {
       "@/*": ["*"]
     }

--- a/packages/template-generator/templates/frontend/native/uniwind/tsconfig.json.hbs
+++ b/packages/template-generator/templates/frontend/native/uniwind/tsconfig.json.hbs
@@ -2,7 +2,6 @@
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./*"]
     }

--- a/packages/template-generator/templates/frontend/react/next/package.json.hbs
+++ b/packages/template-generator/templates/frontend/react/next/package.json.hbs
@@ -22,7 +22,6 @@
     "@types/node": "^20",
     "@types/react": "^19.2.10",
     "@types/react-dom": "^19.2.3",
-    "tailwindcss": "^4.1.18",
-    "typescript": "^5"
+    "tailwindcss": "^4.1.18"
   }
 }

--- a/packages/template-generator/templates/frontend/react/next/tsconfig.json.hbs
+++ b/packages/template-generator/templates/frontend/react/next/tsconfig.json.hbs
@@ -3,7 +3,6 @@
     "target": "ES2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
-    "baseUrl": ".",
     "skipLibCheck": true,
     "strict": true,
     "noEmit": true,

--- a/packages/template-generator/templates/frontend/react/react-router/package.json.hbs
+++ b/packages/template-generator/templates/frontend/react/react-router/package.json.hbs
@@ -29,7 +29,6 @@
     "@types/react-dom": "^19.2.3",
     "react-router-devtools": "^1.1.0",
     "tailwindcss": "^4.2.2",
-    "typescript": "^5.8.3",
     "vite": "^8.0.8",
     "vite-tsconfig-paths": "^6.1.1"
   }

--- a/packages/template-generator/templates/frontend/react/react-router/tsconfig.json.hbs
+++ b/packages/template-generator/templates/frontend/react/react-router/tsconfig.json.hbs
@@ -13,7 +13,6 @@
     "moduleResolution": "bundler",
     "jsx": "react-jsx",
     "rootDirs": [".", "./.react-router/types"],
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
       "@{{projectName}}/ui/*": ["../../packages/ui/src/*"]

--- a/packages/template-generator/templates/frontend/react/tanstack-router/tsconfig.json.hbs
+++ b/packages/template-generator/templates/frontend/react/tanstack-router/tsconfig.json.hbs
@@ -10,7 +10,6 @@
     "skipLibCheck": true,
     "types": ["vite/client"],
     "rootDirs": ["."],
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
       "@{{projectName}}/ui/*": ["../../packages/ui/src/*"]

--- a/packages/template-generator/templates/frontend/react/tanstack-start/tsconfig.json.hbs
+++ b/packages/template-generator/templates/frontend/react/tanstack-start/tsconfig.json.hbs
@@ -20,7 +20,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
       "@{{projectName}}/ui/*": ["../../packages/ui/src/*"]

--- a/packages/template-generator/templates/frontend/solid/tsconfig.json.hbs
+++ b/packages/template-generator/templates/frontend/solid/tsconfig.json.hbs
@@ -21,7 +21,6 @@
     "noUncheckedSideEffectImports": true,
 
     "rootDirs": ["."],
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/packages/template-generator/templates/packages/ui/package.json.hbs
+++ b/packages/template-generator/templates/packages/ui/package.json.hbs
@@ -26,8 +26,7 @@
   "devDependencies": {
     "@types/react": "^19.2.10",
     "@types/react-dom": "^19.2.3",
-    "tailwindcss": "^4.1.18",
-    "typescript": "^5.9.3"
+    "tailwindcss": "^4.1.18"
   },
   "scripts": {
     "check-types": "tsc --noEmit"

--- a/packages/template-generator/templates/packages/ui/tsconfig.json.hbs
+++ b/packages/template-generator/templates/packages/ui/tsconfig.json.hbs
@@ -1,7 +1,6 @@
 {
   "extends": "@{{projectName}}/config/tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "jsx": "react-jsx",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "paths": {


### PR DESCRIPTION
Fixes the following lint error I was getting
<img width="1067" height="540" alt="image" src="https://github.com/user-attachments/assets/1b645adb-75c1-44e2-9b63-a58cb9bd447e" />

Based on the above and following, it is extra and will be removed fully in the future.
"As of TypeScript 4.1, baseUrl is no longer required to be set when using paths" [[1]](https://www.typescriptlang.org/tsconfig/#baseUrl)

https://github.com/microsoft/TypeScript/issues/62508#issuecomment-3348649259



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the TypeScript compiler baseUrl setting from project and generated templates, standardizing resolution to rely on path mappings.
  * Updated template dependency metadata: TypeScript devDependency bumped to v6 in some templates and removed from others, while other tooling entries remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->