### PR TITLE
fix(ci): install latest pnpm in workflows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Extract version from commit message
         id: version
         run: |
-          VERSION=$(echo "${{ github.event.head_commit.message }}" | sed -E 's/^chore\(release\): ([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+          VERSION=$(git log -1 --pretty=%s | sed -nE 's/^chore\(release\): ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Releasing version: $VERSION"
 
@@ -121,7 +121,7 @@ jobs:
 
       - name: Install pnpm
         if: steps.check-version.outputs.exists == 'false'
-        run: npm install --global pnpm@10.32.1
+        run: npm install --global pnpm@latest
 
       # Gate all publishes on the smoke so a failure here doesn't leave a
       # partial release on npm (e.g. types/template-generator published but

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -119,9 +119,11 @@ jobs:
           cd packages/create-bts
           jq --arg v "$VERSION" --arg dep "^$VERSION" '.version = $v | .dependencies["create-better-t-stack"] = $dep' package.json > tmp.json && mv tmp.json package.json
 
-      - name: Install pnpm
+      - name: Setup pnpm
         if: steps.check-version.outputs.exists == 'false'
-        run: npm install --global pnpm@latest
+        uses: pnpm/action-setup@v6
+        with:
+          version: latest
 
       # Gate all publishes on the smoke so a failure here doesn't leave a
       # partial release on npm (e.g. types/template-generator published but

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,7 +52,7 @@ jobs:
           BTS_TELEMETRY: 0
 
       - name: Install pnpm
-        run: npm install --global pnpm@10.32.1
+        run: npm install --global pnpm@latest
 
       - name: Publish smoke test (npm, pnpm, bun)
         run: bun run smoke:publish

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,8 +51,10 @@ jobs:
           AGENT: 1
           BTS_TELEMETRY: 0
 
-      - name: Install pnpm
-        run: npm install --global pnpm@latest
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: latest
 
       - name: Publish smoke test (npm, pnpm, bun)
         run: bun run smoke:publish

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A modern CLI tool for scaffolding end-to-end type-safe TypeScript projects with 
 ## Sponsors
 
 <p align="center">
-<img src="https://sponsors.amanv.dev/sponsors.png" alt="Sponsors">
+<img src="https://sponsors.better-t-stack.dev/sponsors.png" alt="Sponsors">
 </p>
 
 ![demo](https://github.com/user-attachments/assets/12fd4d67-8494-462a-8124-76670798308a)

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -5,7 +5,7 @@ A modern CLI tool for scaffolding end-to-end type-safe TypeScript projects with 
 ## Sponsors
 
 <p align="center">
-<img src="https://sponsors.amanv.dev/sponsors.png" alt="Sponsors">
+<img src="https://sponsors.better-t-stack.dev/sponsors.png" alt="Sponsors">
 </p>
 
 ![demo](https://cdn.jsdelivr.net/gh/amanvarshney01/create-better-t-stack@master/demo.gif)

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -30,13 +30,13 @@ export type Sponsor = {
   name: string;
   githubId: string;
   avatarUrl: string;
-  websiteUrl?: string;
+  websiteUrl?: string | null;
   githubUrl: string;
   tierName: string;
-  totalProcessedAmount?: number;
+  totalProcessedAmount: number;
   sinceWhen: string;
   transactionCount: number;
-  formattedAmount?: string;
+  formattedAmount: string;
 };
 
 export type SponsorsData = {
@@ -52,7 +52,7 @@ export type SponsorsData = {
     top_sponsor: {
       name: string;
       amount: number;
-    };
+    } | null;
   };
   specialSponsors: Sponsor[];
   sponsors: Sponsor[];

--- a/scripts/publish-smoke.ts
+++ b/scripts/publish-smoke.ts
@@ -83,7 +83,7 @@ async function installAndRun(
   rmSync(dir, { recursive: true, force: true });
   mkdirSync(dir, { recursive: true });
 
-  const overrides = {
+  const overrides: Record<string, string> = {
     "@better-t-stack/types": `file:${tarballs["@better-t-stack/types"]}`,
     "@better-t-stack/template-generator": `file:${tarballs["@better-t-stack/template-generator"]}`,
   };
@@ -97,6 +97,37 @@ async function installAndRun(
   else fixture.overrides = overrides;
 
   writeFileSync(join(dir, "package.json"), JSON.stringify(fixture, null, 2));
+
+  if (pm === "pnpm") {
+    writeFileSync(
+      join(dir, ".pnpmfile.cjs"),
+      `const localDeps = ${JSON.stringify(overrides, null, 2)};
+
+module.exports = {
+  hooks: {
+    readPackage(pkg) {
+      if (pkg.name === "create-better-t-stack") {
+        pkg.dependencies = {
+          ...pkg.dependencies,
+          "@better-t-stack/types": localDeps["@better-t-stack/types"],
+          "@better-t-stack/template-generator": localDeps["@better-t-stack/template-generator"],
+        };
+      }
+
+      if (pkg.name === "@better-t-stack/template-generator") {
+        pkg.dependencies = {
+          ...pkg.dependencies,
+          "@better-t-stack/types": localDeps["@better-t-stack/types"],
+        };
+      }
+
+      return pkg;
+    },
+  },
+};
+`,
+    );
+  }
 
   const install = await $`${pm} install --ignore-scripts`.cwd(dir).quiet().nothrow();
   if (install.exitCode !== 0) {


### PR DESCRIPTION
## Summary
- Extract release versions from the commit subject to avoid multiline `$GITHUB_OUTPUT` failures.
- Install `pnpm@latest` in test and release workflows for publish smoke tests.

## Verification
- `git diff --check`
- pre-commit hook ran `bun check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release and CI now derive release version from the latest commit subject and use the latest pnpm setup.
* **Documentation**
  * Updated sponsor image links in project and CLI READMEs.
* **Bug Fixes / Data**
  * Sponsor data handling tightened: sponsor amounts are now required; website links may be null and top-sponsor can be absent.
* **Tests**
  * Improved local smoke-test setup to better apply local package overrides during test installs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AmanVarshney01/create-better-t-stack/pull/1039)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->