### PR TITLE
chore: update GitHub actions to Node 24 runtime

### DIFF
--- a/.github/workflows/pr-preview.yaml
+++ b/.github/workflows/pr-preview.yaml
@@ -20,17 +20,18 @@ jobs:
     if: github.event.label.name == 'preview'
     steps:
       - name: Checkout PR Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: package.json
           check-latest: true
           registry-url: https://registry.npmjs.org
+          package-manager-cache: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,16 +22,17 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: package.json
           check-latest: true
           registry-url: https://registry.npmjs.org
+          package-manager-cache: false
 
       - name: Extract version from commit message
         id: version

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,13 +15,14 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: package.json
           check-latest: true
+          package-manager-cache: false
 
       - name: Setup Git user
         run: |


### PR DESCRIPTION
## Summary
- Update checkout and setup-node actions to v6 across release, preview, and test workflows.
- Disable setup-node package manager cache for deterministic CI/release runs.
- Keep npm trusted publishing behavior unchanged.

## Verification
- git diff --check
- pre-commit hook ran bun check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow versions to the latest major releases for improved security and stability.
  * Optimized build pipeline caching configuration across CI/CD workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AmanVarshney01/create-better-t-stack/pull/1057?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->