### PR TITLE
ci(release): use npm trusted publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,12 +70,6 @@ jobs:
         if: steps.check-version.outputs.exists == 'false'
         run: bun install --frozen-lockfile
 
-      - name: Verify NPM auth
-        if: steps.check-version.outputs.exists == 'false'
-        run: npm whoami
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Update types package version
         if: steps.check-version.outputs.exists == 'false'
         run: |
@@ -134,33 +128,29 @@ jobs:
 
       - name: Publish types to NPM
         if: steps.check-version.outputs.exists == 'false'
-        run: cd packages/types && npm publish --access public --provenance
+        run: cd packages/types && npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           BTS_TELEMETRY: 1
           CONVEX_INGEST_URL: ${{ secrets.CONVEX_INGEST_URL }}
 
       - name: Publish template-generator to NPM
         if: steps.check-version.outputs.exists == 'false'
-        run: cd packages/template-generator && npm publish --access public --provenance
+        run: cd packages/template-generator && npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           BTS_TELEMETRY: 1
           CONVEX_INGEST_URL: ${{ secrets.CONVEX_INGEST_URL }}
 
       - name: Publish CLI to NPM
         if: steps.check-version.outputs.exists == 'false'
-        run: cd apps/cli && npm publish --access public --provenance
+        run: cd apps/cli && npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           BTS_TELEMETRY: 1
           CONVEX_INGEST_URL: ${{ secrets.CONVEX_INGEST_URL }}
 
       - name: Publish create-bts alias to NPM
         if: steps.check-version.outputs.exists == 'false'
-        run: cd packages/create-bts && npm publish --access public --provenance
+        run: cd packages/create-bts && npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           BTS_TELEMETRY: 1
           CONVEX_INGEST_URL: ${{ secrets.CONVEX_INGEST_URL }}
 


### PR DESCRIPTION
## Summary
- Remove token-based `npm whoami` from the release workflow.
- Publish release packages without `NODE_AUTH_TOKEN` so npm can use GitHub Actions OIDC trusted publishing.
- Drop explicit `--provenance` flags because npm trusted publishing generates provenance automatically.

## Notes
- npm trusted publishers must be configured on npmjs.com for each released package with owner `AmanVarshney01`, repo `create-better-t-stack`, workflow filename `release.yaml`, and allowed action `npm publish`.
- `pr-preview.yaml` is intentionally unchanged because npm currently allows one trusted publisher per package; preview publishing still needs token-based auth unless that flow is redesigned.

## Verification
- `bun run check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD release workflow configuration, removing NPM authentication verification and adjusting package publishing process across multiple packages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AmanVarshney01/create-better-t-stack/pull/1051?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->