### PR TITLE
fix(cli): use full node image for Vite+ Docker builds

### DIFF
--- a/apps/cli/test/deployment.test.ts
+++ b/apps/cli/test/deployment.test.ts
@@ -713,6 +713,8 @@ describe("Deployment Configurations", () => {
       expect(compose).toContain("VITE_SERVER_URL: http://localhost:3000");
       expect(webDockerfile).toContain("ARG VITE_SERVER_URL");
       expect(files.get(".dockerignore")).toContain("**/.env");
+      expect(webDockerfile).toContain("FROM node:24-slim AS builder");
+      expect(serverDockerfile).toContain("FROM node:24-slim AS base");
 
       // SPA frontend builds static assets served by nginx with an SPA fallback
       expect(webDockerfile).toContain("FROM nginx:alpine");
@@ -843,8 +845,43 @@ describe("Deployment Configurations", () => {
       expect(viteConfig).toContain("nitro(),");
       expect(webPkg.dependencies.nitro).toBeDefined();
       // SSR chunks require() externals at runtime, so the app runs from the workspace
+      expect(webDockerfile).toContain("FROM node:24-slim AS base");
       expect(webDockerfile).toContain("WORKDIR /app/apps/web");
       expect(webDockerfile).toContain('CMD ["node", ".output/server/index.mjs"]');
+    });
+
+    it("should use the full Node 24 image for Vite+ Docker web builds", async () => {
+      const result = await createVirtual({
+        projectName: "docker-vite-plus",
+        webDeploy: "docker",
+        serverDeploy: "docker",
+        backend: "hono",
+        runtime: "bun",
+        database: "postgres",
+        orm: "prisma",
+        auth: "better-auth",
+        payments: "none",
+        api: "orpc",
+        frontend: ["tanstack-start"],
+        addons: ["vite-plus"],
+        examples: ["none"],
+        dbSetup: "docker",
+        install: false,
+        git: false,
+        packageManager: "bun",
+      });
+
+      if (result.isErr()) {
+        throw result.error;
+      }
+
+      const files = collectFiles(result.value.root, result.value.root.path);
+      const webDockerfile = files.get("apps/web/Dockerfile");
+      const webPkg = JSON.parse(files.get("apps/web/package.json") ?? "{}");
+
+      expect(webPkg.scripts.build).toBe("vp build");
+      expect(webDockerfile).toContain("FROM node:24 AS base");
+      expect(webDockerfile).not.toContain("ca-certificates");
     });
 
     it("should serve React Router SPA builds with nginx", async () => {

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -16234,7 +16234,7 @@ EXPOSE 3001
 
 CMD ["node", "apps/web/server.js"]
 `],
-  ["deploy/docker/web/react/react-router/Dockerfile.hbs", `FROM node:24-slim AS builder
+  ["deploy/docker/web/react/react-router/Dockerfile.hbs", `FROM node:24{{#unless (includes addons "vite-plus")}}-slim{{/unless}} AS builder
 {{#if (eq packageManager "bun")}}
 COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 {{/if}}
@@ -16301,7 +16301,7 @@ CMD ["nginx", "-g", "daemon off;"]
     }
 }
 `],
-  ["deploy/docker/web/react/tanstack-router/Dockerfile.hbs", `FROM node:24-slim AS builder
+  ["deploy/docker/web/react/tanstack-router/Dockerfile.hbs", `FROM node:24{{#unless (includes addons "vite-plus")}}-slim{{/unless}} AS builder
 {{#if (eq packageManager "bun")}}
 COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 {{/if}}
@@ -16368,7 +16368,7 @@ CMD ["nginx", "-g", "daemon off;"]
     }
 }
 `],
-  ["deploy/docker/web/react/tanstack-start/Dockerfile.hbs", `FROM node:24-slim AS base
+  ["deploy/docker/web/react/tanstack-start/Dockerfile.hbs", `FROM node:24{{#unless (includes addons "vite-plus")}}-slim{{/unless}} AS base
 {{#if (eq packageManager "bun")}}
 COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 {{/if}}
@@ -16425,7 +16425,7 @@ EXPOSE 3001
 WORKDIR /app/apps/web
 CMD ["node", ".output/server/index.mjs"]
 `],
-  ["deploy/docker/web/solid/Dockerfile.hbs", `FROM node:24-slim AS builder
+  ["deploy/docker/web/solid/Dockerfile.hbs", `FROM node:24{{#unless (includes addons "vite-plus")}}-slim{{/unless}} AS builder
 {{#if (eq packageManager "bun")}}
 COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 {{/if}}
@@ -16488,7 +16488,7 @@ CMD ["nginx", "-g", "daemon off;"]
     }
 }
 `],
-  ["deploy/docker/web/svelte/Dockerfile.hbs", `FROM node:24-slim AS base
+  ["deploy/docker/web/svelte/Dockerfile.hbs", `FROM node:24{{#unless (includes addons "vite-plus")}}-slim{{/unless}} AS base
 {{#if (eq packageManager "bun")}}
 COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 {{/if}}

--- a/packages/template-generator/templates/deploy/docker/web/react/react-router/Dockerfile.hbs
+++ b/packages/template-generator/templates/deploy/docker/web/react/react-router/Dockerfile.hbs
@@ -1,4 +1,4 @@
-FROM node:24-slim AS builder
+FROM node:24{{#unless (includes addons "vite-plus")}}-slim{{/unless}} AS builder
 {{#if (eq packageManager "bun")}}
 COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 {{/if}}

--- a/packages/template-generator/templates/deploy/docker/web/react/tanstack-router/Dockerfile.hbs
+++ b/packages/template-generator/templates/deploy/docker/web/react/tanstack-router/Dockerfile.hbs
@@ -1,4 +1,4 @@
-FROM node:24-slim AS builder
+FROM node:24{{#unless (includes addons "vite-plus")}}-slim{{/unless}} AS builder
 {{#if (eq packageManager "bun")}}
 COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 {{/if}}

--- a/packages/template-generator/templates/deploy/docker/web/react/tanstack-start/Dockerfile.hbs
+++ b/packages/template-generator/templates/deploy/docker/web/react/tanstack-start/Dockerfile.hbs
@@ -1,4 +1,4 @@
-FROM node:24-slim AS base
+FROM node:24{{#unless (includes addons "vite-plus")}}-slim{{/unless}} AS base
 {{#if (eq packageManager "bun")}}
 COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 {{/if}}

--- a/packages/template-generator/templates/deploy/docker/web/solid/Dockerfile.hbs
+++ b/packages/template-generator/templates/deploy/docker/web/solid/Dockerfile.hbs
@@ -1,4 +1,4 @@
-FROM node:24-slim AS builder
+FROM node:24{{#unless (includes addons "vite-plus")}}-slim{{/unless}} AS builder
 {{#if (eq packageManager "bun")}}
 COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 {{/if}}

--- a/packages/template-generator/templates/deploy/docker/web/svelte/Dockerfile.hbs
+++ b/packages/template-generator/templates/deploy/docker/web/svelte/Dockerfile.hbs
@@ -1,4 +1,4 @@
-FROM node:24-slim AS base
+FROM node:24{{#unless (includes addons "vite-plus")}}-slim{{/unless}} AS base
 {{#if (eq packageManager "bun")}}
 COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 {{/if}}


### PR DESCRIPTION
## Summary

- Use the full `node:24` image for Vite+ Docker web builds while keeping non-Vite+ builds on `node:24-slim`.
- Apply the conditional base image to Vite-powered web Docker templates: TanStack Start, TanStack Router, React Router, Solid, and Svelte.
- Add regression coverage for the Vite+ Docker web build image selection and for existing slim-image behavior.

## Root cause

`vp build` initializes Vite+'s Rust HTTP client during Docker builds. The `node:24-slim` image does not include the system CA bundle, which causes Vite+ to panic with `No CA certificates were loaded from the system`. The full `node:24` image includes the CA bundle while staying pinned to the repository's Node 24 engine.

## Verification

- `bun test test/deployment.test.ts`
- `bun run check`
- Manual Docker verification:
  - Vite+ on `node:24-slim` reproduced the CA certificate panic.
  - Vite+ on full `node:24` has the system CA bundle.
  - Non-Vite+ `vite build` on `node:24-slim` built successfully.
  - Turbo and Nx Docker web builds stayed on `node:24-slim` and built successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Docker Deployment Improvements**
  * Docker deployments now dynamically select the Node.js base image based on project addons—using the optimized slim variant by default, and the full Node.js 24 image when the Vite+ addon is enabled.

* **Tests**
  * Added test coverage for Docker deployment base image selection across multiple framework templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->