### PR TITLE
feat(cli): add Docker deployment support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ templates-binary
 
 # opensrc - source code for packages
 opensrc/
+.scratch-docker-smoke/

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -68,8 +68,8 @@ Options:
   --install                       Install dependencies
   --no-install                    Skip installing dependencies
   --db-setup <setup>              Database setup (turso, d1, neon, supabase, prisma-postgres, planetscale, mongodb-atlas, docker, none)
-  --web-deploy <setup>            Web deployment (cloudflare, none)
-  --server-deploy <setup>         Server deployment (cloudflare, none)
+  --web-deploy <setup>            Web deployment (cloudflare, docker, none)
+  --server-deploy <setup>         Server deployment (cloudflare, docker, none)
   --backend <framework>           Backend framework (hono, express, fastify, elysia, convex, self, none)
   --runtime <runtime>             Runtime (bun, node, workers, none)
   --api <type>                    API type (trpc, orpc, none)
@@ -221,6 +221,12 @@ Create a self-hosted fullstack project on Cloudflare with D1:
 
 ```bash
 npx create-better-t-stack --backend self --frontend next --api trpc --database sqlite --orm drizzle --db-setup d1 --web-deploy cloudflare
+```
+
+Create a self-hosted project that ships as Docker containers (web + server + database via Docker Compose):
+
+```bash
+npx create-better-t-stack --frontend tanstack-router --backend hono --runtime bun --database postgres --orm drizzle --db-setup docker --web-deploy docker --server-deploy docker
 ```
 
 Create a minimal API-only project:

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -71,8 +71,8 @@
   "dependencies": {
     "@better-t-stack/template-generator": "workspace:*",
     "@better-t-stack/types": "workspace:*",
-    "@clack/core": "^1.3.1",
-    "@clack/prompts": "^1.4.0",
+    "@clack/core": "^1.4.1",
+    "@clack/prompts": "^1.5.1",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@trpc/server": "^11.17.0",
     "better-result": "^2.9.2",

--- a/apps/cli/src/helpers/core/post-installation.ts
+++ b/apps/cli/src/helpers/core/post-installation.ts
@@ -629,5 +629,17 @@ function getAlchemyDeployInstructions(
     );
   }
 
+  if (webDeploy === "docker" || serverDeploy === "docker") {
+    const dockerTargets =
+      webDeploy === "docker" && serverDeploy === "docker"
+        ? "web + server"
+        : webDeploy === "docker"
+          ? "web"
+          : "server";
+    instructions.push(
+      `${pc.bold(`Deploy ${dockerTargets} with Docker Compose:`)}\n${pc.cyan("•")} Start: ${`${runCmd} docker:up`}\n${pc.cyan("•")} Logs: ${`${runCmd} docker:logs`}\n${pc.cyan("•")} Stop: ${`${runCmd} docker:down`}\n${pc.cyan("•")} Config: docker-compose.yml`,
+    );
+  }
+
   return instructions.length ? `\n${instructions.join("\n")}` : "";
 }

--- a/apps/cli/src/prompts/addons.ts
+++ b/apps/cli/src/prompts/addons.ts
@@ -160,6 +160,7 @@ export async function getAddonsChoice(
   auth?: Auth,
   backend?: Backend,
   runtime?: Runtime,
+  previousValue?: Addons[],
 ) {
   if (addons !== undefined) return addons;
 
@@ -185,7 +186,7 @@ export async function getAddonsChoice(
 
   sortAndPruneGroupedOptions(groupedOptions);
 
-  const initialValues = DEFAULT_CONFIG.addons.filter((addonValue) =>
+  const initialValues = (previousValue ?? DEFAULT_CONFIG.addons).filter((addonValue) =>
     Object.values(groupedOptions).some((options) =>
       options.some((opt) => opt.value === addonValue),
     ),

--- a/apps/cli/src/prompts/api.ts
+++ b/apps/cli/src/prompts/api.ts
@@ -4,7 +4,7 @@ import {
   validateApiFrontendCompatibility,
 } from "../utils/compatibility-rules";
 import { UserCancelledError } from "../utils/errors";
-import { isCancel, navigableSelect } from "./navigable";
+import { isCancel, navigableSelect, preferValidInitial } from "./navigable";
 
 export async function getApiChoice(
   Api?: API | undefined,
@@ -46,7 +46,7 @@ export async function getApiChoice(
   const apiType = await navigableSelect<API>({
     message: "Select API type",
     options: apiOptions,
-    initialValue: previousValue ?? apiOptions[0].value,
+    initialValue: preferValidInitial(apiOptions, previousValue, apiOptions[0].value),
   });
 
   if (isCancel(apiType)) throw new UserCancelledError({ message: "Operation cancelled" });

--- a/apps/cli/src/prompts/api.ts
+++ b/apps/cli/src/prompts/api.ts
@@ -10,6 +10,7 @@ export async function getApiChoice(
   Api?: API | undefined,
   frontend?: Frontend[],
   backend?: Backend,
+  previousValue?: API,
 ) {
   if (backend === "convex" || backend === "none") {
     return "none";
@@ -45,7 +46,7 @@ export async function getApiChoice(
   const apiType = await navigableSelect<API>({
     message: "Select API type",
     options: apiOptions,
-    initialValue: apiOptions[0].value,
+    initialValue: previousValue ?? apiOptions[0].value,
   });
 
   if (isCancel(apiType)) throw new UserCancelledError({ message: "Operation cancelled" });

--- a/apps/cli/src/prompts/auth.ts
+++ b/apps/cli/src/prompts/auth.ts
@@ -2,7 +2,7 @@ import { DEFAULT_CONFIG } from "../constants";
 import type { Auth, Backend, Frontend } from "../types";
 import { supportsConvexBetterAuth } from "../utils/compatibility-rules";
 import { UserCancelledError } from "../utils/errors";
-import { isCancel, navigableSelect } from "./navigable";
+import { isCancel, navigableSelect, preferValidInitial } from "./navigable";
 
 export function getAvailableAuthProviders(
   backend?: Backend,
@@ -80,11 +80,11 @@ export async function getAuthChoice(
   const response = await navigableSelect({
     message: "Select authentication provider",
     options,
-    initialValue:
-      previousValue ??
-      (options.some((option) => option.value === DEFAULT_CONFIG.auth)
-        ? DEFAULT_CONFIG.auth
-        : "none"),
+    initialValue: preferValidInitial(
+      options,
+      previousValue,
+      options.some((option) => option.value === DEFAULT_CONFIG.auth) ? DEFAULT_CONFIG.auth : "none",
+    ),
   });
 
   if (isCancel(response)) throw new UserCancelledError({ message: "Operation cancelled" });

--- a/apps/cli/src/prompts/auth.ts
+++ b/apps/cli/src/prompts/auth.ts
@@ -49,6 +49,7 @@ export async function getAuthChoice(
   auth: Auth | undefined,
   backend?: Backend,
   frontend: readonly Frontend[] = [],
+  previousValue?: Auth,
 ) {
   if (auth !== undefined) return auth;
   const availableProviders = getAvailableAuthProviders(backend, frontend);
@@ -79,9 +80,11 @@ export async function getAuthChoice(
   const response = await navigableSelect({
     message: "Select authentication provider",
     options,
-    initialValue: options.some((option) => option.value === DEFAULT_CONFIG.auth)
-      ? DEFAULT_CONFIG.auth
-      : "none",
+    initialValue:
+      previousValue ??
+      (options.some((option) => option.value === DEFAULT_CONFIG.auth)
+        ? DEFAULT_CONFIG.auth
+        : "none"),
   });
 
   if (isCancel(response)) throw new UserCancelledError({ message: "Operation cancelled" });

--- a/apps/cli/src/prompts/backend.ts
+++ b/apps/cli/src/prompts/backend.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_CONFIG } from "../constants";
 import type { Backend, Frontend } from "../types";
 import { UserCancelledError } from "../utils/errors";
-import { isCancel, navigableSelect } from "./navigable";
+import { isCancel, navigableSelect, preferValidInitial } from "./navigable";
 
 // Frontends that support backend="self" (fullstack mode with built-in server routes)
 const FULLSTACK_FRONTENDS: readonly Frontend[] = [
@@ -76,7 +76,11 @@ export async function getBackendFrameworkChoice(
   const response = await navigableSelect<Backend>({
     message: "Select backend",
     options: backendOptions,
-    initialValue: previousValue ?? (hasFullstackFrontend ? "self" : DEFAULT_CONFIG.backend),
+    initialValue: preferValidInitial(
+      backendOptions,
+      previousValue,
+      hasFullstackFrontend ? "self" : DEFAULT_CONFIG.backend,
+    ),
   });
 
   if (isCancel(response)) throw new UserCancelledError({ message: "Operation cancelled" });

--- a/apps/cli/src/prompts/backend.ts
+++ b/apps/cli/src/prompts/backend.ts
@@ -15,6 +15,7 @@ const FULLSTACK_FRONTENDS: readonly Frontend[] = [
 export async function getBackendFrameworkChoice(
   backendFramework?: Backend,
   frontends?: Frontend[],
+  previousValue?: Backend,
 ) {
   if (backendFramework !== undefined) return backendFramework;
 
@@ -75,7 +76,7 @@ export async function getBackendFrameworkChoice(
   const response = await navigableSelect<Backend>({
     message: "Select backend",
     options: backendOptions,
-    initialValue: hasFullstackFrontend ? "self" : DEFAULT_CONFIG.backend,
+    initialValue: previousValue ?? (hasFullstackFrontend ? "self" : DEFAULT_CONFIG.backend),
   });
 
   if (isCancel(response)) throw new UserCancelledError({ message: "Operation cancelled" });

--- a/apps/cli/src/prompts/config-prompts.ts
+++ b/apps/cli/src/prompts/config-prompts.ts
@@ -89,66 +89,83 @@ export async function gatherConfig(
 
   const result = await navigableGroup<PromptGroupResults>(
     {
-      frontend: () => getFrontendChoice(flags.frontend, flags.backend, flags.auth),
-      backend: ({ results }) => getBackendFrameworkChoice(flags.backend, results.frontend),
-      runtime: ({ results }) => getRuntimeChoice(flags.runtime, results.backend),
-      database: ({ results }) =>
-        getDatabaseChoice(flags.database, results.backend, results.runtime),
-      orm: ({ results }) =>
+      frontend: ({ previousAnswer }) =>
+        getFrontendChoice(flags.frontend, flags.backend, flags.auth, previousAnswer),
+      backend: ({ results, previousAnswer }) =>
+        getBackendFrameworkChoice(flags.backend, results.frontend, previousAnswer),
+      runtime: ({ results, previousAnswer }) =>
+        getRuntimeChoice(flags.runtime, results.backend, previousAnswer),
+      database: ({ results, previousAnswer }) =>
+        getDatabaseChoice(flags.database, results.backend, results.runtime, previousAnswer),
+      orm: ({ results, previousAnswer }) =>
         getORMChoice(
           flags.orm,
           results.database !== "none",
           results.database,
           results.backend,
           results.runtime,
+          previousAnswer,
         ),
-      api: ({ results }) =>
-        getApiChoice(flags.api, results.frontend, results.backend) as Promise<API>,
-      auth: ({ results }) => getAuthChoice(flags.auth, results.backend, results.frontend),
-      payments: ({ results }) =>
-        getPaymentsChoice(flags.payments, results.auth, results.backend, results.frontend),
-      addons: ({ results }) =>
+      api: ({ results, previousAnswer }) =>
+        getApiChoice(flags.api, results.frontend, results.backend, previousAnswer) as Promise<API>,
+      auth: ({ results, previousAnswer }) =>
+        getAuthChoice(flags.auth, results.backend, results.frontend, previousAnswer),
+      payments: ({ results, previousAnswer }) =>
+        getPaymentsChoice(
+          flags.payments,
+          results.auth,
+          results.backend,
+          results.frontend,
+          previousAnswer,
+        ),
+      addons: ({ results, previousAnswer }) =>
         getAddonsChoice(
           flags.addons,
           results.frontend,
           results.auth,
           results.backend,
           results.runtime,
+          previousAnswer,
         ),
-      examples: ({ results }) =>
+      examples: ({ results, previousAnswer }) =>
         getExamplesChoice(
           flags.examples,
           results.database,
           results.frontend,
           results.backend,
           results.api,
+          previousAnswer,
         ) as Promise<Examples[]>,
-      dbSetup: ({ results }) =>
+      dbSetup: ({ results, previousAnswer }) =>
         getDBSetupChoice(
           results.database ?? "none",
           flags.dbSetup,
           results.orm,
           results.backend,
           results.runtime,
+          previousAnswer,
         ),
-      webDeploy: ({ results }) =>
+      webDeploy: ({ results, previousAnswer }) =>
         getDeploymentChoice(
           flags.webDeploy,
           results.runtime,
           results.backend,
           results.frontend,
           results.dbSetup,
+          previousAnswer,
         ),
-      serverDeploy: ({ results }) =>
+      serverDeploy: ({ results, previousAnswer }) =>
         getServerDeploymentChoice(
           flags.serverDeploy,
           results.runtime,
           results.backend,
           results.webDeploy,
+          previousAnswer,
         ),
-      git: () => getGitChoice(flags.git),
-      packageManager: () => getPackageManagerChoice(flags.packageManager),
-      install: () => getinstallChoice(flags.install),
+      git: ({ previousAnswer }) => getGitChoice(flags.git, previousAnswer),
+      packageManager: ({ previousAnswer }) =>
+        getPackageManagerChoice(flags.packageManager, previousAnswer),
+      install: ({ previousAnswer }) => getinstallChoice(flags.install, previousAnswer),
     },
     {
       onCancel: () => {

--- a/apps/cli/src/prompts/database-setup.ts
+++ b/apps/cli/src/prompts/database-setup.ts
@@ -1,6 +1,6 @@
 import type { Backend, DatabaseSetup, ORM, Runtime } from "../types";
 import { UserCancelledError } from "../utils/errors";
-import { isCancel, navigableSelect } from "./navigable";
+import { isCancel, navigableSelect, preferValidInitial } from "./navigable";
 
 export async function getDBSetupChoice(
   databaseType: string,
@@ -104,7 +104,7 @@ export async function getDBSetupChoice(
   const response = await navigableSelect<DatabaseSetup>({
     message: `Select ${databaseType} setup option`,
     options,
-    initialValue: previousValue ?? "none",
+    initialValue: preferValidInitial(options, previousValue, "none"),
   });
 
   if (isCancel(response)) throw new UserCancelledError({ message: "Operation cancelled" });

--- a/apps/cli/src/prompts/database-setup.ts
+++ b/apps/cli/src/prompts/database-setup.ts
@@ -8,6 +8,7 @@ export async function getDBSetupChoice(
   _orm?: ORM,
   backend?: Backend,
   runtime?: Runtime,
+  previousValue?: DatabaseSetup,
 ) {
   if (backend === "convex") {
     return "none";
@@ -103,7 +104,7 @@ export async function getDBSetupChoice(
   const response = await navigableSelect<DatabaseSetup>({
     message: `Select ${databaseType} setup option`,
     options,
-    initialValue: "none",
+    initialValue: previousValue ?? "none",
   });
 
   if (isCancel(response)) throw new UserCancelledError({ message: "Operation cancelled" });

--- a/apps/cli/src/prompts/database.ts
+++ b/apps/cli/src/prompts/database.ts
@@ -3,7 +3,12 @@ import type { Backend, Database, Runtime } from "../types";
 import { UserCancelledError } from "../utils/errors";
 import { isCancel, navigableSelect } from "./navigable";
 
-export async function getDatabaseChoice(database?: Database, backend?: Backend, runtime?: Runtime) {
+export async function getDatabaseChoice(
+  database?: Database,
+  backend?: Backend,
+  runtime?: Runtime,
+  previousValue?: Database,
+) {
   if (backend === "convex" || backend === "none") {
     return "none";
   }
@@ -48,7 +53,7 @@ export async function getDatabaseChoice(database?: Database, backend?: Backend, 
   const response = await navigableSelect<Database>({
     message: "Select database",
     options: databaseOptions,
-    initialValue: DEFAULT_CONFIG.database,
+    initialValue: previousValue ?? DEFAULT_CONFIG.database,
   });
 
   if (isCancel(response)) throw new UserCancelledError({ message: "Operation cancelled" });

--- a/apps/cli/src/prompts/database.ts
+++ b/apps/cli/src/prompts/database.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_CONFIG } from "../constants";
 import type { Backend, Database, Runtime } from "../types";
 import { UserCancelledError } from "../utils/errors";
-import { isCancel, navigableSelect } from "./navigable";
+import { isCancel, navigableSelect, preferValidInitial } from "./navigable";
 
 export async function getDatabaseChoice(
   database?: Database,
@@ -53,7 +53,7 @@ export async function getDatabaseChoice(
   const response = await navigableSelect<Database>({
     message: "Select database",
     options: databaseOptions,
-    initialValue: previousValue ?? DEFAULT_CONFIG.database,
+    initialValue: preferValidInitial(databaseOptions, previousValue, DEFAULT_CONFIG.database),
   });
 
   if (isCancel(response)) throw new UserCancelledError({ message: "Operation cancelled" });

--- a/apps/cli/src/prompts/examples.ts
+++ b/apps/cli/src/prompts/examples.ts
@@ -10,6 +10,7 @@ export async function getExamplesChoice(
   frontends?: Frontend[],
   backend?: Backend,
   api?: API,
+  previousValue?: Examples[],
 ) {
   if (examples !== undefined) return examples;
 
@@ -42,7 +43,9 @@ export async function getExamplesChoice(
     message: "Include examples",
     options: options,
     required: false,
-    initialValues: DEFAULT_CONFIG.examples?.filter((ex) => options.some((o) => o.value === ex)),
+    initialValues: (previousValue ?? DEFAULT_CONFIG.examples)?.filter((ex) =>
+      options.some((o) => o.value === ex),
+    ),
   });
 
   if (isCancel(response)) throw new UserCancelledError({ message: "Operation cancelled" });

--- a/apps/cli/src/prompts/frontend.ts
+++ b/apps/cli/src/prompts/frontend.ts
@@ -12,12 +12,27 @@ import {
   setIsFirstPrompt,
 } from "./navigable";
 
+const WEB_FRONTEND_VALUES: readonly Frontend[] = [
+  "tanstack-router",
+  "react-router",
+  "next",
+  "nuxt",
+  "svelte",
+  "solid",
+  "astro",
+  "tanstack-start",
+];
+
 export async function getFrontendChoice(
   frontendOptions?: Frontend[],
   backend?: Backend,
   auth?: string,
+  previousValue?: Frontend[],
 ): Promise<Frontend[] | symbol> {
   if (frontendOptions !== undefined) return frontendOptions;
+
+  const previousWeb = previousValue?.find((f) => WEB_FRONTEND_VALUES.includes(f));
+  const previousNative = previousValue?.find((f) => f.startsWith("native-"));
 
   while (true) {
     const wasFirstPrompt = isFirstPrompt();
@@ -37,7 +52,9 @@ export async function getFrontendChoice(
         },
       ],
       required: false,
-      initialValues: ["web"],
+      initialValues: previousValue
+        ? [...(previousWeb ? ["web"] : []), ...(previousNative ? ["native"] : [])]
+        : ["web"],
     });
 
     if (isGoBack(frontendTypes)) return GO_BACK_SYMBOL;
@@ -99,7 +116,7 @@ export async function getFrontendChoice(
       const webFramework = await navigableSelect<Frontend>({
         message: "Choose web",
         options: webOptions,
-        initialValue: DEFAULT_CONFIG.frontend[0],
+        initialValue: previousWeb ?? DEFAULT_CONFIG.frontend[0],
       });
 
       if (isGoBack(webFramework)) {
@@ -136,7 +153,7 @@ export async function getFrontendChoice(
             hint: "Consistent styling for React Native",
           },
         ],
-        initialValue: "native-bare",
+        initialValue: previousNative ?? "native-bare",
       });
 
       if (isGoBack(nativeFramework)) {

--- a/apps/cli/src/prompts/frontend.ts
+++ b/apps/cli/src/prompts/frontend.ts
@@ -9,6 +9,7 @@ import {
   isGoBack,
   navigableMultiselect,
   navigableSelect,
+  preferValidInitial,
   setIsFirstPrompt,
 } from "./navigable";
 
@@ -116,7 +117,7 @@ export async function getFrontendChoice(
       const webFramework = await navigableSelect<Frontend>({
         message: "Choose web",
         options: webOptions,
-        initialValue: previousWeb ?? DEFAULT_CONFIG.frontend[0],
+        initialValue: preferValidInitial(webOptions, previousWeb, DEFAULT_CONFIG.frontend[0]),
       });
 
       if (isGoBack(webFramework)) {

--- a/apps/cli/src/prompts/git.ts
+++ b/apps/cli/src/prompts/git.ts
@@ -2,12 +2,12 @@ import { DEFAULT_CONFIG } from "../constants";
 import { UserCancelledError } from "../utils/errors";
 import { isCancel, navigableConfirm } from "./navigable";
 
-export async function getGitChoice(git?: boolean) {
+export async function getGitChoice(git?: boolean, previousValue?: boolean) {
   if (git !== undefined) return git;
 
   const response = await navigableConfirm({
     message: "Initialize git repository?",
-    initialValue: DEFAULT_CONFIG.git,
+    initialValue: previousValue ?? DEFAULT_CONFIG.git,
   });
 
   if (isCancel(response)) throw new UserCancelledError({ message: "Operation cancelled" });

--- a/apps/cli/src/prompts/install.ts
+++ b/apps/cli/src/prompts/install.ts
@@ -2,12 +2,12 @@ import { DEFAULT_CONFIG } from "../constants";
 import { UserCancelledError } from "../utils/errors";
 import { isCancel, navigableConfirm } from "./navigable";
 
-export async function getinstallChoice(install?: boolean) {
+export async function getinstallChoice(install?: boolean, previousValue?: boolean) {
   if (install !== undefined) return install;
 
   const response = await navigableConfirm({
     message: "Install dependencies?",
-    initialValue: DEFAULT_CONFIG.install,
+    initialValue: previousValue ?? DEFAULT_CONFIG.install,
   });
 
   if (isCancel(response)) throw new UserCancelledError({ message: "Operation cancelled" });

--- a/apps/cli/src/prompts/navigable-group.ts
+++ b/apps/cli/src/prompts/navigable-group.ts
@@ -25,21 +25,33 @@ export interface NavigablePromptGroupOptions<T> {
 export type NavigablePromptGroup<T> = {
   [P in keyof T]: (opts: {
     results: Prettify<Partial<PromptGroupAwaitedReturn<Omit<T, P>>>>;
+    /** The answer this prompt previously returned, when the user navigated back over it. */
+    previousAnswer?: Exclude<Awaited<T[P]>, symbol>;
   }) => undefined | Promise<T[P] | symbol | undefined>;
 };
 
 /**
  * Define a group of prompts that supports going back to previous prompts.
  * Returns a result object with all the values, or handles cancel/go-back navigation.
+ * When navigating back, the discarded answers are replayed to the prompts as
+ * `previousAnswer` so they can preselect what the user chose before.
  */
 export async function navigableGroup<T>(
   prompts: NavigablePromptGroup<T>,
   opts?: NavigablePromptGroupOptions<T>,
 ): Promise<Prettify<PromptGroupAwaitedReturn<T>>> {
   const results = {} as any;
+  const previousAnswers = {} as any;
   const promptNames = Object.keys(prompts) as (keyof T)[];
   let currentIndex = 0;
   let goingBack = false;
+
+  const stepBack = () => {
+    const prevName = promptNames[currentIndex - 1];
+    previousAnswers[prevName] = results[prevName];
+    delete results[prevName];
+    currentIndex--;
+  };
 
   while (currentIndex < promptNames.length) {
     const name = promptNames[currentIndex];
@@ -49,16 +61,14 @@ export async function navigableGroup<T>(
 
     setLastPromptShownUI(false);
 
-    const result = await prompt({ results })?.catch((e) => {
+    const result = await prompt({ results, previousAnswer: previousAnswers[name] })?.catch((e) => {
       throw e;
     });
 
     if (isGoBack(result)) {
       goingBack = true;
       if (currentIndex > 0) {
-        const prevName = promptNames[currentIndex - 1];
-        delete results[prevName];
-        currentIndex--;
+        stepBack();
         continue;
       }
       goingBack = false;
@@ -76,9 +86,7 @@ export async function navigableGroup<T>(
 
     if (goingBack && !didLastPromptShowUI()) {
       if (currentIndex > 0) {
-        const prevName = promptNames[currentIndex - 1];
-        delete results[prevName];
-        currentIndex--;
+        stepBack();
         continue;
       }
     }

--- a/apps/cli/src/prompts/navigable.ts
+++ b/apps/cli/src/prompts/navigable.ts
@@ -9,7 +9,6 @@ import {
   GroupMultiSelectPrompt,
   MultiSelectPrompt,
   SelectPrompt,
-  TextPrompt,
   isCancel,
 } from "@clack/core";
 import pc from "picocolors";
@@ -87,7 +86,7 @@ async function runWithNavigation<T>(prompt: any): Promise<T | symbol> {
   let goBack = false;
 
   prompt.on("key", (char: string | undefined) => {
-    if (char === "b" && !ctxIsFirstPrompt()) {
+    if ((char === "b" || char === "B") && !ctxIsFirstPrompt()) {
       goBack = true;
       prompt.state = "cancel";
     }
@@ -316,54 +315,6 @@ export async function navigableConfirm(opts: NavigableConfirmOptions): Promise<b
   });
 
   return runWithNavigation(prompt) as Promise<boolean | symbol>;
-}
-
-export interface NavigableTextOptions {
-  message: string;
-  placeholder?: string;
-  defaultValue?: string;
-  initialValue?: string;
-  validate?: (value: string | undefined) => string | Error | undefined;
-}
-
-export async function navigableText(opts: NavigableTextOptions): Promise<string | symbol> {
-  const prompt = new TextPrompt({
-    validate: opts.validate,
-    placeholder: opts.placeholder,
-    defaultValue: opts.defaultValue,
-    initialValue: opts.initialValue,
-    render() {
-      const title = `${pc.gray(S_BAR)}\n${symbol(this.state)}  ${opts.message}\n`;
-      const placeholder = opts.placeholder
-        ? pc.inverse(opts.placeholder[0]) + pc.dim(opts.placeholder.slice(1))
-        : pc.inverse(pc.hidden("_"));
-      // biome-ignore lint/suspicious/noExplicitAny: TextPrompt has userInput but types don't expose it
-      const self = this as any;
-      const userInput = !self.userInput ? placeholder : self.userInputWithCursor;
-      const value = this.value ?? "";
-
-      switch (this.state) {
-        case "error": {
-          const errorText = this.error ? `  ${pc.yellow(this.error)}` : "";
-          return `${title.trim()}\n${pc.yellow(S_BAR)}  ${userInput}\n${pc.yellow(S_BAR_END)}${errorText}\n`;
-        }
-        case "submit": {
-          const valueText = value ? `  ${pc.dim(value)}` : "";
-          return `${title}${pc.gray(S_BAR)}${valueText}`;
-        }
-        case "cancel": {
-          const valueText = value ? `  ${pc.strikethrough(pc.dim(value))}` : "";
-          return `${title}${pc.gray(S_BAR)}${valueText}${value.trim() ? `\n${pc.gray(S_BAR)}` : ""}`;
-        }
-        default: {
-          const hint = `\n${pc.gray(S_BAR)}  ${getHint()}`;
-          return `${title}${pc.cyan(S_BAR)}  ${userInput}\n${pc.cyan(S_BAR_END)}${hint}\n`;
-        }
-      }
-    },
-  });
-
-  return runWithNavigation(prompt) as Promise<string | symbol>;
 }
 
 export interface GroupMultiSelectOption<T> {

--- a/apps/cli/src/prompts/navigable.ts
+++ b/apps/cli/src/prompts/navigable.ts
@@ -482,5 +482,14 @@ export async function navigableGroupMultiselect<T>(
   return runWithNavigation(prompt) as Promise<T[] | symbol>;
 }
 
+/** Use the remembered answer as the initial value only while it is still selectable. */
+export function preferValidInitial<T>(
+  options: ReadonlyArray<{ value: T }>,
+  previous: T | undefined,
+  fallback: T,
+): T {
+  return previous !== undefined && options.some((o) => o.value === previous) ? previous : fallback;
+}
+
 export { isCancel };
 export { isGoBack, GO_BACK_SYMBOL } from "../utils/navigation";

--- a/apps/cli/src/prompts/orm.ts
+++ b/apps/cli/src/prompts/orm.ts
@@ -2,7 +2,7 @@ import { DEFAULT_CONFIG } from "../constants";
 import type { Backend, Database, ORM, Runtime } from "../types";
 import { validateOrmDatabaseCompat } from "../utils/config-validation";
 import { UserCancelledError } from "../utils/errors";
-import { isCancel, navigableSelect } from "./navigable";
+import { isCancel, navigableSelect, preferValidInitial } from "./navigable";
 
 const ormOptions = {
   prisma: {
@@ -49,9 +49,11 @@ export async function getORMChoice(
   const response = await navigableSelect<ORM>({
     message: "Select ORM",
     options,
-    initialValue:
-      previousValue ??
-      (database === "mongodb" ? "prisma" : runtime === "workers" ? "drizzle" : DEFAULT_CONFIG.orm),
+    initialValue: preferValidInitial(
+      options,
+      previousValue,
+      database === "mongodb" ? "prisma" : runtime === "workers" ? "drizzle" : DEFAULT_CONFIG.orm,
+    ),
   });
 
   if (isCancel(response)) throw new UserCancelledError({ message: "Operation cancelled" });

--- a/apps/cli/src/prompts/orm.ts
+++ b/apps/cli/src/prompts/orm.ts
@@ -28,6 +28,7 @@ export async function getORMChoice(
   database?: Database,
   backend?: Backend,
   runtime?: Runtime,
+  previousValue?: ORM,
 ) {
   if (backend === "convex") {
     return "none";
@@ -49,7 +50,8 @@ export async function getORMChoice(
     message: "Select ORM",
     options,
     initialValue:
-      database === "mongodb" ? "prisma" : runtime === "workers" ? "drizzle" : DEFAULT_CONFIG.orm,
+      previousValue ??
+      (database === "mongodb" ? "prisma" : runtime === "workers" ? "drizzle" : DEFAULT_CONFIG.orm),
   });
 
   if (isCancel(response)) throw new UserCancelledError({ message: "Operation cancelled" });

--- a/apps/cli/src/prompts/package-manager.ts
+++ b/apps/cli/src/prompts/package-manager.ts
@@ -3,7 +3,10 @@ import { UserCancelledError } from "../utils/errors";
 import { getUserPkgManager } from "../utils/get-package-manager";
 import { isCancel, navigableSelect } from "./navigable";
 
-export async function getPackageManagerChoice(packageManager?: PackageManager) {
+export async function getPackageManagerChoice(
+  packageManager?: PackageManager,
+  previousValue?: PackageManager,
+) {
   if (packageManager !== undefined) return packageManager;
 
   const detectedPackageManager = getUserPkgManager();
@@ -23,7 +26,7 @@ export async function getPackageManagerChoice(packageManager?: PackageManager) {
         hint: "All-in-one JavaScript runtime & toolkit",
       },
     ],
-    initialValue: detectedPackageManager,
+    initialValue: previousValue ?? detectedPackageManager,
   });
 
   if (isCancel(response)) throw new UserCancelledError({ message: "Operation cancelled" });

--- a/apps/cli/src/prompts/payments.ts
+++ b/apps/cli/src/prompts/payments.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_CONFIG } from "../constants";
 import type { Auth, Backend, Frontend, Payments } from "../types";
 import { UserCancelledError } from "../utils/errors";
-import { isCancel, navigableSelect } from "./navigable";
+import { isCancel, navigableSelect, preferValidInitial } from "./navigable";
 
 export async function getPaymentsChoice(
   payments?: Payments,
@@ -38,7 +38,7 @@ export async function getPaymentsChoice(
   const response = await navigableSelect<Payments>({
     message: "Select payments provider",
     options,
-    initialValue: previousValue ?? DEFAULT_CONFIG.payments,
+    initialValue: preferValidInitial(options, previousValue, DEFAULT_CONFIG.payments),
   });
 
   if (isCancel(response)) throw new UserCancelledError({ message: "Operation cancelled" });

--- a/apps/cli/src/prompts/payments.ts
+++ b/apps/cli/src/prompts/payments.ts
@@ -8,6 +8,7 @@ export async function getPaymentsChoice(
   auth?: Auth,
   backend?: Backend,
   _frontends?: Frontend[],
+  previousValue?: Payments,
 ) {
   if (payments !== undefined) return payments;
 
@@ -37,7 +38,7 @@ export async function getPaymentsChoice(
   const response = await navigableSelect<Payments>({
     message: "Select payments provider",
     options,
-    initialValue: DEFAULT_CONFIG.payments,
+    initialValue: previousValue ?? DEFAULT_CONFIG.payments,
   });
 
   if (isCancel(response)) throw new UserCancelledError({ message: "Operation cancelled" });

--- a/apps/cli/src/prompts/runtime.ts
+++ b/apps/cli/src/prompts/runtime.ts
@@ -3,7 +3,11 @@ import type { Backend, Runtime } from "../types";
 import { UserCancelledError } from "../utils/errors";
 import { isCancel, navigableSelect } from "./navigable";
 
-export async function getRuntimeChoice(runtime?: Runtime, backend?: Backend) {
+export async function getRuntimeChoice(
+  runtime?: Runtime,
+  backend?: Backend,
+  previousValue?: Runtime,
+) {
   if (backend === "convex" || backend === "none" || backend === "self") {
     return "none";
   }
@@ -38,7 +42,7 @@ export async function getRuntimeChoice(runtime?: Runtime, backend?: Backend) {
   const response = await navigableSelect<Runtime>({
     message: "Select runtime",
     options: runtimeOptions,
-    initialValue: DEFAULT_CONFIG.runtime,
+    initialValue: previousValue ?? DEFAULT_CONFIG.runtime,
   });
 
   if (isCancel(response)) throw new UserCancelledError({ message: "Operation cancelled" });

--- a/apps/cli/src/prompts/runtime.ts
+++ b/apps/cli/src/prompts/runtime.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_CONFIG } from "../constants";
 import type { Backend, Runtime } from "../types";
 import { UserCancelledError } from "../utils/errors";
-import { isCancel, navigableSelect } from "./navigable";
+import { isCancel, navigableSelect, preferValidInitial } from "./navigable";
 
 export async function getRuntimeChoice(
   runtime?: Runtime,
@@ -42,7 +42,7 @@ export async function getRuntimeChoice(
   const response = await navigableSelect<Runtime>({
     message: "Select runtime",
     options: runtimeOptions,
-    initialValue: previousValue ?? DEFAULT_CONFIG.runtime,
+    initialValue: preferValidInitial(runtimeOptions, previousValue, DEFAULT_CONFIG.runtime),
   });
 
   if (isCancel(response)) throw new UserCancelledError({ message: "Operation cancelled" });

--- a/apps/cli/src/prompts/server-deploy.ts
+++ b/apps/cli/src/prompts/server-deploy.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_CONFIG } from "../constants";
 import type { Backend, Runtime, ServerDeploy, WebDeploy } from "../types";
 import { UserCancelledError } from "../utils/errors";
-import { isCancel, navigableSelect } from "./navigable";
+import { isCancel, navigableSelect, preferValidInitial } from "./navigable";
 
 const SERVER_APP_BACKENDS: Backend[] = ["hono", "express", "fastify", "elysia"];
 
@@ -66,7 +66,7 @@ export async function getServerDeploymentChoice(
   const response = await navigableSelect<ServerDeploy>({
     message: "Select server deployment",
     options,
-    initialValue: previousValue ?? DEFAULT_CONFIG.serverDeploy,
+    initialValue: preferValidInitial(options, previousValue, DEFAULT_CONFIG.serverDeploy),
   });
 
   if (isCancel(response)) throw new UserCancelledError({ message: "Operation cancelled" });

--- a/apps/cli/src/prompts/server-deploy.ts
+++ b/apps/cli/src/prompts/server-deploy.ts
@@ -3,6 +3,8 @@ import type { Backend, Runtime, ServerDeploy, WebDeploy } from "../types";
 import { UserCancelledError } from "../utils/errors";
 import { isCancel, navigableSelect } from "./navigable";
 
+const SERVER_APP_BACKENDS: Backend[] = ["hono", "express", "fastify", "elysia"];
+
 type DeploymentOption = {
   value: ServerDeploy;
   label: string;
@@ -19,6 +21,12 @@ function getDeploymentDisplay(deployment: ServerDeploy): {
       hint: "Deploy to Cloudflare Workers using Alchemy",
     };
   }
+  if (deployment === "docker") {
+    return {
+      label: "Docker",
+      hint: "Self-host with a Dockerfile and docker-compose.yml",
+    };
+  }
   return {
     label: deployment,
     hint: `Add ${deployment} deployment`,
@@ -30,14 +38,11 @@ export async function getServerDeploymentChoice(
   runtime?: Runtime,
   backend?: Backend,
   _webDeploy?: WebDeploy,
+  previousValue?: ServerDeploy,
 ) {
   if (deployment !== undefined) return deployment;
 
-  if (backend === "none" || backend === "convex") {
-    return "none";
-  }
-
-  if (backend !== "hono") {
+  if (!backend || !SERVER_APP_BACKENDS.includes(backend)) {
     return "none";
   }
 
@@ -46,7 +51,27 @@ export async function getServerDeploymentChoice(
     return "cloudflare";
   }
 
-  return "none";
+  if (runtime !== "bun" && runtime !== "node") {
+    return "none";
+  }
+
+  const options: DeploymentOption[] = (["docker", "none"] as const).map((deploy) => {
+    const { label, hint } =
+      deploy === "none"
+        ? { label: "None", hint: "Skip deployment setup" }
+        : getDeploymentDisplay(deploy);
+    return { value: deploy, label, hint };
+  });
+
+  const response = await navigableSelect<ServerDeploy>({
+    message: "Select server deployment",
+    options,
+    initialValue: previousValue ?? DEFAULT_CONFIG.serverDeploy,
+  });
+
+  if (isCancel(response)) throw new UserCancelledError({ message: "Operation cancelled" });
+
+  return response;
 }
 
 export async function getServerDeploymentToAdd(
@@ -54,25 +79,33 @@ export async function getServerDeploymentToAdd(
   existingDeployment?: ServerDeploy,
   backend?: Backend,
 ) {
-  if (backend !== "hono") {
+  if (!backend || !SERVER_APP_BACKENDS.includes(backend)) {
+    return "none";
+  }
+
+  // A project can only have one server deployment target; nothing to add.
+  if (existingDeployment && existingDeployment !== "none") {
     return "none";
   }
 
   const options: DeploymentOption[] = [];
 
   if (runtime === "workers") {
-    if (existingDeployment !== "cloudflare") {
-      const { label, hint } = getDeploymentDisplay("cloudflare");
-      options.push({
-        value: "cloudflare",
-        label,
-        hint,
-      });
-    }
+    const { label, hint } = getDeploymentDisplay("cloudflare");
+    options.push({
+      value: "cloudflare",
+      label,
+      hint,
+    });
   }
 
-  if (existingDeployment && existingDeployment !== "none") {
-    return "none";
+  if (runtime === "bun" || runtime === "node") {
+    const { label, hint } = getDeploymentDisplay("docker");
+    options.push({
+      value: "docker",
+      label,
+      hint,
+    });
   }
 
   if (options.length === 0) {

--- a/apps/cli/src/prompts/web-deploy.ts
+++ b/apps/cli/src/prompts/web-deploy.ts
@@ -24,6 +24,12 @@ function getDeploymentDisplay(deployment: WebDeploy): {
       hint: "Deploy to Cloudflare Workers using Alchemy",
     };
   }
+  if (deployment === "docker") {
+    return {
+      label: "Docker",
+      hint: "Self-host with a Dockerfile and docker-compose.yml",
+    };
+  }
   return {
     label: deployment,
     hint: `Add ${deployment} deployment`,
@@ -36,6 +42,7 @@ export async function getDeploymentChoice(
   backend?: Backend,
   frontend: Frontend[] = [],
   dbSetup?: DatabaseSetup,
+  previousValue?: WebDeploy,
 ) {
   if (deployment !== undefined) return deployment;
   if (!hasWebFrontend(frontend)) {
@@ -46,7 +53,7 @@ export async function getDeploymentChoice(
     return "cloudflare";
   }
 
-  const availableDeployments = ["cloudflare", "none"];
+  const availableDeployments = ["cloudflare", "docker", "none"];
 
   const options: DeploymentOption[] = availableDeployments.map((deploy) => {
     const { label, hint } = getDeploymentDisplay(deploy as WebDeploy);
@@ -60,7 +67,7 @@ export async function getDeploymentChoice(
   const response = await navigableSelect<WebDeploy>({
     message: "Select web deployment",
     options,
-    initialValue: DEFAULT_CONFIG.webDeploy,
+    initialValue: previousValue ?? DEFAULT_CONFIG.webDeploy,
   });
 
   if (isCancel(response)) throw new UserCancelledError({ message: "Operation cancelled" });
@@ -73,32 +80,21 @@ export async function getDeploymentToAdd(frontend: Frontend[], existingDeploymen
     return "none";
   }
 
-  const options: DeploymentOption[] = [];
-
-  if (existingDeployment !== "cloudflare") {
-    const { label, hint } = getDeploymentDisplay("cloudflare");
-    options.push({
-      value: "cloudflare",
-      label,
-      hint,
-    });
-  }
-
+  // A project can only have one web deployment target; nothing to add.
   if (existingDeployment && existingDeployment !== "none") {
     return "none";
   }
 
-  if (options.length > 0) {
-    options.push({
-      value: "none",
-      label: "None",
-      hint: "Skip deployment setup",
-    });
-  }
+  const options: DeploymentOption[] = (["cloudflare", "docker"] as const).map((deploy) => {
+    const { label, hint } = getDeploymentDisplay(deploy);
+    return { value: deploy, label, hint };
+  });
 
-  if (options.length === 0) {
-    return "none";
-  }
+  options.push({
+    value: "none",
+    label: "None",
+    hint: "Skip deployment setup",
+  });
 
   const response = await navigableSelect<WebDeploy>({
     message: "Select web deployment",

--- a/apps/cli/src/prompts/web-deploy.ts
+++ b/apps/cli/src/prompts/web-deploy.ts
@@ -2,7 +2,7 @@ import { DEFAULT_CONFIG } from "../constants";
 import type { Backend, DatabaseSetup, Frontend, Runtime, WebDeploy } from "../types";
 import { WEB_FRAMEWORKS } from "../utils/compatibility";
 import { UserCancelledError } from "../utils/errors";
-import { isCancel, navigableSelect } from "./navigable";
+import { isCancel, navigableSelect, preferValidInitial } from "./navigable";
 
 function hasWebFrontend(frontends: Frontend[]) {
   return frontends.some((f) => WEB_FRAMEWORKS.includes(f));
@@ -67,7 +67,7 @@ export async function getDeploymentChoice(
   const response = await navigableSelect<WebDeploy>({
     message: "Select web deployment",
     options,
-    initialValue: previousValue ?? DEFAULT_CONFIG.webDeploy,
+    initialValue: preferValidInitial(options, previousValue, DEFAULT_CONFIG.webDeploy),
   });
 
   if (isCancel(response)) throw new UserCancelledError({ message: "Operation cancelled" });

--- a/apps/cli/src/utils/compatibility-rules.ts
+++ b/apps/cli/src/utils/compatibility-rules.ts
@@ -306,6 +306,28 @@ export function validateServerDeployRequiresBackend(
   return Result.ok(undefined);
 }
 
+export function validateDockerServerDeploy(
+  serverDeploy: ServerDeploy | undefined,
+  backend: Backend | undefined,
+  runtime: Runtime | undefined,
+): ValidationResult {
+  if (serverDeploy !== "docker") return Result.ok(undefined);
+
+  if (backend === "convex" || backend === "self") {
+    return validationErr(
+      "'--server-deploy docker' requires a separate server backend (hono, express, fastify, elysia). For a fullstack 'self' backend, use '--web-deploy docker' instead.",
+    );
+  }
+
+  if (runtime === "workers") {
+    return validationErr(
+      "'--server-deploy docker' is not compatible with '--runtime workers'. Use '--runtime bun' or '--runtime node', or choose '--server-deploy cloudflare'.",
+    );
+  }
+
+  return Result.ok(undefined);
+}
+
 export function validateAddonCompatibility(
   addon: Addons,
   frontend: Frontend[],

--- a/apps/cli/src/utils/config-validation.ts
+++ b/apps/cli/src/utils/config-validation.ts
@@ -12,6 +12,7 @@ import {
   validateExamplesCompatibility,
   validatePaymentsCompatibility,
   validateSelfBackendCompatibility,
+  validateDockerServerDeploy,
   validateServerDeployRequiresBackend,
   validateWebDeployRequiresWebFrontend,
   validateWorkersCompatibility,
@@ -499,6 +500,7 @@ export function validateFullConfig(
     yield* validateApiConstraints(config, options);
 
     yield* validateServerDeployRequiresBackend(config.serverDeploy, config.backend);
+    yield* validateDockerServerDeploy(config.serverDeploy, config.backend, config.runtime);
 
     yield* validateSelfBackendCompatibility(providedFlags, options, config);
     yield* validateWorkersCompatibility(providedFlags, options, config);

--- a/apps/cli/test/deployment.test.ts
+++ b/apps/cli/test/deployment.test.ts
@@ -705,9 +705,14 @@ describe("Deployment Configurations", () => {
       expect(compose).toContain('"3000:3000"');
       expect(compose).toContain("CORS_ORIGIN: http://localhost:3001");
       expect(compose).toContain(
-        "DATABASE_URL: postgresql://postgres:password@postgres:5432/docker-full-stack",
+        // biome-ignore format: compose interpolation syntax
+        "DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD:-password}@postgres:5432/docker-full-stack",
       );
       expect(compose).toContain("condition: service_healthy");
+      // public client values are baked via build args, not .env files in the context
+      expect(compose).toContain("VITE_SERVER_URL: http://localhost:3000");
+      expect(webDockerfile).toContain("ARG VITE_SERVER_URL");
+      expect(files.get(".dockerignore")).toContain("**/.env");
 
       // SPA frontend builds static assets served by nginx with an SPA fallback
       expect(webDockerfile).toContain("FROM nginx:alpine");
@@ -758,7 +763,8 @@ describe("Deployment Configurations", () => {
       expect(compose).toContain('"3001:3001"');
       expect(compose).toContain("BETTER_AUTH_URL: http://localhost:3001");
       expect(compose).toContain(
-        "DATABASE_URL: postgresql://postgres:password@postgres:5432/docker-self-next",
+        // biome-ignore format: compose interpolation syntax
+        "DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD:-password}@postgres:5432/docker-self-next",
       );
       expect(webDockerfile).toContain("npm install -g pnpm");
       // Next.js Docker deploys use standalone output for a minimal runtime image

--- a/apps/cli/test/deployment.test.ts
+++ b/apps/cli/test/deployment.test.ts
@@ -656,4 +656,372 @@ describe("Deployment Configurations", () => {
       expectError(result, "'--web-deploy' requires a web frontend");
     });
   });
+
+  describe("Docker Deployment", () => {
+    it("should generate a full Docker Compose stack (web + server + db)", async () => {
+      const result = await createVirtual({
+        projectName: "docker-full-stack",
+        webDeploy: "docker",
+        serverDeploy: "docker",
+        backend: "hono",
+        runtime: "bun",
+        database: "postgres",
+        orm: "drizzle",
+        auth: "better-auth",
+        payments: "none",
+        api: "trpc",
+        frontend: ["tanstack-router"],
+        addons: ["turborepo"],
+        examples: ["none"],
+        dbSetup: "docker",
+        install: false,
+        git: false,
+        packageManager: "bun",
+      });
+
+      if (result.isErr()) {
+        throw result.error;
+      }
+
+      const files = collectFiles(result.value.root, result.value.root.path);
+      const compose = files.get("docker-compose.yml");
+      const webDockerfile = files.get("apps/web/Dockerfile");
+      const serverDockerfile = files.get("apps/server/Dockerfile");
+      const rootPkg = JSON.parse(files.get("package.json") ?? "{}");
+      const readme = files.get("README.md");
+
+      expect(files.has(".dockerignore")).toBe(true);
+      expect(files.has("apps/web/nginx.conf")).toBe(true);
+
+      // The database service is inlined in the root compose, not a separate file
+      expect(files.has("packages/db/docker-compose.yml")).toBe(false);
+      expect(compose).not.toContain("include:");
+      expect(compose).toContain("container_name: docker-full-stack-postgres");
+      expect(compose).toContain("docker-full-stack_postgres_data:");
+      expect(compose).toContain("init: true");
+      expect(compose).toContain("dockerfile: apps/web/Dockerfile");
+      expect(compose).toContain("dockerfile: apps/server/Dockerfile");
+      expect(compose).toContain('"3001:80"');
+      expect(compose).toContain('"3000:3000"');
+      expect(compose).toContain("CORS_ORIGIN: http://localhost:3001");
+      expect(compose).toContain(
+        "DATABASE_URL: postgresql://postgres:password@postgres:5432/docker-full-stack",
+      );
+      expect(compose).toContain("condition: service_healthy");
+
+      // SPA frontend builds static assets served by nginx with an SPA fallback
+      expect(webDockerfile).toContain("FROM nginx:alpine");
+      expect(files.get("apps/web/nginx.conf")).toContain("try_files $uri $uri/ /index.html");
+
+      expect(serverDockerfile).toContain('CMD ["bun", "dist/index.mjs"]');
+      expect(serverDockerfile).toContain("bun install");
+
+      expect(rootPkg.scripts["docker:up"]).toBe("docker compose up -d --build");
+      expect(rootPkg.scripts["docker:down"]).toBe("docker compose down");
+      // db scripts are scoped to the database service of the root compose
+      expect(rootPkg.scripts["db:start"]).toBe("docker compose up -d postgres");
+      expect(rootPkg.scripts["db:stop"]).toBe("docker compose stop postgres");
+      expect(readme).toContain("### Docker Compose");
+    });
+
+    it("should generate a web-only container for a fullstack self backend", async () => {
+      const result = await createVirtual({
+        projectName: "docker-self-next",
+        webDeploy: "docker",
+        serverDeploy: "none",
+        backend: "self",
+        runtime: "none",
+        database: "postgres",
+        orm: "prisma",
+        auth: "better-auth",
+        payments: "none",
+        api: "trpc",
+        frontend: ["next"],
+        addons: ["turborepo"],
+        examples: ["none"],
+        dbSetup: "docker",
+        install: false,
+        git: false,
+        packageManager: "pnpm",
+      });
+
+      if (result.isErr()) {
+        throw result.error;
+      }
+
+      const files = collectFiles(result.value.root, result.value.root.path);
+      const compose = files.get("docker-compose.yml");
+      const webDockerfile = files.get("apps/web/Dockerfile");
+
+      expect(files.has("apps/server/Dockerfile")).toBe(false);
+      expect(compose).not.toContain("dockerfile: apps/server/Dockerfile");
+      expect(compose).toContain('"3001:3001"');
+      expect(compose).toContain("BETTER_AUTH_URL: http://localhost:3001");
+      expect(compose).toContain(
+        "DATABASE_URL: postgresql://postgres:password@postgres:5432/docker-self-next",
+      );
+      expect(webDockerfile).toContain("npm install -g pnpm");
+      // Next.js Docker deploys use standalone output for a minimal runtime image
+      expect(webDockerfile).toContain(".next/standalone");
+      expect(webDockerfile).toContain('CMD ["node", "apps/web/server.js"]');
+      expect(files.get("apps/web/next.config.ts")).toContain('output: "standalone"');
+    });
+
+    it("should switch Svelte to adapter-node for Docker web deploys", async () => {
+      const result = await createVirtual({
+        projectName: "docker-svelte",
+        webDeploy: "docker",
+        serverDeploy: "none",
+        backend: "none",
+        runtime: "none",
+        database: "none",
+        orm: "none",
+        auth: "none",
+        payments: "none",
+        api: "none",
+        frontend: ["svelte"],
+        addons: ["none"],
+        examples: ["none"],
+        dbSetup: "none",
+        install: false,
+        git: false,
+        packageManager: "npm",
+      });
+
+      if (result.isErr()) {
+        throw result.error;
+      }
+
+      const files = collectFiles(result.value.root, result.value.root.path);
+      const svelteConfig = files.get("apps/web/svelte.config.js");
+      const webPkg = JSON.parse(files.get("apps/web/package.json") ?? "{}");
+      const webDockerfile = files.get("apps/web/Dockerfile");
+
+      expect(svelteConfig).toContain("@sveltejs/adapter-node");
+      expect(svelteConfig).not.toContain("@sveltejs/adapter-auto");
+      expect(webPkg.devDependencies["@sveltejs/adapter-node"]).toBeDefined();
+      expect(webDockerfile).toContain('CMD ["node", "build/index.js"]');
+    });
+
+    it("should add the nitro plugin for TanStack Start Docker web deploys", async () => {
+      const result = await createVirtual({
+        projectName: "docker-tanstack-start",
+        webDeploy: "docker",
+        serverDeploy: "none",
+        backend: "none",
+        runtime: "none",
+        database: "none",
+        orm: "none",
+        auth: "none",
+        payments: "none",
+        api: "none",
+        frontend: ["tanstack-start"],
+        addons: ["none"],
+        examples: ["none"],
+        dbSetup: "none",
+        install: false,
+        git: false,
+        packageManager: "bun",
+      });
+
+      if (result.isErr()) {
+        throw result.error;
+      }
+
+      const files = collectFiles(result.value.root, result.value.root.path);
+      const viteConfig = files.get("apps/web/vite.config.ts");
+      const webPkg = JSON.parse(files.get("apps/web/package.json") ?? "{}");
+      const webDockerfile = files.get("apps/web/Dockerfile");
+
+      expect(viteConfig).toContain('import { nitro } from "nitro/vite"');
+      expect(viteConfig).toContain("nitro(),");
+      expect(webPkg.dependencies.nitro).toBeDefined();
+      // SSR chunks require() externals at runtime, so the app runs from the workspace
+      expect(webDockerfile).toContain("WORKDIR /app/apps/web");
+      expect(webDockerfile).toContain('CMD ["node", ".output/server/index.mjs"]');
+    });
+
+    it("should serve React Router SPA builds with nginx", async () => {
+      const result = await createVirtual({
+        projectName: "docker-react-router",
+        webDeploy: "docker",
+        serverDeploy: "none",
+        backend: "none",
+        runtime: "none",
+        database: "none",
+        orm: "none",
+        auth: "none",
+        payments: "none",
+        api: "none",
+        frontend: ["react-router"],
+        addons: ["none"],
+        examples: ["none"],
+        dbSetup: "none",
+        install: false,
+        git: false,
+        packageManager: "npm",
+      });
+
+      if (result.isErr()) {
+        throw result.error;
+      }
+
+      const files = collectFiles(result.value.root, result.value.root.path);
+      const webDockerfile = files.get("apps/web/Dockerfile");
+      const compose = files.get("docker-compose.yml");
+
+      // react-router scaffolds with ssr: false, so the build is a static SPA
+      expect(webDockerfile).toContain("FROM nginx:alpine");
+      expect(webDockerfile).toContain("/app/apps/web/build/client");
+      expect(files.has("apps/web/nginx.conf")).toBe(true);
+      expect(compose).toContain('"3001:80"');
+    });
+
+    it("should generate a server-only Docker setup with web on another deploy", async () => {
+      const result = await createVirtual({
+        projectName: "docker-server-only",
+        webDeploy: "none",
+        serverDeploy: "docker",
+        backend: "express",
+        runtime: "node",
+        database: "postgres",
+        orm: "drizzle",
+        auth: "none",
+        payments: "none",
+        api: "orpc",
+        frontend: ["nuxt"],
+        addons: ["none"],
+        examples: ["none"],
+        dbSetup: "none",
+        install: false,
+        git: false,
+        packageManager: "npm",
+      });
+
+      if (result.isErr()) {
+        throw result.error;
+      }
+
+      const files = collectFiles(result.value.root, result.value.root.path);
+      const compose = files.get("docker-compose.yml");
+      const serverDockerfile = files.get("apps/server/Dockerfile");
+      const webPkg = JSON.parse(files.get("apps/web/package.json") ?? "{}");
+
+      // Explicit vue 3 pin keeps npm's resolver off the vue 2 optional-peer path
+      expect(webPkg.dependencies.vue).toBeDefined();
+      expect(files.has("apps/web/Dockerfile")).toBe(false);
+      expect(compose).not.toContain("dockerfile: apps/web/Dockerfile");
+      expect(compose).toContain("dockerfile: apps/server/Dockerfile");
+      // External database: connection string comes from apps/server/.env
+      expect(compose).not.toContain("DATABASE_URL:");
+      expect(compose).not.toContain("include:");
+      expect(serverDockerfile).toContain('CMD ["node", "dist/index.mjs"]');
+    });
+
+    it("should keep Solid production builds resolvable without an API layer", async () => {
+      const result = await createVirtual({
+        projectName: "docker-solid-no-api",
+        webDeploy: "docker",
+        serverDeploy: "none",
+        backend: "none",
+        runtime: "none",
+        database: "none",
+        orm: "none",
+        auth: "none",
+        payments: "none",
+        api: "none",
+        frontend: ["solid"],
+        addons: ["none"],
+        examples: ["none"],
+        dbSetup: "none",
+        install: false,
+        git: false,
+        packageManager: "bun",
+      });
+
+      if (result.isErr()) {
+        throw result.error;
+      }
+
+      const files = collectFiles(result.value.root, result.value.root.path);
+      const webPkg = JSON.parse(files.get("apps/web/package.json") ?? "{}");
+
+      // __root.tsx imports the router devtools unconditionally
+      expect(webPkg.devDependencies["@tanstack/solid-router-devtools"]).toBeDefined();
+      expect(files.get("apps/web/Dockerfile")).toContain("FROM nginx:alpine");
+    });
+
+    it("should bind Fastify to all interfaces for Docker deploys", async () => {
+      const result = await createVirtual({
+        projectName: "docker-fastify-host",
+        webDeploy: "none",
+        serverDeploy: "docker",
+        backend: "fastify",
+        runtime: "node",
+        database: "none",
+        orm: "none",
+        auth: "none",
+        payments: "none",
+        api: "orpc",
+        frontend: ["nuxt"],
+        addons: ["none"],
+        examples: ["none"],
+        dbSetup: "none",
+        install: false,
+        git: false,
+        packageManager: "npm",
+      });
+
+      if (result.isErr()) {
+        throw result.error;
+      }
+
+      const files = collectFiles(result.value.root, result.value.root.path);
+      expect(files.get("apps/server/src/index.ts")).toContain(
+        'fastify.listen({ port: 3000, host: "0.0.0.0" }',
+      );
+    });
+
+    it("should fail with docker server deploy + workers runtime", async () => {
+      const result = await runTRPCTest({
+        projectName: "docker-workers-fail",
+        webDeploy: "none",
+        serverDeploy: "docker",
+        backend: "hono",
+        runtime: "workers",
+        database: "sqlite",
+        orm: "drizzle",
+        auth: "none",
+        api: "trpc",
+        frontend: ["tanstack-router"],
+        addons: ["none"],
+        examples: ["none"],
+        dbSetup: "none",
+        expectError: true,
+      });
+
+      expectError(result, "'--server-deploy docker' is not compatible with '--runtime workers'");
+    });
+
+    it("should fail with docker server deploy + self backend", async () => {
+      const result = await runTRPCTest({
+        projectName: "docker-self-server-fail",
+        webDeploy: "none",
+        serverDeploy: "docker",
+        backend: "self",
+        runtime: "none",
+        database: "postgres",
+        orm: "drizzle",
+        auth: "none",
+        api: "trpc",
+        frontend: ["next"],
+        addons: ["none"],
+        examples: ["none"],
+        dbSetup: "none",
+        expectError: true,
+      });
+
+      expectError(result, "'--server-deploy docker' requires a separate server backend");
+    });
+  });
 });

--- a/apps/cli/test/pnpm-workspace.test.ts
+++ b/apps/cli/test/pnpm-workspace.test.ts
@@ -139,6 +139,55 @@ describe("pnpm workspace", () => {
     expect(workspace.allowBuilds).toEqual({ "msgpackr-extract": true });
   });
 
+  it("adds build approvals for Docker deploys so non-interactive installs succeed", async () => {
+    const workspace = await readPnpmWorkspace({
+      projectName: "pnpm-docker-next",
+      frontend: ["next"],
+      backend: "self",
+      runtime: "none",
+      api: "trpc",
+      database: "postgres",
+      orm: "prisma",
+      auth: "better-auth",
+      payments: "none",
+      addons: ["none"],
+      examples: ["none"],
+      dbSetup: "docker",
+      webDeploy: "docker",
+      serverDeploy: "none",
+    });
+
+    expect(workspace.allowBuilds).toMatchObject({
+      esbuild: true,
+      sharp: true,
+      "@prisma/engines": true,
+    });
+  });
+
+  it("approves Nuxt lifecycle-script dependencies", async () => {
+    const workspace = await readPnpmWorkspace({
+      projectName: "pnpm-nuxt-builds",
+      frontend: ["nuxt"],
+      backend: "fastify",
+      runtime: "node",
+      api: "orpc",
+      database: "none",
+      orm: "none",
+      auth: "none",
+      payments: "none",
+      addons: ["none"],
+      examples: ["none"],
+      dbSetup: "none",
+      webDeploy: "docker",
+      serverDeploy: "docker",
+    });
+
+    expect(workspace.allowBuilds).toMatchObject({
+      "@parcel/watcher": true,
+      "vue-demi": true,
+    });
+  });
+
   it("does not add build approvals for stacks without lifecycle-script dependencies", async () => {
     const workspace = await readPnpmWorkspace({
       projectName: "pnpm-svelte",

--- a/apps/web/content/docs/cli/options.mdx
+++ b/apps/web/content/docs/cli/options.mdx
@@ -347,9 +347,10 @@ Web deployment configuration:
 
 - `none`: No deployment setup
 - `cloudflare`: Cloudflare Workers deployment (via Alchemy infrastructure as code)
+- `docker`: Self-hosted deployment with a Dockerfile and a root `docker-compose.yml`
 
 ```bash
-create-better-t-stack --web-deploy cloudflare
+create-better-t-stack --web-deploy docker
 ```
 
 **Note:** Alchemy uses TypeScript to define infrastructure programmatically. See the [Deploying to Cloudflare with Alchemy Guide](/docs/guides/cloudflare-alchemy) for details.
@@ -373,9 +374,10 @@ Server deployment configuration:
 
 - `none`: No deployment setup
 - `cloudflare`: Cloudflare Workers deployment (when runtime is workers, via Alchemy infrastructure as code)
+- `docker`: Self-hosted deployment with a Dockerfile and a root `docker-compose.yml` (requires the bun or node runtime)
 
 ```bash
-create-better-t-stack --server-deploy cloudflare
+create-better-t-stack --server-deploy docker
 ```
 
 **Note:** Alchemy uses TypeScript to define infrastructure programmatically. See the [Deploying to Cloudflare with Alchemy Guide](/docs/guides/cloudflare-alchemy) for details.

--- a/apps/web/content/docs/project-structure.mdx
+++ b/apps/web/content/docs/project-structure.mdx
@@ -442,8 +442,8 @@ Electrobun adds an `apps/desktop` workspace with its own `package.json`, `electr
   "packageManager": "<bun|pnpm|npm>",
   "dbSetup": "<turso|neon|prisma-postgres|planetscale|mongodb-atlas|supabase|d1|docker|none>",
   "api": "<none|trpc|orpc>",
-  "webDeploy": "<cloudflare|none>",
-  "serverDeploy": "<cloudflare|none>"
+  "webDeploy": "<cloudflare|docker|none>",
+  "serverDeploy": "<cloudflare|docker|none>"
 }
 ```
 

--- a/apps/web/src/app/(home)/new/_components/utils.ts
+++ b/apps/web/src/app/(home)/new/_components/utils.ts
@@ -717,6 +717,15 @@ export const analyzeStackCompatibility = (stack: StackState): CompatibilityResul
     }
   }
 
+  if (nextStack.serverDeploy === "docker" && nextStack.runtime === "workers") {
+    nextStack.serverDeploy = "cloudflare";
+    changed = true;
+    changes.push({
+      category: "serverDeploy",
+      message: "Server deploy set to 'Cloudflare' (Workers runtime deploys via Cloudflare)",
+    });
+  }
+
   if (
     nextStack.serverDeploy !== "none" &&
     (["none", "convex"].includes(nextStack.backend) ||
@@ -1145,6 +1154,9 @@ export const getDisabledReason = (
     if (optionId === "cloudflare") {
       if (currentStack.runtime !== "workers") return "Cloudflare requires Workers runtime";
       if (currentStack.backend !== "hono") return "Cloudflare requires Hono backend";
+    }
+    if (optionId === "docker" && currentStack.runtime === "workers") {
+      return "Docker server deployment requires the Bun or Node runtime";
     }
     if (optionId !== "none") {
       if (

--- a/apps/web/src/lib/constant.ts
+++ b/apps/web/src/lib/constant.ts
@@ -404,6 +404,13 @@ export const TECH_OPTIONS: Record<
       color: "from-orange-400 to-orange-600",
     },
     {
+      id: "docker",
+      name: "Docker",
+      description: "Self-host with a Dockerfile and docker-compose.yml",
+      icon: `${ICON_BASE_URL}/docker.svg`,
+      color: "from-blue-400 to-blue-600",
+    },
+    {
       id: "none",
       name: "None",
       description: "Skip deployment setup",
@@ -419,6 +426,13 @@ export const TECH_OPTIONS: Record<
       description: "Deploy to Cloudflare Workers using Alchemy",
       icon: `${ICON_BASE_URL}/workers.svg`,
       color: "from-orange-400 to-orange-600",
+    },
+    {
+      id: "docker",
+      name: "Docker",
+      description: "Self-host with a Dockerfile and docker-compose.yml",
+      icon: `${ICON_BASE_URL}/docker.svg`,
+      color: "from-blue-400 to-blue-600",
     },
     {
       id: "none",

--- a/apps/web/test/stack-builder-compatibility.test.ts
+++ b/apps/web/test/stack-builder-compatibility.test.ts
@@ -301,3 +301,73 @@ describe("stack builder D1 compatibility", () => {
     expect(getDisabledReason(fullstackStack, "addons", "evlog")).toBeNull();
   });
 });
+
+describe("stack builder Docker deployment compatibility", () => {
+  test("allows Docker web deploy with a web frontend", () => {
+    const stack = createStack({
+      webFrontend: ["tanstack-router"],
+      backend: "hono",
+      runtime: "bun",
+    });
+
+    expect(getDisabledReason(stack, "webDeploy", "docker")).toBeNull();
+
+    const command = generateStackCommand({
+      ...stack,
+      webDeploy: "docker",
+    });
+    expect(command).toContain("--web-deploy docker");
+  });
+
+  test("allows Docker server deploy on bun/node runtimes only", () => {
+    const bunStack = createStack({
+      backend: "hono",
+      runtime: "bun",
+    });
+    const workersStack = createStack({
+      backend: "hono",
+      runtime: "workers",
+      serverDeploy: "cloudflare",
+      database: "sqlite",
+      orm: "drizzle",
+      dbSetup: "d1",
+    });
+
+    expect(getDisabledReason(bunStack, "serverDeploy", "docker")).toBeNull();
+    expect(getDisabledReason(workersStack, "serverDeploy", "docker")).toBe(
+      "Docker server deployment requires the Bun or Node runtime",
+    );
+  });
+
+  test("switches Docker server deploy to Cloudflare when runtime becomes workers", () => {
+    const stack = createStack({
+      backend: "hono",
+      runtime: "workers",
+      serverDeploy: "docker",
+      database: "sqlite",
+      orm: "drizzle",
+      dbSetup: "d1",
+    });
+
+    const result = analyzeStackCompatibility(stack);
+
+    expect(result.adjustedStack).toMatchObject({
+      serverDeploy: "cloudflare",
+    });
+  });
+
+  test("clears Docker server deploy for backends without a server app", () => {
+    const stack = createStack({
+      webFrontend: ["next"],
+      backend: "self-next",
+      runtime: "none",
+      serverDeploy: "docker",
+    });
+
+    const result = analyzeStackCompatibility(stack);
+
+    expect(result.adjustedStack).toMatchObject({
+      serverDeploy: "none",
+    });
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "better-t-stack",
       "dependencies": {
-        "@clack/prompts": "^1.4.0",
+        "@clack/prompts": "^1.5.1",
       },
       "devDependencies": {
         "@types/bun": "^1.3.14",
@@ -27,8 +27,8 @@
       "dependencies": {
         "@better-t-stack/template-generator": "workspace:*",
         "@better-t-stack/types": "workspace:*",
-        "@clack/core": "^1.3.1",
-        "@clack/prompts": "^1.4.0",
+        "@clack/core": "^1.4.1",
+        "@clack/prompts": "^1.5.1",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@trpc/server": "^11.17.0",
         "better-result": "^2.9.2",
@@ -237,9 +237,9 @@
 
     "@better-t-stack/types": ["@better-t-stack/types@workspace:packages/types"],
 
-    "@clack/core": ["@clack/core@1.3.1", "", { "dependencies": { "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-fT1qHVGAag4IEkrupZ6lRRbNCs1vS9P01KB/sG8zKgvUztbYtFBtQpjSITNwooDZ83tpsPzP0mRNs1/KVszCRA=="],
+    "@clack/core": ["@clack/core@1.4.1", "", { "dependencies": { "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-FILJa1gGKEFTGZAJE9RpVhrjKz3c3h4ar60dSv6cGuDqufQ84YEIS3GAGvZiN+H6yaLbbvTFNejjCC4tXpZEuw=="],
 
-    "@clack/prompts": ["@clack/prompts@1.4.0", "", { "dependencies": { "@clack/core": "1.3.1", "fast-string-width": "^3.0.2", "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-S0My7XPGIgpRWMDG8uRqalbgT+a6FmCUdOW+HaIOVVpUPHOb7RrpvjTjiODadKp06fsrVDJZlIzc6yCTp4AnxA=="],
+    "@clack/prompts": ["@clack/prompts@1.5.1", "", { "dependencies": { "@clack/core": "1.4.1", "fast-string-width": "^3.0.2", "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-zccHj2z2oCCO4yrDiRSlFOxWerGqRiysP7a5jPK6uoI9URKAquwY42Dd/iUP8JWHxEzdRe4TlbvZCo8z1/mhrw=="],
 
     "@convex-dev/crons": ["@convex-dev/crons@0.2.0", "", { "dependencies": { "cron-parser": "^4.9.0" }, "peerDependencies": { "convex": "^1.24.8" } }, "sha512-JowF/DDPl8FuhXml2/0jmEa6uIKr/UK1UwP+FdbPt2BRVxACRX4CNlzDQEtHbO2p2FVKiJh4zEg8p5/YM27PEA=="],
 

--- a/package.json
+++ b/package.json
@@ -44,10 +44,11 @@
     "deploy:convex": "turbo run --filter=@better-t-stack/backend deploy",
     "deploy:web": "turbo run deploy --filter=web",
     "generate": "turbo run generate-schema --filter=web",
-    "deploy": "turbo run deploy --filter=web"
+    "deploy": "turbo run deploy --filter=web",
+    "smoke:docker": "bash scripts/docker-smoke.sh"
   },
   "dependencies": {
-    "@clack/prompts": "^1.4.0"
+    "@clack/prompts": "^1.5.1"
   },
   "devDependencies": {
     "@types/bun": "^1.3.14",

--- a/packages/template-generator/src/core/template-processor.ts
+++ b/packages/template-generator/src/core/template-processor.ts
@@ -22,6 +22,7 @@ export function transformFilename(filename: string): string {
   const basename = result.split("/").pop() || result;
   if (basename === "_gitignore") result = result.replace(/_gitignore$/, ".gitignore");
   else if (basename === "_npmrc") result = result.replace(/_npmrc$/, ".npmrc");
+  else if (basename === "_dockerignore") result = result.replace(/_dockerignore$/, ".dockerignore");
 
   return result;
 }

--- a/packages/template-generator/src/core/template-processor.ts
+++ b/packages/template-generator/src/core/template-processor.ts
@@ -6,6 +6,7 @@ Handlebars.registerHelper("eq", (a, b) => a === b);
 Handlebars.registerHelper("ne", (a, b) => a !== b);
 Handlebars.registerHelper("and", (...args) => args.slice(0, -1).every(Boolean));
 Handlebars.registerHelper("or", (...args) => args.slice(0, -1).some(Boolean));
+Handlebars.registerHelper("not", (a) => !a);
 Handlebars.registerHelper("includes", (arr, val) => Array.isArray(arr) && arr.includes(val));
 
 export function processTemplateString(content: string, context: ProjectConfig): string {

--- a/packages/template-generator/src/post-process/package-configs.ts
+++ b/packages/template-generator/src/post-process/package-configs.ts
@@ -154,11 +154,21 @@ function updateRootPackageJson(vfs: VirtualFileSystem, config: ProjectConfig): v
     scripts["db:local"] = pmConfig.filter(dbPackageName, "db:local");
   }
 
+  const hasDockerDeployScripts = config.webDeploy === "docker" || config.serverDeploy === "docker";
   if (dbSetup === "docker") {
-    scripts["db:start"] = pmConfig.filter(dbPackageName, "db:start");
-    scripts["db:watch"] = pmConfig.filter(dbPackageName, "db:watch");
-    scripts["db:stop"] = pmConfig.filter(dbPackageName, "db:stop");
-    scripts["db:down"] = pmConfig.filter(dbPackageName, "db:down");
+    if (hasDockerDeployScripts) {
+      // The database service lives in the root docker-compose.yml; scope the
+      // dev scripts to just that service so they don't touch web/server.
+      scripts["db:start"] = `docker compose up -d ${database}`;
+      scripts["db:watch"] = `docker compose up ${database}`;
+      scripts["db:stop"] = `docker compose stop ${database}`;
+      scripts["db:down"] = `docker compose down ${database}`;
+    } else {
+      scripts["db:start"] = pmConfig.filter(dbPackageName, "db:start");
+      scripts["db:watch"] = pmConfig.filter(dbPackageName, "db:watch");
+      scripts["db:stop"] = pmConfig.filter(dbPackageName, "db:stop");
+      scripts["db:down"] = pmConfig.filter(dbPackageName, "db:down");
+    }
   }
 
   // Add deploy/destroy scripts when using alchemy (cloudflare deployment)
@@ -166,6 +176,14 @@ function updateRootPackageJson(vfs: VirtualFileSystem, config: ProjectConfig): v
   if (config.webDeploy === "cloudflare" || config.serverDeploy === "cloudflare") {
     scripts.deploy = pmConfig.filter(infraPackageName, "deploy");
     scripts.destroy = pmConfig.filter(infraPackageName, "destroy");
+  }
+
+  // Add compose scripts when deploying web/server as Docker containers
+  if (config.webDeploy === "docker" || config.serverDeploy === "docker") {
+    scripts["docker:build"] = "docker compose build";
+    scripts["docker:up"] = "docker compose up -d --build";
+    scripts["docker:down"] = "docker compose down";
+    scripts["docker:logs"] = "docker compose logs -f";
   }
 
   // Note: packageManager version is set by CLI at runtime since it requires running the actual CLI
@@ -411,7 +429,8 @@ function updateDbPackageJson(vfs: VirtualFileSystem, config: ProjectConfig): voi
     }
   }
 
-  if (dbSetup === "docker") {
+  const hasDockerDeploy = config.webDeploy === "docker" || config.serverDeploy === "docker";
+  if (dbSetup === "docker" && !hasDockerDeploy) {
     scripts["db:start"] = "docker compose up -d";
     scripts["db:watch"] = "docker compose up";
     scripts["db:stop"] = "docker compose stop";

--- a/packages/template-generator/src/processors/deploy-deps.ts
+++ b/packages/template-generator/src/processors/deploy-deps.ts
@@ -8,9 +8,30 @@ export function processDeployDeps(vfs: VirtualFileSystem, config: ProjectConfig)
 
   const isCloudflareWeb = webDeploy === "cloudflare";
   const isCloudflareServer = serverDeploy === "cloudflare";
+  const isDockerWeb = webDeploy === "docker";
   const isBackendSelf = backend === "self";
 
-  if (!isCloudflareWeb && !isCloudflareServer) return;
+  if (!isCloudflareWeb && !isCloudflareServer && !isDockerWeb) return;
+
+  if (isDockerWeb) {
+    const webPkgPath = "apps/web/package.json";
+    if (vfs.exists(webPkgPath)) {
+      if (frontend.includes("svelte")) {
+        addPackageDependency({
+          vfs,
+          packagePath: webPkgPath,
+          devDependencies: ["@sveltejs/adapter-node"],
+        });
+      } else if (frontend.includes("tanstack-start")) {
+        // Same section as the evlog addon so the two never duplicate nitro
+        addPackageDependency({
+          vfs,
+          packagePath: webPkgPath,
+          dependencies: ["nitro"],
+        });
+      }
+    }
+  }
 
   if (isCloudflareWeb || isCloudflareServer) {
     addPackageDependency({

--- a/packages/template-generator/src/processors/readme-generator.ts
+++ b/packages/template-generator/src/processors/readme-generator.ts
@@ -766,7 +766,8 @@ function generateScriptsList(
   }
 
   if (webDeploy === "docker" || serverDeploy === "docker") {
-    scripts += `\n- \`${packageManagerRunCmd} docker:up\`: Build and start the Docker Compose stack
+    scripts += `\n- \`${packageManagerRunCmd} docker:build\`: Build the Docker Compose images
+- \`${packageManagerRunCmd} docker:up\`: Build and start the Docker Compose stack
 - \`${packageManagerRunCmd} docker:logs\`: Tail logs from the Docker Compose stack
 - \`${packageManagerRunCmd} docker:down\`: Stop the Docker Compose stack`;
   }

--- a/packages/template-generator/src/processors/readme-generator.ts
+++ b/packages/template-generator/src/processors/readme-generator.ts
@@ -665,7 +665,7 @@ function generateScriptsList(
   config: ProjectConfig,
   hasNative: boolean,
 ): string {
-  const { database, addons, backend, dbSetup, frontend } = config;
+  const { database, addons, backend, dbSetup, frontend, webDeploy, serverDeploy } = config;
   const isConvex = backend === "convex";
   const isBackendSelf = backend === "self";
   const hasWeb = frontend.some((f) =>
@@ -765,6 +765,12 @@ function generateScriptsList(
 - \`cd apps/docs && ${packageManagerRunCmd} build\`: Build documentation site`;
   }
 
+  if (webDeploy === "docker" || serverDeploy === "docker") {
+    scripts += `\n- \`${packageManagerRunCmd} docker:up\`: Build and start the Docker Compose stack
+- \`${packageManagerRunCmd} docker:logs\`: Tail logs from the Docker Compose stack
+- \`${packageManagerRunCmd} docker:down\`: Stop the Docker Compose stack`;
+  }
+
   return scripts;
 }
 
@@ -774,29 +780,58 @@ function generateDeploymentCommands(
   serverDeploy: ProjectConfig["serverDeploy"],
   backend: ProjectConfig["backend"],
 ): string {
-  if (webDeploy !== "cloudflare" && serverDeploy !== "cloudflare") {
+  const hasCloudflare = webDeploy === "cloudflare" || serverDeploy === "cloudflare";
+  const hasDocker = webDeploy === "docker" || serverDeploy === "docker";
+
+  if (!hasCloudflare && !hasDocker) {
     return "";
   }
 
-  const lines: string[] = ["## Deployment (Cloudflare via Alchemy)"];
-  const targetLabel =
-    webDeploy === "cloudflare" && (serverDeploy === "cloudflare" || backend === "self")
-      ? "web + server"
-      : webDeploy === "cloudflare"
-        ? "web"
-        : "server";
+  const lines: string[] = ["## Deployment"];
 
-  lines.push(
-    `- Target: ${targetLabel}`,
-    `- Dev: ${packageManagerRunCmd} dev`,
-    `- Deploy: ${packageManagerRunCmd} deploy`,
-    `- Destroy: ${packageManagerRunCmd} destroy`,
-  );
+  if (hasCloudflare) {
+    const targetLabel =
+      webDeploy === "cloudflare" && (serverDeploy === "cloudflare" || backend === "self")
+        ? "web + server"
+        : webDeploy === "cloudflare"
+          ? "web"
+          : "server";
 
-  lines.push(
-    "",
-    "For more details, see the guide on [Deploying to Cloudflare with Alchemy](https://www.better-t-stack.dev/docs/guides/cloudflare-alchemy).",
-  );
+    lines.push(
+      "",
+      "### Cloudflare via Alchemy",
+      "",
+      `- Target: ${targetLabel}`,
+      `- Dev: ${packageManagerRunCmd} dev`,
+      `- Deploy: ${packageManagerRunCmd} deploy`,
+      `- Destroy: ${packageManagerRunCmd} destroy`,
+      "",
+      "For more details, see the guide on [Deploying to Cloudflare with Alchemy](https://www.better-t-stack.dev/docs/guides/cloudflare-alchemy).",
+    );
+  }
+
+  if (hasDocker) {
+    const targetLabel =
+      webDeploy === "docker" && (serverDeploy === "docker" || backend === "self")
+        ? "web + server"
+        : webDeploy === "docker"
+          ? "web"
+          : "server";
+
+    lines.push(
+      "",
+      "### Docker Compose",
+      "",
+      `- Target: ${targetLabel}`,
+      "- Config: `docker-compose.yml` (app Dockerfiles live in `apps/*/Dockerfile`)",
+      `- Build images: ${packageManagerRunCmd} docker:build`,
+      `- Start: ${packageManagerRunCmd} docker:up`,
+      `- Logs: ${packageManagerRunCmd} docker:logs`,
+      `- Stop: ${packageManagerRunCmd} docker:down`,
+      "",
+      "Environment variables are read from each app's `.env` file (baked into web builds for public variables) and overridden in `docker-compose.yml` for container networking.",
+    );
+  }
 
   return `${lines.join("\n")}\n`;
 }

--- a/packages/template-generator/src/template-handlers/database.ts
+++ b/packages/template-generator/src/template-handlers/database.ts
@@ -21,7 +21,10 @@ export async function processDbTemplates(
     config,
   );
 
-  if (config.dbSetup === "docker") {
+  // With a Docker deploy target, the database service lives in the root
+  // docker-compose.yml instead of a separate packages/db compose file.
+  const hasDockerDeploy = config.webDeploy === "docker" || config.serverDeploy === "docker";
+  if (config.dbSetup === "docker" && !hasDockerDeploy) {
     processTemplatesFromPrefix(
       vfs,
       templates,

--- a/packages/template-generator/src/template-handlers/deploy.ts
+++ b/packages/template-generator/src/template-handlers/deploy.ts
@@ -14,6 +14,10 @@ export async function processDeployTemplates(
     processTemplatesFromPrefix(vfs, templates, "packages/infra", "packages/infra", config);
   }
 
+  if (config.webDeploy === "docker" || config.serverDeploy === "docker") {
+    processTemplatesFromPrefix(vfs, templates, "deploy/docker/compose", "", config);
+  }
+
   if (config.webDeploy !== "none" && config.webDeploy !== "cloudflare") {
     const templateMap: Record<string, string> = {
       "tanstack-router": "react/tanstack-router",
@@ -23,6 +27,7 @@ export async function processDeployTemplates(
       next: "react/next",
       nuxt: "nuxt",
       svelte: "svelte",
+      astro: "astro",
     };
 
     for (const f of config.frontend) {

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -1273,7 +1273,9 @@ import { createTanstackQueryUtils } from "@orpc/tanstack-query";
 
 export default defineNuxtPlugin(() => {
   const config = useRuntimeConfig();
-  const rpcUrl = \`\${config.public.serverUrl}/rpc\`;
+  const serverUrl =
+    (import.meta.server && config.serverUrl) || config.public.serverUrl;
+  const rpcUrl = \`\${serverUrl}/rpc\`;
 
   const rpcLink = new RPCLink({
     url: rpcUrl,
@@ -9519,7 +9521,7 @@ export default defineNuxtPlugin(() => {
 
   const authClient = createAuthClient({
     {{#if (ne backend "self")}}
-    baseURL: config.public.serverUrl,
+    baseURL: (import.meta.server && config.serverUrl) || config.public.serverUrl,
     {{/if}}
     {{#if (eq payments "polar")}}
     plugins: [polarClient()],
@@ -15857,7 +15859,11 @@ Dockerfile
 **/Dockerfile
 docker-compose.yml
 
-# Keep .env files: frameworks bake public variables from them at build time
+# Secrets stay out of image layers; runtime env comes from compose env_file,
+# build-time public values come from compose build args
+**/.env
+**/.env.*
+!**/.env.example
 `],
   ["deploy/docker/compose/docker-compose.yml.hbs", `name: {{projectName}}
 
@@ -15867,6 +15873,18 @@ services:
     build:
       context: .
       dockerfile: apps/web/Dockerfile
+{{#if (and (not (includes frontend "nuxt")) (or (and (ne backend "self") (ne backend "none") (ne backend "convex")) (eq backend "convex") (and (eq auth "clerk") (or (includes frontend "next") (includes frontend "react-router") (includes frontend "tanstack-router") (includes frontend "tanstack-start")))))}}
+      args:
+{{#if (and (ne backend "self") (ne backend "none") (ne backend "convex"))}}
+        {{#if (includes frontend "next")}}NEXT_PUBLIC_SERVER_URL{{else if (or (includes frontend "svelte") (includes frontend "astro"))}}PUBLIC_SERVER_URL{{else}}VITE_SERVER_URL{{/if}}: http://localhost:3000
+{{/if}}
+{{#if (eq backend "convex")}}
+        {{#if (includes frontend "next")}}NEXT_PUBLIC_CONVEX_URL{{else if (or (includes frontend "svelte") (includes frontend "astro"))}}PUBLIC_CONVEX_URL{{else}}VITE_CONVEX_URL{{/if}}: \${CONVEX_URL:-}
+{{/if}}
+{{#if (and (eq auth "clerk") (or (includes frontend "next") (includes frontend "react-router") (includes frontend "tanstack-router") (includes frontend "tanstack-start")))}}
+        {{#if (includes frontend "next")}}NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY{{else}}VITE_CLERK_PUBLISHABLE_KEY{{/if}}: \${CLERK_PUBLISHABLE_KEY:-}
+{{/if}}
+{{/if}}
     init: true
     ports:
 {{#if (or (includes frontend "tanstack-router") (includes frontend "react-router") (includes frontend "solid"))}}
@@ -15885,13 +15903,13 @@ services:
       CORS_ORIGIN: http://localhost:3001
 {{/if}}
 {{#if (and (eq dbSetup "docker") (eq database "postgres"))}}
-      DATABASE_URL: postgresql://postgres:password@postgres:5432/{{projectName}}
+      DATABASE_URL: postgresql://postgres:\${POSTGRES_PASSWORD:-password}@postgres:5432/{{projectName}}
 {{/if}}
 {{#if (and (eq dbSetup "docker") (eq database "mysql"))}}
-      DATABASE_URL: mysql://user:password@mysql:3306/{{projectName}}
+      DATABASE_URL: mysql://user:\${MYSQL_PASSWORD:-password}@mysql:3306/{{projectName}}
 {{/if}}
 {{#if (and (eq dbSetup "docker") (eq database "mongodb"))}}
-      DATABASE_URL: mongodb://root:password@mongodb:27017/{{projectName}}?authSource=admin
+      DATABASE_URL: mongodb://root:\${MONGO_PASSWORD:-password}@mongodb:27017/{{projectName}}?authSource=admin
 {{/if}}
 {{/if}}
 {{#if (eq dbSetup "docker")}}
@@ -15907,7 +15925,7 @@ services:
       NEXT_PUBLIC_SERVER_URL: http://server:3000
 {{/if}}
 {{#if (includes frontend "nuxt")}}
-      NUXT_PUBLIC_SERVER_URL: http://server:3000
+      NUXT_SERVER_URL: http://server:3000
 {{/if}}
 {{/if}}
     depends_on:
@@ -15935,13 +15953,13 @@ services:
       CORS_ORIGIN: http://localhost:3001
 {{/if}}
 {{#if (and (eq dbSetup "docker") (eq database "postgres"))}}
-      DATABASE_URL: postgresql://postgres:password@postgres:5432/{{projectName}}
+      DATABASE_URL: postgresql://postgres:\${POSTGRES_PASSWORD:-password}@postgres:5432/{{projectName}}
 {{/if}}
 {{#if (and (eq dbSetup "docker") (eq database "mysql"))}}
-      DATABASE_URL: mysql://user:password@mysql:3306/{{projectName}}
+      DATABASE_URL: mysql://user:\${MYSQL_PASSWORD:-password}@mysql:3306/{{projectName}}
 {{/if}}
 {{#if (and (eq dbSetup "docker") (eq database "mongodb"))}}
-      DATABASE_URL: mongodb://root:password@mongodb:27017/{{projectName}}?authSource=admin
+      DATABASE_URL: mongodb://root:\${MONGO_PASSWORD:-password}@mongodb:27017/{{projectName}}?authSource=admin
 {{/if}}
 {{/if}}
     healthcheck:
@@ -15972,7 +15990,7 @@ services:
     environment:
       POSTGRES_DB: {{projectName}}
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: password
+      POSTGRES_PASSWORD: \${POSTGRES_PASSWORD:-password}
     ports:
       - "5432:5432"
     volumes:
@@ -15989,10 +16007,10 @@ services:
     image: mysql
     container_name: {{projectName}}-mysql
     environment:
-      MYSQL_ROOT_PASSWORD: password
+      MYSQL_ROOT_PASSWORD: \${MYSQL_ROOT_PASSWORD:-password}
       MYSQL_DATABASE: {{projectName}}
       MYSQL_USER: user
-      MYSQL_PASSWORD: password
+      MYSQL_PASSWORD: \${MYSQL_PASSWORD:-password}
     ports:
       - "3306:3306"
     volumes:
@@ -16010,7 +16028,7 @@ services:
     container_name: {{projectName}}-mongodb
     environment:
       MONGO_INITDB_ROOT_USERNAME: root
-      MONGO_INITDB_ROOT_PASSWORD: password
+      MONGO_INITDB_ROOT_PASSWORD: \${MONGO_PASSWORD:-password}
       MONGO_INITDB_DATABASE: {{projectName}}
     ports:
       - "27017:27017"
@@ -16036,6 +16054,11 @@ COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 RUN npm install -g pnpm
 {{/if}}
 WORKDIR /app
+ENV SKIP_ENV_VALIDATION=1
+{{#if (eq orm "prisma")}}
+# prisma generate resolves DATABASE_URL at install time; the real value comes from compose at runtime
+ENV DATABASE_URL={{#if (eq database "mysql")}}mysql://build:build@localhost:3306/build{{else if (eq database "mongodb")}}mongodb://localhost:27017/build{{else if (eq database "sqlite")}}file:./build.db{{else}}postgresql://build:build@localhost:5432/build{{/if}}
+{{/if}}
 
 COPY . .
 {{#if (eq packageManager "bun")}}
@@ -16048,6 +16071,10 @@ RUN --mount=type=cache,target=/root/.npm npm install
 
 ENV NODE_ENV=production
 RUN cd apps/server && {{packageManager}} run build
+ENV SKIP_ENV_VALIDATION=
+{{#if (eq orm "prisma")}}
+ENV DATABASE_URL=
+{{/if}}
 
 EXPOSE 3000
 
@@ -16066,6 +16093,15 @@ COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 RUN npm install -g pnpm
 {{/if}}
 WORKDIR /app
+ENV SKIP_ENV_VALIDATION=1
+{{#if (and (eq backend "self") (eq auth "better-auth"))}}
+# the build evaluates the auth config; the real secret comes from compose at runtime
+ENV BETTER_AUTH_SECRET=build-time-placeholder-secret-not-used-at-runtime
+{{/if}}
+{{#if (eq orm "prisma")}}
+# prisma generate resolves DATABASE_URL at install time; the real value comes from compose at runtime
+ENV DATABASE_URL={{#if (eq database "mysql")}}mysql://build:build@localhost:3306/build{{else if (eq database "mongodb")}}mongodb://localhost:27017/build{{else if (eq database "sqlite")}}file:./build.db{{else}}postgresql://build:build@localhost:5432/build{{/if}}
+{{/if}}
 
 COPY . .
 {{#if (eq packageManager "bun")}}
@@ -16076,8 +16112,23 @@ RUN --mount=type=cache,target=/pnpm-store pnpm install --store-dir /pnpm-store
 RUN --mount=type=cache,target=/root/.npm npm install
 {{/if}}
 
+{{#if (and (ne backend "self") (ne backend "none") (ne backend "convex"))}}
+ARG PUBLIC_SERVER_URL
+ENV PUBLIC_SERVER_URL=\${PUBLIC_SERVER_URL}
+{{/if}}
+{{#if (eq backend "convex")}}
+ARG PUBLIC_CONVEX_URL
+ENV PUBLIC_CONVEX_URL=\${PUBLIC_CONVEX_URL}
+{{/if}}
 ENV NODE_ENV=production
 RUN cd apps/web && {{packageManager}} run build
+ENV SKIP_ENV_VALIDATION=
+{{#if (and (eq backend "self") (eq auth "better-auth"))}}
+ENV BETTER_AUTH_SECRET=
+{{/if}}
+{{#if (eq orm "prisma")}}
+ENV DATABASE_URL=
+{{/if}}
 
 ENV HOST=0.0.0.0
 ENV PORT=3001
@@ -16094,6 +16145,15 @@ COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 RUN npm install -g pnpm
 {{/if}}
 WORKDIR /app
+ENV SKIP_ENV_VALIDATION=1
+{{#if (and (eq backend "self") (eq auth "better-auth"))}}
+# the build evaluates the auth config; the real secret comes from compose at runtime
+ENV BETTER_AUTH_SECRET=build-time-placeholder-secret-not-used-at-runtime
+{{/if}}
+{{#if (eq orm "prisma")}}
+# prisma generate resolves DATABASE_URL at install time; the real value comes from compose at runtime
+ENV DATABASE_URL={{#if (eq database "mysql")}}mysql://build:build@localhost:3306/build{{else if (eq database "mongodb")}}mongodb://localhost:27017/build{{else if (eq database "sqlite")}}file:./build.db{{else}}postgresql://build:build@localhost:5432/build{{/if}}
+{{/if}}
 
 COPY . .
 {{#if (eq packageManager "bun")}}
@@ -16127,6 +16187,15 @@ COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 RUN npm install -g pnpm
 {{/if}}
 WORKDIR /app
+ENV SKIP_ENV_VALIDATION=1
+{{#if (and (eq backend "self") (eq auth "better-auth"))}}
+# the build evaluates the auth config; the real secret comes from compose at runtime
+ENV BETTER_AUTH_SECRET=build-time-placeholder-secret-not-used-at-runtime
+{{/if}}
+{{#if (eq orm "prisma")}}
+# prisma generate resolves DATABASE_URL at install time; the real value comes from compose at runtime
+ENV DATABASE_URL={{#if (eq database "mysql")}}mysql://build:build@localhost:3306/build{{else if (eq database "mongodb")}}mongodb://localhost:27017/build{{else if (eq database "sqlite")}}file:./build.db{{else}}postgresql://build:build@localhost:5432/build{{/if}}
+{{/if}}
 
 COPY . .
 {{#if (eq packageManager "bun")}}
@@ -16137,6 +16206,18 @@ RUN --mount=type=cache,target=/pnpm-store pnpm install --store-dir /pnpm-store
 RUN --mount=type=cache,target=/root/.npm npm install
 {{/if}}
 
+{{#if (and (ne backend "self") (ne backend "none") (ne backend "convex"))}}
+ARG NEXT_PUBLIC_SERVER_URL
+ENV NEXT_PUBLIC_SERVER_URL=\${NEXT_PUBLIC_SERVER_URL}
+{{/if}}
+{{#if (eq backend "convex")}}
+ARG NEXT_PUBLIC_CONVEX_URL
+ENV NEXT_PUBLIC_CONVEX_URL=\${NEXT_PUBLIC_CONVEX_URL}
+{{/if}}
+{{#if (eq auth "clerk")}}
+ARG NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+ENV NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=\${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}
+{{/if}}
 ENV NODE_ENV=production
 RUN cd apps/web && {{packageManager}} run build
 
@@ -16161,6 +16242,15 @@ COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 RUN npm install -g pnpm
 {{/if}}
 WORKDIR /app
+ENV SKIP_ENV_VALIDATION=1
+{{#if (and (eq backend "self") (eq auth "better-auth"))}}
+# the build evaluates the auth config; the real secret comes from compose at runtime
+ENV BETTER_AUTH_SECRET=build-time-placeholder-secret-not-used-at-runtime
+{{/if}}
+{{#if (eq orm "prisma")}}
+# prisma generate resolves DATABASE_URL at install time; the real value comes from compose at runtime
+ENV DATABASE_URL={{#if (eq database "mysql")}}mysql://build:build@localhost:3306/build{{else if (eq database "mongodb")}}mongodb://localhost:27017/build{{else if (eq database "sqlite")}}file:./build.db{{else}}postgresql://build:build@localhost:5432/build{{/if}}
+{{/if}}
 
 COPY . .
 {{#if (eq packageManager "bun")}}
@@ -16171,6 +16261,18 @@ RUN --mount=type=cache,target=/pnpm-store pnpm install --store-dir /pnpm-store
 RUN --mount=type=cache,target=/root/.npm npm install
 {{/if}}
 
+{{#if (and (ne backend "self") (ne backend "none") (ne backend "convex"))}}
+ARG VITE_SERVER_URL
+ENV VITE_SERVER_URL=\${VITE_SERVER_URL}
+{{/if}}
+{{#if (eq backend "convex")}}
+ARG VITE_CONVEX_URL
+ENV VITE_CONVEX_URL=\${VITE_CONVEX_URL}
+{{/if}}
+{{#if (eq auth "clerk")}}
+ARG VITE_CLERK_PUBLISHABLE_KEY
+ENV VITE_CLERK_PUBLISHABLE_KEY=\${VITE_CLERK_PUBLISHABLE_KEY}
+{{/if}}
 ENV NODE_ENV=production
 RUN cd apps/web && {{packageManager}} run build
 
@@ -16207,6 +16309,15 @@ COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 RUN npm install -g pnpm
 {{/if}}
 WORKDIR /app
+ENV SKIP_ENV_VALIDATION=1
+{{#if (and (eq backend "self") (eq auth "better-auth"))}}
+# the build evaluates the auth config; the real secret comes from compose at runtime
+ENV BETTER_AUTH_SECRET=build-time-placeholder-secret-not-used-at-runtime
+{{/if}}
+{{#if (eq orm "prisma")}}
+# prisma generate resolves DATABASE_URL at install time; the real value comes from compose at runtime
+ENV DATABASE_URL={{#if (eq database "mysql")}}mysql://build:build@localhost:3306/build{{else if (eq database "mongodb")}}mongodb://localhost:27017/build{{else if (eq database "sqlite")}}file:./build.db{{else}}postgresql://build:build@localhost:5432/build{{/if}}
+{{/if}}
 
 COPY . .
 {{#if (eq packageManager "bun")}}
@@ -16217,6 +16328,18 @@ RUN --mount=type=cache,target=/pnpm-store pnpm install --store-dir /pnpm-store
 RUN --mount=type=cache,target=/root/.npm npm install
 {{/if}}
 
+{{#if (and (ne backend "self") (ne backend "none") (ne backend "convex"))}}
+ARG VITE_SERVER_URL
+ENV VITE_SERVER_URL=\${VITE_SERVER_URL}
+{{/if}}
+{{#if (eq backend "convex")}}
+ARG VITE_CONVEX_URL
+ENV VITE_CONVEX_URL=\${VITE_CONVEX_URL}
+{{/if}}
+{{#if (eq auth "clerk")}}
+ARG VITE_CLERK_PUBLISHABLE_KEY
+ENV VITE_CLERK_PUBLISHABLE_KEY=\${VITE_CLERK_PUBLISHABLE_KEY}
+{{/if}}
 ENV NODE_ENV=production
 RUN cd apps/web && {{packageManager}} run build
 
@@ -16253,6 +16376,15 @@ COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 RUN npm install -g pnpm
 {{/if}}
 WORKDIR /app
+ENV SKIP_ENV_VALIDATION=1
+{{#if (and (eq backend "self") (eq auth "better-auth"))}}
+# the build evaluates the auth config; the real secret comes from compose at runtime
+ENV BETTER_AUTH_SECRET=build-time-placeholder-secret-not-used-at-runtime
+{{/if}}
+{{#if (eq orm "prisma")}}
+# prisma generate resolves DATABASE_URL at install time; the real value comes from compose at runtime
+ENV DATABASE_URL={{#if (eq database "mysql")}}mysql://build:build@localhost:3306/build{{else if (eq database "mongodb")}}mongodb://localhost:27017/build{{else if (eq database "sqlite")}}file:./build.db{{else}}postgresql://build:build@localhost:5432/build{{/if}}
+{{/if}}
 
 COPY . .
 {{#if (eq packageManager "bun")}}
@@ -16263,8 +16395,27 @@ RUN --mount=type=cache,target=/pnpm-store pnpm install --store-dir /pnpm-store
 RUN --mount=type=cache,target=/root/.npm npm install
 {{/if}}
 
+{{#if (and (ne backend "self") (ne backend "none") (ne backend "convex"))}}
+ARG VITE_SERVER_URL
+ENV VITE_SERVER_URL=\${VITE_SERVER_URL}
+{{/if}}
+{{#if (eq backend "convex")}}
+ARG VITE_CONVEX_URL
+ENV VITE_CONVEX_URL=\${VITE_CONVEX_URL}
+{{/if}}
+{{#if (eq auth "clerk")}}
+ARG VITE_CLERK_PUBLISHABLE_KEY
+ENV VITE_CLERK_PUBLISHABLE_KEY=\${VITE_CLERK_PUBLISHABLE_KEY}
+{{/if}}
 ENV NODE_ENV=production
 RUN cd apps/web && {{packageManager}} run build
+ENV SKIP_ENV_VALIDATION=
+{{#if (and (eq backend "self") (eq auth "better-auth"))}}
+ENV BETTER_AUTH_SECRET=
+{{/if}}
+{{#if (eq orm "prisma")}}
+ENV DATABASE_URL=
+{{/if}}
 
 ENV HOST=0.0.0.0
 ENV PORT=3001
@@ -16282,6 +16433,15 @@ COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 RUN npm install -g pnpm
 {{/if}}
 WORKDIR /app
+ENV SKIP_ENV_VALIDATION=1
+{{#if (and (eq backend "self") (eq auth "better-auth"))}}
+# the build evaluates the auth config; the real secret comes from compose at runtime
+ENV BETTER_AUTH_SECRET=build-time-placeholder-secret-not-used-at-runtime
+{{/if}}
+{{#if (eq orm "prisma")}}
+# prisma generate resolves DATABASE_URL at install time; the real value comes from compose at runtime
+ENV DATABASE_URL={{#if (eq database "mysql")}}mysql://build:build@localhost:3306/build{{else if (eq database "mongodb")}}mongodb://localhost:27017/build{{else if (eq database "sqlite")}}file:./build.db{{else}}postgresql://build:build@localhost:5432/build{{/if}}
+{{/if}}
 
 COPY . .
 {{#if (eq packageManager "bun")}}
@@ -16292,6 +16452,14 @@ RUN --mount=type=cache,target=/pnpm-store pnpm install --store-dir /pnpm-store
 RUN --mount=type=cache,target=/root/.npm npm install
 {{/if}}
 
+{{#if (and (ne backend "self") (ne backend "none") (ne backend "convex"))}}
+ARG VITE_SERVER_URL
+ENV VITE_SERVER_URL=\${VITE_SERVER_URL}
+{{/if}}
+{{#if (eq backend "convex")}}
+ARG VITE_CONVEX_URL
+ENV VITE_CONVEX_URL=\${VITE_CONVEX_URL}
+{{/if}}
 ENV NODE_ENV=production
 RUN cd apps/web && {{packageManager}} run build
 
@@ -16328,6 +16496,15 @@ COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 RUN npm install -g pnpm
 {{/if}}
 WORKDIR /app
+ENV SKIP_ENV_VALIDATION=1
+{{#if (and (eq backend "self") (eq auth "better-auth"))}}
+# the build evaluates the auth config; the real secret comes from compose at runtime
+ENV BETTER_AUTH_SECRET=build-time-placeholder-secret-not-used-at-runtime
+{{/if}}
+{{#if (eq orm "prisma")}}
+# prisma generate resolves DATABASE_URL at install time; the real value comes from compose at runtime
+ENV DATABASE_URL={{#if (eq database "mysql")}}mysql://build:build@localhost:3306/build{{else if (eq database "mongodb")}}mongodb://localhost:27017/build{{else if (eq database "sqlite")}}file:./build.db{{else}}postgresql://build:build@localhost:5432/build{{/if}}
+{{/if}}
 
 COPY . .
 {{#if (eq packageManager "bun")}}
@@ -16338,8 +16515,23 @@ RUN --mount=type=cache,target=/pnpm-store pnpm install --store-dir /pnpm-store
 RUN --mount=type=cache,target=/root/.npm npm install
 {{/if}}
 
+{{#if (and (ne backend "self") (ne backend "none") (ne backend "convex"))}}
+ARG PUBLIC_SERVER_URL
+ENV PUBLIC_SERVER_URL=\${PUBLIC_SERVER_URL}
+{{/if}}
+{{#if (eq backend "convex")}}
+ARG PUBLIC_CONVEX_URL
+ENV PUBLIC_CONVEX_URL=\${PUBLIC_CONVEX_URL}
+{{/if}}
 ENV NODE_ENV=production
 RUN cd apps/web && {{packageManager}} run build
+ENV SKIP_ENV_VALIDATION=
+{{#if (and (eq backend "self") (eq auth "better-auth"))}}
+ENV BETTER_AUTH_SECRET=
+{{/if}}
+{{#if (eq orm "prisma")}}
+ENV DATABASE_URL=
+{{/if}}
 
 ENV HOST=0.0.0.0
 ENV PORT=3001
@@ -27081,6 +27273,8 @@ export default defineNuxtConfig({
   },
   {{else if (and (ne backend "self") (ne backend "none"))}}
   runtimeConfig: {
+    // server-side override for SSR fetches (NUXT_SERVER_URL); falls back to the public URL
+    serverUrl: "",
     public: {
       serverUrl: process.env.NUXT_PUBLIC_SERVER_URL ?? "",
     }
@@ -30209,6 +30403,7 @@ export const env = createEnv({
 		NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
 	},
 	runtimeEnv: process.env,
+	skipValidation: !!process.env.SKIP_ENV_VALIDATION,
 	emptyStringAsUndefined: true,
 });
 {{/if}}
@@ -30334,6 +30529,7 @@ export const env = createEnv({
 	runtimeEnv: (import.meta as any).env,
 {{/if}}
 {{/if}}
+	skipValidation: !!process.env.SKIP_ENV_VALIDATION,
 	emptyStringAsUndefined: true,
 });
 `],

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -14754,7 +14754,7 @@ fastify.get('/', async () => {
 	return 'OK';
 });
 
-fastify.listen({ port: 3000 }, (err) => {
+fastify.listen({ port: 3000{{#if (eq serverDeploy "docker")}}, host: "0.0.0.0"{{/if}} }, (err) => {
 	if (err) {
 		fastify.log.error(err);
 		process.exit(1);
@@ -15833,6 +15833,520 @@ const prisma = createPrismaClient();
 export default prisma;
 {{/if}}
 {{/if}}
+`],
+  ["deploy/docker/compose/_dockerignore", `**/node_modules
+.git
+
+**/dist
+**/build
+**/.next
+**/.nuxt
+**/.output
+**/.svelte-kit
+**/.astro
+**/.turbo
+.turbo
+
+**/.wrangler
+**/.alchemy
+**/.expo
+**/.vercel
+*.log
+
+Dockerfile
+**/Dockerfile
+docker-compose.yml
+
+# Keep .env files: frameworks bake public variables from them at build time
+`],
+  ["deploy/docker/compose/docker-compose.yml.hbs", `name: {{projectName}}
+
+services:
+{{#if (eq webDeploy "docker")}}
+  web:
+    build:
+      context: .
+      dockerfile: apps/web/Dockerfile
+    init: true
+    ports:
+{{#if (or (includes frontend "tanstack-router") (includes frontend "react-router") (includes frontend "solid"))}}
+      - "3001:80"
+{{else}}
+      - "3001:3001"
+{{/if}}
+    env_file:
+      - path: apps/web/.env
+        required: false
+{{#if (eq backend "self")}}
+{{#if (or (eq dbSetup "docker") (eq auth "better-auth"))}}
+    environment:
+{{#if (eq auth "better-auth")}}
+      BETTER_AUTH_URL: http://localhost:3001
+      CORS_ORIGIN: http://localhost:3001
+{{/if}}
+{{#if (and (eq dbSetup "docker") (eq database "postgres"))}}
+      DATABASE_URL: postgresql://postgres:password@postgres:5432/{{projectName}}
+{{/if}}
+{{#if (and (eq dbSetup "docker") (eq database "mysql"))}}
+      DATABASE_URL: mysql://user:password@mysql:3306/{{projectName}}
+{{/if}}
+{{#if (and (eq dbSetup "docker") (eq database "mongodb"))}}
+      DATABASE_URL: mongodb://root:password@mongodb:27017/{{projectName}}?authSource=admin
+{{/if}}
+{{/if}}
+{{#if (eq dbSetup "docker")}}
+    depends_on:
+      {{database}}:
+        condition: service_healthy
+{{/if}}
+{{else}}
+{{#if (eq serverDeploy "docker")}}
+{{#if (or (includes frontend "next") (includes frontend "nuxt"))}}
+    environment:
+{{#if (includes frontend "next")}}
+      NEXT_PUBLIC_SERVER_URL: http://server:3000
+{{/if}}
+{{#if (includes frontend "nuxt")}}
+      NUXT_PUBLIC_SERVER_URL: http://server:3000
+{{/if}}
+{{/if}}
+    depends_on:
+      server:
+        condition: service_healthy
+{{/if}}
+{{/if}}
+    restart: unless-stopped
+
+{{/if}}
+{{#if (and (eq serverDeploy "docker") (ne backend "self"))}}
+  server:
+    build:
+      context: .
+      dockerfile: apps/server/Dockerfile
+    init: true
+    ports:
+      - "3000:3000"
+    env_file:
+      - path: apps/server/.env
+        required: false
+{{#if (or (eq webDeploy "docker") (eq dbSetup "docker"))}}
+    environment:
+{{#if (eq webDeploy "docker")}}
+      CORS_ORIGIN: http://localhost:3001
+{{/if}}
+{{#if (and (eq dbSetup "docker") (eq database "postgres"))}}
+      DATABASE_URL: postgresql://postgres:password@postgres:5432/{{projectName}}
+{{/if}}
+{{#if (and (eq dbSetup "docker") (eq database "mysql"))}}
+      DATABASE_URL: mysql://user:password@mysql:3306/{{projectName}}
+{{/if}}
+{{#if (and (eq dbSetup "docker") (eq database "mongodb"))}}
+      DATABASE_URL: mongodb://root:password@mongodb:27017/{{projectName}}?authSource=admin
+{{/if}}
+{{/if}}
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://localhost:3000/').then((r) => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+{{#if (eq dbSetup "docker")}}
+    depends_on:
+      {{database}}:
+        condition: service_healthy
+{{/if}}
+    restart: unless-stopped
+
+{{/if}}
+{{#if (eq dbSetup "docker")}}
+{{#if (eq database "postgres")}}
+  postgres:
+    image: postgres
+    container_name: {{projectName}}-postgres
+    environment:
+      POSTGRES_DB: {{projectName}}
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+    ports:
+      - "5432:5432"
+    volumes:
+      - {{projectName}}_postgres_data:/var/lib/postgresql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+{{/if}}
+{{#if (eq database "mysql")}}
+  mysql:
+    image: mysql
+    container_name: {{projectName}}-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: {{projectName}}
+      MYSQL_USER: user
+      MYSQL_PASSWORD: password
+    ports:
+      - "3306:3306"
+    volumes:
+      - {{projectName}}_mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+{{/if}}
+{{#if (eq database "mongodb")}}
+  mongodb:
+    image: mongo
+    container_name: {{projectName}}-mongodb
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: password
+      MONGO_INITDB_DATABASE: {{projectName}}
+    ports:
+      - "27017:27017"
+    volumes:
+      - {{projectName}}_mongodb_data:/data/db
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+{{/if}}
+
+volumes:
+  {{projectName}}_{{database}}_data:
+{{/if}}
+`],
+  ["deploy/docker/server/Dockerfile.hbs", `FROM node:24-slim AS base
+{{#if (or (eq packageManager "bun") (eq runtime "bun"))}}
+COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
+{{/if}}
+{{#if (eq packageManager "pnpm")}}
+RUN npm install -g pnpm
+{{/if}}
+WORKDIR /app
+
+COPY . .
+{{#if (eq packageManager "bun")}}
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install
+{{else if (eq packageManager "pnpm")}}
+RUN --mount=type=cache,target=/pnpm-store pnpm install --store-dir /pnpm-store
+{{else}}
+RUN --mount=type=cache,target=/root/.npm npm install
+{{/if}}
+
+ENV NODE_ENV=production
+RUN cd apps/server && {{packageManager}} run build
+
+EXPOSE 3000
+
+WORKDIR /app/apps/server
+{{#if (eq runtime "bun")}}
+CMD ["bun", "dist/index.mjs"]
+{{else}}
+CMD ["node", "dist/index.mjs"]
+{{/if}}
+`],
+  ["deploy/docker/web/astro/Dockerfile.hbs", `FROM node:24-slim AS base
+{{#if (eq packageManager "bun")}}
+COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
+{{/if}}
+{{#if (eq packageManager "pnpm")}}
+RUN npm install -g pnpm
+{{/if}}
+WORKDIR /app
+
+COPY . .
+{{#if (eq packageManager "bun")}}
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install
+{{else if (eq packageManager "pnpm")}}
+RUN --mount=type=cache,target=/pnpm-store pnpm install --store-dir /pnpm-store
+{{else}}
+RUN --mount=type=cache,target=/root/.npm npm install
+{{/if}}
+
+ENV NODE_ENV=production
+RUN cd apps/web && {{packageManager}} run build
+
+ENV HOST=0.0.0.0
+ENV PORT=3001
+EXPOSE 3001
+
+WORKDIR /app/apps/web
+CMD ["node", "dist/server/entry.mjs"]
+`],
+  ["deploy/docker/web/nuxt/Dockerfile.hbs", `FROM node:24-slim AS builder
+{{#if (eq packageManager "bun")}}
+COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
+{{/if}}
+{{#if (eq packageManager "pnpm")}}
+RUN npm install -g pnpm
+{{/if}}
+WORKDIR /app
+
+COPY . .
+{{#if (eq packageManager "bun")}}
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install
+{{else if (eq packageManager "pnpm")}}
+RUN --mount=type=cache,target=/pnpm-store pnpm install --store-dir /pnpm-store
+{{else}}
+RUN --mount=type=cache,target=/root/.npm npm install
+{{/if}}
+
+ENV NODE_ENV=production
+RUN cd apps/web && {{packageManager}} run build
+
+FROM node:24-slim AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY --from=builder /app/apps/web/.output ./
+
+ENV HOST=0.0.0.0
+ENV PORT=3001
+EXPOSE 3001
+
+CMD ["node", "server/index.mjs"]
+`],
+  ["deploy/docker/web/react/next/Dockerfile.hbs", `FROM node:24-slim AS builder
+{{#if (eq packageManager "bun")}}
+COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
+{{/if}}
+{{#if (eq packageManager "pnpm")}}
+RUN npm install -g pnpm
+{{/if}}
+WORKDIR /app
+
+COPY . .
+{{#if (eq packageManager "bun")}}
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install
+{{else if (eq packageManager "pnpm")}}
+RUN --mount=type=cache,target=/pnpm-store pnpm install --store-dir /pnpm-store
+{{else}}
+RUN --mount=type=cache,target=/root/.npm npm install
+{{/if}}
+
+ENV NODE_ENV=production
+RUN cd apps/web && {{packageManager}} run build
+
+FROM node:24-slim AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY --from=builder /app/apps/web/.next/standalone ./
+COPY --from=builder /app/apps/web/.next/static ./apps/web/.next/static
+
+ENV HOSTNAME=0.0.0.0
+ENV PORT=3001
+EXPOSE 3001
+
+CMD ["node", "apps/web/server.js"]
+`],
+  ["deploy/docker/web/react/react-router/Dockerfile.hbs", `FROM node:24-slim AS builder
+{{#if (eq packageManager "bun")}}
+COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
+{{/if}}
+{{#if (eq packageManager "pnpm")}}
+RUN npm install -g pnpm
+{{/if}}
+WORKDIR /app
+
+COPY . .
+{{#if (eq packageManager "bun")}}
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install
+{{else if (eq packageManager "pnpm")}}
+RUN --mount=type=cache,target=/pnpm-store pnpm install --store-dir /pnpm-store
+{{else}}
+RUN --mount=type=cache,target=/root/.npm npm install
+{{/if}}
+
+ENV NODE_ENV=production
+RUN cd apps/web && {{packageManager}} run build
+
+FROM nginx:alpine AS runner
+COPY --from=builder /app/apps/web/build/client /usr/share/nginx/html
+COPY apps/web/nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]
+`],
+  ["deploy/docker/web/react/react-router/nginx.conf", `server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript image/svg+xml;
+
+    location /assets/ {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+
+    # SPA fallback
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}
+`],
+  ["deploy/docker/web/react/tanstack-router/Dockerfile.hbs", `FROM node:24-slim AS builder
+{{#if (eq packageManager "bun")}}
+COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
+{{/if}}
+{{#if (eq packageManager "pnpm")}}
+RUN npm install -g pnpm
+{{/if}}
+WORKDIR /app
+
+COPY . .
+{{#if (eq packageManager "bun")}}
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install
+{{else if (eq packageManager "pnpm")}}
+RUN --mount=type=cache,target=/pnpm-store pnpm install --store-dir /pnpm-store
+{{else}}
+RUN --mount=type=cache,target=/root/.npm npm install
+{{/if}}
+
+ENV NODE_ENV=production
+RUN cd apps/web && {{packageManager}} run build
+
+FROM nginx:alpine AS runner
+COPY --from=builder /app/apps/web/dist /usr/share/nginx/html
+COPY apps/web/nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]
+`],
+  ["deploy/docker/web/react/tanstack-router/nginx.conf", `server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript image/svg+xml;
+
+    location /assets/ {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+
+    # SPA fallback
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}
+`],
+  ["deploy/docker/web/react/tanstack-start/Dockerfile.hbs", `FROM node:24-slim AS base
+{{#if (eq packageManager "bun")}}
+COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
+{{/if}}
+{{#if (eq packageManager "pnpm")}}
+RUN npm install -g pnpm
+{{/if}}
+WORKDIR /app
+
+COPY . .
+{{#if (eq packageManager "bun")}}
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install
+{{else if (eq packageManager "pnpm")}}
+RUN --mount=type=cache,target=/pnpm-store pnpm install --store-dir /pnpm-store
+{{else}}
+RUN --mount=type=cache,target=/root/.npm npm install
+{{/if}}
+
+ENV NODE_ENV=production
+RUN cd apps/web && {{packageManager}} run build
+
+ENV HOST=0.0.0.0
+ENV PORT=3001
+EXPOSE 3001
+
+# SSR chunks require() externals at runtime; must run from the workspace
+WORKDIR /app/apps/web
+CMD ["node", ".output/server/index.mjs"]
+`],
+  ["deploy/docker/web/solid/Dockerfile.hbs", `FROM node:24-slim AS builder
+{{#if (eq packageManager "bun")}}
+COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
+{{/if}}
+{{#if (eq packageManager "pnpm")}}
+RUN npm install -g pnpm
+{{/if}}
+WORKDIR /app
+
+COPY . .
+{{#if (eq packageManager "bun")}}
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install
+{{else if (eq packageManager "pnpm")}}
+RUN --mount=type=cache,target=/pnpm-store pnpm install --store-dir /pnpm-store
+{{else}}
+RUN --mount=type=cache,target=/root/.npm npm install
+{{/if}}
+
+ENV NODE_ENV=production
+RUN cd apps/web && {{packageManager}} run build
+
+FROM nginx:alpine AS runner
+COPY --from=builder /app/apps/web/dist /usr/share/nginx/html
+COPY apps/web/nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]
+`],
+  ["deploy/docker/web/solid/nginx.conf", `server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript image/svg+xml;
+
+    location /assets/ {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+
+    # SPA fallback
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}
+`],
+  ["deploy/docker/web/svelte/Dockerfile.hbs", `FROM node:24-slim AS base
+{{#if (eq packageManager "bun")}}
+COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
+{{/if}}
+{{#if (eq packageManager "pnpm")}}
+RUN npm install -g pnpm
+{{/if}}
+WORKDIR /app
+
+COPY . .
+{{#if (eq packageManager "bun")}}
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install
+{{else if (eq packageManager "pnpm")}}
+RUN --mount=type=cache,target=/pnpm-store pnpm install --store-dir /pnpm-store
+{{else}}
+RUN --mount=type=cache,target=/root/.npm npm install
+{{/if}}
+
+ENV NODE_ENV=production
+RUN cd apps/web && {{packageManager}} run build
+
+ENV HOST=0.0.0.0
+ENV PORT=3001
+EXPOSE 3001
+
+WORKDIR /app/apps/web
+CMD ["node", "build/index.js"]
 `],
   ["examples/ai/convex/packages/backend/convex/agent.ts.hbs", `import { Agent } from "@convex-dev/agent";
 import { google } from "@ai-sdk/google";
@@ -22365,12 +22879,12 @@ declare module "cloudflare:workers" {
   ["extras/pnpm-workspace.yaml.hbs", `packages:
   - "apps/*"
   - "packages/*"
-{{#if (or (eq runtime "node") (eq webDeploy "cloudflare") (eq serverDeploy "cloudflare") (eq orm "prisma") (includes addons "lefthook") (includes addons "nx") (includes addons "pwa") (includes frontend "tanstack-router") (includes frontend "react-router") (includes frontend "tanstack-start") (includes frontend "next") (includes frontend "native-bare") (includes frontend "native-uniwind") (includes frontend "native-unistyles"))}}
+{{#if (or (eq runtime "node") (eq webDeploy "cloudflare") (eq serverDeploy "cloudflare") (eq webDeploy "docker") (eq serverDeploy "docker") (eq orm "prisma") (includes addons "lefthook") (includes addons "nx") (includes addons "pwa") (includes frontend "tanstack-router") (includes frontend "react-router") (includes frontend "tanstack-start") (includes frontend "next") (includes frontend "nuxt") (includes frontend "native-bare") (includes frontend "native-uniwind") (includes frontend "native-unistyles"))}}
 
 # pnpm 11 blocks dependency lifecycle scripts unless they are approved here.
 # Entries are scoped to packages this generated stack can pull in.
 allowBuilds:
-{{#if (or (eq runtime "node") (eq webDeploy "cloudflare") (eq serverDeploy "cloudflare") (includes frontend "tanstack-start"))}}
+{{#if (or (eq runtime "node") (eq webDeploy "cloudflare") (eq serverDeploy "cloudflare") (eq webDeploy "docker") (eq serverDeploy "docker") (includes frontend "tanstack-start"))}}
   esbuild: true
 {{/if}}
 {{#if (or (includes frontend "tanstack-router") (includes frontend "react-router") (includes frontend "tanstack-start") (includes frontend "next"))}}
@@ -22379,7 +22893,11 @@ allowBuilds:
 {{#if (or (includes frontend "native-bare") (includes frontend "native-uniwind") (includes frontend "native-unistyles"))}}
   msgpackr-extract: true
 {{/if}}
-{{#if (or (eq webDeploy "cloudflare") (eq serverDeploy "cloudflare") (includes addons "pwa"))}}
+{{#if (includes frontend "nuxt")}}
+  "@parcel/watcher": true
+  vue-demi: true
+{{/if}}
+{{#if (or (eq webDeploy "cloudflare") (eq serverDeploy "cloudflare") (eq webDeploy "docker") (includes addons "pwa"))}}
   sharp: true
 {{/if}}
 {{#if (or (eq webDeploy "cloudflare") (eq serverDeploy "cloudflare"))}}
@@ -26583,7 +27101,8 @@ export default defineNuxtConfig({
   },
   "dependencies": {
     "@nuxt/ui": "^4.5.1",
-    "nuxt": "^4.4.4"
+    "nuxt": "^4.4.4",
+    "vue": "^3.5.38"
   },
   "devDependencies": {
     "tailwindcss": "^4.2.1",
@@ -26633,6 +27152,9 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
 	typedRoutes: true,
 	reactCompiler: true,
+	{{#if (eq webDeploy "docker")}}
+	output: "standalone",
+	{{/if}}
 	{{#if (includes examples "ai")}}
 	transpilePackages: ["shiki"],
 	{{/if}}
@@ -28603,6 +29125,9 @@ function HomeComponent() {
 `],
   ["frontend/react/tanstack-start/vite.config.ts.hbs", `import { defineConfig } from "{{#if (includes addons "vite-plus")}}vite-plus{{else}}vite{{/if}}";
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
+{{#if (eq webDeploy "docker")}}
+import { nitro } from "nitro/vite";
+{{/if}}
 import tailwindcss from "@tailwindcss/vite";
 import viteReact from "@vitejs/plugin-react";
 
@@ -28616,6 +29141,9 @@ export default defineConfig({
   plugins: [
     tailwindcss(),
     tanstackStart(),
+{{#if (eq webDeploy "docker")}}
+    nitro(),
+{{/if}}
     viteReact(),
   ],
 {{#if (and (eq backend "convex") (eq auth "better-auth"))}}
@@ -28849,6 +29377,7 @@ dist-ssr
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
+    "@tanstack/solid-router-devtools": "^1.166.13",
     "vite": "^8.0.8",
     "vite-plugin-solid": "^2.11.12"
   }
@@ -29405,6 +29934,8 @@ const TITLE_TEXT = \`
   ["frontend/svelte/static/favicon.png", `[Binary file]`],
   ["frontend/svelte/svelte.config.js.hbs", `{{#if (eq webDeploy "cloudflare")}}
 import alchemy from 'alchemy/cloudflare/sveltekit';
+{{else if (eq webDeploy "docker")}}
+import adapter from '@sveltejs/adapter-node';
 {{else}}
 import adapter from '@sveltejs/adapter-auto';
 {{/if}}
@@ -29420,6 +29951,9 @@ const config = {
 {{#if (eq webDeploy "cloudflare")}}
 		// Alchemy's adapter wraps SvelteKit's Cloudflare adapter for local platform.env and Worker builds.
 		adapter: alchemy()
+{{else if (eq webDeploy "docker")}}
+		// adapter-node builds a standalone Node server (run with \`node build/index.js\`).
+		adapter: adapter()
 {{else}}
 		// adapter-auto only supports some environments, see https://svelte.dev/docs/kit/adapter-auto for a list.
 		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.
@@ -31257,4 +31791,4 @@ function SuccessPage() {
 `]
 ]);
 
-export const TEMPLATE_COUNT = 483;
+export const TEMPLATE_COUNT = 497;

--- a/packages/template-generator/src/utils/add-deps.ts
+++ b/packages/template-generator/src/utils/add-deps.ts
@@ -151,6 +151,7 @@ export const dependencyVersionMap = {
   "@opennextjs/cloudflare": "^1.17.3",
   "nitro-cloudflare-dev": "^0.2.2",
   "@sveltejs/adapter-cloudflare": "^7.2.8",
+  "@sveltejs/adapter-node": "^5.5.4",
   "@cloudflare/workers-types": "^4.20251213.0",
   "@astrojs/cloudflare": "^13.0.1",
   "@astrojs/node": "^10.0.0-beta.9",

--- a/packages/template-generator/templates/api/orpc/web/nuxt/app/plugins/orpc.ts.hbs
+++ b/packages/template-generator/templates/api/orpc/web/nuxt/app/plugins/orpc.ts.hbs
@@ -6,7 +6,9 @@ import { createTanstackQueryUtils } from "@orpc/tanstack-query";
 
 export default defineNuxtPlugin(() => {
   const config = useRuntimeConfig();
-  const rpcUrl = `${config.public.serverUrl}/rpc`;
+  const serverUrl =
+    (import.meta.server && config.serverUrl) || config.public.serverUrl;
+  const rpcUrl = `${serverUrl}/rpc`;
 
   const rpcLink = new RPCLink({
     url: rpcUrl,

--- a/packages/template-generator/templates/auth/better-auth/web/nuxt/app/plugins/auth-client.ts.hbs
+++ b/packages/template-generator/templates/auth/better-auth/web/nuxt/app/plugins/auth-client.ts.hbs
@@ -10,7 +10,7 @@ export default defineNuxtPlugin(() => {
 
   const authClient = createAuthClient({
     {{#if (ne backend "self")}}
-    baseURL: config.public.serverUrl,
+    baseURL: (import.meta.server && config.serverUrl) || config.public.serverUrl,
     {{/if}}
     {{#if (eq payments "polar")}}
     plugins: [polarClient()],

--- a/packages/template-generator/templates/backend/server/fastify/src/index.ts.hbs
+++ b/packages/template-generator/templates/backend/server/fastify/src/index.ts.hbs
@@ -207,7 +207,7 @@ fastify.get('/', async () => {
 	return 'OK';
 });
 
-fastify.listen({ port: 3000 }, (err) => {
+fastify.listen({ port: 3000{{#if (eq serverDeploy "docker")}}, host: "0.0.0.0"{{/if}} }, (err) => {
 	if (err) {
 		fastify.log.error(err);
 		process.exit(1);

--- a/packages/template-generator/templates/deploy/docker/compose/_dockerignore
+++ b/packages/template-generator/templates/deploy/docker/compose/_dockerignore
@@ -1,0 +1,24 @@
+**/node_modules
+.git
+
+**/dist
+**/build
+**/.next
+**/.nuxt
+**/.output
+**/.svelte-kit
+**/.astro
+**/.turbo
+.turbo
+
+**/.wrangler
+**/.alchemy
+**/.expo
+**/.vercel
+*.log
+
+Dockerfile
+**/Dockerfile
+docker-compose.yml
+
+# Keep .env files: frameworks bake public variables from them at build time

--- a/packages/template-generator/templates/deploy/docker/compose/_dockerignore
+++ b/packages/template-generator/templates/deploy/docker/compose/_dockerignore
@@ -21,4 +21,8 @@ Dockerfile
 **/Dockerfile
 docker-compose.yml
 
-# Keep .env files: frameworks bake public variables from them at build time
+# Secrets stay out of image layers; runtime env comes from compose env_file,
+# build-time public values come from compose build args
+**/.env
+**/.env.*
+!**/.env.example

--- a/packages/template-generator/templates/deploy/docker/compose/docker-compose.yml.hbs
+++ b/packages/template-generator/templates/deploy/docker/compose/docker-compose.yml.hbs
@@ -6,6 +6,18 @@ services:
     build:
       context: .
       dockerfile: apps/web/Dockerfile
+{{#if (and (not (includes frontend "nuxt")) (or (and (ne backend "self") (ne backend "none") (ne backend "convex")) (eq backend "convex") (and (eq auth "clerk") (or (includes frontend "next") (includes frontend "react-router") (includes frontend "tanstack-router") (includes frontend "tanstack-start")))))}}
+      args:
+{{#if (and (ne backend "self") (ne backend "none") (ne backend "convex"))}}
+        {{#if (includes frontend "next")}}NEXT_PUBLIC_SERVER_URL{{else if (or (includes frontend "svelte") (includes frontend "astro"))}}PUBLIC_SERVER_URL{{else}}VITE_SERVER_URL{{/if}}: http://localhost:3000
+{{/if}}
+{{#if (eq backend "convex")}}
+        {{#if (includes frontend "next")}}NEXT_PUBLIC_CONVEX_URL{{else if (or (includes frontend "svelte") (includes frontend "astro"))}}PUBLIC_CONVEX_URL{{else}}VITE_CONVEX_URL{{/if}}: ${CONVEX_URL:-}
+{{/if}}
+{{#if (and (eq auth "clerk") (or (includes frontend "next") (includes frontend "react-router") (includes frontend "tanstack-router") (includes frontend "tanstack-start")))}}
+        {{#if (includes frontend "next")}}NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY{{else}}VITE_CLERK_PUBLISHABLE_KEY{{/if}}: ${CLERK_PUBLISHABLE_KEY:-}
+{{/if}}
+{{/if}}
     init: true
     ports:
 {{#if (or (includes frontend "tanstack-router") (includes frontend "react-router") (includes frontend "solid"))}}
@@ -24,13 +36,13 @@ services:
       CORS_ORIGIN: http://localhost:3001
 {{/if}}
 {{#if (and (eq dbSetup "docker") (eq database "postgres"))}}
-      DATABASE_URL: postgresql://postgres:password@postgres:5432/{{projectName}}
+      DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD:-password}@postgres:5432/{{projectName}}
 {{/if}}
 {{#if (and (eq dbSetup "docker") (eq database "mysql"))}}
-      DATABASE_URL: mysql://user:password@mysql:3306/{{projectName}}
+      DATABASE_URL: mysql://user:${MYSQL_PASSWORD:-password}@mysql:3306/{{projectName}}
 {{/if}}
 {{#if (and (eq dbSetup "docker") (eq database "mongodb"))}}
-      DATABASE_URL: mongodb://root:password@mongodb:27017/{{projectName}}?authSource=admin
+      DATABASE_URL: mongodb://root:${MONGO_PASSWORD:-password}@mongodb:27017/{{projectName}}?authSource=admin
 {{/if}}
 {{/if}}
 {{#if (eq dbSetup "docker")}}
@@ -46,7 +58,7 @@ services:
       NEXT_PUBLIC_SERVER_URL: http://server:3000
 {{/if}}
 {{#if (includes frontend "nuxt")}}
-      NUXT_PUBLIC_SERVER_URL: http://server:3000
+      NUXT_SERVER_URL: http://server:3000
 {{/if}}
 {{/if}}
     depends_on:
@@ -74,13 +86,13 @@ services:
       CORS_ORIGIN: http://localhost:3001
 {{/if}}
 {{#if (and (eq dbSetup "docker") (eq database "postgres"))}}
-      DATABASE_URL: postgresql://postgres:password@postgres:5432/{{projectName}}
+      DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD:-password}@postgres:5432/{{projectName}}
 {{/if}}
 {{#if (and (eq dbSetup "docker") (eq database "mysql"))}}
-      DATABASE_URL: mysql://user:password@mysql:3306/{{projectName}}
+      DATABASE_URL: mysql://user:${MYSQL_PASSWORD:-password}@mysql:3306/{{projectName}}
 {{/if}}
 {{#if (and (eq dbSetup "docker") (eq database "mongodb"))}}
-      DATABASE_URL: mongodb://root:password@mongodb:27017/{{projectName}}?authSource=admin
+      DATABASE_URL: mongodb://root:${MONGO_PASSWORD:-password}@mongodb:27017/{{projectName}}?authSource=admin
 {{/if}}
 {{/if}}
     healthcheck:
@@ -111,7 +123,7 @@ services:
     environment:
       POSTGRES_DB: {{projectName}}
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: password
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-password}
     ports:
       - "5432:5432"
     volumes:
@@ -128,10 +140,10 @@ services:
     image: mysql
     container_name: {{projectName}}-mysql
     environment:
-      MYSQL_ROOT_PASSWORD: password
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-password}
       MYSQL_DATABASE: {{projectName}}
       MYSQL_USER: user
-      MYSQL_PASSWORD: password
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-password}
     ports:
       - "3306:3306"
     volumes:
@@ -149,7 +161,7 @@ services:
     container_name: {{projectName}}-mongodb
     environment:
       MONGO_INITDB_ROOT_USERNAME: root
-      MONGO_INITDB_ROOT_PASSWORD: password
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PASSWORD:-password}
       MONGO_INITDB_DATABASE: {{projectName}}
     ports:
       - "27017:27017"

--- a/packages/template-generator/templates/deploy/docker/compose/docker-compose.yml.hbs
+++ b/packages/template-generator/templates/deploy/docker/compose/docker-compose.yml.hbs
@@ -1,0 +1,168 @@
+name: {{projectName}}
+
+services:
+{{#if (eq webDeploy "docker")}}
+  web:
+    build:
+      context: .
+      dockerfile: apps/web/Dockerfile
+    init: true
+    ports:
+{{#if (or (includes frontend "tanstack-router") (includes frontend "react-router") (includes frontend "solid"))}}
+      - "3001:80"
+{{else}}
+      - "3001:3001"
+{{/if}}
+    env_file:
+      - path: apps/web/.env
+        required: false
+{{#if (eq backend "self")}}
+{{#if (or (eq dbSetup "docker") (eq auth "better-auth"))}}
+    environment:
+{{#if (eq auth "better-auth")}}
+      BETTER_AUTH_URL: http://localhost:3001
+      CORS_ORIGIN: http://localhost:3001
+{{/if}}
+{{#if (and (eq dbSetup "docker") (eq database "postgres"))}}
+      DATABASE_URL: postgresql://postgres:password@postgres:5432/{{projectName}}
+{{/if}}
+{{#if (and (eq dbSetup "docker") (eq database "mysql"))}}
+      DATABASE_URL: mysql://user:password@mysql:3306/{{projectName}}
+{{/if}}
+{{#if (and (eq dbSetup "docker") (eq database "mongodb"))}}
+      DATABASE_URL: mongodb://root:password@mongodb:27017/{{projectName}}?authSource=admin
+{{/if}}
+{{/if}}
+{{#if (eq dbSetup "docker")}}
+    depends_on:
+      {{database}}:
+        condition: service_healthy
+{{/if}}
+{{else}}
+{{#if (eq serverDeploy "docker")}}
+{{#if (or (includes frontend "next") (includes frontend "nuxt"))}}
+    environment:
+{{#if (includes frontend "next")}}
+      NEXT_PUBLIC_SERVER_URL: http://server:3000
+{{/if}}
+{{#if (includes frontend "nuxt")}}
+      NUXT_PUBLIC_SERVER_URL: http://server:3000
+{{/if}}
+{{/if}}
+    depends_on:
+      server:
+        condition: service_healthy
+{{/if}}
+{{/if}}
+    restart: unless-stopped
+
+{{/if}}
+{{#if (and (eq serverDeploy "docker") (ne backend "self"))}}
+  server:
+    build:
+      context: .
+      dockerfile: apps/server/Dockerfile
+    init: true
+    ports:
+      - "3000:3000"
+    env_file:
+      - path: apps/server/.env
+        required: false
+{{#if (or (eq webDeploy "docker") (eq dbSetup "docker"))}}
+    environment:
+{{#if (eq webDeploy "docker")}}
+      CORS_ORIGIN: http://localhost:3001
+{{/if}}
+{{#if (and (eq dbSetup "docker") (eq database "postgres"))}}
+      DATABASE_URL: postgresql://postgres:password@postgres:5432/{{projectName}}
+{{/if}}
+{{#if (and (eq dbSetup "docker") (eq database "mysql"))}}
+      DATABASE_URL: mysql://user:password@mysql:3306/{{projectName}}
+{{/if}}
+{{#if (and (eq dbSetup "docker") (eq database "mongodb"))}}
+      DATABASE_URL: mongodb://root:password@mongodb:27017/{{projectName}}?authSource=admin
+{{/if}}
+{{/if}}
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://localhost:3000/').then((r) => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+{{#if (eq dbSetup "docker")}}
+    depends_on:
+      {{database}}:
+        condition: service_healthy
+{{/if}}
+    restart: unless-stopped
+
+{{/if}}
+{{#if (eq dbSetup "docker")}}
+{{#if (eq database "postgres")}}
+  postgres:
+    image: postgres
+    container_name: {{projectName}}-postgres
+    environment:
+      POSTGRES_DB: {{projectName}}
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+    ports:
+      - "5432:5432"
+    volumes:
+      - {{projectName}}_postgres_data:/var/lib/postgresql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+{{/if}}
+{{#if (eq database "mysql")}}
+  mysql:
+    image: mysql
+    container_name: {{projectName}}-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: {{projectName}}
+      MYSQL_USER: user
+      MYSQL_PASSWORD: password
+    ports:
+      - "3306:3306"
+    volumes:
+      - {{projectName}}_mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+{{/if}}
+{{#if (eq database "mongodb")}}
+  mongodb:
+    image: mongo
+    container_name: {{projectName}}-mongodb
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: password
+      MONGO_INITDB_DATABASE: {{projectName}}
+    ports:
+      - "27017:27017"
+    volumes:
+      - {{projectName}}_mongodb_data:/data/db
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+{{/if}}
+
+volumes:
+  {{projectName}}_{{database}}_data:
+{{/if}}

--- a/packages/template-generator/templates/deploy/docker/server/Dockerfile.hbs
+++ b/packages/template-generator/templates/deploy/docker/server/Dockerfile.hbs
@@ -1,0 +1,29 @@
+FROM node:24-slim AS base
+{{#if (or (eq packageManager "bun") (eq runtime "bun"))}}
+COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
+{{/if}}
+{{#if (eq packageManager "pnpm")}}
+RUN npm install -g pnpm
+{{/if}}
+WORKDIR /app
+
+COPY . .
+{{#if (eq packageManager "bun")}}
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install
+{{else if (eq packageManager "pnpm")}}
+RUN --mount=type=cache,target=/pnpm-store pnpm install --store-dir /pnpm-store
+{{else}}
+RUN --mount=type=cache,target=/root/.npm npm install
+{{/if}}
+
+ENV NODE_ENV=production
+RUN cd apps/server && {{packageManager}} run build
+
+EXPOSE 3000
+
+WORKDIR /app/apps/server
+{{#if (eq runtime "bun")}}
+CMD ["bun", "dist/index.mjs"]
+{{else}}
+CMD ["node", "dist/index.mjs"]
+{{/if}}

--- a/packages/template-generator/templates/deploy/docker/server/Dockerfile.hbs
+++ b/packages/template-generator/templates/deploy/docker/server/Dockerfile.hbs
@@ -6,6 +6,11 @@ COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 RUN npm install -g pnpm
 {{/if}}
 WORKDIR /app
+ENV SKIP_ENV_VALIDATION=1
+{{#if (eq orm "prisma")}}
+# prisma generate resolves DATABASE_URL at install time; the real value comes from compose at runtime
+ENV DATABASE_URL={{#if (eq database "mysql")}}mysql://build:build@localhost:3306/build{{else if (eq database "mongodb")}}mongodb://localhost:27017/build{{else if (eq database "sqlite")}}file:./build.db{{else}}postgresql://build:build@localhost:5432/build{{/if}}
+{{/if}}
 
 COPY . .
 {{#if (eq packageManager "bun")}}
@@ -18,6 +23,10 @@ RUN --mount=type=cache,target=/root/.npm npm install
 
 ENV NODE_ENV=production
 RUN cd apps/server && {{packageManager}} run build
+ENV SKIP_ENV_VALIDATION=
+{{#if (eq orm "prisma")}}
+ENV DATABASE_URL=
+{{/if}}
 
 EXPOSE 3000
 

--- a/packages/template-generator/templates/deploy/docker/web/astro/Dockerfile.hbs
+++ b/packages/template-generator/templates/deploy/docker/web/astro/Dockerfile.hbs
@@ -1,0 +1,27 @@
+FROM node:24-slim AS base
+{{#if (eq packageManager "bun")}}
+COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
+{{/if}}
+{{#if (eq packageManager "pnpm")}}
+RUN npm install -g pnpm
+{{/if}}
+WORKDIR /app
+
+COPY . .
+{{#if (eq packageManager "bun")}}
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install
+{{else if (eq packageManager "pnpm")}}
+RUN --mount=type=cache,target=/pnpm-store pnpm install --store-dir /pnpm-store
+{{else}}
+RUN --mount=type=cache,target=/root/.npm npm install
+{{/if}}
+
+ENV NODE_ENV=production
+RUN cd apps/web && {{packageManager}} run build
+
+ENV HOST=0.0.0.0
+ENV PORT=3001
+EXPOSE 3001
+
+WORKDIR /app/apps/web
+CMD ["node", "dist/server/entry.mjs"]

--- a/packages/template-generator/templates/deploy/docker/web/astro/Dockerfile.hbs
+++ b/packages/template-generator/templates/deploy/docker/web/astro/Dockerfile.hbs
@@ -6,6 +6,15 @@ COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 RUN npm install -g pnpm
 {{/if}}
 WORKDIR /app
+ENV SKIP_ENV_VALIDATION=1
+{{#if (and (eq backend "self") (eq auth "better-auth"))}}
+# the build evaluates the auth config; the real secret comes from compose at runtime
+ENV BETTER_AUTH_SECRET=build-time-placeholder-secret-not-used-at-runtime
+{{/if}}
+{{#if (eq orm "prisma")}}
+# prisma generate resolves DATABASE_URL at install time; the real value comes from compose at runtime
+ENV DATABASE_URL={{#if (eq database "mysql")}}mysql://build:build@localhost:3306/build{{else if (eq database "mongodb")}}mongodb://localhost:27017/build{{else if (eq database "sqlite")}}file:./build.db{{else}}postgresql://build:build@localhost:5432/build{{/if}}
+{{/if}}
 
 COPY . .
 {{#if (eq packageManager "bun")}}
@@ -16,8 +25,23 @@ RUN --mount=type=cache,target=/pnpm-store pnpm install --store-dir /pnpm-store
 RUN --mount=type=cache,target=/root/.npm npm install
 {{/if}}
 
+{{#if (and (ne backend "self") (ne backend "none") (ne backend "convex"))}}
+ARG PUBLIC_SERVER_URL
+ENV PUBLIC_SERVER_URL=${PUBLIC_SERVER_URL}
+{{/if}}
+{{#if (eq backend "convex")}}
+ARG PUBLIC_CONVEX_URL
+ENV PUBLIC_CONVEX_URL=${PUBLIC_CONVEX_URL}
+{{/if}}
 ENV NODE_ENV=production
 RUN cd apps/web && {{packageManager}} run build
+ENV SKIP_ENV_VALIDATION=
+{{#if (and (eq backend "self") (eq auth "better-auth"))}}
+ENV BETTER_AUTH_SECRET=
+{{/if}}
+{{#if (eq orm "prisma")}}
+ENV DATABASE_URL=
+{{/if}}
 
 ENV HOST=0.0.0.0
 ENV PORT=3001

--- a/packages/template-generator/templates/deploy/docker/web/nuxt/Dockerfile.hbs
+++ b/packages/template-generator/templates/deploy/docker/web/nuxt/Dockerfile.hbs
@@ -6,6 +6,15 @@ COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 RUN npm install -g pnpm
 {{/if}}
 WORKDIR /app
+ENV SKIP_ENV_VALIDATION=1
+{{#if (and (eq backend "self") (eq auth "better-auth"))}}
+# the build evaluates the auth config; the real secret comes from compose at runtime
+ENV BETTER_AUTH_SECRET=build-time-placeholder-secret-not-used-at-runtime
+{{/if}}
+{{#if (eq orm "prisma")}}
+# prisma generate resolves DATABASE_URL at install time; the real value comes from compose at runtime
+ENV DATABASE_URL={{#if (eq database "mysql")}}mysql://build:build@localhost:3306/build{{else if (eq database "mongodb")}}mongodb://localhost:27017/build{{else if (eq database "sqlite")}}file:./build.db{{else}}postgresql://build:build@localhost:5432/build{{/if}}
+{{/if}}
 
 COPY . .
 {{#if (eq packageManager "bun")}}

--- a/packages/template-generator/templates/deploy/docker/web/nuxt/Dockerfile.hbs
+++ b/packages/template-generator/templates/deploy/docker/web/nuxt/Dockerfile.hbs
@@ -1,0 +1,32 @@
+FROM node:24-slim AS builder
+{{#if (eq packageManager "bun")}}
+COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
+{{/if}}
+{{#if (eq packageManager "pnpm")}}
+RUN npm install -g pnpm
+{{/if}}
+WORKDIR /app
+
+COPY . .
+{{#if (eq packageManager "bun")}}
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install
+{{else if (eq packageManager "pnpm")}}
+RUN --mount=type=cache,target=/pnpm-store pnpm install --store-dir /pnpm-store
+{{else}}
+RUN --mount=type=cache,target=/root/.npm npm install
+{{/if}}
+
+ENV NODE_ENV=production
+RUN cd apps/web && {{packageManager}} run build
+
+FROM node:24-slim AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY --from=builder /app/apps/web/.output ./
+
+ENV HOST=0.0.0.0
+ENV PORT=3001
+EXPOSE 3001
+
+CMD ["node", "server/index.mjs"]

--- a/packages/template-generator/templates/deploy/docker/web/react/next/Dockerfile.hbs
+++ b/packages/template-generator/templates/deploy/docker/web/react/next/Dockerfile.hbs
@@ -1,0 +1,33 @@
+FROM node:24-slim AS builder
+{{#if (eq packageManager "bun")}}
+COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
+{{/if}}
+{{#if (eq packageManager "pnpm")}}
+RUN npm install -g pnpm
+{{/if}}
+WORKDIR /app
+
+COPY . .
+{{#if (eq packageManager "bun")}}
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install
+{{else if (eq packageManager "pnpm")}}
+RUN --mount=type=cache,target=/pnpm-store pnpm install --store-dir /pnpm-store
+{{else}}
+RUN --mount=type=cache,target=/root/.npm npm install
+{{/if}}
+
+ENV NODE_ENV=production
+RUN cd apps/web && {{packageManager}} run build
+
+FROM node:24-slim AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY --from=builder /app/apps/web/.next/standalone ./
+COPY --from=builder /app/apps/web/.next/static ./apps/web/.next/static
+
+ENV HOSTNAME=0.0.0.0
+ENV PORT=3001
+EXPOSE 3001
+
+CMD ["node", "apps/web/server.js"]

--- a/packages/template-generator/templates/deploy/docker/web/react/next/Dockerfile.hbs
+++ b/packages/template-generator/templates/deploy/docker/web/react/next/Dockerfile.hbs
@@ -6,6 +6,15 @@ COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 RUN npm install -g pnpm
 {{/if}}
 WORKDIR /app
+ENV SKIP_ENV_VALIDATION=1
+{{#if (and (eq backend "self") (eq auth "better-auth"))}}
+# the build evaluates the auth config; the real secret comes from compose at runtime
+ENV BETTER_AUTH_SECRET=build-time-placeholder-secret-not-used-at-runtime
+{{/if}}
+{{#if (eq orm "prisma")}}
+# prisma generate resolves DATABASE_URL at install time; the real value comes from compose at runtime
+ENV DATABASE_URL={{#if (eq database "mysql")}}mysql://build:build@localhost:3306/build{{else if (eq database "mongodb")}}mongodb://localhost:27017/build{{else if (eq database "sqlite")}}file:./build.db{{else}}postgresql://build:build@localhost:5432/build{{/if}}
+{{/if}}
 
 COPY . .
 {{#if (eq packageManager "bun")}}
@@ -16,6 +25,18 @@ RUN --mount=type=cache,target=/pnpm-store pnpm install --store-dir /pnpm-store
 RUN --mount=type=cache,target=/root/.npm npm install
 {{/if}}
 
+{{#if (and (ne backend "self") (ne backend "none") (ne backend "convex"))}}
+ARG NEXT_PUBLIC_SERVER_URL
+ENV NEXT_PUBLIC_SERVER_URL=${NEXT_PUBLIC_SERVER_URL}
+{{/if}}
+{{#if (eq backend "convex")}}
+ARG NEXT_PUBLIC_CONVEX_URL
+ENV NEXT_PUBLIC_CONVEX_URL=${NEXT_PUBLIC_CONVEX_URL}
+{{/if}}
+{{#if (eq auth "clerk")}}
+ARG NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+ENV NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}
+{{/if}}
 ENV NODE_ENV=production
 RUN cd apps/web && {{packageManager}} run build
 

--- a/packages/template-generator/templates/deploy/docker/web/react/react-router/Dockerfile.hbs
+++ b/packages/template-generator/templates/deploy/docker/web/react/react-router/Dockerfile.hbs
@@ -1,0 +1,26 @@
+FROM node:24-slim AS builder
+{{#if (eq packageManager "bun")}}
+COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
+{{/if}}
+{{#if (eq packageManager "pnpm")}}
+RUN npm install -g pnpm
+{{/if}}
+WORKDIR /app
+
+COPY . .
+{{#if (eq packageManager "bun")}}
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install
+{{else if (eq packageManager "pnpm")}}
+RUN --mount=type=cache,target=/pnpm-store pnpm install --store-dir /pnpm-store
+{{else}}
+RUN --mount=type=cache,target=/root/.npm npm install
+{{/if}}
+
+ENV NODE_ENV=production
+RUN cd apps/web && {{packageManager}} run build
+
+FROM nginx:alpine AS runner
+COPY --from=builder /app/apps/web/build/client /usr/share/nginx/html
+COPY apps/web/nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/packages/template-generator/templates/deploy/docker/web/react/react-router/Dockerfile.hbs
+++ b/packages/template-generator/templates/deploy/docker/web/react/react-router/Dockerfile.hbs
@@ -6,6 +6,15 @@ COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 RUN npm install -g pnpm
 {{/if}}
 WORKDIR /app
+ENV SKIP_ENV_VALIDATION=1
+{{#if (and (eq backend "self") (eq auth "better-auth"))}}
+# the build evaluates the auth config; the real secret comes from compose at runtime
+ENV BETTER_AUTH_SECRET=build-time-placeholder-secret-not-used-at-runtime
+{{/if}}
+{{#if (eq orm "prisma")}}
+# prisma generate resolves DATABASE_URL at install time; the real value comes from compose at runtime
+ENV DATABASE_URL={{#if (eq database "mysql")}}mysql://build:build@localhost:3306/build{{else if (eq database "mongodb")}}mongodb://localhost:27017/build{{else if (eq database "sqlite")}}file:./build.db{{else}}postgresql://build:build@localhost:5432/build{{/if}}
+{{/if}}
 
 COPY . .
 {{#if (eq packageManager "bun")}}
@@ -16,6 +25,18 @@ RUN --mount=type=cache,target=/pnpm-store pnpm install --store-dir /pnpm-store
 RUN --mount=type=cache,target=/root/.npm npm install
 {{/if}}
 
+{{#if (and (ne backend "self") (ne backend "none") (ne backend "convex"))}}
+ARG VITE_SERVER_URL
+ENV VITE_SERVER_URL=${VITE_SERVER_URL}
+{{/if}}
+{{#if (eq backend "convex")}}
+ARG VITE_CONVEX_URL
+ENV VITE_CONVEX_URL=${VITE_CONVEX_URL}
+{{/if}}
+{{#if (eq auth "clerk")}}
+ARG VITE_CLERK_PUBLISHABLE_KEY
+ENV VITE_CLERK_PUBLISHABLE_KEY=${VITE_CLERK_PUBLISHABLE_KEY}
+{{/if}}
 ENV NODE_ENV=production
 RUN cd apps/web && {{packageManager}} run build
 

--- a/packages/template-generator/templates/deploy/docker/web/react/react-router/nginx.conf
+++ b/packages/template-generator/templates/deploy/docker/web/react/react-router/nginx.conf
@@ -1,0 +1,18 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript image/svg+xml;
+
+    location /assets/ {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+
+    # SPA fallback
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/packages/template-generator/templates/deploy/docker/web/react/tanstack-router/Dockerfile.hbs
+++ b/packages/template-generator/templates/deploy/docker/web/react/tanstack-router/Dockerfile.hbs
@@ -1,0 +1,26 @@
+FROM node:24-slim AS builder
+{{#if (eq packageManager "bun")}}
+COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
+{{/if}}
+{{#if (eq packageManager "pnpm")}}
+RUN npm install -g pnpm
+{{/if}}
+WORKDIR /app
+
+COPY . .
+{{#if (eq packageManager "bun")}}
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install
+{{else if (eq packageManager "pnpm")}}
+RUN --mount=type=cache,target=/pnpm-store pnpm install --store-dir /pnpm-store
+{{else}}
+RUN --mount=type=cache,target=/root/.npm npm install
+{{/if}}
+
+ENV NODE_ENV=production
+RUN cd apps/web && {{packageManager}} run build
+
+FROM nginx:alpine AS runner
+COPY --from=builder /app/apps/web/dist /usr/share/nginx/html
+COPY apps/web/nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/packages/template-generator/templates/deploy/docker/web/react/tanstack-router/Dockerfile.hbs
+++ b/packages/template-generator/templates/deploy/docker/web/react/tanstack-router/Dockerfile.hbs
@@ -6,6 +6,15 @@ COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 RUN npm install -g pnpm
 {{/if}}
 WORKDIR /app
+ENV SKIP_ENV_VALIDATION=1
+{{#if (and (eq backend "self") (eq auth "better-auth"))}}
+# the build evaluates the auth config; the real secret comes from compose at runtime
+ENV BETTER_AUTH_SECRET=build-time-placeholder-secret-not-used-at-runtime
+{{/if}}
+{{#if (eq orm "prisma")}}
+# prisma generate resolves DATABASE_URL at install time; the real value comes from compose at runtime
+ENV DATABASE_URL={{#if (eq database "mysql")}}mysql://build:build@localhost:3306/build{{else if (eq database "mongodb")}}mongodb://localhost:27017/build{{else if (eq database "sqlite")}}file:./build.db{{else}}postgresql://build:build@localhost:5432/build{{/if}}
+{{/if}}
 
 COPY . .
 {{#if (eq packageManager "bun")}}
@@ -16,6 +25,18 @@ RUN --mount=type=cache,target=/pnpm-store pnpm install --store-dir /pnpm-store
 RUN --mount=type=cache,target=/root/.npm npm install
 {{/if}}
 
+{{#if (and (ne backend "self") (ne backend "none") (ne backend "convex"))}}
+ARG VITE_SERVER_URL
+ENV VITE_SERVER_URL=${VITE_SERVER_URL}
+{{/if}}
+{{#if (eq backend "convex")}}
+ARG VITE_CONVEX_URL
+ENV VITE_CONVEX_URL=${VITE_CONVEX_URL}
+{{/if}}
+{{#if (eq auth "clerk")}}
+ARG VITE_CLERK_PUBLISHABLE_KEY
+ENV VITE_CLERK_PUBLISHABLE_KEY=${VITE_CLERK_PUBLISHABLE_KEY}
+{{/if}}
 ENV NODE_ENV=production
 RUN cd apps/web && {{packageManager}} run build
 

--- a/packages/template-generator/templates/deploy/docker/web/react/tanstack-router/nginx.conf
+++ b/packages/template-generator/templates/deploy/docker/web/react/tanstack-router/nginx.conf
@@ -1,0 +1,18 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript image/svg+xml;
+
+    location /assets/ {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+
+    # SPA fallback
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/packages/template-generator/templates/deploy/docker/web/react/tanstack-start/Dockerfile.hbs
+++ b/packages/template-generator/templates/deploy/docker/web/react/tanstack-start/Dockerfile.hbs
@@ -6,6 +6,15 @@ COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 RUN npm install -g pnpm
 {{/if}}
 WORKDIR /app
+ENV SKIP_ENV_VALIDATION=1
+{{#if (and (eq backend "self") (eq auth "better-auth"))}}
+# the build evaluates the auth config; the real secret comes from compose at runtime
+ENV BETTER_AUTH_SECRET=build-time-placeholder-secret-not-used-at-runtime
+{{/if}}
+{{#if (eq orm "prisma")}}
+# prisma generate resolves DATABASE_URL at install time; the real value comes from compose at runtime
+ENV DATABASE_URL={{#if (eq database "mysql")}}mysql://build:build@localhost:3306/build{{else if (eq database "mongodb")}}mongodb://localhost:27017/build{{else if (eq database "sqlite")}}file:./build.db{{else}}postgresql://build:build@localhost:5432/build{{/if}}
+{{/if}}
 
 COPY . .
 {{#if (eq packageManager "bun")}}
@@ -16,8 +25,27 @@ RUN --mount=type=cache,target=/pnpm-store pnpm install --store-dir /pnpm-store
 RUN --mount=type=cache,target=/root/.npm npm install
 {{/if}}
 
+{{#if (and (ne backend "self") (ne backend "none") (ne backend "convex"))}}
+ARG VITE_SERVER_URL
+ENV VITE_SERVER_URL=${VITE_SERVER_URL}
+{{/if}}
+{{#if (eq backend "convex")}}
+ARG VITE_CONVEX_URL
+ENV VITE_CONVEX_URL=${VITE_CONVEX_URL}
+{{/if}}
+{{#if (eq auth "clerk")}}
+ARG VITE_CLERK_PUBLISHABLE_KEY
+ENV VITE_CLERK_PUBLISHABLE_KEY=${VITE_CLERK_PUBLISHABLE_KEY}
+{{/if}}
 ENV NODE_ENV=production
 RUN cd apps/web && {{packageManager}} run build
+ENV SKIP_ENV_VALIDATION=
+{{#if (and (eq backend "self") (eq auth "better-auth"))}}
+ENV BETTER_AUTH_SECRET=
+{{/if}}
+{{#if (eq orm "prisma")}}
+ENV DATABASE_URL=
+{{/if}}
 
 ENV HOST=0.0.0.0
 ENV PORT=3001

--- a/packages/template-generator/templates/deploy/docker/web/react/tanstack-start/Dockerfile.hbs
+++ b/packages/template-generator/templates/deploy/docker/web/react/tanstack-start/Dockerfile.hbs
@@ -1,0 +1,28 @@
+FROM node:24-slim AS base
+{{#if (eq packageManager "bun")}}
+COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
+{{/if}}
+{{#if (eq packageManager "pnpm")}}
+RUN npm install -g pnpm
+{{/if}}
+WORKDIR /app
+
+COPY . .
+{{#if (eq packageManager "bun")}}
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install
+{{else if (eq packageManager "pnpm")}}
+RUN --mount=type=cache,target=/pnpm-store pnpm install --store-dir /pnpm-store
+{{else}}
+RUN --mount=type=cache,target=/root/.npm npm install
+{{/if}}
+
+ENV NODE_ENV=production
+RUN cd apps/web && {{packageManager}} run build
+
+ENV HOST=0.0.0.0
+ENV PORT=3001
+EXPOSE 3001
+
+# SSR chunks require() externals at runtime; must run from the workspace
+WORKDIR /app/apps/web
+CMD ["node", ".output/server/index.mjs"]

--- a/packages/template-generator/templates/deploy/docker/web/solid/Dockerfile.hbs
+++ b/packages/template-generator/templates/deploy/docker/web/solid/Dockerfile.hbs
@@ -1,0 +1,26 @@
+FROM node:24-slim AS builder
+{{#if (eq packageManager "bun")}}
+COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
+{{/if}}
+{{#if (eq packageManager "pnpm")}}
+RUN npm install -g pnpm
+{{/if}}
+WORKDIR /app
+
+COPY . .
+{{#if (eq packageManager "bun")}}
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install
+{{else if (eq packageManager "pnpm")}}
+RUN --mount=type=cache,target=/pnpm-store pnpm install --store-dir /pnpm-store
+{{else}}
+RUN --mount=type=cache,target=/root/.npm npm install
+{{/if}}
+
+ENV NODE_ENV=production
+RUN cd apps/web && {{packageManager}} run build
+
+FROM nginx:alpine AS runner
+COPY --from=builder /app/apps/web/dist /usr/share/nginx/html
+COPY apps/web/nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/packages/template-generator/templates/deploy/docker/web/solid/Dockerfile.hbs
+++ b/packages/template-generator/templates/deploy/docker/web/solid/Dockerfile.hbs
@@ -6,6 +6,15 @@ COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 RUN npm install -g pnpm
 {{/if}}
 WORKDIR /app
+ENV SKIP_ENV_VALIDATION=1
+{{#if (and (eq backend "self") (eq auth "better-auth"))}}
+# the build evaluates the auth config; the real secret comes from compose at runtime
+ENV BETTER_AUTH_SECRET=build-time-placeholder-secret-not-used-at-runtime
+{{/if}}
+{{#if (eq orm "prisma")}}
+# prisma generate resolves DATABASE_URL at install time; the real value comes from compose at runtime
+ENV DATABASE_URL={{#if (eq database "mysql")}}mysql://build:build@localhost:3306/build{{else if (eq database "mongodb")}}mongodb://localhost:27017/build{{else if (eq database "sqlite")}}file:./build.db{{else}}postgresql://build:build@localhost:5432/build{{/if}}
+{{/if}}
 
 COPY . .
 {{#if (eq packageManager "bun")}}
@@ -16,6 +25,14 @@ RUN --mount=type=cache,target=/pnpm-store pnpm install --store-dir /pnpm-store
 RUN --mount=type=cache,target=/root/.npm npm install
 {{/if}}
 
+{{#if (and (ne backend "self") (ne backend "none") (ne backend "convex"))}}
+ARG VITE_SERVER_URL
+ENV VITE_SERVER_URL=${VITE_SERVER_URL}
+{{/if}}
+{{#if (eq backend "convex")}}
+ARG VITE_CONVEX_URL
+ENV VITE_CONVEX_URL=${VITE_CONVEX_URL}
+{{/if}}
 ENV NODE_ENV=production
 RUN cd apps/web && {{packageManager}} run build
 

--- a/packages/template-generator/templates/deploy/docker/web/solid/nginx.conf
+++ b/packages/template-generator/templates/deploy/docker/web/solid/nginx.conf
@@ -1,0 +1,18 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript image/svg+xml;
+
+    location /assets/ {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+
+    # SPA fallback
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/packages/template-generator/templates/deploy/docker/web/svelte/Dockerfile.hbs
+++ b/packages/template-generator/templates/deploy/docker/web/svelte/Dockerfile.hbs
@@ -6,6 +6,15 @@ COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 RUN npm install -g pnpm
 {{/if}}
 WORKDIR /app
+ENV SKIP_ENV_VALIDATION=1
+{{#if (and (eq backend "self") (eq auth "better-auth"))}}
+# the build evaluates the auth config; the real secret comes from compose at runtime
+ENV BETTER_AUTH_SECRET=build-time-placeholder-secret-not-used-at-runtime
+{{/if}}
+{{#if (eq orm "prisma")}}
+# prisma generate resolves DATABASE_URL at install time; the real value comes from compose at runtime
+ENV DATABASE_URL={{#if (eq database "mysql")}}mysql://build:build@localhost:3306/build{{else if (eq database "mongodb")}}mongodb://localhost:27017/build{{else if (eq database "sqlite")}}file:./build.db{{else}}postgresql://build:build@localhost:5432/build{{/if}}
+{{/if}}
 
 COPY . .
 {{#if (eq packageManager "bun")}}
@@ -16,8 +25,23 @@ RUN --mount=type=cache,target=/pnpm-store pnpm install --store-dir /pnpm-store
 RUN --mount=type=cache,target=/root/.npm npm install
 {{/if}}
 
+{{#if (and (ne backend "self") (ne backend "none") (ne backend "convex"))}}
+ARG PUBLIC_SERVER_URL
+ENV PUBLIC_SERVER_URL=${PUBLIC_SERVER_URL}
+{{/if}}
+{{#if (eq backend "convex")}}
+ARG PUBLIC_CONVEX_URL
+ENV PUBLIC_CONVEX_URL=${PUBLIC_CONVEX_URL}
+{{/if}}
 ENV NODE_ENV=production
 RUN cd apps/web && {{packageManager}} run build
+ENV SKIP_ENV_VALIDATION=
+{{#if (and (eq backend "self") (eq auth "better-auth"))}}
+ENV BETTER_AUTH_SECRET=
+{{/if}}
+{{#if (eq orm "prisma")}}
+ENV DATABASE_URL=
+{{/if}}
 
 ENV HOST=0.0.0.0
 ENV PORT=3001

--- a/packages/template-generator/templates/deploy/docker/web/svelte/Dockerfile.hbs
+++ b/packages/template-generator/templates/deploy/docker/web/svelte/Dockerfile.hbs
@@ -1,0 +1,27 @@
+FROM node:24-slim AS base
+{{#if (eq packageManager "bun")}}
+COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
+{{/if}}
+{{#if (eq packageManager "pnpm")}}
+RUN npm install -g pnpm
+{{/if}}
+WORKDIR /app
+
+COPY . .
+{{#if (eq packageManager "bun")}}
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install
+{{else if (eq packageManager "pnpm")}}
+RUN --mount=type=cache,target=/pnpm-store pnpm install --store-dir /pnpm-store
+{{else}}
+RUN --mount=type=cache,target=/root/.npm npm install
+{{/if}}
+
+ENV NODE_ENV=production
+RUN cd apps/web && {{packageManager}} run build
+
+ENV HOST=0.0.0.0
+ENV PORT=3001
+EXPOSE 3001
+
+WORKDIR /app/apps/web
+CMD ["node", "build/index.js"]

--- a/packages/template-generator/templates/extras/pnpm-workspace.yaml.hbs
+++ b/packages/template-generator/templates/extras/pnpm-workspace.yaml.hbs
@@ -1,12 +1,12 @@
 packages:
   - "apps/*"
   - "packages/*"
-{{#if (or (eq runtime "node") (eq webDeploy "cloudflare") (eq serverDeploy "cloudflare") (eq orm "prisma") (includes addons "lefthook") (includes addons "nx") (includes addons "pwa") (includes frontend "tanstack-router") (includes frontend "react-router") (includes frontend "tanstack-start") (includes frontend "next") (includes frontend "native-bare") (includes frontend "native-uniwind") (includes frontend "native-unistyles"))}}
+{{#if (or (eq runtime "node") (eq webDeploy "cloudflare") (eq serverDeploy "cloudflare") (eq webDeploy "docker") (eq serverDeploy "docker") (eq orm "prisma") (includes addons "lefthook") (includes addons "nx") (includes addons "pwa") (includes frontend "tanstack-router") (includes frontend "react-router") (includes frontend "tanstack-start") (includes frontend "next") (includes frontend "nuxt") (includes frontend "native-bare") (includes frontend "native-uniwind") (includes frontend "native-unistyles"))}}
 
 # pnpm 11 blocks dependency lifecycle scripts unless they are approved here.
 # Entries are scoped to packages this generated stack can pull in.
 allowBuilds:
-{{#if (or (eq runtime "node") (eq webDeploy "cloudflare") (eq serverDeploy "cloudflare") (includes frontend "tanstack-start"))}}
+{{#if (or (eq runtime "node") (eq webDeploy "cloudflare") (eq serverDeploy "cloudflare") (eq webDeploy "docker") (eq serverDeploy "docker") (includes frontend "tanstack-start"))}}
   esbuild: true
 {{/if}}
 {{#if (or (includes frontend "tanstack-router") (includes frontend "react-router") (includes frontend "tanstack-start") (includes frontend "next"))}}
@@ -15,7 +15,11 @@ allowBuilds:
 {{#if (or (includes frontend "native-bare") (includes frontend "native-uniwind") (includes frontend "native-unistyles"))}}
   msgpackr-extract: true
 {{/if}}
-{{#if (or (eq webDeploy "cloudflare") (eq serverDeploy "cloudflare") (includes addons "pwa"))}}
+{{#if (includes frontend "nuxt")}}
+  "@parcel/watcher": true
+  vue-demi: true
+{{/if}}
+{{#if (or (eq webDeploy "cloudflare") (eq serverDeploy "cloudflare") (eq webDeploy "docker") (includes addons "pwa"))}}
   sharp: true
 {{/if}}
 {{#if (or (eq webDeploy "cloudflare") (eq serverDeploy "cloudflare"))}}

--- a/packages/template-generator/templates/frontend/nuxt/nuxt.config.ts.hbs
+++ b/packages/template-generator/templates/frontend/nuxt/nuxt.config.ts.hbs
@@ -23,6 +23,8 @@ export default defineNuxtConfig({
   },
   {{else if (and (ne backend "self") (ne backend "none"))}}
   runtimeConfig: {
+    // server-side override for SSR fetches (NUXT_SERVER_URL); falls back to the public URL
+    serverUrl: "",
     public: {
       serverUrl: process.env.NUXT_PUBLIC_SERVER_URL ?? "",
     }

--- a/packages/template-generator/templates/frontend/nuxt/package.json.hbs
+++ b/packages/template-generator/templates/frontend/nuxt/package.json.hbs
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "@nuxt/ui": "^4.5.1",
-    "nuxt": "^4.4.4"
+    "nuxt": "^4.4.4",
+    "vue": "^3.5.38"
   },
   "devDependencies": {
     "tailwindcss": "^4.2.1",

--- a/packages/template-generator/templates/frontend/react/next/next.config.ts.hbs
+++ b/packages/template-generator/templates/frontend/react/next/next.config.ts.hbs
@@ -7,6 +7,9 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
 	typedRoutes: true,
 	reactCompiler: true,
+	{{#if (eq webDeploy "docker")}}
+	output: "standalone",
+	{{/if}}
 	{{#if (includes examples "ai")}}
 	transpilePackages: ["shiki"],
 	{{/if}}

--- a/packages/template-generator/templates/frontend/react/tanstack-start/vite.config.ts.hbs
+++ b/packages/template-generator/templates/frontend/react/tanstack-start/vite.config.ts.hbs
@@ -1,5 +1,8 @@
 import { defineConfig } from "{{#if (includes addons "vite-plus")}}vite-plus{{else}}vite{{/if}}";
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
+{{#if (eq webDeploy "docker")}}
+import { nitro } from "nitro/vite";
+{{/if}}
 import tailwindcss from "@tailwindcss/vite";
 import viteReact from "@vitejs/plugin-react";
 
@@ -13,6 +16,9 @@ export default defineConfig({
   plugins: [
     tailwindcss(),
     tanstackStart(),
+{{#if (eq webDeploy "docker")}}
+    nitro(),
+{{/if}}
     viteReact(),
   ],
 {{#if (and (eq backend "convex") (eq auth "better-auth"))}}

--- a/packages/template-generator/templates/frontend/solid/package.json.hbs
+++ b/packages/template-generator/templates/frontend/solid/package.json.hbs
@@ -17,6 +17,7 @@
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
+    "@tanstack/solid-router-devtools": "^1.166.13",
     "vite": "^8.0.8",
     "vite-plugin-solid": "^2.11.12"
   }

--- a/packages/template-generator/templates/frontend/svelte/svelte.config.js.hbs
+++ b/packages/template-generator/templates/frontend/svelte/svelte.config.js.hbs
@@ -1,5 +1,7 @@
 {{#if (eq webDeploy "cloudflare")}}
 import alchemy from 'alchemy/cloudflare/sveltekit';
+{{else if (eq webDeploy "docker")}}
+import adapter from '@sveltejs/adapter-node';
 {{else}}
 import adapter from '@sveltejs/adapter-auto';
 {{/if}}
@@ -15,6 +17,9 @@ const config = {
 {{#if (eq webDeploy "cloudflare")}}
 		// Alchemy's adapter wraps SvelteKit's Cloudflare adapter for local platform.env and Worker builds.
 		adapter: alchemy()
+{{else if (eq webDeploy "docker")}}
+		// adapter-node builds a standalone Node server (run with `node build/index.js`).
+		adapter: adapter()
 {{else}}
 		// adapter-auto only supports some environments, see https://svelte.dev/docs/kit/adapter-auto for a list.
 		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.

--- a/packages/template-generator/templates/packages/env/src/server.ts.hbs
+++ b/packages/template-generator/templates/packages/env/src/server.ts.hbs
@@ -127,6 +127,7 @@ export const env = createEnv({
 		NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
 	},
 	runtimeEnv: process.env,
+	skipValidation: !!process.env.SKIP_ENV_VALIDATION,
 	emptyStringAsUndefined: true,
 });
 {{/if}}

--- a/packages/template-generator/templates/packages/env/src/web.ts.hbs
+++ b/packages/template-generator/templates/packages/env/src/web.ts.hbs
@@ -119,5 +119,6 @@ export const env = createEnv({
 	runtimeEnv: (import.meta as any).env,
 {{/if}}
 {{/if}}
+	skipValidation: !!process.env.SKIP_ENV_VALIDATION,
 	emptyStringAsUndefined: true,
 });

--- a/packages/types/src/schemas.ts
+++ b/packages/types/src/schemas.ts
@@ -93,9 +93,11 @@ export const AuthSchema = z
 
 export const PaymentsSchema = z.enum(["polar", "none"]).describe("Payments provider");
 
-export const WebDeploySchema = z.enum(["cloudflare", "none"]).describe("Web deployment");
+export const WebDeploySchema = z.enum(["cloudflare", "docker", "none"]).describe("Web deployment");
 
-export const ServerDeploySchema = z.enum(["cloudflare", "none"]).describe("Server deployment");
+export const ServerDeploySchema = z
+  .enum(["cloudflare", "docker", "none"])
+  .describe("Server deployment");
 
 export const DirectoryConflictSchema = z
   .enum(["merge", "overwrite", "increment", "error"])

--- a/scripts/docker-smoke.sh
+++ b/scripts/docker-smoke.sh
@@ -36,12 +36,12 @@ for entry in "${TESTS[@]}"; do
   dir="$SCRATCH/$name"
   echo "=== [$i/${#TESTS[@]}] $name ===" | tee -a "$RESULTS"
   rm -rf "$dir"
-  cd "$SCRATCH"
+  cd "$SCRATCH" || { echo "RESULT $name: FAIL (cd scratch)" | tee -a "$RESULTS"; continue; }
   bun "$REPO/apps/cli/src/cli.ts" "$name" $flags --no-install --no-git > "/tmp/smoke-$name-scaffold.log" 2>&1
   if [ ! -f "$dir/docker-compose.yml" ]; then
     echo "RESULT $name: FAIL (scaffold - no compose)" | tee -a "$RESULTS"; continue
   fi
-  cd "$dir"
+  cd "$dir" || { echo "RESULT $name: FAIL (cd project)" | tee -a "$RESULTS"; continue; }
   sedi "s/\"3001:3001\"/\"$WEB_PORT:3001\"/; s/\"3001:80\"/\"$WEB_PORT:80\"/; s/\"3000:3000\"/\"$SRV_PORT:3000\"/; s/\"5432:5432\"/\"$DB_PORT:5432\"/; s/\"3306:3306\"/\"$DB_PORT:3306\"/; s/\"27017:27017\"/\"$DB_PORT:27017\"/" docker-compose.yml
 
   docker compose config --quiet || { echo "RESULT $name: FAIL (compose config)" | tee -a "$RESULTS"; continue; }

--- a/scripts/docker-smoke.sh
+++ b/scripts/docker-smoke.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Live smoke test for Docker deployments: scaffolds each combination, builds
+# the images, starts the stack, and probes the running services.
+# Requires a running Docker daemon. Usage: bash scripts/docker-smoke.sh
+set -u
+REPO=$(cd "$(dirname "$0")/.." && pwd)
+SCRATCH=$REPO/.scratch-docker-smoke
+RESULTS=${RESULTS:-/tmp/docker-smoke-results.txt}
+mkdir -p "$SCRATCH"
+: > "$RESULTS"
+
+sedi() { if sed --version >/dev/null 2>&1; then sed -i "$@"; else sed -i '' "$@"; fi; }
+
+# name|flags|web_port_internal(3001|80|none)|has_server|spa(0|1)
+TESTS=(
+"next-hono-node-pnpm|--frontend next --backend hono --runtime node --database postgres --orm drizzle --db-setup docker --web-deploy docker --server-deploy docker --api trpc --auth better-auth --payments none --addons turborepo --examples none --package-manager pnpm|3001|1|0"
+"nuxt-fastify-node-pnpm|--frontend nuxt --backend fastify --runtime node --database none --orm none --db-setup none --web-deploy docker --server-deploy docker --api orpc --auth none --payments none --addons none --examples none --package-manager pnpm|3001|1|0"
+"nuxt-express-node-npm|--frontend nuxt --backend express --runtime node --database postgres --orm drizzle --db-setup docker --web-deploy docker --server-deploy docker --api orpc --auth none --payments none --addons none --examples none --package-manager npm|3001|1|0"
+"svelte-self-npm|--frontend svelte --backend self --runtime none --database postgres --orm drizzle --db-setup docker --web-deploy docker --server-deploy none --api orpc --auth better-auth --payments none --addons none --examples none --package-manager npm|3001|0|0"
+"astro-elysia-bun-bun|--frontend astro --backend elysia --runtime bun --database none --orm none --db-setup none --web-deploy docker --server-deploy docker --api orpc --auth none --payments none --addons none --examples none --package-manager bun|3001|1|0"
+"react-router-npm|--frontend react-router --backend none --runtime none --database none --orm none --db-setup none --web-deploy docker --server-deploy none --api none --auth none --payments none --addons none --examples none --package-manager npm|80|0|1"
+"tanstack-router-hono-bun-bun|--frontend tanstack-router --backend hono --runtime bun --database postgres --orm drizzle --db-setup docker --web-deploy docker --server-deploy docker --api trpc --auth better-auth --payments none --addons turborepo --examples none --package-manager bun|80|1|1"
+"tanstack-start-express-node-pnpm|--frontend tanstack-start --backend express --runtime node --database none --orm none --db-setup none --web-deploy docker --server-deploy docker --api orpc --auth none --payments none --addons none --examples none --package-manager pnpm|3001|1|0"
+"solid-bun|--frontend solid --backend none --runtime none --database none --orm none --db-setup none --web-deploy docker --server-deploy none --api none --auth none --payments none --addons none --examples none --package-manager bun|80|0|1"
+"mongo-hono-bun-bun|--frontend tanstack-router --backend hono --runtime bun --database mongodb --orm mongoose --db-setup docker --web-deploy docker --server-deploy docker --api orpc --auth none --payments none --addons none --examples none --package-manager bun|80|1|1"
+"mysql-elysia-bun-prisma|--frontend tanstack-start --backend elysia --runtime bun --database mysql --orm prisma --db-setup docker --web-deploy docker --server-deploy docker --api orpc --auth better-auth --payments none --addons turborepo --examples none --package-manager bun|3001|1|0"
+"fastify-node-server-only-npm|--frontend none --backend fastify --runtime node --database postgres --orm drizzle --db-setup docker --web-deploy none --server-deploy docker --api orpc --auth none --payments none --addons none --examples none --package-manager npm|none|1|0"
+"nuxt-self-bun|--frontend nuxt --backend self --runtime none --database postgres --orm drizzle --db-setup docker --web-deploy docker --server-deploy none --api orpc --auth better-auth --payments none --addons none --examples none --package-manager bun|3001|0|0"
+)
+
+i=0
+for entry in "${TESTS[@]}"; do
+  i=$((i+1))
+  IFS='|' read -r name flags webint has_server spa <<< "$entry"
+  WEB_PORT=$((4100+i)); SRV_PORT=$((4200+i)); DB_PORT=$((4300+i))
+  dir="$SCRATCH/$name"
+  echo "=== [$i/${#TESTS[@]}] $name ===" | tee -a "$RESULTS"
+  rm -rf "$dir"
+  cd "$SCRATCH"
+  bun "$REPO/apps/cli/src/cli.ts" "$name" $flags --no-install --no-git > "/tmp/smoke-$name-scaffold.log" 2>&1
+  if [ ! -f "$dir/docker-compose.yml" ]; then
+    echo "RESULT $name: FAIL (scaffold - no compose)" | tee -a "$RESULTS"; continue
+  fi
+  cd "$dir"
+  sedi "s/\"3001:3001\"/\"$WEB_PORT:3001\"/; s/\"3001:80\"/\"$WEB_PORT:80\"/; s/\"3000:3000\"/\"$SRV_PORT:3000\"/; s/\"5432:5432\"/\"$DB_PORT:5432\"/; s/\"3306:3306\"/\"$DB_PORT:3306\"/; s/\"27017:27017\"/\"$DB_PORT:27017\"/" docker-compose.yml
+
+  docker compose config --quiet || { echo "RESULT $name: FAIL (compose config)" | tee -a "$RESULTS"; continue; }
+
+  docker compose build > "/tmp/smoke-$name-build.log" 2>&1
+  build_exit=$?
+  if [ $build_exit -ne 0 ]; then
+    echo "RESULT $name: FAIL (build exit $build_exit, log: /tmp/smoke-$name-build.log)" | tee -a "$RESULTS"
+    continue
+  fi
+
+  docker compose up -d --wait > "/tmp/smoke-$name-up.log" 2>&1
+  up_exit=$?
+  sleep 4
+
+  fail=""
+  if [ "$webint" != "none" ]; then
+    code=$(curl -s -o /tmp/smoke-body.html -w "%{http_code}" "http://localhost:$WEB_PORT" || echo 000)
+    [ "$code" = "200" ] || fail="$fail web:$code"
+    grep -qi "<html" /tmp/smoke-body.html || fail="$fail web:not-html"
+    if [ "$spa" = "1" ]; then
+      dcode=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$WEB_PORT/some/deep/route" || echo 000)
+      [ "$dcode" = "200" ] || fail="$fail deeplink:$dcode"
+    fi
+  fi
+  if [ "$has_server" = "1" ]; then
+    scode=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$SRV_PORT" || echo 000)
+    [ "$scode" = "200" ] || fail="$fail server:$scode"
+  fi
+  errcount=$(docker compose logs web server 2>/dev/null | grep -ci "cannot find module\|unhandled\|ECONNREFUSED\|EADDRINUSE\|MODULE_NOT_FOUND")
+  [ "$errcount" = "0" ] || fail="$fail logs:$errcount-errors"
+  [ $up_exit -eq 0 ] || fail="$fail up-exit:$up_exit"
+
+  if [ -z "$fail" ]; then
+    echo "RESULT $name: PASS" | tee -a "$RESULTS"
+  else
+    echo "RESULT $name: FAIL ($fail)" | tee -a "$RESULTS"
+    docker compose logs web server 2>/dev/null | tail -15 >> "$RESULTS"
+  fi
+  docker compose down -v --rmi local > /dev/null 2>&1
+done
+
+echo "=== DONE ===" | tee -a "$RESULTS"
+pass=$(grep -c "RESULT.*: PASS" "$RESULTS")
+total=${#TESTS[@]}
+echo "$pass/$total passed" | tee -a "$RESULTS"
+grep "RESULT.*FAIL" "$RESULTS"
+[ "$pass" = "$total" ]


### PR DESCRIPTION
## What

Adds `docker` as a deployment option for both `--web-deploy` and `--server-deploy`. Generated projects get per-app Dockerfiles and a single root `docker-compose.yml` that orchestrates web, server, and (when `--db-setup docker`) the database — `bun run docker:up` brings up the whole stack in dependency order.

## Generated output

- **Web Dockerfiles per frontend**: nginx multi-stage with SPA fallback for tanstack-router / react-router / solid; Next.js `output: "standalone"` minimal runner (per the official with-docker example, ~405MB); Nuxt ships only the self-contained `.output` (~355MB); TanStack Start / Svelte / Astro run from the workspace (their SSR output `require()`s externals at runtime).
- **Server Dockerfile**: tsdown bundle, `node`/`bun` CMD per runtime, all four backends.
- **Root compose**: inlined db service (no separate `packages/db` compose when a docker deploy is selected), healthcheck chain (db healthy → server healthy → web), `init: true`, env overrides for container networking (`DATABASE_URL`, `CORS_ORIGIN`, SSR server URLs), BuildKit cache mounts for all three package managers.
- **Scripts**: `docker:build|up|down|logs` at the root; `db:*` scripts become service-scoped (`docker compose up -d postgres`).
- CLI prompts + flag validation (docker server deploy requires a separate backend on bun/node), stack-builder options/rules, docs, README generation, post-install instructions.

## Bug fixes surfaced by live verification (several pre-existing on main)

- **Solid + `--api none`**: `__root.tsx` imports `@tanstack/solid-router-devtools` unconditionally but the dep was only added when an API was selected — production builds failed. Dep moved into the template.
- **Fastify in containers**: `fastify.listen({ port })` binds 127.0.0.1 by default (unlike hono/express/elysia) — published port unreachable while the localhost healthcheck passed. Docker deploys bind `0.0.0.0`.
- **pnpm 11 build-script gates**: non-interactive installs (Docker/CI) hard-fail on unapproved scripts. `sharp`, `esbuild`, `@parcel/watcher`, `vue-demi` added to generated `allowBuilds` where the stack pulls them.
- **npm + Nuxt ERESOLVE**: the web app never declared `vue`, letting npm resolve vue 2 via `@vue/composition-api`'s optional peer. Explicit `vue: ^3.5.38` pin fixes `npm install` for all npm+Nuxt scaffolds.
- **TanStack Start SSR in containers**: nitro's `_libs` bundling still leaves bare `require('react')` calls in SSR chunks; runs from the workspace instead of a minimal copy.

## Prompt UX (bundled)

- Going **back** (`b`) now restores your previous answers as initial values instead of resetting every prompt to defaults (threaded through `navigableGroup` → all prompt functions; stale values filtered for multiselects).
- `@clack/core` 1.3.1 → 1.4.1, `@clack/prompts` 1.4.0 → 1.5.1; removed the unused `navigableText` wrapper; uppercase `B` accepted.

## Verification

- `scripts/docker-smoke.sh` (`bun run smoke:docker`): live matrix that scaffolds, builds, boots, and probes 13 combinations — all 8 web frontends, all 4 backends across both runtimes, all 3 package managers, all 3 docker databases, self-backends, and a server-only shape. **13/13 passing**: HTTP 200 with real HTML, SPA deep links, server endpoints, and error-free logs.
- 635 CLI tests + 19 web tests passing; lint/typecheck clean.
- Back-navigation verified with scripted PTY sessions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Docker deployment support for web and server, including Docker Compose and framework-specific Dockerfiles
  * CLI prompts now preserve and prefill previous selections for a smoother interactive flow
  * README/examples now include a self-hosted Docker example

* **Documentation**
  * Updated CLI options and project-structure docs to list Docker deployment choices

* **Tests**
  * Added Docker deployment compatibility tests and a Docker stack smoke-test suite
<!-- end of auto-generated comment: release notes by coderabbit.ai -->