### PR TITLE
test(ci): add publish smoke test for npm, pnpm, bun

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -135,6 +135,14 @@ jobs:
           cd packages/create-bts
           jq --arg v "$VERSION" --arg dep "^$VERSION" '.version = $v | .dependencies["create-better-t-stack"] = $dep' package.json > tmp.json && mv tmp.json package.json
 
+      - name: Enable pnpm via corepack
+        if: steps.check-version.outputs.exists == 'false'
+        run: corepack enable pnpm
+
+      - name: Publish smoke test (npm, pnpm, bun)
+        if: steps.check-version.outputs.exists == 'false'
+        run: bun run smoke:publish
+
       - name: Publish CLI to NPM
         if: steps.check-version.outputs.exists == 'false'
         run: cd apps/cli && npm publish --access public --provenance

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,14 +87,6 @@ jobs:
         if: steps.check-version.outputs.exists == 'false'
         run: cd packages/types && bun run build
 
-      - name: Publish types to NPM
-        if: steps.check-version.outputs.exists == 'false'
-        run: cd packages/types && npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          BTS_TELEMETRY: 1
-          CONVEX_INGEST_URL: ${{ secrets.CONVEX_INGEST_URL }}
-
       - name: Update template-generator package version and types dependency
         if: steps.check-version.outputs.exists == 'false'
         run: |
@@ -105,14 +97,6 @@ jobs:
       - name: Build template-generator package
         if: steps.check-version.outputs.exists == 'false'
         run: cd packages/template-generator && bun run build
-
-      - name: Publish template-generator to NPM
-        if: steps.check-version.outputs.exists == 'false'
-        run: cd packages/template-generator && npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          BTS_TELEMETRY: 1
-          CONVEX_INGEST_URL: ${{ secrets.CONVEX_INGEST_URL }}
 
       - name: Update CLI types and template-generator dependencies and version
         if: steps.check-version.outputs.exists == 'false'
@@ -139,9 +123,28 @@ jobs:
         if: steps.check-version.outputs.exists == 'false'
         run: corepack enable pnpm
 
+      # Gate all publishes on the smoke so a failure here doesn't leave a
+      # partial release on npm (e.g. types/template-generator published but
+      # create-better-t-stack broken).
       - name: Publish smoke test (npm, pnpm, bun)
         if: steps.check-version.outputs.exists == 'false'
         run: bun run smoke:publish
+
+      - name: Publish types to NPM
+        if: steps.check-version.outputs.exists == 'false'
+        run: cd packages/types && npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          BTS_TELEMETRY: 1
+          CONVEX_INGEST_URL: ${{ secrets.CONVEX_INGEST_URL }}
+
+      - name: Publish template-generator to NPM
+        if: steps.check-version.outputs.exists == 'false'
+        run: cd packages/template-generator && npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          BTS_TELEMETRY: 1
+          CONVEX_INGEST_URL: ${{ secrets.CONVEX_INGEST_URL }}
 
       - name: Publish CLI to NPM
         if: steps.check-version.outputs.exists == 'false'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,3 +50,9 @@ jobs:
         env:
           AGENT: 1
           BTS_TELEMETRY: 0
+
+      - name: Enable pnpm via corepack
+        run: corepack enable pnpm
+
+      - name: Publish smoke test (npm, pnpm, bun)
+        run: bun run smoke:publish

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "dev": "turbo run dev",
     "dev:cli": "turbo run dev --filter=create-better-t-stack",
     "cli": "cd apps/cli && node dist/cli.js",
+    "smoke:publish": "bun run scripts/publish-smoke.ts",
     "dev:web": "turbo run dev --filter=web",
     "build:web": "turbo run build --filter=web",
     "build:cli": "turbo run build --filter=create-better-t-stack",

--- a/scripts/publish-smoke.ts
+++ b/scripts/publish-smoke.ts
@@ -46,19 +46,29 @@ async function pack(pkg: Publishable, outDir: string): Promise<string> {
 
   if (pkg.rewriteWorkspaceDeps) {
     const parsed = JSON.parse(original);
-    for (const d of pkg.rewriteWorkspaceDeps) {
-      if (parsed.dependencies?.[d]?.startsWith("workspace:")) {
-        parsed.dependencies[d] = `^${parsed.version}`;
+    for (const bucket of [
+      "dependencies",
+      "devDependencies",
+      "peerDependencies",
+      "optionalDependencies",
+    ] as const) {
+      const deps = parsed[bucket];
+      if (!deps) continue;
+      for (const d of pkg.rewriteWorkspaceDeps) {
+        if (deps[d]?.startsWith("workspace:")) {
+          deps[d] = `^${parsed.version}`;
+        }
       }
     }
     writeFileSync(pkgJsonPath, `${JSON.stringify(parsed, null, 2)}\n`);
   }
 
   try {
-    const r = await $`npm pack --pack-destination=${outDir} --silent`
+    const r = await $`npm pack --pack-destination=${outDir} --json`
       .cwd(join(ROOT, pkg.dir))
       .quiet();
-    return join(outDir, r.stdout.toString().trim().split("\n").pop()!.trim());
+    const [entry] = JSON.parse(r.stdout.toString()) as Array<{ filename: string }>;
+    return join(outDir, entry.filename);
   } finally {
     if (pkg.rewriteWorkspaceDeps) writeFileSync(pkgJsonPath, original);
   }

--- a/scripts/publish-smoke.ts
+++ b/scripts/publish-smoke.ts
@@ -1,0 +1,136 @@
+#!/usr/bin/env bun
+// Verify create-better-t-stack installs and runs under npm, pnpm, and bun.
+// Catches any regression that breaks the published artifact for consumers —
+// unresolved protocol refs, missing files, broken bin entry, import failures
+// from missing transitive deps, etc.
+//
+// Packs each publishable workspace with `npm pack` (matching the release
+// workflow, which uses `npm publish`), installs the CLI tarball in a temp
+// dir using overrides to redirect sibling workspace deps at their local
+// tarballs, then runs `create-better-t-stack --version` to prove the binary
+// actually executes.
+
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { $ } from "bun";
+
+const ROOT = resolve(import.meta.dir, "..");
+
+type Publishable = {
+  name: string;
+  dir: string;
+  // Release workflow rewrites workspace:* → ^<version> via jq before publish.
+  // Mirror that here so the tarball matches what actually ships.
+  rewriteWorkspaceDeps?: string[];
+};
+
+const PUBLISHABLES: Publishable[] = [
+  { name: "@better-t-stack/types", dir: "packages/types" },
+  { name: "@better-t-stack/template-generator", dir: "packages/template-generator" },
+  {
+    name: "create-better-t-stack",
+    dir: "apps/cli",
+    rewriteWorkspaceDeps: ["@better-t-stack/types", "@better-t-stack/template-generator"],
+  },
+];
+
+const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
+const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
+const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
+
+async function pack(pkg: Publishable, outDir: string): Promise<string> {
+  const pkgJsonPath = join(ROOT, pkg.dir, "package.json");
+  const original = readFileSync(pkgJsonPath, "utf-8");
+
+  if (pkg.rewriteWorkspaceDeps) {
+    const parsed = JSON.parse(original);
+    for (const d of pkg.rewriteWorkspaceDeps) {
+      if (parsed.dependencies?.[d]?.startsWith("workspace:")) {
+        parsed.dependencies[d] = `^${parsed.version}`;
+      }
+    }
+    writeFileSync(pkgJsonPath, `${JSON.stringify(parsed, null, 2)}\n`);
+  }
+
+  try {
+    const r = await $`npm pack --pack-destination=${outDir} --silent`
+      .cwd(join(ROOT, pkg.dir))
+      .quiet();
+    return join(outDir, r.stdout.toString().trim().split("\n").pop()!.trim());
+  } finally {
+    if (pkg.rewriteWorkspaceDeps) writeFileSync(pkgJsonPath, original);
+  }
+}
+
+async function installAndRun(
+  pm: "npm" | "pnpm" | "bun",
+  tarballs: Record<string, string>,
+  smokeRoot: string,
+) {
+  const dir = join(smokeRoot, `install-${pm}`);
+  rmSync(dir, { recursive: true, force: true });
+  mkdirSync(dir, { recursive: true });
+
+  const overrides = {
+    "@better-t-stack/types": `file:${tarballs["@better-t-stack/types"]}`,
+    "@better-t-stack/template-generator": `file:${tarballs["@better-t-stack/template-generator"]}`,
+  };
+  const fixture: Record<string, unknown> = {
+    name: `smoke-${pm}`,
+    private: true,
+    version: "0.0.0",
+    dependencies: { "create-better-t-stack": `file:${tarballs["create-better-t-stack"]}` },
+  };
+  if (pm === "pnpm") fixture.pnpm = { overrides };
+  else fixture.overrides = overrides;
+
+  writeFileSync(join(dir, "package.json"), JSON.stringify(fixture, null, 2));
+
+  const install = await $`${pm} install --ignore-scripts`.cwd(dir).quiet().nothrow();
+  if (install.exitCode !== 0) {
+    console.error(red(`✗ ${pm} install failed`));
+    console.error(dim(install.stderr.toString()));
+    process.exit(1);
+  }
+
+  // Execute the CLI via its installed bin path to prove it actually works —
+  // not just that the file got linked into node_modules/.bin.
+  const bin = join(dir, "node_modules", ".bin", "create-better-t-stack");
+  const run = await $`${bin} --version`.cwd(dir).quiet().nothrow();
+  if (run.exitCode !== 0) {
+    console.error(red(`✗ ${pm}: create-better-t-stack --version failed (exit ${run.exitCode})`));
+    console.error(dim(run.stderr.toString() + run.stdout.toString()));
+    process.exit(1);
+  }
+
+  console.log(green(`✓ ${pm}`) + dim(`  v${run.stdout.toString().trim()}`));
+}
+
+async function hasPackageManager(pm: string): Promise<boolean> {
+  return (await $`which ${pm}`.quiet().nothrow()).exitCode === 0;
+}
+
+const smokeRoot = join(tmpdir(), `bts-publish-smoke-${Date.now()}`);
+const tarballDir = join(smokeRoot, "tarballs");
+mkdirSync(tarballDir, { recursive: true });
+
+console.log("Packing...");
+const tarballs: Record<string, string> = {};
+for (const pkg of PUBLISHABLES) {
+  tarballs[pkg.name] = await pack(pkg, tarballDir);
+  console.log(dim(`  ${pkg.name}`));
+}
+
+console.log("\nInstalling and running create-better-t-stack under each package manager...");
+for (const pm of ["npm", "pnpm", "bun"] as const) {
+  if (!(await hasPackageManager(pm))) {
+    console.log(dim(`  - ${pm} not available, skipping`));
+    continue;
+  }
+  await installAndRun(pm, tarballs, smokeRoot);
+}
+
+rmSync(smokeRoot, { recursive: true, force: true });
+console.log(green("\n✓ publish smoke test passed"));


### PR DESCRIPTION
## Summary
Nothing in CI currently verifies that the published CLI actually installs and runs for consumers. The 3.27.3 breakage would have been caught by a simple pack → install → run loop across all three package managers; this PR adds exactly that.

`scripts/publish-smoke.ts` (run via `bun run smoke:publish`):
1. `npm pack` on every publishable workspace (`@better-t-stack/types`, `@better-t-stack/template-generator`, `create-better-t-stack`), mirroring what the release workflow's `npm publish` produces.
2. For each of **npm, pnpm, bun**: create a fresh temp dir, install the CLI tarball (with `overrides` / `pnpm.overrides` redirecting sibling workspace deps at their local tarballs so we don't depend on the registry), then execute `create-better-t-stack --version` via its installed bin to prove the binary actually runs.

Failure is hard — any install or exec failure exits non-zero with the offending PM's stderr.

Wired into:
- `test.yaml` on every PR
- `release.yaml` right before `npm publish` (belt-and-suspenders — can't ship a broken tarball even if PR CI is bypassed)

## Test plan
- [x] Passes locally for all three PMs: `✓ npm`, `✓ pnpm`, `✓ bun`
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added cross-package-manager publish smoke tests that pack, install, and run published artifacts (npm, pnpm, bun) to verify installation and that the CLI executes.
* **Chores**
  * CI now conditionally enables pnpm and runs the publish smoke verification during test and release pipelines before publishing core packages and the CLI.
* **Chores**
  * Added a root-level script to invoke the publish smoke verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->