### PR TITLE
fix(template-generator): drop useless fallback in pkgJson.overrides spread

### DIFF
--- a/packages/template-generator/src/post-process/package-configs.ts
+++ b/packages/template-generator/src/post-process/package-configs.ts
@@ -161,7 +161,7 @@ function updateRootPackageJson(vfs: VirtualFileSystem, config: ProjectConfig): v
 
   if (config.api === "orpc" && config.frontend.includes("nuxt")) {
     pkgJson.overrides = {
-      ...(pkgJson.overrides || {}),
+      ...pkgJson.overrides,
       "@vue/devtools-api": "^8.0.7",
     };
   }


### PR DESCRIPTION
## Summary
Fixes the `eslint-plugin-unicorn/no-useless-fallback-in-spread` warning that started showing after #1012 bumped oxlint. Spreading `undefined` in an object literal is a no-op, so `...pkgJson.overrides` works the same as `...(pkgJson.overrides || {})` when `overrides` is undefined.

Note: PR #1012 was merged before I pushed this fix, so it lands as a small follow-up. Pushing to the original branch isn't possible post-merge.

## Test plan
- [x] `bun run check` (oxfmt + oxlint): 0 warnings, 0 errors
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of package override configurations when using Nuxt with the oRPC API. The template generator now correctly manages the Vue devtools-api dependency version in affected projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->