### PR TITLE
chore: bump typescript to ^6.0.3 across templates

### DIFF
--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -150,7 +150,7 @@ export default {
   "devDependencies": {
     "@types/bun": "^1.3.4",
     "concurrently": "^9.1.0",
-    "typescript": "^5"
+    "typescript": "^6.0.3"
   }
 }
 `],
@@ -25228,8 +25228,7 @@ initOpenNextCloudflareForDev();
     "@types/node": "^20",
     "@types/react": "^19.2.10",
     "@types/react-dom": "^19.2.3",
-    "tailwindcss": "^4.1.18",
-    "typescript": "^5"
+    "tailwindcss": "^4.1.18"
   }
 }
 `],
@@ -25638,7 +25637,6 @@ export function ThemeProvider({
     "@types/react-dom": "^19.2.3",
     "react-router-devtools": "^1.1.0",
     "tailwindcss": "^4.2.2",
-    "typescript": "^5.8.3",
     "vite": "^8.0.8",
     "vite-tsconfig-paths": "^6.1.1"
   }
@@ -28740,8 +28738,7 @@ await app.finalize();
   "devDependencies": {
     "@types/react": "^19.2.10",
     "@types/react-dom": "^19.2.3",
-    "tailwindcss": "^4.1.18",
-    "typescript": "^5.9.3"
+    "tailwindcss": "^4.1.18"
   },
   "scripts": {
     "check-types": "tsc --noEmit"

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -150,7 +150,7 @@ export default {
   "devDependencies": {
     "@types/bun": "^1.3.4",
     "concurrently": "^9.1.0",
-    "typescript": "^6.0.3"
+    "typescript": "^6"
   }
 }
 `],

--- a/packages/template-generator/src/utils/add-deps.ts
+++ b/packages/template-generator/src/utils/add-deps.ts
@@ -12,7 +12,7 @@ type PackageJson = {
 };
 
 export const dependencyVersionMap = {
-  typescript: "^6.0.3",
+  typescript: "^6",
 
   "better-auth": "1.5.5",
   "@better-auth/expo": "1.5.5",

--- a/packages/template-generator/src/utils/add-deps.ts
+++ b/packages/template-generator/src/utils/add-deps.ts
@@ -12,7 +12,7 @@ type PackageJson = {
 };
 
 export const dependencyVersionMap = {
-  typescript: "^5",
+  typescript: "^6.0.3",
 
   "better-auth": "1.5.5",
   "@better-auth/expo": "1.5.5",

--- a/packages/template-generator/templates/addons/electrobun/apps/desktop/package.json.hbs
+++ b/packages/template-generator/templates/addons/electrobun/apps/desktop/package.json.hbs
@@ -9,6 +9,6 @@
   "devDependencies": {
     "@types/bun": "^1.3.4",
     "concurrently": "^9.1.0",
-    "typescript": "^6.0.3"
+    "typescript": "^6"
   }
 }

--- a/packages/template-generator/templates/addons/electrobun/apps/desktop/package.json.hbs
+++ b/packages/template-generator/templates/addons/electrobun/apps/desktop/package.json.hbs
@@ -9,6 +9,6 @@
   "devDependencies": {
     "@types/bun": "^1.3.4",
     "concurrently": "^9.1.0",
-    "typescript": "^5"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/template-generator/templates/frontend/react/next/package.json.hbs
+++ b/packages/template-generator/templates/frontend/react/next/package.json.hbs
@@ -22,7 +22,6 @@
     "@types/node": "^20",
     "@types/react": "^19.2.10",
     "@types/react-dom": "^19.2.3",
-    "tailwindcss": "^4.1.18",
-    "typescript": "^5"
+    "tailwindcss": "^4.1.18"
   }
 }

--- a/packages/template-generator/templates/frontend/react/react-router/package.json.hbs
+++ b/packages/template-generator/templates/frontend/react/react-router/package.json.hbs
@@ -29,7 +29,6 @@
     "@types/react-dom": "^19.2.3",
     "react-router-devtools": "^1.1.0",
     "tailwindcss": "^4.2.2",
-    "typescript": "^5.8.3",
     "vite": "^8.0.8",
     "vite-tsconfig-paths": "^6.1.1"
   }

--- a/packages/template-generator/templates/packages/ui/package.json.hbs
+++ b/packages/template-generator/templates/packages/ui/package.json.hbs
@@ -26,8 +26,7 @@
   "devDependencies": {
     "@types/react": "^19.2.10",
     "@types/react-dom": "^19.2.3",
-    "tailwindcss": "^4.1.18",
-    "typescript": "^5.9.3"
+    "tailwindcss": "^4.1.18"
   },
   "scripts": {
     "check-types": "tsc --noEmit"


### PR DESCRIPTION
## Summary
- Bump the shared `dependencyVersionMap` entry for `typescript` from `"^5"` to `"^6"`. Since `workspace-deps.ts` adds `typescript` as a devDep to every generated workspace package, this propagates to all generated projects automatically.
- Drop the redundant inline `typescript` pins in `next`, `react-router`, and `ui` package.json templates — the workspace-deps processor already writes it from the shared map, so the inline pins were dead duplication (and out-of-sync in places: `^5`, `^5.8.3`, `^5.9.3`).
- Keep `typescript` inline in `addons/electrobun/apps/desktop/package.json.hbs` since that addon isn't handled by `workspace-deps.ts`. Bumped it to `^6` too for consistency.

## Migration notes
TS 6.0 changed several defaults, but our templates are already compatible:
- `moduleResolution: bundler` — every template tsconfig already uses this.
- `strict: true` — already explicit everywhere.
- `types: [...]` — explicit in every tsconfig that needs `vite/client`, `node`, `bun`, etc.
- No templates use removed options (`amd`/`umd`/`systemjs` module, `classic` resolution, `target: es5`, `outFile`).

The TanStack canonical examples also use `^6.x`, so the ecosystem has moved.

## Test plan
- [x] \`bun run typecheck\` across template-generator and apps/cli
- [x] \`bun test\` on frontend, api, auth, addons, integration, basic-configurations, cli-validation — 265/265 green
- [ ] Smoke-generate a tanstack-start + trpc + better-auth project and \`bun run check-types\` on the generated tree
- [ ] Smoke-generate a next.js + hono + prisma project and confirm \`typescript ^6\` resolves + \`tsc --noEmit\` passes