### PR TITLE
fix(template-generator): exclude next cache from turbo outputs

### DIFF
--- a/apps/web/content/docs/project-structure.mdx
+++ b/apps/web/content/docs/project-structure.mdx
@@ -461,7 +461,7 @@ Generated only if you chose the Nx addon.
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**", ".next/**"]
+      "outputs": ["dist/**", ".next/**", "!.next/cache/**"]
     },
     "dev": {
       "cache": false,

--- a/packages/template-generator/src/processors/turbo-generator.ts
+++ b/packages/template-generator/src/processors/turbo-generator.ts
@@ -58,12 +58,12 @@ function generateTurboConfig(config: ProjectConfig): TurboConfig {
 function getBaseTasks(frontend: string[]): Record<string, TurboTask> {
   // Build outputs per framework:
   // - Vite-based (tanstack-router, react-router, tanstack-start, solid, svelte): dist/**
-  // - Next.js: .next/**
+  // - Next.js: .next/** excluding .next/cache/**
   // - Nuxt: .nuxt/**, .output/**
   const buildOutputs = ["dist/**"];
 
   if (frontend.includes("next")) {
-    buildOutputs.push(".next/**");
+    buildOutputs.push(".next/**", "!.next/cache/**");
   }
 
   if (frontend.includes("nuxt")) {


### PR DESCRIPTION
## Summary

- exclude `.next/cache/**` from generated Turborepo build outputs for Next.js while still caching the rest of `.next/**`
- update the docs example to match the generated config and current Turborepo guidance

Fixes #1054

## Verification

- checked current Turborepo docs: https://turborepo.com/docs/crafting-your-repository/configuring-tasks#specifying-outputs and https://turborepo.com/docs/reference/configuration#outputs
- `bun run check`
- pre-commit hook ran


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Turbo build configuration examples for Next.js projects.

* **Chores**
  * Updated template generator to reflect current Turbo configuration standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->