### PR TITLE
fix(web): prefix fumadocs .source path with ./

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -15,7 +15,7 @@
     "jsx": "react-jsx",
     "incremental": true,
     "paths": {
-      "fumadocs-mdx:collections/*": [".source/*"],
+      "fumadocs-mdx:collections/*": ["./.source/*"],
       "@/*": ["./src/*"],
       "@/public/*": ["./public/*"]
     },


### PR DESCRIPTION
## Summary
After #1003 removed \`baseUrl\` from \`apps/web/tsconfig.json\`, TS now rejects bare paths in the \`paths\` map — the \`fumadocs-mdx:collections/*\` entry resolved \`.source/*\` as a non-relative module specifier and \`next build\` failed type-check with:

\`\`\`
Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
\`\`\`

Prefix the target with \`./\`:

\`\`\`diff
- "fumadocs-mdx:collections/*": [".source/*"],
+ "fumadocs-mdx:collections/*": ["./.source/*"],
\`\`\`

## Test plan
- [x] \`cd apps/web && bun run build\` passes end-to-end (Turbopack compile + next type-check + SSG generation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated module resolution configuration in TypeScript settings to ensure proper path resolution during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->