### PR TITLE
fix(release): publish previews for release PRs

### DIFF
--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -11,6 +11,7 @@ const TEMPLATE_GENERATOR_PACKAGE_JSON_PATH = join(
   process.cwd(),
   "packages/template-generator/package.json",
 );
+const PREVIEW_LABEL = "preview";
 
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
@@ -145,10 +146,21 @@ This PR bumps the version to \`${newVersion}\`.
 - Updated \`@better-t-stack/types\` to v${newVersion}
 - Updated \`@better-t-stack/template-generator\` to v${newVersion}
 
+### Preview Release
+A preview release will be published automatically and posted as a PR comment.
+
 ---
 *This PR was automatically created by \`bun run bump\`*`;
 
-  await $`gh pr create --title ${prTitle} --body ${prBody} --base main --head ${branchName}`;
+  const prUrl = (
+    await $`gh pr create --title ${prTitle} --body ${prBody} --base main --head ${branchName}`.text()
+  ).trim();
+
+  if (prUrl) {
+    console.log(prUrl);
+  }
+
+  await enablePreviewRelease(prUrl || branchName);
 
   // Ask if user wants to enable auto-merge
   const shouldAutoMerge = await confirm({
@@ -164,16 +176,49 @@ This PR bumps the version to \`${newVersion}\`.
 
   console.log(`\n✅ Release PR created for v${newVersion}`);
   console.log(`\n📋 Next steps:`);
-  console.log(`   1. Wait for the "Test Suite" check to pass`);
+  console.log(`   1. Wait for the "Test Suite" and "Publish Preview" checks to pass`);
+  console.log(`   2. Use the preview release comment to test the release candidate`);
   if (!shouldAutoMerge) {
-    console.log(`   2. Merge the PR manually`);
+    console.log(`   3. Merge the PR manually`);
   }
   console.log(
-    `   ${shouldAutoMerge ? "2" : "3"}. The release workflow will automatically publish to NPM`,
+    `   ${shouldAutoMerge ? "3" : "4"}. The release workflow will automatically publish to NPM`,
   );
 
   // Switch back to main
   await $`git checkout main`;
+}
+
+async function enablePreviewRelease(prSelector: string): Promise<void> {
+  try {
+    await ensurePreviewLabelExists();
+    await $`gh pr edit ${prSelector} --add-label ${PREVIEW_LABEL}`;
+    console.log(
+      `✅ Added "${PREVIEW_LABEL}" label. A preview release will be published and commented on the PR.`,
+    );
+  } catch (error) {
+    console.warn(
+      `⚠️ Could not add the "${PREVIEW_LABEL}" label automatically. Add it manually to publish a preview release.`,
+    );
+    console.warn(formatError(error));
+  }
+}
+
+async function ensurePreviewLabelExists(): Promise<void> {
+  const labels =
+    await $`gh label list --search ${PREVIEW_LABEL} --json name --jq ".[].name"`.text();
+  const hasPreviewLabel = labels.split(/\r?\n/).some((name) => name.trim() === PREVIEW_LABEL);
+
+  if (hasPreviewLabel) {
+    return;
+  }
+
+  console.log(`\n🏷️ Creating "${PREVIEW_LABEL}" label for PR preview releases...`);
+  await $`gh label create ${PREVIEW_LABEL} --description "Publish an npm preview release for a PR" --color 2EA44F`;
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 main().catch(console.error);

--- a/scripts/publish-smoke.ts
+++ b/scripts/publish-smoke.ts
@@ -18,6 +18,9 @@ import { $ } from "bun";
 
 const ROOT = resolve(import.meta.dir, "..");
 
+// Corepack's pnpm shim can prompt before downloading pnpm; smoke tests run non-interactively.
+process.env.COREPACK_ENABLE_DOWNLOAD_PROMPT = "0";
+
 type Publishable = {
   name: string;
   dir: string;


### PR DESCRIPTION
## Summary
- add the preview label to release PRs created by `bun run bump` so the existing PR preview workflow publishes and comments automatically
- mention the preview release in the generated release PR body and next steps
- disable Corepack's pnpm download prompt inside the publish smoke test so CI doesn't fail non-interactively

## Verification
- `bun run check`
- `bun run bump patch --dry-run`
- `gh label list --search preview --json name --jq '.[].name'`
- `bun run smoke:publish`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automatic preview release label support for release candidate PRs.
  * Enhanced release PR body with Preview Release section details.
  * Improved release process messaging clarity based on configuration.
  * Fixed smoke test automation to run non-interactively.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AmanVarshney01/create-better-t-stack/pull/1037)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->