### PR TITLE
fix(cli): ignore Alchemy state in native Metro

### DIFF
--- a/apps/cli/test/deployment.test.ts
+++ b/apps/cli/test/deployment.test.ts
@@ -1,5 +1,7 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 
+import { createVirtual } from "../src/index";
+import { collectFiles } from "./setup";
 import {
   expectError,
   expectSuccess,
@@ -336,6 +338,73 @@ describe("Deployment Configurations", () => {
       });
 
       expectSuccess(result);
+    });
+
+    it("should keep native Metro from watching Alchemy state", async () => {
+      const result = await createVirtual({
+        projectName: "native-astro-alchemy",
+        frontend: ["astro", "native-unistyles"],
+        backend: "hono",
+        runtime: "workers",
+        api: "orpc",
+        auth: "better-auth",
+        payments: "none",
+        database: "sqlite",
+        orm: "drizzle",
+        dbSetup: "d1",
+        packageManager: "pnpm",
+        git: false,
+        webDeploy: "cloudflare",
+        serverDeploy: "cloudflare",
+        install: false,
+        addons: ["evlog", "lefthook", "turborepo", "ultracite"],
+        examples: ["none"],
+      });
+
+      if (result.isErr()) {
+        throw result.error;
+      }
+
+      const files = collectFiles(result.value.root, result.value.root.path);
+      const metroConfig = files.get("apps/native/metro.config.js");
+
+      expect(metroConfig).toContain("config.resolver.blockList = [");
+      expect(metroConfig).toContain("[/\\\\]packages[/\\\\]infra[/\\\\]\\.alchemy(?:[/\\\\]|$)");
+      expect(metroConfig).not.toContain("config.watchFolders =");
+    });
+
+    it("should keep native Metro minimal without Cloudflare deploys", async () => {
+      const result = await createVirtual({
+        projectName: "native-no-alchemy",
+        frontend: ["native-unistyles"],
+        backend: "hono",
+        runtime: "bun",
+        api: "orpc",
+        auth: "none",
+        payments: "none",
+        database: "sqlite",
+        orm: "drizzle",
+        dbSetup: "none",
+        packageManager: "pnpm",
+        git: false,
+        webDeploy: "none",
+        serverDeploy: "none",
+        install: false,
+        addons: ["none"],
+        examples: ["none"],
+      });
+
+      if (result.isErr()) {
+        throw result.error;
+      }
+
+      const files = collectFiles(result.value.root, result.value.root.path);
+      const metroConfig = files.get("apps/native/metro.config.js");
+
+      expect(metroConfig).toBeDefined();
+      expect(metroConfig).not.toContain("node:path");
+      expect(metroConfig).not.toContain("config.resolver.blockList");
+      expect(metroConfig).not.toContain("\\.alchemy");
     });
 
     it("should work with different deploy providers", async () => {

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -23670,6 +23670,16 @@ export function useColorScheme() {
 const { getDefaultConfig } = require("expo/metro-config");
 
 const config = getDefaultConfig(__dirname);
+{{#if (or (eq webDeploy "cloudflare") (eq serverDeploy "cloudflare"))}}
+// Alchemy writes runtime state here; block it to avoid Metro refresh loops.
+const blockList = config.resolver.blockList ?? [];
+const blockListPatterns = Array.isArray(blockList) ? blockList : [blockList];
+
+config.resolver.blockList = [
+	...blockListPatterns,
+	/[/\\\\]packages[/\\\\]infra[/\\\\]\\.alchemy(?:[/\\\\]|$)/,
+];
+{{/if}}
 
 module.exports = config;
 `],
@@ -24971,6 +24981,16 @@ import './unistyles';
   ["frontend/native/unistyles/metro.config.js.hbs", `const { getDefaultConfig } = require("expo/metro-config");
 
 const config = getDefaultConfig(__dirname);
+{{#if (or (eq webDeploy "cloudflare") (eq serverDeploy "cloudflare"))}}
+// Alchemy writes runtime state here; block it to avoid Metro refresh loops.
+const blockList = config.resolver.blockList ?? [];
+const blockListPatterns = Array.isArray(blockList) ? blockList : [blockList];
+
+config.resolver.blockList = [
+	...blockListPatterns,
+	/[/\\\\]packages[/\\\\]infra[/\\\\]\\.alchemy(?:[/\\\\]|$)/,
+];
+{{/if}}
 
 module.exports = config;
 `],
@@ -26088,6 +26108,16 @@ const { wrapWithReanimatedMetroConfig } = require("react-native-reanimated/metro
 
 /** @type {import('expo/metro-config').MetroConfig} */
 const config = getDefaultConfig(__dirname);
+{{#if (or (eq webDeploy "cloudflare") (eq serverDeploy "cloudflare"))}}
+// Alchemy writes runtime state here; block it to avoid Metro refresh loops.
+const blockList = config.resolver.blockList ?? [];
+const blockListPatterns = Array.isArray(blockList) ? blockList : [blockList];
+
+config.resolver.blockList = [
+	...blockListPatterns,
+	/[/\\\\]packages[/\\\\]infra[/\\\\]\\.alchemy(?:[/\\\\]|$)/,
+];
+{{/if}}
 
 const uniwindConfig = withUniwindConfig(wrapWithReanimatedMetroConfig(config), {
   cssEntryFile: "./global.css",

--- a/packages/template-generator/templates/frontend/native/bare/metro.config.js.hbs
+++ b/packages/template-generator/templates/frontend/native/bare/metro.config.js.hbs
@@ -2,5 +2,15 @@
 const { getDefaultConfig } = require("expo/metro-config");
 
 const config = getDefaultConfig(__dirname);
+{{#if (or (eq webDeploy "cloudflare") (eq serverDeploy "cloudflare"))}}
+// Alchemy writes runtime state here; block it to avoid Metro refresh loops.
+const blockList = config.resolver.blockList ?? [];
+const blockListPatterns = Array.isArray(blockList) ? blockList : [blockList];
+
+config.resolver.blockList = [
+	...blockListPatterns,
+	/[/\\]packages[/\\]infra[/\\]\.alchemy(?:[/\\]|$)/,
+];
+{{/if}}
 
 module.exports = config;

--- a/packages/template-generator/templates/frontend/native/unistyles/metro.config.js.hbs
+++ b/packages/template-generator/templates/frontend/native/unistyles/metro.config.js.hbs
@@ -1,5 +1,15 @@
 const { getDefaultConfig } = require("expo/metro-config");
 
 const config = getDefaultConfig(__dirname);
+{{#if (or (eq webDeploy "cloudflare") (eq serverDeploy "cloudflare"))}}
+// Alchemy writes runtime state here; block it to avoid Metro refresh loops.
+const blockList = config.resolver.blockList ?? [];
+const blockListPatterns = Array.isArray(blockList) ? blockList : [blockList];
+
+config.resolver.blockList = [
+	...blockListPatterns,
+	/[/\\]packages[/\\]infra[/\\]\.alchemy(?:[/\\]|$)/,
+];
+{{/if}}
 
 module.exports = config;

--- a/packages/template-generator/templates/frontend/native/uniwind/metro.config.js.hbs
+++ b/packages/template-generator/templates/frontend/native/uniwind/metro.config.js.hbs
@@ -4,6 +4,16 @@ const { wrapWithReanimatedMetroConfig } = require("react-native-reanimated/metro
 
 /** @type {import('expo/metro-config').MetroConfig} */
 const config = getDefaultConfig(__dirname);
+{{#if (or (eq webDeploy "cloudflare") (eq serverDeploy "cloudflare"))}}
+// Alchemy writes runtime state here; block it to avoid Metro refresh loops.
+const blockList = config.resolver.blockList ?? [];
+const blockListPatterns = Array.isArray(blockList) ? blockList : [blockList];
+
+config.resolver.blockList = [
+	...blockListPatterns,
+	/[/\\]packages[/\\]infra[/\\]\.alchemy(?:[/\\]|$)/,
+];
+{{/if}}
 
 const uniwindConfig = withUniwindConfig(wrapWithReanimatedMetroConfig(config), {
   cssEntryFile: "./global.css",


### PR DESCRIPTION
## Summary

- Add a conditional Metro blocklist for native templates when Cloudflare deploys generate Alchemy infra.
- Preserve Expo's default Metro config and existing blocklist entries while ignoring `packages/infra/.alchemy`.
- Add regression coverage for the reported Astro + native-unistyles + Cloudflare stack and for non-Cloudflare native stacks staying minimal.

## Root Cause

Expo's monorepo Metro config watches workspace packages. Cloudflare deploy stacks include `packages/infra`, and Alchemy writes runtime state under `packages/infra/.alchemy`; when root `turbo dev` runs Expo and Alchemy together, those state writes can trigger native refresh loops.

## Verification

- `cd packages/template-generator && bun run build`
- `bun run check`
- `bun test apps/cli/test/deployment.test.ts apps/cli/test/frontend.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage validating Metro config for native apps with and without Cloudflare deployment, including utilities to generate and inspect virtual projects.

* **Chores**
  * Updated native Metro templates to conditionally extend the resolver block list when Cloudflare deployment is selected, preventing refresh loops by blocking internal runtime state files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->