### PR TITLE
fix(template-generator): align d1 setup instructions

### DIFF
--- a/apps/web/content/docs/guides/cloudflare-alchemy.mdx
+++ b/apps/web/content/docs/guides/cloudflare-alchemy.mdx
@@ -87,7 +87,9 @@ const app = await alchemy("my-app");
 
 // Create D1 database (if using D1)
 const db = await D1Database("database", {
-  migrationsDir: "../../packages/db/src/migrations",
+  // Prisma projects use "../../packages/db/prisma/migrations"
+  // Drizzle projects use "../../packages/db/src/migrations"
+  migrationsDir: "../../packages/db/prisma/migrations",
 });
 
 // Deploy web frontend
@@ -108,7 +110,6 @@ export const server = await Worker("server", {
     CORS_ORIGIN: alchemy.env.CORS_ORIGIN!,
     BETTER_AUTH_SECRET: alchemy.secret.env.BETTER_AUTH_SECRET!,
     BETTER_AUTH_URL: alchemy.env.BETTER_AUTH_URL!,
-    DATABASE_URL: alchemy.secret.env.DATABASE_URL!,
   },
   dev: {
     port: 3000,
@@ -594,7 +595,7 @@ Pay careful attention to CORS settings when moving between stages. A configurati
 ### "D1 migrations failed"
 
 1. Ensure migrations directory path is correct in `alchemy.run.ts`
-2. Run migrations locally first: `bun run db:push`
+2. Generate or update migrations first: `bun run db:generate` (and `bun run db:migrate` for Prisma)
 3. Check migration files are valid SQL
 
 ### "Worker size too large"

--- a/apps/web/content/docs/project-structure.mdx
+++ b/apps/web/content/docs/project-structure.mdx
@@ -533,7 +533,7 @@ Without Turborepo or Nx (example for Bun):
 Notes:
 
 - Convex adds `dev:setup` for initial backend configuration.
-- Database scripts (`db:*`) are added only when a database + ORM are selected (Drizzle/Prisma). D1 + Cloudflare omits `db:studio`.
+- Database scripts (`db:*`) are added only when a database + ORM are selected (Drizzle/Prisma). D1 + Cloudflare omits `db:push` and `db:studio`.
 
 ## Key Details
 

--- a/packages/template-generator/src/post-process/package-configs.ts
+++ b/packages/template-generator/src/post-process/package-configs.ts
@@ -120,7 +120,9 @@ function updateRootPackageJson(vfs: VirtualFileSystem, config: ProjectConfig): v
   }
 
   if (needsDbScripts) {
-    scripts["db:push"] = pmConfig.filter(dbPackageName, "db:push");
+    if (dbSupport.hasDbPush) {
+      scripts["db:push"] = pmConfig.filter(dbPackageName, "db:push");
+    }
 
     if (!isD1Alchemy) {
       scripts["db:studio"] = pmConfig.filter(dbPackageName, "db:studio");
@@ -310,7 +312,8 @@ function updateDbPackageJson(vfs: VirtualFileSystem, config: ProjectConfig): voi
 
   const scripts = pkgJson.scripts;
   const { database, orm, dbSetup } = config;
-  const { isD1Alchemy } = getDbScriptSupport(config);
+  const dbSupport = getDbScriptSupport(config);
+  const { isD1Alchemy } = dbSupport;
 
   if (database !== "none") {
     if (database === "sqlite" && dbSetup !== "d1") {
@@ -318,7 +321,9 @@ function updateDbPackageJson(vfs: VirtualFileSystem, config: ProjectConfig): voi
     }
 
     if (orm === "prisma") {
-      scripts["db:push"] = "prisma db push";
+      if (dbSupport.hasDbPush) {
+        scripts["db:push"] = "prisma db push";
+      }
       scripts["db:generate"] = "prisma generate";
       scripts["db:migrate"] = "prisma migrate dev";
       scripts.postinstall ??= "prisma generate";
@@ -326,7 +331,9 @@ function updateDbPackageJson(vfs: VirtualFileSystem, config: ProjectConfig): voi
         scripts["db:studio"] = "prisma studio";
       }
     } else if (orm === "drizzle") {
-      scripts["db:push"] = "drizzle-kit push";
+      if (dbSupport.hasDbPush) {
+        scripts["db:push"] = "drizzle-kit push";
+      }
       scripts["db:generate"] = "drizzle-kit generate";
       if (!isD1Alchemy) {
         scripts["db:studio"] = "drizzle-kit studio";

--- a/packages/template-generator/src/processors/readme-generator.ts
+++ b/packages/template-generator/src/processors/readme-generator.ts
@@ -160,6 +160,7 @@ function generateReadmeContent(options: ProjectConfig): string {
     frontend = ["tanstack-router"],
     backend = "hono",
     api = "trpc",
+    dbSetup,
     webDeploy,
     serverDeploy,
   } = options;
@@ -187,7 +188,7 @@ This project was created with [Better-T-Stack](https://github.com/AmanVarshney01
 
 ## Features
 
-${generateFeaturesList(database, auth, addons, orm, runtime, frontend, backend, api)}
+${generateFeaturesList(database, auth, addons, orm, runtime, frontend, backend, api, dbSetup)}
 
 ## Getting Started
 
@@ -451,6 +452,7 @@ function generateFeaturesList(
   frontend: ProjectConfig["frontend"],
   backend: ProjectConfig["backend"],
   api: ProjectConfig["api"],
+  dbSetup: ProjectConfig["dbSetup"],
 ): string {
   const isConvex = backend === "convex";
   const hasNative = hasNativeFrontend(frontend);
@@ -525,7 +527,7 @@ function generateFeaturesList(
       mongoose: "Mongoose",
     };
     const dbNames: Record<string, string> = {
-      sqlite: "SQLite/Turso",
+      sqlite: dbSetup === "d1" ? "Cloudflare D1" : "SQLite/Turso",
       postgres: "PostgreSQL",
       mysql: "MySQL",
       mongodb: "MongoDB",
@@ -576,8 +578,40 @@ function generateDatabaseSetup(config: ProjectConfig, packageManagerRunCmd: stri
   };
   const ormDesc = orm === "none" ? "" : ` with ${ormLabels[orm] || orm}`;
   const dbSupport = getDbScriptSupport(config);
+  const isD1Alchemy = dbSupport.isD1Alchemy;
 
   let setup = "## Database Setup\n\n";
+
+  if (isD1Alchemy) {
+    const steps: string[] = [];
+
+    if (dbSupport.hasDbGenerate) {
+      steps.push(
+        `${steps.length + 1}. ${
+          orm === "prisma" ? "Generate the Prisma client" : "Generate migration files"
+        }:
+\`\`\`bash
+${packageManagerRunCmd} db:generate
+\`\`\``,
+      );
+    }
+
+    if (dbSupport.hasDbMigrate) {
+      steps.push(`${steps.length + 1}. Create and apply Prisma migrations locally:
+\`\`\`bash
+${packageManagerRunCmd} db:migrate
+\`\`\``);
+    }
+
+    return `${setup}This project uses Cloudflare D1 (SQLite)${ormDesc}.
+
+Runtime database access uses the Cloudflare \`DB\` binding from \`packages/infra/alchemy.run.ts\`. If a local \`DATABASE_URL\` is present, it is only for database tooling.
+
+Alchemy provisions the D1 database and applies migrations during \`dev\` and \`deploy\`.
+
+${steps.join("\n\n")}
+`;
+  }
 
   const dbDescriptions: Record<string, string> = {
     sqlite: `This project uses SQLite${ormDesc}.
@@ -666,7 +700,9 @@ function generateScriptsList(
   }
 
   if (dbSupport.hasDbScripts) {
-    scripts += `\n- \`${packageManagerRunCmd} db:push\`: Push schema changes to database`;
+    if (dbSupport.hasDbPush) {
+      scripts += `\n- \`${packageManagerRunCmd} db:push\`: Push schema changes to database`;
+    }
     if (dbSupport.hasDbGenerate) {
       scripts += `\n- \`${packageManagerRunCmd} db:generate\`: Generate database client/types`;
     }

--- a/packages/template-generator/src/utils/db-scripts.ts
+++ b/packages/template-generator/src/utils/db-scripts.ts
@@ -32,12 +32,13 @@ export function getDbScriptSupport(config: ProjectConfig): DbScriptSupport {
     };
   }
 
+  const hasDbPush = !isD1Alchemy;
   const hasDbMigrate = config.orm === "prisma" || (config.orm === "drizzle" && !isD1Alchemy);
   const hasDbStudio = !isD1Alchemy;
 
   return {
     hasDbScripts: true,
-    hasDbPush: true,
+    hasDbPush,
     hasDbGenerate: true,
     hasDbMigrate,
     hasDbStudio,


### PR DESCRIPTION
## Summary

- omit `db:push` from generated D1 + Cloudflare projects so local SQLite push is not presented as D1 setup
- update generated README output to label Cloudflare D1, clarify the `DB` binding vs local `DATABASE_URL`, and list D1 migration commands
- refresh Cloudflare Alchemy docs for D1 migration directories and D1 troubleshooting

Fixes #1035

## Verification

- `bun run check`
- `bun run build:cli`
- Scaffolded the #1035 command locally and verified generated root/db scripts omit `db:push`, while README points to `db:generate`/`db:migrate` and the D1 `DB` binding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Cloudflare+Alchemy guide with clarified migration commands and binding configuration
  * Expanded project structure notes to document database script behavior with D1+Cloudflare

* **Improvements**
  * Enhanced template generation to properly handle database scripts for D1+Alchemy configurations, conditionally including db:push based on database backend

<!-- end of auto-generated comment: release notes by coderabbit.ai -->