### PR TITLE
fix(cli): remove CSS side-effect import from router.tsx to prevent FOUC in TanStack Start

### DIFF
--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -27037,12 +27037,10 @@ import { setupRouterSsrQueryIntegration } from "@tanstack/react-router-ssr-query
 import { ConvexQueryClient } from "@convex-dev/react-query";
 import { routeTree } from "./routeTree.gen";
 import Loader from "./components/loader";
-import "./index.css";
 import { env } from "@{{projectName}}/env/web";
 {{else}}
 import { createRouter as createTanStackRouter } from "@tanstack/react-router";
 import Loader from "./components/loader";
-import "./index.css";
 import { routeTree } from "./routeTree.gen";
 {{#if (eq api "trpc")}}
 import { QueryCache, QueryClient } from "@tanstack/react-query";

--- a/packages/template-generator/templates/frontend/react/tanstack-start/src/router.tsx.hbs
+++ b/packages/template-generator/templates/frontend/react/tanstack-start/src/router.tsx.hbs
@@ -5,12 +5,10 @@ import { setupRouterSsrQueryIntegration } from "@tanstack/react-router-ssr-query
 import { ConvexQueryClient } from "@convex-dev/react-query";
 import { routeTree } from "./routeTree.gen";
 import Loader from "./components/loader";
-import "./index.css";
 import { env } from "@{{projectName}}/env/web";
 {{else}}
 import { createRouter as createTanStackRouter } from "@tanstack/react-router";
 import Loader from "./components/loader";
-import "./index.css";
 import { routeTree } from "./routeTree.gen";
 {{#if (eq api "trpc")}}
 import { QueryCache, QueryClient } from "@tanstack/react-query";


### PR DESCRIPTION
## Problem

`router.tsx` had `import "./index.css"` in both template branches (Convex and non-Convex). In TanStack Start's SSR pipeline, this side-effect CSS import causes Vite/Vinxi to handle the CSS as a JS-injected module rather than a static `<link>` tag. The CSS only loads after client-side hydration, resulting in a Flash of Unstyled Content (FOUC).

The `?url` import + `<link>` tag in `__root.tsx` was already the correct SSR pattern — the bare import in `router.tsx` was redundant and harmful.

## Changes

- Removed `import "./index.css"` from both `{{#if backend "convex"}}` and `{{else}}`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an unnecessary CSS import from templates when using non-Convex backend configurations.

* **Refactor**
  * Reorganized top-level template imports for Convex backend to improve template consistency and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AmanVarshney01/create-better-t-stack/pull/1048?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->