### PR TITLE
fix(cli): refresh tanstack & vite templates, bump deps

### DIFF
--- a/apps/cli/src/prompts/api.ts
+++ b/apps/cli/src/prompts/api.ts
@@ -1,6 +1,9 @@
 import type { API, Backend, Frontend } from "../types";
-import { allowedApisForFrontends } from "../utils/compatibility-rules";
-import { UserCancelledError, ValidationError } from "../utils/errors";
+import {
+  allowedApisForFrontends,
+  validateApiFrontendCompatibility,
+} from "../utils/compatibility-rules";
+import { UserCancelledError } from "../utils/errors";
 import { isCancel, navigableSelect } from "./navigable";
 
 export async function getApiChoice(
@@ -15,14 +18,8 @@ export async function getApiChoice(
   const allowed = allowedApisForFrontends(frontend ?? []);
 
   if (Api) {
-    if (!allowed.includes(Api)) {
-      const incompatibleFrontend = (frontend ?? []).find((f) =>
-        ["nuxt", "svelte", "solid", "astro"].includes(f),
-      );
-      throw new ValidationError({
-        message: `API '${Api}' is not supported with '${incompatibleFrontend ?? frontend?.join(", ")}' frontend. Allowed: ${allowed.join(", ")}.`,
-      });
-    }
+    const compat = validateApiFrontendCompatibility(Api, frontend ?? []);
+    if (compat.isErr()) throw compat.error;
     return Api;
   }
   const apiOptions = allowed.map((a) =>

--- a/apps/cli/src/prompts/api.ts
+++ b/apps/cli/src/prompts/api.ts
@@ -1,6 +1,6 @@
 import type { API, Backend, Frontend } from "../types";
 import { allowedApisForFrontends } from "../utils/compatibility-rules";
-import { UserCancelledError } from "../utils/errors";
+import { UserCancelledError, ValidationError } from "../utils/errors";
 import { isCancel, navigableSelect } from "./navigable";
 
 export async function getApiChoice(
@@ -15,7 +15,15 @@ export async function getApiChoice(
   const allowed = allowedApisForFrontends(frontend ?? []);
 
   if (Api) {
-    return allowed.includes(Api) ? Api : allowed[0];
+    if (!allowed.includes(Api)) {
+      const incompatibleFrontend = (frontend ?? []).find((f) =>
+        ["nuxt", "svelte", "solid", "astro"].includes(f),
+      );
+      throw new ValidationError({
+        message: `API '${Api}' is not supported with '${incompatibleFrontend ?? frontend?.join(", ")}' frontend. Allowed: ${allowed.join(", ")}.`,
+      });
+    }
+    return Api;
   }
   const apiOptions = allowed.map((a) =>
     a === "trpc"

--- a/apps/cli/src/prompts/orm.ts
+++ b/apps/cli/src/prompts/orm.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_CONFIG } from "../constants";
 import type { Backend, Database, ORM, Runtime } from "../types";
-import { UserCancelledError } from "../utils/errors";
+import { UserCancelledError, ValidationError } from "../utils/errors";
 import { isCancel, navigableSelect } from "./navigable";
 
 const ormOptions = {
@@ -33,7 +33,21 @@ export async function getORMChoice(
   }
 
   if (!hasDatabase) return "none";
-  if (orm !== undefined) return orm;
+  if (orm !== undefined) {
+    if (orm === "drizzle" && database === "mongodb") {
+      throw new ValidationError({
+        message:
+          "Drizzle ORM does not support MongoDB. Please use '--orm mongoose' or '--orm prisma' or choose a different database.",
+      });
+    }
+    if (orm === "mongoose" && database && database !== "mongodb") {
+      throw new ValidationError({
+        message:
+          "Mongoose ORM requires MongoDB database. Please use '--database mongodb' or choose a different ORM.",
+      });
+    }
+    return orm;
+  }
 
   const options =
     database === "mongodb"

--- a/apps/cli/src/prompts/orm.ts
+++ b/apps/cli/src/prompts/orm.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_CONFIG } from "../constants";
 import type { Backend, Database, ORM, Runtime } from "../types";
-import { UserCancelledError, ValidationError } from "../utils/errors";
+import { validateOrmDatabaseCompat } from "../utils/config-validation";
+import { UserCancelledError } from "../utils/errors";
 import { isCancel, navigableSelect } from "./navigable";
 
 const ormOptions = {
@@ -34,18 +35,8 @@ export async function getORMChoice(
 
   if (!hasDatabase) return "none";
   if (orm !== undefined) {
-    if (orm === "drizzle" && database === "mongodb") {
-      throw new ValidationError({
-        message:
-          "Drizzle ORM does not support MongoDB. Please use '--orm mongoose' or '--orm prisma' or choose a different database.",
-      });
-    }
-    if (orm === "mongoose" && database && database !== "mongodb") {
-      throw new ValidationError({
-        message:
-          "Mongoose ORM requires MongoDB database. Please use '--database mongodb' or choose a different ORM.",
-      });
-    }
+    const compat = validateOrmDatabaseCompat(orm, database);
+    if (compat.isErr()) throw compat.error;
     return orm;
   }
 

--- a/apps/cli/src/utils/compatibility-rules.ts
+++ b/apps/cli/src/utils/compatibility-rules.ts
@@ -151,16 +151,6 @@ export function validateWorkersCompatibility(
   }
 
   if (
-    providedFlags.has("runtime") &&
-    options.runtime === "workers" &&
-    config.dbSetup === "docker"
-  ) {
-    return validationErr(
-      "Cloudflare Workers runtime (--runtime workers) is not compatible with Docker setup. Workers runtime uses serverless databases (D1) and doesn't support local Docker containers. Please use '--db-setup d1' for SQLite or choose a different runtime.",
-    );
-  }
-
-  if (
     providedFlags.has("database") &&
     config.database === "mongodb" &&
     config.runtime === "workers"

--- a/apps/cli/src/utils/config-validation.ts
+++ b/apps/cli/src/utils/config-validation.ts
@@ -54,53 +54,56 @@ function canResolveSelfCloudflareD1Target(config: Partial<ProjectConfig>) {
   );
 }
 
-export function validateDatabaseOrmAuth(
-  cfg: Partial<ProjectConfig>,
-  flags?: Set<string>,
+/**
+ * Pure ORM + database compatibility check. Used by the flag-path
+ * validator below and by the orm prompt directly (for flag+prompt
+ * combos where one value came from a flag and the other from a
+ * prompt).
+ */
+export function validateOrmDatabaseCompat(
+  orm: ProjectConfig["orm"] | undefined,
+  database: ProjectConfig["database"] | undefined,
 ): ValidationResult {
-  const db = cfg.database;
-  const orm = cfg.orm;
-  const has = (k: string) => (flags ? flags.has(k) : true);
-
-  if (has("orm") && has("database") && orm === "mongoose" && db !== "mongodb") {
+  if (orm === "mongoose" && database && database !== "mongodb") {
     return validationErr(
       "Mongoose ORM requires MongoDB database. Please use '--database mongodb' or choose a different ORM.",
     );
   }
 
-  if (has("orm") && has("database") && orm === "drizzle" && db === "mongodb") {
+  if (orm === "drizzle" && database === "mongodb") {
     return validationErr(
       "Drizzle ORM does not support MongoDB. Please use '--orm mongoose' or '--orm prisma' or choose a different database.",
     );
   }
 
-  if (
-    has("database") &&
-    has("orm") &&
-    db === "mongodb" &&
-    orm &&
-    orm !== "mongoose" &&
-    orm !== "prisma" &&
-    orm !== "none"
-  ) {
+  if (database === "mongodb" && orm && orm !== "mongoose" && orm !== "prisma" && orm !== "none") {
     return validationErr(
       "MongoDB database requires Mongoose or Prisma ORM. Please use '--orm mongoose' or '--orm prisma' or choose a different database.",
     );
   }
 
-  if (has("database") && has("orm") && db && db !== "none" && orm === "none") {
+  if (database && database !== "none" && orm === "none") {
     return validationErr(
       "Database selection requires an ORM. Please choose '--orm drizzle', '--orm prisma', or '--orm mongoose'.",
     );
   }
 
-  if (has("orm") && has("database") && orm && orm !== "none" && db === "none") {
+  if (orm && orm !== "none" && database === "none") {
     return validationErr(
       "ORM selection requires a database. Please choose a database or set '--orm none'.",
     );
   }
 
   return Result.ok(undefined);
+}
+
+export function validateDatabaseOrmAuth(
+  cfg: Partial<ProjectConfig>,
+  flags?: Set<string>,
+): ValidationResult {
+  const has = (k: string) => (flags ? flags.has(k) : true);
+  if (!has("orm") || !has("database")) return Result.ok(undefined);
+  return validateOrmDatabaseCompat(cfg.orm, cfg.database);
 }
 
 export function validateDatabaseSetup(

--- a/packages/template-generator/src/processors/api-deps.ts
+++ b/packages/template-generator/src/processors/api-deps.ts
@@ -41,7 +41,7 @@ export function processApiDeps(vfs: VirtualFileSystem, config: ProjectConfig): v
   addApiPackageDeps(vfs, api, backend, frontend, auth);
   addServerDeps(vfs, api, backend);
   addSelfBackendWebDeps(vfs, api, backend, frontendType);
-  addWebClientDeps(vfs, api, backend, frontendType);
+  addWebClientDeps(vfs, api, backend, frontend, frontendType);
   if (frontendType.hasNative) addNativeDeps(vfs, api, backend);
   addQueryDeps(vfs, frontend, backend);
 }
@@ -148,22 +148,35 @@ function addWebClientDeps(
   vfs: VirtualFileSystem,
   api: API,
   backend: Backend,
+  frontend: Frontend[],
   frontendType: FrontendType,
 ): void {
   const webPath = "apps/web/package.json";
   if (!vfs.exists(webPath) || backend === "convex") return;
 
   if (api === "trpc" && frontendType.hasReactWeb) {
+    const deps: AvailableDependencies[] = [
+      "@trpc/tanstack-react-query",
+      "@trpc/client",
+      "@trpc/server",
+    ];
+    if (frontend.includes("tanstack-start")) {
+      deps.push("@tanstack/react-router-ssr-query");
+    }
     addPackageDependency({
       vfs,
       packagePath: webPath,
-      dependencies: ["@trpc/tanstack-react-query", "@trpc/client", "@trpc/server"],
+      dependencies: deps,
     });
   } else if (api === "orpc" && frontendType.hasReactWeb) {
+    const deps: AvailableDependencies[] = ["@orpc/tanstack-query", "@orpc/client", "@orpc/server"];
+    if (frontend.includes("tanstack-start")) {
+      deps.push("@tanstack/react-router-ssr-query");
+    }
     addPackageDependency({
       vfs,
       packagePath: webPath,
-      dependencies: ["@orpc/tanstack-query", "@orpc/client", "@orpc/server"],
+      dependencies: deps,
     });
   } else if (api === "orpc" && frontendType.hasNuxtWeb) {
     addPackageDependency({

--- a/packages/template-generator/src/processors/env-vars.ts
+++ b/packages/template-generator/src/processors/env-vars.ts
@@ -271,9 +271,7 @@ function buildConvexBackendVars(
   const defaultSiteUrl =
     hasNative && !hasWeb
       ? "http://localhost:8081"
-      : frontend.includes("react-router") ||
-          frontend.includes("tanstack-router") ||
-          frontend.includes("svelte")
+      : frontend.includes("react-router") || frontend.includes("svelte")
         ? "http://localhost:5173"
         : frontend.includes("astro")
           ? "http://localhost:4321"
@@ -349,9 +347,7 @@ function buildConvexCommentBlocks(
   const defaultSiteUrl =
     hasNative && !hasWeb
       ? "http://localhost:8081"
-      : frontend.includes("react-router") ||
-          frontend.includes("tanstack-router") ||
-          frontend.includes("svelte")
+      : frontend.includes("react-router") || frontend.includes("svelte")
         ? "http://localhost:5173"
         : frontend.includes("astro")
           ? "http://localhost:4321"
@@ -389,17 +385,14 @@ function buildServerVars(
   examples: ProjectConfig["examples"],
 ): EnvVariable[] {
   const hasReactRouter = frontend.includes("react-router");
-  const hasTanStackRouter = frontend.includes("tanstack-router");
   const hasSvelte = frontend.includes("svelte");
   const hasAstro = frontend.includes("astro");
 
   let corsOrigin = "http://localhost:3001";
   if (hasAstro) {
     corsOrigin = "http://localhost:4321";
-  } else if (hasReactRouter || hasTanStackRouter || hasSvelte) {
+  } else if (hasReactRouter || hasSvelte) {
     corsOrigin = "http://localhost:5173";
-  } else if (backend === "self") {
-    corsOrigin = "http://localhost:3001";
   }
 
   let databaseUrl: string | null = null;

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -25619,28 +25619,28 @@ export function ThemeProvider({
   },
   "dependencies": {
     "@{{projectName}}/ui": "{{#if (eq packageManager "npm")}}*{{else}}workspace:*{{/if}}",
-    "@react-router/fs-routes": "^7.10.1",
-    "@react-router/node": "^7.10.1",
-    "@react-router/serve": "^7.10.1",
-    "isbot": "^5.1.28",
-    "lucide-react": "^0.546.0",
+    "@react-router/fs-routes": "^7.14.1",
+    "@react-router/node": "^7.14.1",
+    "@react-router/serve": "^7.14.1",
+    "isbot": "^5.1.39",
+    "lucide-react": "^1.8.0",
     "next-themes": "^0.4.6",
-    "react": "^19.2.3",
-    "react-dom": "^19.2.3",
-    "react-router": "^7.10.1",
-    "sonner": "^2.0.5"
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
+    "react-router": "^7.14.1",
+    "sonner": "^2.0.7"
   },
   "devDependencies": {
-    "@react-router/dev": "^7.10.1",
-    "@tailwindcss/vite": "^4.1.18",
+    "@react-router/dev": "^7.14.1",
+    "@tailwindcss/vite": "^4.2.2",
     "@types/node": "^20",
-    "@types/react": "^19.2.10",
+    "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "react-router-devtools": "^1.1.0",
-    "tailwindcss": "^4.1.18",
+    "tailwindcss": "^4.2.2",
     "typescript": "^5.8.3",
-    "vite": "^7.2.7",
-    "vite-tsconfig-paths": "^5.1.4"
+    "vite": "^8.0.8",
+    "vite-tsconfig-paths": "^6.1.1"
   }
 }
 `],
@@ -26164,26 +26164,26 @@ export default defineConfig({
 		"check-types": "vite build && tsc --noEmit"
 	},
 	"dependencies": {
-        "@hookform/resolvers": "^5.1.1",
+        "@hookform/resolvers": "^5.2.2",
         "@{{projectName}}/ui": "{{#if (eq packageManager "npm")}}*{{else}}workspace:*{{/if}}",
-		"@tailwindcss/vite": "^4.1.18",
-		"@tanstack/react-router": "^1.141.1",
-		"lucide-react": "^0.546.0",
+		"@tailwindcss/vite": "^4.2.2",
+		"@tanstack/react-router": "^1.168.22",
+		"lucide-react": "^1.8.0",
         "next-themes": "^0.4.6",
-		"react": "^19.2.3",
-		"react-dom": "^19.2.3",
-        "sonner": "^2.0.5"
+		"react": "^19.2.5",
+		"react-dom": "^19.2.5",
+        "sonner": "^2.0.7"
 	},
 	"devDependencies": {
-		"@tanstack/react-router-devtools": "^1.141.1",
-		"@tanstack/router-plugin": "^1.141.1",
+		"@tanstack/react-router-devtools": "^1.166.13",
+		"@tanstack/router-plugin": "^1.167.22",
 		"@types/node": "^22.13.14",
-		"@types/react": "^19.2.10",
+		"@types/react": "^19.2.14",
 		"@types/react-dom": "^19.2.3",
-		"@vitejs/plugin-react": "^4.3.4",
-		"postcss": "^8.5.3",
-		"tailwindcss": "^4.1.18",
-		"vite": "^6.2.2"
+		"@vitejs/plugin-react": "^6.0.1",
+		"postcss": "^8.5.10",
+		"tailwindcss": "^4.2.2",
+		"vite": "^8.0.8"
 	}
 }
 `],
@@ -26290,6 +26290,7 @@ function ClerkApiAuthBridge() {
 const router = createRouter({
   routeTree,
   defaultPreload: "intent",
+  scrollRestoration: true,
   defaultPendingComponent: () => <Loader />,
   {{#if (eq api "orpc")}}
   context: { orpc, queryClient },
@@ -26571,7 +26572,6 @@ function HomeComponent() {
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "verbatimModuleSyntax": true,
     "skipLibCheck": true,
     "types": ["vite/client"],
     "rootDirs": ["."],
@@ -26586,24 +26586,25 @@ function HomeComponent() {
   ["frontend/react/tanstack-router/vite.config.ts.hbs", `import tailwindcss from "@tailwindcss/vite";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import react from "@vitejs/plugin-react";
-import path from "node:path";
 import { defineConfig } from "vite";
 
 export default defineConfig({
-  plugins: [
-    tailwindcss(),
-    tanstackRouter({}),
-    react(),
-  ],
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
-    },
-  },
   server: {
     port: 3001,
   },
-});`],
+  resolve: {
+    tsconfigPaths: true,
+  },
+  plugins: [
+    tailwindcss(),
+    tanstackRouter({
+      target: "react",
+      autoCodeSplitting: true,
+    }),
+    react(),
+  ],
+});
+`],
   ["frontend/react/tanstack-start/package.json.hbs", `{
   "name": "web",
   "private": true,
@@ -26615,30 +26616,27 @@ export default defineConfig({
   },
   "dependencies": {
     "@{{projectName}}/ui": "{{#if (eq packageManager "npm")}}*{{else}}workspace:*{{/if}}",
-    "@tailwindcss/vite": "^4.1.18",
-    "@tanstack/react-query": "^5.80.6",
-    "@tanstack/react-router": "^1.141.1",
-    "@tanstack/react-router-with-query": "^1.130.17",
-    "@tanstack/react-start": "^1.141.1",
-    "@tanstack/router-plugin": "^1.141.1",
-    "lucide-react": "^0.546.0",
+    "@tailwindcss/vite": "^4.2.2",
+    "@tanstack/react-query": "^5.99.0",
+    "@tanstack/react-router": "^1.168.22",
+    "@tanstack/react-start": "^1.167.41",
+    "lucide-react": "^1.8.0",
     "next-themes": "^0.4.6",
-    "react": "^19.2.3",
-    "react-dom": "^19.2.3",
-    "sonner": "^2.0.5",
-    "tailwindcss": "^4.1.18",
-    "vite-tsconfig-paths": "^5.1.4"
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
+    "sonner": "^2.0.7",
+    "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
-    "@tanstack/react-router-devtools": "^1.141.1",
-    "@testing-library/dom": "^10.4.0",
-    "@testing-library/react": "^16.2.0",
-    "@types/react": "^19.2.10",
+    "@tanstack/react-router-devtools": "^1.166.13",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
+    "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^5.0.4",
-    "jsdom": "^26.0.0",
-    "vite": "^7.0.2",
-    "web-vitals": "^5.0.3"
+    "@vitejs/plugin-react": "^6.0.1",
+    "jsdom": "^29.0.2",
+    "vite": "^8.0.8",
+    "web-vitals": "^5.2.0"
   }
 }
 `],
@@ -26661,7 +26659,8 @@ import Loader from "./components/loader";
 import "./index.css";
 import { routeTree } from "./routeTree.gen";
 {{#if (eq api "trpc")}}
-import { QueryCache, QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryCache, QueryClient } from "@tanstack/react-query";
+import { setupRouterSsrQueryIntegration } from "@tanstack/react-router-ssr-query";
 import { createTRPCClient, httpBatchLink } from "@trpc/client";
 import { createTRPCOptionsProxy } from "@trpc/tanstack-react-query";
 import { toast } from "sonner";
@@ -26674,7 +26673,7 @@ import { env } from "@{{projectName}}/env/web";
 import { getClerkAuthToken } from "@/utils/clerk-auth";
 {{/if}}
 {{else if (eq api "orpc")}}
-import { QueryClientProvider } from "@tanstack/react-query";
+import { setupRouterSsrQueryIntegration } from "@tanstack/react-router-ssr-query";
 import { orpc, queryClient } from "./utils/orpc";
 {{/if}}
 {{/if}}
@@ -26686,7 +26685,7 @@ export function getRouter() {
 		throw new Error("VITE_CONVEX_URL is not set");
 	}
 
-	const convexQueryClient = new ConvexQueryClient(convexUrl);
+	const convexQueryClient = new ConvexQueryClient(convexUrl{{#if (eq auth "better-auth")}}, { expectAuth: true }{{/if}});
 
 	const queryClient: QueryClient = new QueryClient({
 		defaultOptions: {
@@ -26774,22 +26773,20 @@ export const getRouter = () => {
 		defaultNotFoundComponent: () => <div>Not Found</div>,
 {{#if (eq api "trpc")}}
 		Wrap: ({ children }) => (
-			<QueryClientProvider client={queryClient}>
-				<TRPCProvider trpcClient={trpcClient} queryClient={queryClient}>
-					{children}
-				</TRPCProvider>
-			</QueryClientProvider>
-		),
-{{else if (eq api "orpc")}}
-		Wrap: ({ children }) => (
-			<QueryClientProvider client={queryClient}>
+			<TRPCProvider trpcClient={trpcClient} queryClient={queryClient}>
 				{children}
-			</QueryClientProvider>
+			</TRPCProvider>
 		),
-{{else}}
-		Wrap: ({ children }) => <>{children}</>,
 {{/if}}
 	});
+{{#if (or (eq api "trpc") (eq api "orpc"))}}
+
+	setupRouterSsrQueryIntegration({
+		router,
+		queryClient,
+	});
+{{/if}}
+
 	return router;
 };
 {{/if}}
@@ -27154,7 +27151,6 @@ function HomeComponent() {
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
-    "verbatimModuleSyntax": true,
     "noEmit": true,
 
     /* Linting */
@@ -27173,21 +27169,22 @@ function HomeComponent() {
 }
 `],
   ["frontend/react/tanstack-start/vite.config.ts.hbs", `import { defineConfig } from "vite";
-import tsconfigPaths from "vite-tsconfig-paths";
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 import tailwindcss from "@tailwindcss/vite";
 import viteReact from "@vitejs/plugin-react";
 
 export default defineConfig({
+  server: {
+    port: 3001,
+  },
+  resolve: {
+    tsconfigPaths: true,
+  },
   plugins: [
-    tsconfigPaths(),
     tailwindcss(),
     tanstackStart(),
     viteReact(),
   ],
-  server: {
-    port: 3001,
-  },
 {{#if (and (eq backend "convex") (eq auth "better-auth"))}}
   ssr: {
     noExternal: ["@convex-dev/better-auth"],
@@ -27411,16 +27408,16 @@ dist-ssr
     "test": "vitest run"
   },
   "dependencies": {
-    "@tailwindcss/vite": "^4.1.13",
-    "@tanstack/router-plugin": "^1.131.44",
-    "@tanstack/solid-router": "^1.131.44",
-    "lucide-solid": "^0.544.0",
-    "solid-js": "^1.9.9",
-    "tailwindcss": "^4.1.13"
+    "@tailwindcss/vite": "^4.2.2",
+    "@tanstack/router-plugin": "^1.167.22",
+    "@tanstack/solid-router": "^1.168.20",
+    "lucide-solid": "^1.8.0",
+    "solid-js": "^1.9.12",
+    "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
-    "vite": "^7.1.5",
-    "vite-plugin-solid": "^2.11.8"
+    "vite": "^8.0.8",
+    "vite-plugin-solid": "^2.11.12"
   }
 }
 `],
@@ -27725,14 +27722,14 @@ vite.config.ts.timestamp-*
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
 	},
 	"devDependencies": {
-		"@sveltejs/adapter-auto": "^6.1.0",
-		"@sveltejs/kit": "^2.31.1",
-		"@sveltejs/vite-plugin-svelte": "^6.1.2",
-		"@tailwindcss/vite": "^4.1.12",
-		"svelte": "^5.38.1",
-		"svelte-check": "^4.3.1",
-		"tailwindcss": "^4.1.12",
-		"vite": "^7.1.2"
+		"@sveltejs/adapter-auto": "^7.0.1",
+		"@sveltejs/kit": "^2.57.1",
+		"@sveltejs/vite-plugin-svelte": "^7.0.0",
+		"@tailwindcss/vite": "^4.2.2",
+		"svelte": "^5.55.4",
+		"svelte-check": "^4.4.6",
+		"tailwindcss": "^4.2.2",
+		"vite": "^8.0.8"
 	},
 	"dependencies": {}
 }

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -26685,7 +26685,7 @@ export function getRouter() {
 		throw new Error("VITE_CONVEX_URL is not set");
 	}
 
-	const convexQueryClient = new ConvexQueryClient(convexUrl{{#if (eq auth "better-auth")}}, { expectAuth: true }{{/if}});
+	const convexQueryClient = new ConvexQueryClient(convexUrl);
 
 	const queryClient: QueryClient = new QueryClient({
 		defaultOptions: {

--- a/packages/template-generator/src/utils/add-deps.ts
+++ b/packages/template-generator/src/utils/add-deps.ts
@@ -23,7 +23,7 @@ export const dependencyVersionMap = {
   "@clerk/nextjs": "^7.0.5",
   "@clerk/react": "^6.1.1",
   "@clerk/react-router": "^3.0.5",
-  "@clerk/tanstack-react-start": "^1.0.5",
+  "@clerk/tanstack-react-start": "^1.1.3",
   "@clerk/expo": "^3.1.3",
 
   "drizzle-orm": "^0.45.1",
@@ -53,8 +53,8 @@ export const dependencyVersionMap = {
 
   mongoose: "^8.14.0",
 
-  "vite-plugin-pwa": "^1.0.1",
-  "@vite-pwa/assets-generator": "^1.0.0",
+  "vite-plugin-pwa": "^1.2.0",
+  "@vite-pwa/assets-generator": "^1.0.2",
 
   "@tauri-apps/cli": "^2.4.0",
 
@@ -102,15 +102,15 @@ export const dependencyVersionMap = {
   streamdown: "^1.6.10",
   shiki: "^3.20.0",
 
-  "@orpc/server": "^1.12.2",
-  "@orpc/client": "^1.12.2",
-  "@orpc/openapi": "^1.12.2",
-  "@orpc/zod": "^1.12.2",
-  "@orpc/tanstack-query": "^1.13.6",
+  "@orpc/server": "^1.13.14",
+  "@orpc/client": "^1.13.14",
+  "@orpc/openapi": "^1.13.14",
+  "@orpc/zod": "^1.13.14",
+  "@orpc/tanstack-query": "^1.13.14",
 
-  "@trpc/tanstack-react-query": "^11.13.4",
-  "@trpc/server": "^11.13.4",
-  "@trpc/client": "^11.13.4",
+  "@trpc/tanstack-react-query": "^11.16.0",
+  "@trpc/server": "^11.16.0",
+  "@trpc/client": "^11.16.0",
 
   next: "^16.2.0",
 
@@ -120,7 +120,7 @@ export const dependencyVersionMap = {
   "convex-svelte": "^0.0.12",
   "convex-nuxt": "0.1.5",
   "convex-vue": "^0.1.5",
-  "@convex-dev/better-auth": "^0.11.3",
+  "@convex-dev/better-auth": "^0.11.4",
 
   "@tanstack/svelte-query": "^5.85.3",
   "@tanstack/svelte-query-devtools": "^5.85.3",
@@ -131,19 +131,19 @@ export const dependencyVersionMap = {
   "@tanstack/react-query-devtools": "^5.91.1",
   "@tanstack/react-query": "^5.90.12",
   "@tanstack/react-form": "^1.28.0",
-  "@tanstack/react-router-ssr-query": "^1.142.7",
+  "@tanstack/react-router-ssr-query": "^1.166.11",
   "@tanstack/solid-form": "^1.28.0",
   "@tanstack/svelte-form": "^1.28.0",
 
-  "@tanstack/solid-query": "^5.87.4",
-  "@tanstack/solid-query-devtools": "^5.87.4",
-  "@tanstack/solid-router-devtools": "^1.131.44",
+  "@tanstack/solid-query": "^5.99.1",
+  "@tanstack/solid-query-devtools": "^5.99.1",
+  "@tanstack/solid-router-devtools": "^1.166.13",
 
   wrangler: "^4.77.0",
   "@cloudflare/vite-plugin": "^1.17.1",
   "@opennextjs/cloudflare": "^1.17.3",
   "nitro-cloudflare-dev": "^0.2.2",
-  "@sveltejs/adapter-cloudflare": "^7.2.4",
+  "@sveltejs/adapter-cloudflare": "^7.2.8",
   "@cloudflare/workers-types": "^4.20251213.0",
   "@astrojs/cloudflare": "^13.0.1",
   "@astrojs/node": "^10.0.0-beta.9",

--- a/packages/template-generator/src/utils/add-deps.ts
+++ b/packages/template-generator/src/utils/add-deps.ts
@@ -41,15 +41,15 @@ export const dependencyVersionMap = {
 
   mysql2: "^3.14.0",
 
-  "@prisma/client": "^7.2.0",
-  prisma: "^7.2.0",
-  "@prisma/adapter-d1": "^7.2.0",
-  "@prisma/adapter-neon": "^7.2.0",
-  "@prisma/adapter-mariadb": "^7.2.0",
-  "@prisma/adapter-libsql": "^7.2.0",
-  "@prisma/adapter-better-sqlite3": "^7.2.0",
-  "@prisma/adapter-pg": "^7.2.0",
-  "@prisma/adapter-planetscale": "^7.2.0",
+  "@prisma/client": "^7.7.0",
+  prisma: "^7.7.0",
+  "@prisma/adapter-d1": "^7.7.0",
+  "@prisma/adapter-neon": "^7.7.0",
+  "@prisma/adapter-mariadb": "^7.7.0",
+  "@prisma/adapter-libsql": "^7.7.0",
+  "@prisma/adapter-better-sqlite3": "^7.7.0",
+  "@prisma/adapter-pg": "^7.7.0",
+  "@prisma/adapter-planetscale": "^7.7.0",
 
   mongoose: "^8.14.0",
 

--- a/packages/template-generator/src/utils/add-deps.ts
+++ b/packages/template-generator/src/utils/add-deps.ts
@@ -148,7 +148,7 @@ export const dependencyVersionMap = {
   "@astrojs/cloudflare": "^13.0.1",
   "@astrojs/node": "^10.0.0-beta.9",
 
-  alchemy: "^0.90.0",
+  alchemy: "^0.91.2",
 
   dotenv: "^17.2.2",
   tsdown: "^0.16.5",

--- a/packages/template-generator/templates/frontend/react/react-router/package.json.hbs
+++ b/packages/template-generator/templates/frontend/react/react-router/package.json.hbs
@@ -10,27 +10,27 @@
   },
   "dependencies": {
     "@{{projectName}}/ui": "{{#if (eq packageManager "npm")}}*{{else}}workspace:*{{/if}}",
-    "@react-router/fs-routes": "^7.10.1",
-    "@react-router/node": "^7.10.1",
-    "@react-router/serve": "^7.10.1",
-    "isbot": "^5.1.28",
-    "lucide-react": "^0.546.0",
+    "@react-router/fs-routes": "^7.14.1",
+    "@react-router/node": "^7.14.1",
+    "@react-router/serve": "^7.14.1",
+    "isbot": "^5.1.39",
+    "lucide-react": "^1.8.0",
     "next-themes": "^0.4.6",
-    "react": "^19.2.3",
-    "react-dom": "^19.2.3",
-    "react-router": "^7.10.1",
-    "sonner": "^2.0.5"
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
+    "react-router": "^7.14.1",
+    "sonner": "^2.0.7"
   },
   "devDependencies": {
-    "@react-router/dev": "^7.10.1",
-    "@tailwindcss/vite": "^4.1.18",
+    "@react-router/dev": "^7.14.1",
+    "@tailwindcss/vite": "^4.2.2",
     "@types/node": "^20",
-    "@types/react": "^19.2.10",
+    "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "react-router-devtools": "^1.1.0",
-    "tailwindcss": "^4.1.18",
+    "tailwindcss": "^4.2.2",
     "typescript": "^5.8.3",
-    "vite": "^7.2.7",
-    "vite-tsconfig-paths": "^5.1.4"
+    "vite": "^8.0.8",
+    "vite-tsconfig-paths": "^6.1.1"
   }
 }

--- a/packages/template-generator/templates/frontend/react/tanstack-router/package.json.hbs
+++ b/packages/template-generator/templates/frontend/react/tanstack-router/package.json.hbs
@@ -11,25 +11,25 @@
 		"check-types": "vite build && tsc --noEmit"
 	},
 	"dependencies": {
-        "@hookform/resolvers": "^5.1.1",
+        "@hookform/resolvers": "^5.2.2",
         "@{{projectName}}/ui": "{{#if (eq packageManager "npm")}}*{{else}}workspace:*{{/if}}",
-		"@tailwindcss/vite": "^4.1.18",
-		"@tanstack/react-router": "^1.141.1",
-		"lucide-react": "^0.546.0",
+		"@tailwindcss/vite": "^4.2.2",
+		"@tanstack/react-router": "^1.168.22",
+		"lucide-react": "^1.8.0",
         "next-themes": "^0.4.6",
-		"react": "^19.2.3",
-		"react-dom": "^19.2.3",
-        "sonner": "^2.0.5"
+		"react": "^19.2.5",
+		"react-dom": "^19.2.5",
+        "sonner": "^2.0.7"
 	},
 	"devDependencies": {
-		"@tanstack/react-router-devtools": "^1.141.1",
-		"@tanstack/router-plugin": "^1.141.1",
+		"@tanstack/react-router-devtools": "^1.166.13",
+		"@tanstack/router-plugin": "^1.167.22",
 		"@types/node": "^22.13.14",
-		"@types/react": "^19.2.10",
+		"@types/react": "^19.2.14",
 		"@types/react-dom": "^19.2.3",
-		"@vitejs/plugin-react": "^4.3.4",
-		"postcss": "^8.5.3",
-		"tailwindcss": "^4.1.18",
-		"vite": "^6.2.2"
+		"@vitejs/plugin-react": "^6.0.1",
+		"postcss": "^8.5.10",
+		"tailwindcss": "^4.2.2",
+		"vite": "^8.0.8"
 	}
 }

--- a/packages/template-generator/templates/frontend/react/tanstack-router/src/main.tsx.hbs
+++ b/packages/template-generator/templates/frontend/react/tanstack-router/src/main.tsx.hbs
@@ -59,6 +59,7 @@ function ClerkApiAuthBridge() {
 const router = createRouter({
   routeTree,
   defaultPreload: "intent",
+  scrollRestoration: true,
   defaultPendingComponent: () => <Loader />,
   {{#if (eq api "orpc")}}
   context: { orpc, queryClient },

--- a/packages/template-generator/templates/frontend/react/tanstack-router/tsconfig.json.hbs
+++ b/packages/template-generator/templates/frontend/react/tanstack-router/tsconfig.json.hbs
@@ -6,7 +6,6 @@
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "verbatimModuleSyntax": true,
     "skipLibCheck": true,
     "types": ["vite/client"],
     "rootDirs": ["."],

--- a/packages/template-generator/templates/frontend/react/tanstack-router/vite.config.ts.hbs
+++ b/packages/template-generator/templates/frontend/react/tanstack-router/vite.config.ts.hbs
@@ -1,21 +1,21 @@
 import tailwindcss from "@tailwindcss/vite";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import react from "@vitejs/plugin-react";
-import path from "node:path";
 import { defineConfig } from "vite";
 
 export default defineConfig({
-  plugins: [
-    tailwindcss(),
-    tanstackRouter({}),
-    react(),
-  ],
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
-    },
-  },
   server: {
     port: 3001,
   },
+  resolve: {
+    tsconfigPaths: true,
+  },
+  plugins: [
+    tailwindcss(),
+    tanstackRouter({
+      target: "react",
+      autoCodeSplitting: true,
+    }),
+    react(),
+  ],
 });

--- a/packages/template-generator/templates/frontend/react/tanstack-start/package.json.hbs
+++ b/packages/template-generator/templates/frontend/react/tanstack-start/package.json.hbs
@@ -9,29 +9,26 @@
   },
   "dependencies": {
     "@{{projectName}}/ui": "{{#if (eq packageManager "npm")}}*{{else}}workspace:*{{/if}}",
-    "@tailwindcss/vite": "^4.1.18",
-    "@tanstack/react-query": "^5.80.6",
-    "@tanstack/react-router": "^1.141.1",
-    "@tanstack/react-router-with-query": "^1.130.17",
-    "@tanstack/react-start": "^1.141.1",
-    "@tanstack/router-plugin": "^1.141.1",
-    "lucide-react": "^0.546.0",
+    "@tailwindcss/vite": "^4.2.2",
+    "@tanstack/react-query": "^5.99.0",
+    "@tanstack/react-router": "^1.168.22",
+    "@tanstack/react-start": "^1.167.41",
+    "lucide-react": "^1.8.0",
     "next-themes": "^0.4.6",
-    "react": "^19.2.3",
-    "react-dom": "^19.2.3",
-    "sonner": "^2.0.5",
-    "tailwindcss": "^4.1.18",
-    "vite-tsconfig-paths": "^5.1.4"
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
+    "sonner": "^2.0.7",
+    "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
-    "@tanstack/react-router-devtools": "^1.141.1",
-    "@testing-library/dom": "^10.4.0",
-    "@testing-library/react": "^16.2.0",
-    "@types/react": "^19.2.10",
+    "@tanstack/react-router-devtools": "^1.166.13",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
+    "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^5.0.4",
-    "jsdom": "^26.0.0",
-    "vite": "^7.0.2",
-    "web-vitals": "^5.0.3"
+    "@vitejs/plugin-react": "^6.0.1",
+    "jsdom": "^29.0.2",
+    "vite": "^8.0.8",
+    "web-vitals": "^5.2.0"
   }
 }

--- a/packages/template-generator/templates/frontend/react/tanstack-start/src/router.tsx.hbs
+++ b/packages/template-generator/templates/frontend/react/tanstack-start/src/router.tsx.hbs
@@ -39,7 +39,7 @@ export function getRouter() {
 		throw new Error("VITE_CONVEX_URL is not set");
 	}
 
-	const convexQueryClient = new ConvexQueryClient(convexUrl{{#if (eq auth "better-auth")}}, { expectAuth: true }{{/if}});
+	const convexQueryClient = new ConvexQueryClient(convexUrl);
 
 	const queryClient: QueryClient = new QueryClient({
 		defaultOptions: {

--- a/packages/template-generator/templates/frontend/react/tanstack-start/src/router.tsx.hbs
+++ b/packages/template-generator/templates/frontend/react/tanstack-start/src/router.tsx.hbs
@@ -13,7 +13,8 @@ import Loader from "./components/loader";
 import "./index.css";
 import { routeTree } from "./routeTree.gen";
 {{#if (eq api "trpc")}}
-import { QueryCache, QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryCache, QueryClient } from "@tanstack/react-query";
+import { setupRouterSsrQueryIntegration } from "@tanstack/react-router-ssr-query";
 import { createTRPCClient, httpBatchLink } from "@trpc/client";
 import { createTRPCOptionsProxy } from "@trpc/tanstack-react-query";
 import { toast } from "sonner";
@@ -26,7 +27,7 @@ import { env } from "@{{projectName}}/env/web";
 import { getClerkAuthToken } from "@/utils/clerk-auth";
 {{/if}}
 {{else if (eq api "orpc")}}
-import { QueryClientProvider } from "@tanstack/react-query";
+import { setupRouterSsrQueryIntegration } from "@tanstack/react-router-ssr-query";
 import { orpc, queryClient } from "./utils/orpc";
 {{/if}}
 {{/if}}
@@ -38,7 +39,7 @@ export function getRouter() {
 		throw new Error("VITE_CONVEX_URL is not set");
 	}
 
-	const convexQueryClient = new ConvexQueryClient(convexUrl);
+	const convexQueryClient = new ConvexQueryClient(convexUrl{{#if (eq auth "better-auth")}}, { expectAuth: true }{{/if}});
 
 	const queryClient: QueryClient = new QueryClient({
 		defaultOptions: {
@@ -126,22 +127,20 @@ export const getRouter = () => {
 		defaultNotFoundComponent: () => <div>Not Found</div>,
 {{#if (eq api "trpc")}}
 		Wrap: ({ children }) => (
-			<QueryClientProvider client={queryClient}>
-				<TRPCProvider trpcClient={trpcClient} queryClient={queryClient}>
-					{children}
-				</TRPCProvider>
-			</QueryClientProvider>
-		),
-{{else if (eq api "orpc")}}
-		Wrap: ({ children }) => (
-			<QueryClientProvider client={queryClient}>
+			<TRPCProvider trpcClient={trpcClient} queryClient={queryClient}>
 				{children}
-			</QueryClientProvider>
+			</TRPCProvider>
 		),
-{{else}}
-		Wrap: ({ children }) => <>{children}</>,
 {{/if}}
 	});
+{{#if (or (eq api "trpc") (eq api "orpc"))}}
+
+	setupRouterSsrQueryIntegration({
+		router,
+		queryClient,
+	});
+{{/if}}
+
 	return router;
 };
 {{/if}}

--- a/packages/template-generator/templates/frontend/react/tanstack-start/tsconfig.json.hbs
+++ b/packages/template-generator/templates/frontend/react/tanstack-start/tsconfig.json.hbs
@@ -10,7 +10,6 @@
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
-    "verbatimModuleSyntax": true,
     "noEmit": true,
 
     /* Linting */

--- a/packages/template-generator/templates/frontend/react/tanstack-start/vite.config.ts.hbs
+++ b/packages/template-generator/templates/frontend/react/tanstack-start/vite.config.ts.hbs
@@ -1,19 +1,20 @@
 import { defineConfig } from "vite";
-import tsconfigPaths from "vite-tsconfig-paths";
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 import tailwindcss from "@tailwindcss/vite";
 import viteReact from "@vitejs/plugin-react";
 
 export default defineConfig({
+  server: {
+    port: 3001,
+  },
+  resolve: {
+    tsconfigPaths: true,
+  },
   plugins: [
-    tsconfigPaths(),
     tailwindcss(),
     tanstackStart(),
     viteReact(),
   ],
-  server: {
-    port: 3001,
-  },
 {{#if (and (eq backend "convex") (eq auth "better-auth"))}}
   ssr: {
     noExternal: ["@convex-dev/better-auth"],

--- a/packages/template-generator/templates/frontend/solid/package.json.hbs
+++ b/packages/template-generator/templates/frontend/solid/package.json.hbs
@@ -9,15 +9,15 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@tailwindcss/vite": "^4.1.13",
-    "@tanstack/router-plugin": "^1.131.44",
-    "@tanstack/solid-router": "^1.131.44",
-    "lucide-solid": "^0.544.0",
-    "solid-js": "^1.9.9",
-    "tailwindcss": "^4.1.13"
+    "@tailwindcss/vite": "^4.2.2",
+    "@tanstack/router-plugin": "^1.167.22",
+    "@tanstack/solid-router": "^1.168.20",
+    "lucide-solid": "^1.8.0",
+    "solid-js": "^1.9.12",
+    "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
-    "vite": "^7.1.5",
-    "vite-plugin-solid": "^2.11.8"
+    "vite": "^8.0.8",
+    "vite-plugin-solid": "^2.11.12"
   }
 }

--- a/packages/template-generator/templates/frontend/svelte/package.json.hbs
+++ b/packages/template-generator/templates/frontend/svelte/package.json.hbs
@@ -12,14 +12,14 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
 	},
 	"devDependencies": {
-		"@sveltejs/adapter-auto": "^6.1.0",
-		"@sveltejs/kit": "^2.31.1",
-		"@sveltejs/vite-plugin-svelte": "^6.1.2",
-		"@tailwindcss/vite": "^4.1.12",
-		"svelte": "^5.38.1",
-		"svelte-check": "^4.3.1",
-		"tailwindcss": "^4.1.12",
-		"vite": "^7.1.2"
+		"@sveltejs/adapter-auto": "^7.0.1",
+		"@sveltejs/kit": "^2.57.1",
+		"@sveltejs/vite-plugin-svelte": "^7.0.0",
+		"@tailwindcss/vite": "^4.2.2",
+		"svelte": "^5.55.4",
+		"svelte-check": "^4.4.6",
+		"tailwindcss": "^4.2.2",
+		"vite": "^8.0.8"
 	},
 	"dependencies": {}
 }


### PR DESCRIPTION
## Summary
- TanStack Start template refresh: Vite 8, `@tanstack/react-start` 1.167, `@vitejs/plugin-react` 6, native `resolve.tsconfigPaths`, drop unused `@tanstack/router-plugin` + `@tanstack/react-router-with-query`, remove `verbatimModuleSyntax` per TanStack docs warning, wire `setupRouterSsrQueryIntegration` for trpc/orpc paths, pass `expectAuth: true` for Convex+Better-Auth.
- TanStack Router SPA template: add `autoCodeSplitting: true` + `target: "react"`, `scrollRestoration: true`, native tsconfigPaths. (Without `autoCodeSplitting` the whole app shipped in one bundle — material fix.)
- All Vite-based frontend templates (`tanstack-router`, `react-router`, `solid`, `svelte`) bumped to Vite 8 + latest plugin peers; `lucide-react`/`lucide-solid` 1.x; Tailwind 4.2; React 19.2.5; misc minors.
- Shared `add-deps.ts` version map: Prisma `^7.7.0`, Alchemy `^0.91.2`, tRPC `^11.16.0`, oRPC `^1.13.14`, `@clerk/tanstack-react-start` `^1.1.3`, `@tanstack/react-router-ssr-query` `^1.166.11`, `@convex-dev/better-auth` `^0.11.4`, solid-query/devtools, svelte adapter-cloudflare, vite-plugin-pwa.
- CLI prompt validation: close flag+prompt gap where `--api trpc` with a prompted nuxt/svelte/solid/astro frontend silently coerced to `orpc`, and `--orm drizzle` with prompted `mongodb` (or `--orm mongoose` with non-mongodb) passed through unchecked. Both now throw the same validation error the all-flags path already did.
- Allow `docker` dbSetup with `workers` runtime — Docker is a local-dev database; Workers connects via whatever `DATABASE_URL` points at. Previously rejected.
- Fix `CORS_ORIGIN` / `SITE_URL` defaults for `tanstack-router` and `solid` (they run on `3001` per their Vite configs, not `5173`).

## Test plan
- [x] `bun run typecheck` across template-generator and apps/cli
- [x] `bun test` on frontend, api, auth, addons, database-orm, database-setup, deployment, integration, basic-configurations, cli-validation, dry-run, silent-create-output, examples, input-schemas — all green
- [ ] Smoke-generate a tanstack-start project (trpc + better-auth + postgres) and `bun run dev` to confirm HMR + SSR react-query integration
- [ ] Smoke-generate a tanstack-router SPA and confirm route-level code splitting in the build output
- [ ] Generate tanstack-router + hono + self and confirm `CORS_ORIGIN=http://localhost:3001` in the server `.env`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Explicit compatibility checks for selected API/frontend and ORM/database choices with clear errors.

* **Bug Fixes**
  * Removed a spurious error blocking Workers runtime when using Docker database setup.

* **Dependencies**
  * Bumped React, React Router, TanStack, Tailwind, Vite, Prisma and related template dependencies.

* **Improvements**
  * Dynamic TanStack dependency selection, improved SSR/query integration, simplified router and CORS defaults, and scroll restoration on navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->