### PR TITLE
fix(web): normalize react tweet entities

### DIFF
--- a/apps/web/src/app/(home)/_components/testimonials.tsx
+++ b/apps/web/src/app/(home)/_components/testimonials.tsx
@@ -119,7 +119,7 @@ const TweetCard = ({ tweetId, index }: { tweetId: string; index: number }) => (
       </div>
       <div className="w-full min-w-0 overflow-hidden">
         <div style={{ width: "100%", minWidth: 0, maxWidth: "100%" }}>
-          <Tweet id={tweetId} components={components} />
+          <Tweet id={tweetId} apiUrl={`/api/tweet/${tweetId}`} components={components} />
         </div>
       </div>
     </div>

--- a/apps/web/src/app/api/tweet/[id]/route.ts
+++ b/apps/web/src/app/api/tweet/[id]/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse } from "next/server";
+import { fetchTweet, TwitterApiError, type Tweet } from "react-tweet/api";
+
+export const revalidate = 86_400;
+
+type TweetEntityArrays = {
+  hashtags?: unknown[];
+  media?: unknown[];
+  symbols?: unknown[];
+  urls?: unknown[];
+  user_mentions?: unknown[];
+};
+
+type TweetWithEntities = {
+  entities?: TweetEntityArrays;
+  parent?: TweetWithEntities;
+  quoted_tweet?: TweetWithEntities;
+};
+
+type RouteContext = {
+  params: Promise<{
+    id: string;
+  }>;
+};
+
+export async function GET(_request: Request, { params }: RouteContext) {
+  const { id } = await params;
+
+  try {
+    const { data, notFound, tombstone } = await fetchTweet(id);
+
+    if (notFound || tombstone || !data) {
+      return NextResponse.json({ data: null }, { status: 404 });
+    }
+
+    return NextResponse.json({ data: normalizeTweet(data) });
+  } catch (error) {
+    if (error instanceof TwitterApiError) {
+      return NextResponse.json(
+        {
+          data: null,
+          error: error.message,
+        },
+        { status: error.status },
+      );
+    }
+
+    console.error("Tweet fetch error:", error);
+    return NextResponse.json({ data: null, error: "Failed to fetch tweet" }, { status: 500 });
+  }
+}
+
+function normalizeTweet<T extends TweetWithEntities>(tweet: T): T {
+  return {
+    ...tweet,
+    entities: normalizeEntities(tweet.entities),
+    parent: tweet.parent ? normalizeTweet(tweet.parent) : tweet.parent,
+    quoted_tweet: tweet.quoted_tweet ? normalizeTweet(tweet.quoted_tweet) : tweet.quoted_tweet,
+  };
+}
+
+function normalizeEntities(entities?: TweetEntityArrays): Tweet["entities"] {
+  const media = normalizeEntityArray(entities?.media);
+
+  return {
+    ...entities,
+    hashtags: normalizeEntityArray(entities?.hashtags),
+    media: media.length > 0 ? media : undefined,
+    symbols: normalizeEntityArray(entities?.symbols),
+    urls: normalizeEntityArray(entities?.urls),
+    user_mentions: normalizeEntityArray(entities?.user_mentions),
+  } as Tweet["entities"];
+}
+
+function normalizeEntityArray(entities?: unknown[]) {
+  if (!Array.isArray(entities)) return [];
+
+  return entities.filter((entity) => {
+    if (!entity || typeof entity !== "object" || !("indices" in entity)) return false;
+
+    const indices = entity.indices;
+    return (
+      Array.isArray(indices) &&
+      indices.length === 2 &&
+      typeof indices[0] === "number" &&
+      typeof indices[1] === "number"
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- Add a local `/api/tweet/[id]` route that fetches tweets through `react-tweet/api` and normalizes inconsistent entity arrays.
- Point homepage testimonial tweet embeds at the local normalized API route.

## Root Cause

Twitter syndication responses can omit or reshape tweet entity arrays. `react-tweet` currently assumes those fields are iterable, matching the upstream issue: https://github.com/vercel/react-tweet/issues/218. When one testimonial tweet returned incomplete entities, the homepage crashed during hydration with `This page couldn't load`.

## Verification

- `bun run check`
- `bun run build`
- Verified the local homepage renders at `http://localhost:3333/`
- Verified `/api/tweet/1907728148294447538` returns normalized entity arrays

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API endpoint for tweet data retrieval with 24-hour caching for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->