### PR TITLE
feat(cli): add RevenueCat payments provider for native frontends

### DIFF
--- a/apps/cli/src/helpers/addons/mcp-setup.ts
+++ b/apps/cli/src/helpers/addons/mcp-setup.ts
@@ -187,6 +187,12 @@ function getAllMcpServers(config: ProjectConfig): McpServerDef[] {
       name: "polar",
       target: "https://mcp.polar.sh/mcp/polar-mcp",
     },
+    {
+      key: "revenuecat",
+      label: "RevenueCat",
+      name: "revenuecat",
+      target: "https://mcp.revenuecat.ai/mcp",
+    },
   ];
 }
 
@@ -259,6 +265,10 @@ export function getRecommendedMcpServers(
 
   if (config.payments === "polar") {
     recommendedServerKeys.push("polar");
+  }
+
+  if (config.payments === "revenuecat") {
+    recommendedServerKeys.push("revenuecat");
   }
 
   return uniqueValues(recommendedServerKeys)

--- a/apps/cli/src/helpers/addons/mcp-setup.ts
+++ b/apps/cli/src/helpers/addons/mcp-setup.ts
@@ -192,6 +192,12 @@ function getAllMcpServers(config: ProjectConfig): McpServerDef[] {
       name: "polar",
       target: "https://mcp.polar.sh/mcp/polar-mcp",
     },
+    {
+      key: "revenuecat",
+      label: "RevenueCat",
+      name: "revenuecat",
+      target: "https://mcp.revenuecat.ai/mcp",
+    },
   ];
 }
 
@@ -264,6 +270,10 @@ export function getRecommendedMcpServers(
 
   if (config.payments === "polar") {
     recommendedServerKeys.push("polar");
+  }
+
+  if (config.payments === "revenuecat") {
+    recommendedServerKeys.push("revenuecat");
   }
 
   return uniqueValues(recommendedServerKeys)

--- a/apps/cli/src/helpers/core/post-installation.ts
+++ b/apps/cli/src/helpers/core/post-installation.ts
@@ -615,7 +615,8 @@ function getRevenueCatInstructions(backend: Backend, packageManager: string) {
     `${pc.cyan("•")} Create a project, entitlement, and offering in ${pc.underline("https://app.revenuecat.com/")}\n` +
     `${pc.cyan("•")} Set the public SDK keys in ${pc.white("apps/native/.env")}:\n` +
     `${pc.white("   EXPO_PUBLIC_REVENUECAT_IOS_KEY=appl_your_ios_key")}\n` +
-    `${pc.white("   EXPO_PUBLIC_REVENUECAT_ANDROID_KEY=goog_your_android_key")}`;
+    `${pc.white("   EXPO_PUBLIC_REVENUECAT_ANDROID_KEY=goog_your_android_key")}\n` +
+    `${pc.white("   EXPO_PUBLIC_REVENUECAT_ENTITLEMENT_ID=pro")}`;
 
   if (backend === "convex") {
     const cmd = packageManager === "npm" ? "npx" : packageManager;

--- a/apps/cli/src/helpers/core/post-installation.ts
+++ b/apps/cli/src/helpers/core/post-installation.ts
@@ -141,6 +141,8 @@ export async function displayPostInstallInstructions(
     config.payments === "polar" && config.auth === "better-auth"
       ? getPolarInstructions(backend, packageManager)
       : "";
+  const revenueCatInstructions =
+    config.payments === "revenuecat" ? getRevenueCatInstructions(backend, packageManager) : "";
 
   const bunWebNativeWarning =
     packageManager === "bun" && hasNative && hasWeb ? getBunWebNativeWarning() : "";
@@ -237,6 +239,7 @@ export async function displayPostInstallInstructions(
   if (clerkInstructions) output += `\n${clerkInstructions.trim()}\n`;
   if (betterAuthConvexInstructions) output += `\n${betterAuthConvexInstructions.trim()}\n`;
   if (polarInstructions) output += `\n${polarInstructions.trim()}\n`;
+  if (revenueCatInstructions) output += `\n${revenueCatInstructions.trim()}\n`;
 
   if (noOrmWarning) output += `\n${noOrmWarning.trim()}\n`;
   if (bunWebNativeWarning) output += `\n${bunWebNativeWarning.trim()}\n`;
@@ -604,6 +607,28 @@ function getPolarInstructions(backend: Backend, packageManager: string) {
 
   const envPath = backend === "self" ? "apps/web/.env" : "apps/server/.env";
   return `${pc.bold("Polar Payments Setup:")}\n${pc.cyan("•")} Get access token & product ID from ${pc.underline("https://sandbox.polar.sh/")}\n${pc.cyan("•")} Set POLAR_ACCESS_TOKEN in ${envPath}`;
+}
+
+function getRevenueCatInstructions(backend: Backend, packageManager: string) {
+  const base =
+    `${pc.bold("RevenueCat Payments Setup:")}\n` +
+    `${pc.cyan("•")} Create a project, entitlement, and offering in ${pc.underline("https://app.revenuecat.com/")}\n` +
+    `${pc.cyan("•")} Set the public SDK keys in ${pc.white("apps/native/.env")}:\n` +
+    `${pc.white("   EXPO_PUBLIC_REVENUECAT_IOS_KEY=appl_your_ios_key")}\n` +
+    `${pc.white("   EXPO_PUBLIC_REVENUECAT_ANDROID_KEY=goog_your_android_key")}`;
+
+  if (backend === "convex") {
+    const cmd = packageManager === "npm" ? "npx" : packageManager;
+    return (
+      `${base}\n` +
+      `${pc.cyan("•")} Set the webhook secret (min 32 chars) from ${pc.white("packages/backend")}:\n` +
+      `${pc.white("   cd packages/backend")}\n` +
+      `${pc.white(`   ${cmd} convex env set REVENUECAT_WEBHOOK_AUTH your_webhook_secret`)}\n` +
+      `${pc.cyan("•")} Configure a RevenueCat webhook to ${pc.white("https://<your-convex-site-url>/webhooks/revenuecat")} using the same value as the Authorization header`
+    );
+  }
+
+  return base;
 }
 
 function getAlchemyDeployInstructions(

--- a/apps/cli/src/helpers/core/post-installation.ts
+++ b/apps/cli/src/helpers/core/post-installation.ts
@@ -151,6 +151,8 @@ export async function displayPostInstallInstructions(
     config.payments === "polar" && config.auth === "better-auth"
       ? getPolarInstructions(backend, packageManager)
       : "";
+  const revenueCatInstructions =
+    config.payments === "revenuecat" ? getRevenueCatInstructions(backend, packageManager) : "";
 
   const bunWebNativeWarning =
     packageManager === "bun" && hasNative && hasWeb ? getBunWebNativeWarning() : "";
@@ -273,6 +275,7 @@ export async function displayPostInstallInstructions(
   if (clerkInstructions) output += `\n${clerkInstructions.trim()}\n`;
   if (betterAuthConvexInstructions) output += `\n${betterAuthConvexInstructions.trim()}\n`;
   if (polarInstructions) output += `\n${polarInstructions.trim()}\n`;
+  if (revenueCatInstructions) output += `\n${revenueCatInstructions.trim()}\n`;
   // Deploy steps come last so env sync happens after auth/payment keys exist
   if (alchemyDeployInstructions) output += `\n${alchemyDeployInstructions.trim()}\n`;
 
@@ -692,6 +695,29 @@ function getPolarInstructions(backend: Backend, packageManager: string) {
 
   const envPath = backend === "self" ? "apps/web/.env" : "apps/server/.env";
   return `${pc.bold("Polar Payments Setup:")}\n${pc.cyan("•")} Get access token & product ID from ${pc.underline("https://sandbox.polar.sh/")}\n${pc.cyan("•")} Set POLAR_ACCESS_TOKEN in ${envPath}`;
+}
+
+function getRevenueCatInstructions(backend: Backend, packageManager: string) {
+  const base =
+    `${pc.bold("RevenueCat Payments Setup:")}\n` +
+    `${pc.cyan("•")} Create a project, entitlement, and offering in ${pc.underline("https://app.revenuecat.com/")}\n` +
+    `${pc.cyan("•")} Set the public SDK keys in ${pc.white("apps/native/.env")}:\n` +
+    `${pc.white("   EXPO_PUBLIC_REVENUECAT_IOS_KEY=appl_your_ios_key")}\n` +
+    `${pc.white("   EXPO_PUBLIC_REVENUECAT_ANDROID_KEY=goog_your_android_key")}\n` +
+    `${pc.white("   EXPO_PUBLIC_REVENUECAT_ENTITLEMENT_ID=pro")}`;
+
+  if (backend === "convex") {
+    const cmd = packageManager === "npm" ? "npx" : packageManager;
+    return (
+      `${base}\n` +
+      `${pc.cyan("•")} Set the webhook secret (min 32 chars) from ${pc.white("packages/backend")}:\n` +
+      `${pc.white("   cd packages/backend")}\n` +
+      `${pc.white(`   ${cmd} convex env set REVENUECAT_WEBHOOK_AUTH your_webhook_secret`)}\n` +
+      `${pc.cyan("•")} Configure a RevenueCat webhook to ${pc.white("https://<your-convex-site-url>/webhooks/revenuecat")} using the same value as the Authorization header`
+    );
+  }
+
+  return base;
 }
 
 function getAlchemyDeployInstructions(

--- a/apps/cli/src/prompts/payments.ts
+++ b/apps/cli/src/prompts/payments.ts
@@ -7,7 +7,7 @@ export async function getPaymentsChoice(
   payments?: Payments,
   auth?: Auth,
   backend?: Backend,
-  _frontends?: Frontend[],
+  frontends?: Frontend[],
   previousValue?: Payments,
 ) {
   if (payments !== undefined) return payments;
@@ -17,23 +17,41 @@ export async function getPaymentsChoice(
   }
 
   const isPolarCompatible = auth === "better-auth";
+  const hasNativeFrontend = (frontends ?? []).some(
+    (frontend) =>
+      frontend === "native-bare" ||
+      frontend === "native-uniwind" ||
+      frontend === "native-unistyles",
+  );
+  const isRevenueCatCompatible = hasNativeFrontend;
 
-  if (!isPolarCompatible) {
+  if (!isPolarCompatible && !isRevenueCatCompatible) {
     return "none" as Payments;
   }
 
-  const options = [
-    {
+  const options: Array<{ value: Payments; label: string; hint: string }> = [];
+
+  if (isPolarCompatible) {
+    options.push({
       value: "polar" as Payments,
       label: "Polar",
       hint: "Turn your software into a business. 6 lines of code.",
-    },
-    {
-      value: "none" as Payments,
-      label: "None",
-      hint: "No payments integration",
-    },
-  ];
+    });
+  }
+
+  if (isRevenueCatCompatible) {
+    options.push({
+      value: "revenuecat" as Payments,
+      label: "RevenueCat",
+      hint: "In-app subscriptions and cross-platform monetization for mobile.",
+    });
+  }
+
+  options.push({
+    value: "none" as Payments,
+    label: "None",
+    hint: "No payments integration",
+  });
 
   const response = await navigableSelect<Payments>({
     message: "Select payments provider",

--- a/apps/cli/src/prompts/payments.ts
+++ b/apps/cli/src/prompts/payments.ts
@@ -7,7 +7,7 @@ export async function getPaymentsChoice(
   payments?: Payments,
   auth?: Auth,
   backend?: Backend,
-  _frontends?: Frontend[],
+  frontends?: Frontend[],
   previousValue?: Payments,
 ) {
   if (payments !== undefined) return payments;
@@ -17,23 +17,41 @@ export async function getPaymentsChoice(
   }
 
   const isPolarCompatible = auth === "better-auth";
+  const hasNativeFrontend = (frontends ?? []).some(
+    (frontend) =>
+      frontend === "native-bare" ||
+      frontend === "native-uniwind" ||
+      frontend === "native-unistyles",
+  );
+  const isRevenueCatCompatible = hasNativeFrontend;
 
-  if (!isPolarCompatible) {
+  if (!isPolarCompatible && !isRevenueCatCompatible) {
     return "none" as Payments;
   }
 
-  const options = [
-    {
+  const options: Array<{ value: Payments; label: string; hint: string }> = [];
+
+  if (isPolarCompatible) {
+    options.push({
       value: "polar" as Payments,
       label: "Polar",
       hint: "Turn your software into a business. 6 lines of code.",
-    },
-    {
-      value: "none" as Payments,
-      label: "None",
-      hint: "No payments integration",
-    },
-  ];
+    });
+  }
+
+  if (isRevenueCatCompatible) {
+    options.push({
+      value: "revenuecat" as Payments,
+      label: "RevenueCat",
+      hint: "In-app subscriptions and cross-platform monetization for mobile.",
+    });
+  }
+
+  options.push({
+    value: "none" as Payments,
+    label: "None",
+    hint: "No payments integration",
+  });
 
   const response = await navigableSelect<Payments>({
     message: "Add payments?",

--- a/apps/cli/src/utils/compatibility-rules.ts
+++ b/apps/cli/src/utils/compatibility-rules.ts
@@ -437,7 +437,7 @@ export function validatePaymentsCompatibility(
   payments: Payments | undefined,
   auth: Auth | undefined,
   _backend: Backend | undefined,
-  _frontends: Frontend[] = [],
+  frontends: Frontend[] = [],
 ): ValidationResult {
   if (!payments || payments === "none") return Result.ok(undefined);
 
@@ -445,6 +445,15 @@ export function validatePaymentsCompatibility(
     if (!auth || auth === "none" || auth !== "better-auth") {
       return validationErr(
         "Polar payments requires Better Auth. Please use '--auth better-auth' or choose a different payments provider.",
+      );
+    }
+  }
+
+  if (payments === "revenuecat") {
+    const { native } = splitFrontends(frontends);
+    if (native.length === 0) {
+      return validationErr(
+        "RevenueCat payments requires a native frontend (native-bare, native-uniwind, or native-unistyles). Please select a native frontend or choose a different payments provider.",
       );
     }
   }

--- a/apps/cli/src/utils/compatibility-rules.ts
+++ b/apps/cli/src/utils/compatibility-rules.ts
@@ -651,7 +651,7 @@ export function validatePaymentsCompatibility(
   payments: Payments | undefined,
   auth: Auth | undefined,
   _backend: Backend | undefined,
-  _frontends: Frontend[] = [],
+  frontends: Frontend[] = [],
 ): ValidationResult {
   if (!payments || payments === "none") return Result.ok(undefined);
 
@@ -659,6 +659,15 @@ export function validatePaymentsCompatibility(
     if (!auth || auth === "none" || auth !== "better-auth") {
       return validationErr(
         "Polar payments requires Better Auth. Please use '--auth better-auth' or choose a different payments provider.",
+      );
+    }
+  }
+
+  if (payments === "revenuecat") {
+    const { native } = splitFrontends(frontends);
+    if (native.length === 0) {
+      return validationErr(
+        "RevenueCat payments requires a native frontend (native-bare, native-uniwind, or native-unistyles). Please select a native frontend or choose a different payments provider.",
       );
     }
   }

--- a/apps/cli/test/matrix/cases.ts
+++ b/apps/cli/test/matrix/cases.ts
@@ -30,7 +30,7 @@ export const MATRIX_NATIVE_FRONTENDS = [
 ] as const;
 export const MATRIX_APIS = ["trpc", "orpc", "none"] as const;
 export const MATRIX_AUTHS = ["better-auth", "clerk", "none"] as const;
-export const MATRIX_PAYMENTS = ["polar", "none"] as const;
+export const MATRIX_PAYMENTS = ["polar", "revenuecat", "none"] as const;
 export const MATRIX_DB_SETUPS = [
   "turso",
   "neon",
@@ -319,6 +319,26 @@ export function createSmokeMatrixCases(): MatrixCase[] {
         frontend: [...frontend],
       });
     }
+  }
+
+  for (const convexAuth of ["none", "better-auth"] as const) {
+    pushUnique(configs, seen, {
+      payments: "revenuecat",
+      backend: "convex",
+      runtime: "none",
+      database: "none",
+      orm: "none",
+      api: "none",
+      auth: convexAuth,
+      frontend: ["native-bare"],
+    });
+  }
+
+  for (const nativeFrontend of MATRIX_NATIVE_FRONTENDS) {
+    pushUnique(configs, seen, {
+      payments: "revenuecat",
+      frontend: [nativeFrontend],
+    });
   }
 
   for (const dbSetup of MATRIX_DB_SETUPS) {

--- a/apps/cli/test/matrix/oracle.ts
+++ b/apps/cli/test/matrix/oracle.ts
@@ -31,6 +31,7 @@ export type MatrixRule =
   | "orm-mongodb-requires-mongoose-or-prisma"
   | "orm-requires-database"
   | "payments-polar-requires-better-auth"
+  | "payments-revenuecat-requires-native-frontend"
   | "runtime-none-requires-terminal-backend"
   | "server-deploy-requires-backend"
   | "server-deploy-requires-workers-runtime"
@@ -63,6 +64,12 @@ const FULLSTACK_FRONTENDS: readonly Frontend[] = [
   "astro",
 ] as const;
 
+const NATIVE_FRONTENDS: readonly Frontend[] = [
+  "native-bare",
+  "native-uniwind",
+  "native-unistyles",
+] as const;
+
 const CONVEX_INCOMPATIBLE_FRONTENDS: readonly Frontend[] = ["solid", "astro"] as const;
 
 const CONVEX_BETTER_AUTH_SUPPORTED_FRONTENDS: readonly Frontend[] = [
@@ -90,6 +97,10 @@ function hasFrontend(frontends: readonly Frontend[], values: readonly Frontend[]
 
 function hasWebFrontend(frontends: readonly Frontend[]) {
   return hasFrontend(frontends, WEB_FRONTENDS);
+}
+
+function hasNativeFrontend(frontends: readonly Frontend[]) {
+  return hasFrontend(frontends, NATIVE_FRONTENDS);
 }
 
 function addRule(rules: Set<MatrixRule>, condition: boolean, rule: MatrixRule) {
@@ -306,6 +317,12 @@ function validatePayments(config: ProjectConfig, rules: Set<MatrixRule>) {
     config.payments === "polar" && config.auth !== "better-auth",
     "payments-polar-requires-better-auth",
   );
+
+  addRule(
+    rules,
+    config.payments === "revenuecat" && !hasNativeFrontend(config.frontend),
+    "payments-revenuecat-requires-native-frontend",
+  );
 }
 
 function validateExamples(config: ProjectConfig, rules: Set<MatrixRule>) {
@@ -417,6 +434,9 @@ export function classifyMatrixError(message: string): MatrixRule | "unknown" {
   if (message.includes("ORM selection requires a database")) return "orm-requires-database";
   if (message.includes("Polar payments requires Better Auth")) {
     return "payments-polar-requires-better-auth";
+  }
+  if (message.includes("RevenueCat payments requires a native frontend")) {
+    return "payments-revenuecat-requires-native-frontend";
   }
   if (message.includes("'--runtime none' is only supported")) {
     return "runtime-none-requires-terminal-backend";

--- a/apps/cli/test/matrix/oracle.ts
+++ b/apps/cli/test/matrix/oracle.ts
@@ -31,6 +31,7 @@ export type MatrixRule =
   | "orm-mongodb-requires-mongoose-or-prisma"
   | "orm-requires-database"
   | "payments-polar-requires-better-auth"
+  | "payments-revenuecat-requires-native-frontend"
   | "runtime-none-requires-terminal-backend"
   | "server-deploy-requires-backend"
   | "server-deploy-requires-workers-runtime"
@@ -64,6 +65,12 @@ const FULLSTACK_FRONTENDS: readonly Frontend[] = [
   "astro",
 ] as const;
 
+const NATIVE_FRONTENDS: readonly Frontend[] = [
+  "native-bare",
+  "native-uniwind",
+  "native-unistyles",
+] as const;
+
 const CONVEX_INCOMPATIBLE_FRONTENDS: readonly Frontend[] = ["solid", "astro"] as const;
 
 const CONVEX_BETTER_AUTH_SUPPORTED_FRONTENDS: readonly Frontend[] = [
@@ -91,6 +98,10 @@ function hasFrontend(frontends: readonly Frontend[], values: readonly Frontend[]
 
 function hasWebFrontend(frontends: readonly Frontend[]) {
   return hasFrontend(frontends, WEB_FRONTENDS);
+}
+
+function hasNativeFrontend(frontends: readonly Frontend[]) {
+  return hasFrontend(frontends, NATIVE_FRONTENDS);
 }
 
 function addRule(rules: Set<MatrixRule>, condition: boolean, rule: MatrixRule) {
@@ -304,6 +315,12 @@ function validatePayments(config: ProjectConfig, rules: Set<MatrixRule>) {
     config.payments === "polar" && config.auth !== "better-auth",
     "payments-polar-requires-better-auth",
   );
+
+  addRule(
+    rules,
+    config.payments === "revenuecat" && !hasNativeFrontend(config.frontend),
+    "payments-revenuecat-requires-native-frontend",
+  );
 }
 
 function validateExamples(config: ProjectConfig, rules: Set<MatrixRule>) {
@@ -415,6 +432,9 @@ export function classifyMatrixError(message: string): MatrixRule | "unknown" {
   if (message.includes("ORM selection requires a database")) return "orm-requires-database";
   if (message.includes("Polar payments requires Better Auth")) {
     return "payments-polar-requires-better-auth";
+  }
+  if (message.includes("RevenueCat payments requires a native frontend")) {
+    return "payments-revenuecat-requires-native-frontend";
   }
   if (message.includes("'--runtime none' is only supported")) {
     return "runtime-none-requires-terminal-backend";

--- a/apps/web/src/app/(home)/new/_components/utils.ts
+++ b/apps/web/src/app/(home)/new/_components/utils.ts
@@ -89,6 +89,9 @@ export const hasClerkCompatibleFrontend = (webFrontend: string[], nativeFrontend
   ) ||
   nativeFrontend.some((f) => ["native-bare", "native-uniwind", "native-unistyles"].includes(f));
 
+export const hasNativeFrontend = (nativeFrontend: string[]) =>
+  nativeFrontend.some((f) => ["native-bare", "native-uniwind", "native-unistyles"].includes(f));
+
 export const hasClerkCompatibleBackend = (backend: string) =>
   clerkSupportedBackends.includes(backend as (typeof clerkSupportedBackends)[number]);
 
@@ -609,6 +612,15 @@ export const analyzeStackCompatibility = (stack: StackState): CompatibilityResul
     }
   }
 
+  if (nextStack.payments === "revenuecat" && !hasNativeFrontend(nextStack.nativeFrontend)) {
+    nextStack.payments = "none";
+    changed = true;
+    changes.push({
+      category: "payments",
+      message: "Payments set to 'None' (RevenueCat requires a native frontend)",
+    });
+  }
+
   // ============================================
   // ADDONS CONSTRAINTS
   // ============================================
@@ -1078,6 +1090,12 @@ export const getDisabledReason = (
   if (category === "payments" && optionId === "polar") {
     if (currentStack.auth !== "better-auth") {
       return "Polar requires Better Auth";
+    }
+  }
+
+  if (category === "payments" && optionId === "revenuecat") {
+    if (!hasNativeFrontend(currentStack.nativeFrontend)) {
+      return "RevenueCat requires a native frontend (Expo)";
     }
   }
 

--- a/apps/web/src/app/(home)/new/_components/utils.ts
+++ b/apps/web/src/app/(home)/new/_components/utils.ts
@@ -131,6 +131,9 @@ const isClerkFrontendSelectionCompatible = (webFrontend: string[], nativeFronten
   !hasClerkIncompatibleFrontend(webFrontend) &&
   hasClerkCompatibleFrontend(webFrontend, nativeFrontend);
 
+export const hasNativeFrontend = (nativeFrontend: string[]) =>
+  nativeFrontend.some((f) => ["native-bare", "native-uniwind", "native-unistyles"].includes(f));
+
 export const hasClerkCompatibleBackend = (backend: string) =>
   clerkSupportedBackends.includes(backend as (typeof clerkSupportedBackends)[number]);
 
@@ -745,6 +748,15 @@ export const analyzeStackCompatibility = (stack: StackState): CompatibilityResul
     }
   }
 
+  if (nextStack.payments === "revenuecat" && !hasNativeFrontend(nextStack.nativeFrontend)) {
+    nextStack.payments = "none";
+    changed = true;
+    changes.push({
+      category: "payments",
+      message: "Payments set to 'None' (RevenueCat requires a native frontend)",
+    });
+  }
+
   // ============================================
   // ADDONS CONSTRAINTS
   // ============================================
@@ -1357,6 +1369,12 @@ export const getDisabledReason = (
   if (category === "payments" && optionId === "polar") {
     if (currentStack.auth !== "better-auth") {
       return "Polar requires Better Auth";
+    }
+  }
+
+  if (category === "payments" && optionId === "revenuecat") {
+    if (!hasNativeFrontend(currentStack.nativeFrontend)) {
+      return "RevenueCat requires a native frontend (Expo)";
     }
   }
 

--- a/apps/web/src/lib/constant.ts
+++ b/apps/web/src/lib/constant.ts
@@ -477,6 +477,14 @@ export const TECH_OPTIONS: Record<
       default: false,
     },
     {
+      id: "revenuecat",
+      name: "RevenueCat",
+      description: "In-app subscriptions and cross-platform monetization for mobile.",
+      icon: `${ICON_BASE_URL}/revenuecat.svg`,
+      color: "from-red-400 to-red-600",
+      default: false,
+    },
+    {
       id: "none",
       name: "No Payments",
       description: "Skip payments integration",

--- a/apps/web/src/lib/constant.ts
+++ b/apps/web/src/lib/constant.ts
@@ -503,6 +503,14 @@ export const TECH_OPTIONS = {
       default: false,
     },
     {
+      id: "revenuecat",
+      name: "RevenueCat",
+      description: "In-app subscriptions and cross-platform monetization for mobile.",
+      icon: `${ICON_BASE_URL}/revenuecat.svg`,
+      color: "from-red-400 to-red-600",
+      default: false,
+    },
+    {
       id: "none",
       name: "No Payments",
       description: "Skip payments integration",

--- a/packages/template-generator/src/processors/env-vars.ts
+++ b/packages/template-generator/src/processors/env-vars.ts
@@ -206,6 +206,7 @@ function buildNativeVars(
   frontend: string[],
   backend: ProjectConfig["backend"],
   auth: ProjectConfig["auth"],
+  payments: ProjectConfig["payments"],
 ): EnvVariable[] {
   const hasAstro = frontend.includes("astro");
   const hasSvelte = frontend.includes("svelte");
@@ -249,6 +250,26 @@ function buildNativeVars(
       value: "https://<YOUR_CONVEX_URL>",
       condition: true,
     });
+  }
+
+  if (payments === "revenuecat") {
+    vars.push(
+      {
+        key: "EXPO_PUBLIC_REVENUECAT_IOS_KEY",
+        value: "",
+        condition: true,
+      },
+      {
+        key: "EXPO_PUBLIC_REVENUECAT_ANDROID_KEY",
+        value: "",
+        condition: true,
+      },
+      {
+        key: "EXPO_PUBLIC_REVENUECAT_ENTITLEMENT_ID",
+        value: "pro",
+        condition: true,
+      },
+    );
   }
 
   return vars;
@@ -363,6 +384,15 @@ function buildConvexBackendVars(
     );
   }
 
+  if (payments === "revenuecat") {
+    vars.push({
+      key: "REVENUECAT_WEBHOOK_AUTH",
+      value: "",
+      condition: true,
+      comment: "Shared secret for RevenueCat webhook authentication (min 32 characters)",
+    });
+  }
+
   return vars;
 }
 
@@ -418,6 +448,15 @@ ${needsConvexSiteUrl ? "# npx convex env set CONVEX_SITE_URL https://<YOUR_CONVE
 # Optional: npx convex env set POLAR_SERVER production
 # Create a Polar webhook at https://<your-convex-site-url>/polar/events
 # Enable: product.created, product.updated, subscription.created, subscription.updated
+
+`;
+  }
+
+  if (payments === "revenuecat") {
+    commentBlocks += `# Set RevenueCat environment variables
+# npx convex env set REVENUECAT_WEBHOOK_AUTH your_webhook_secret_min_32_chars
+# Create a RevenueCat webhook at https://<your-convex-site-url>/webhooks/revenuecat
+# Set the webhook Authorization header to the same REVENUECAT_WEBHOOK_AUTH value
 
 `;
   }
@@ -606,7 +645,7 @@ export function processEnvVariables(vfs: VirtualFileSystem, config: ProjectConfi
     const nativeDir = "apps/native";
     if (vfs.directoryExists(nativeDir)) {
       const envPath = `${nativeDir}/.env`;
-      const nativeVars = buildNativeVars(frontend, backend, auth);
+      const nativeVars = buildNativeVars(frontend, backend, auth, payments);
       writeEnvFile(vfs, envPath, nativeVars);
     }
   }

--- a/packages/template-generator/src/processors/env-vars.ts
+++ b/packages/template-generator/src/processors/env-vars.ts
@@ -199,6 +199,7 @@ function buildNativeVars(
   frontend: string[],
   backend: ProjectConfig["backend"],
   auth: ProjectConfig["auth"],
+  payments: ProjectConfig["payments"],
 ): EnvVariable[] {
   const hasAstro = frontend.includes("astro");
   const hasSvelte = frontend.includes("svelte");
@@ -242,6 +243,26 @@ function buildNativeVars(
       value: CONVEX_SITE_URL_PLACEHOLDER,
       condition: true,
     });
+  }
+
+  if (payments === "revenuecat") {
+    vars.push(
+      {
+        key: "EXPO_PUBLIC_REVENUECAT_IOS_KEY",
+        value: "",
+        condition: true,
+      },
+      {
+        key: "EXPO_PUBLIC_REVENUECAT_ANDROID_KEY",
+        value: "",
+        condition: true,
+      },
+      {
+        key: "EXPO_PUBLIC_REVENUECAT_ENTITLEMENT_ID",
+        value: "pro",
+        condition: true,
+      },
+    );
   }
 
   return vars;
@@ -356,6 +377,15 @@ function buildConvexBackendVars(
     );
   }
 
+  if (payments === "revenuecat") {
+    vars.push({
+      key: "REVENUECAT_WEBHOOK_AUTH",
+      value: "",
+      condition: true,
+      comment: "Shared secret for RevenueCat webhook authentication (min 32 characters)",
+    });
+  }
+
   return vars;
 }
 
@@ -411,6 +441,15 @@ ${needsConvexSiteUrl ? `# npx convex env set CONVEX_SITE_URL ${CONVEX_SITE_URL_P
 # Optional: npx convex env set POLAR_SERVER production
 # Create a Polar webhook at https://<your-convex-site-url>/polar/events
 # Enable: product.created, product.updated, subscription.created, subscription.updated
+
+`;
+  }
+
+  if (payments === "revenuecat") {
+    commentBlocks += `# Set RevenueCat environment variables
+# npx convex env set REVENUECAT_WEBHOOK_AUTH your_webhook_secret_min_32_chars
+# Create a RevenueCat webhook at https://<your-convex-site-url>/webhooks/revenuecat
+# Set the webhook Authorization header to the same REVENUECAT_WEBHOOK_AUTH value
 
 `;
   }
@@ -641,7 +680,7 @@ export function processEnvVariables(vfs: VirtualFileSystem, config: ProjectConfi
     const nativeDir = "apps/native";
     if (vfs.directoryExists(nativeDir)) {
       const envPath = `${nativeDir}/.env`;
-      const nativeVars = buildNativeVars(frontend, backend, auth);
+      const nativeVars = buildNativeVars(frontend, backend, auth, payments);
       writeEnvFile(vfs, envPath, nativeVars);
     }
   }

--- a/packages/template-generator/src/processors/payments-deps.ts
+++ b/packages/template-generator/src/processors/payments-deps.ts
@@ -72,4 +72,27 @@ export function processPaymentsDeps(vfs: VirtualFileSystem, config: ProjectConfi
       }
     }
   }
+
+  if (payments === "revenuecat") {
+    const nativePath = "apps/native/package.json";
+    const hasNativeFrontend = frontend.some((f) =>
+      ["native-bare", "native-uniwind", "native-unistyles"].includes(f),
+    );
+
+    if (hasNativeFrontend && vfs.exists(nativePath)) {
+      addPackageDependency({
+        vfs,
+        packagePath: nativePath,
+        dependencies: ["react-native-purchases"],
+      });
+    }
+
+    if (backend === "convex" && vfs.exists(backendPath)) {
+      addPackageDependency({
+        vfs,
+        packagePath: backendPath,
+        dependencies: ["convex-revenuecat"],
+      });
+    }
+  }
 }

--- a/packages/template-generator/src/template-handlers/payments.ts
+++ b/packages/template-generator/src/template-handlers/payments.ts
@@ -17,6 +17,14 @@ export async function processPaymentsTemplates(
   const hasSvelteWeb = config.frontend.includes("svelte");
   const hasSolidWeb = config.frontend.includes("solid");
 
+  const nativeVariant = config.frontend.includes("native-bare")
+    ? "bare"
+    : config.frontend.includes("native-uniwind")
+      ? "uniwind"
+      : config.frontend.includes("native-unistyles")
+        ? "unistyles"
+        : null;
+
   if (config.backend === "convex") {
     processTemplatesFromPrefix(
       vfs,
@@ -25,7 +33,16 @@ export async function processPaymentsTemplates(
       "packages/backend",
       config,
     );
-    return;
+
+    if (config.payments === "revenuecat" && config.auth !== "better-auth") {
+      processTemplatesFromPrefix(
+        vfs,
+        templates,
+        "payments/revenuecat/convex/no-better-auth",
+        "packages/backend",
+        config,
+      );
+    }
   } else if (config.backend !== "none") {
     processTemplatesFromPrefix(
       vfs,
@@ -35,6 +52,25 @@ export async function processPaymentsTemplates(
       config,
     );
   }
+
+  if (nativeVariant) {
+    processTemplatesFromPrefix(
+      vfs,
+      templates,
+      `payments/${config.payments}/native/base`,
+      "apps/native",
+      config,
+    );
+    processTemplatesFromPrefix(
+      vfs,
+      templates,
+      `payments/${config.payments}/native/${nativeVariant}`,
+      "apps/native",
+      config,
+    );
+  }
+
+  if (config.backend === "convex") return;
 
   if (hasReactWeb) {
     const reactFramework = config.frontend.find((f) =>

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -23500,7 +23500,7 @@ import { NAV_THEME } from "@/lib/constants";
 import { useColorScheme } from "@/lib/use-color-scheme";
 import { StyleSheet } from "react-native";
 {{#if (eq payments "revenuecat")}}
-import { RevenueCatProvider } from "@/providers/RevenueCatProvider";
+import { RevenueCatProvider } from "@/contexts/revenuecat-context";
 {{/if}}
 
 const LIGHT_THEME = {
@@ -24723,7 +24723,7 @@ import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { useUnistyles } from "react-native-unistyles";
 import { StatusBar } from "expo-status-bar";
 {{#if (eq payments "revenuecat")}}
-import { RevenueCatProvider } from "@/providers/RevenueCatProvider";
+import { RevenueCatProvider } from "@/contexts/revenuecat-context";
 {{/if}}
 
 export const unstable_settings = {
@@ -26134,7 +26134,7 @@ import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { KeyboardProvider } from "react-native-keyboard-controller";
 import { AppThemeProvider } from "@/contexts/app-theme-context";
 {{#if (eq payments "revenuecat")}}
-import { RevenueCatProvider } from "@/providers/RevenueCatProvider";
+import { RevenueCatProvider } from "@/contexts/revenuecat-context";
 {{/if}}
 
 {{#if (eq api "trpc")}}
@@ -32049,7 +32049,7 @@ export default http;
 import { ActivityIndicator, Alert, Pressable, StyleSheet, Text, View } from "react-native";
 import type { PurchasesPackage } from "react-native-purchases";
 
-import { useRevenueCat } from "@/providers/RevenueCatProvider";
+import { useRevenueCat } from "@/contexts/revenuecat-context";
 
 export function PaywallExample() {
   const { isPro, getPackages, purchasePackage, restorePurchases } = useRevenueCat();
@@ -32175,7 +32175,7 @@ const styles = StyleSheet.create({
 `],
   ["payments/revenuecat/native/bare/components/subscription-status-card.tsx.hbs", `import { StyleSheet, Text, View } from "react-native";
 
-import { useRevenueCat } from "@/providers/RevenueCatProvider";
+import { useRevenueCat } from "@/contexts/revenuecat-context";
 
 export function SubscriptionStatusCard() {
   const { isPro, isConfigured } = useRevenueCat();
@@ -32219,205 +32219,7 @@ const styles = StyleSheet.create({
   },
 });
 `],
-  ["payments/revenuecat/native/base/lib/revenue-cat/index.ts.hbs", `import { Platform } from "react-native";
-import Purchases, {
-  type CustomerInfo,
-  LOG_LEVEL,
-  type PurchasesOffering,
-  type PurchasesPackage,
-} from "react-native-purchases";
-
-// RevenueCat SDK utility layer. Thin wrappers around \`react-native-purchases\`.
-// These are pure functions with no React state — they talk to the SDK directly.
-// In components, prefer the \`useRevenueCat()\` / \`useIsPro()\` hooks from
-// \`@/providers/RevenueCatProvider\` instead of importing from this file.
-
-function normalizeEnvValue(value: string | undefined): string | undefined {
-  const normalized = value?.trim();
-  return normalized ? normalized : undefined;
-}
-
-const iosApiKey = normalizeEnvValue(process.env.EXPO_PUBLIC_REVENUECAT_IOS_KEY);
-const androidApiKey = normalizeEnvValue(process.env.EXPO_PUBLIC_REVENUECAT_ANDROID_KEY);
-
-const proEntitlementId =
-  normalizeEnvValue(process.env.EXPO_PUBLIC_REVENUECAT_ENTITLEMENT_ID) ?? "pro";
-const preferredOfferingId = normalizeEnvValue(process.env.EXPO_PUBLIC_REVENUECAT_OFFERING_ID);
-
-export const PRO_ENTITLEMENT_IDS: readonly string[] = [proEntitlementId];
-
-let hasConfiguredRevenueCat = false;
-
-export type RevenueCatInitFailureReason = "unsupported_platform" | "missing_api_key";
-
-export type RevenueCatInitResult =
-  | { configured: true }
-  | { configured: false; reason: RevenueCatInitFailureReason };
-
-type RevenueCatPurchaseError = {
-  userCancelled?: boolean;
-};
-
-type CustomerInfoListener = (customerInfo: CustomerInfo) => void;
-
-type PurchasesWithRemoveListener = typeof Purchases & {
-  removeCustomerInfoUpdateListener?: (listener: CustomerInfoListener) => void;
-};
-
-export function hasProEntitlement(customerInfo: CustomerInfo | null): boolean {
-  if (!customerInfo) return false;
-
-  return PRO_ENTITLEMENT_IDS.some((id) => customerInfo.entitlements.active[id] !== undefined);
-}
-
-function hasPackages(offering: PurchasesOffering | null | undefined): offering is PurchasesOffering {
-  return !!offering && offering.availablePackages.length > 0;
-}
-
-function pickFirstOfferingWithPackages(
-  offeringsById: Record<string, PurchasesOffering>,
-): PurchasesOffering | null {
-  for (const offering of Object.values(offeringsById)) {
-    if (hasPackages(offering)) {
-      return offering;
-    }
-  }
-  return null;
-}
-
-/**
- * One-time SDK initialization. Safe to call multiple times (no-ops after first).
- * Only \`RevenueCatProvider\` should call this — it owns the SDK lifecycle.
- */
-export async function configureRevenueCat(): Promise<RevenueCatInitResult> {
-  if (Platform.OS !== "ios" && Platform.OS !== "android") {
-    return { configured: false, reason: "unsupported_platform" };
-  }
-
-  if (hasConfiguredRevenueCat) {
-    return { configured: true };
-  }
-
-  const apiKey = Platform.OS === "ios" ? iosApiKey : androidApiKey;
-
-  if (!apiKey) {
-    return { configured: false, reason: "missing_api_key" };
-  }
-
-  Purchases.setLogLevel(__DEV__ ? LOG_LEVEL.WARN : LOG_LEVEL.ERROR);
-
-  Purchases.configure({ apiKey });
-
-  hasConfiguredRevenueCat = true;
-
-  return { configured: true };
-}
-
-/**
- * Subscribe to real-time entitlement changes. Returns an unsubscribe function.
- * Only \`RevenueCatProvider\` should use this directly.
- */
-export function onCustomerInfoUpdated(listener: CustomerInfoListener): () => void {
-  Purchases.addCustomerInfoUpdateListener(listener);
-
-  return () => {
-    (Purchases as PurchasesWithRemoveListener).removeCustomerInfoUpdateListener?.(listener);
-  };
-}
-
-/** Fetch latest CustomerInfo and return current pro status. */
-export async function refreshProEntitlement(): Promise<boolean> {
-  const customerInfo = await Purchases.getCustomerInfo();
-  return hasProEntitlement(customerInfo);
-}
-
-/**
- * Identify the user in RevenueCat via \`Purchases.logIn\` so purchases follow the
- * account across devices. Pass a stable auth user id. Returns pro status.
- */
-export async function identifyUser(userId: string): Promise<boolean> {
-  const { customerInfo } = await Purchases.logIn(userId);
-  return hasProEntitlement(customerInfo);
-}
-
-/** Log out the current user from RevenueCat (resets to an anonymous id). */
-export async function logOutUser(): Promise<void> {
-  await Purchases.logOut();
-}
-
-/** Set user attributes for tracking in the RevenueCat dashboard. */
-export async function setUserAttributes(attributes: {
-  email?: string;
-  displayName?: string;
-}): Promise<void> {
-  if (attributes.email) {
-    await Purchases.setEmail(attributes.email);
-  }
-  if (attributes.displayName) {
-    await Purchases.setDisplayName(attributes.displayName);
-  }
-}
-
-async function getOffering(): Promise<PurchasesOffering | null> {
-  const offerings = await Purchases.getOfferings();
-
-  if (preferredOfferingId) {
-    const preferredOffering = offerings.all[preferredOfferingId];
-    if (hasPackages(preferredOffering)) {
-      return preferredOffering;
-    }
-
-    if (__DEV__) {
-      console.warn(
-        \`[RevenueCat] Offering '\${preferredOfferingId}' was configured but has no available packages; falling back to current offering.\`,
-      );
-    }
-  }
-
-  if (hasPackages(offerings.current)) {
-    return offerings.current;
-  }
-
-  const fallbackOffering = pickFirstOfferingWithPackages(offerings.all);
-  if (fallbackOffering) {
-    return fallbackOffering;
-  }
-
-  return offerings.current ?? null;
-}
-
-/** Get available subscription packages from the resolved offering. */
-export async function getPackages(): Promise<PurchasesPackage[]> {
-  const offering = await getOffering();
-  return offering?.availablePackages ?? [];
-}
-
-/** Attempt a package purchase and return the resulting pro status. */
-export async function purchaseAndCheckPro(pack: PurchasesPackage): Promise<boolean> {
-  const { customerInfo } = await Purchases.purchasePackage(pack);
-  return hasProEntitlement(customerInfo);
-}
-
-/** Restore purchases from the App Store / Play Store. */
-export async function restoreAndCheckPro(): Promise<boolean> {
-  const customerInfo = await Purchases.restorePurchases();
-  return hasProEntitlement(customerInfo);
-}
-
-/** Force-sync local store state with RevenueCat servers. Debug / recovery only. */
-export async function syncAndCheckPro(): Promise<boolean> {
-  const { customerInfo } = await Purchases.syncPurchasesForResult();
-  return hasProEntitlement(customerInfo);
-}
-
-/** Check whether an error thrown during purchase is a user cancellation. */
-export function isPurchaseCancelledError(error: unknown): boolean {
-  if (!error || typeof error !== "object") return false;
-
-  return (error as RevenueCatPurchaseError).userCancelled === true;
-}
-`],
-  ["payments/revenuecat/native/base/providers/RevenueCatProvider.tsx.hbs", `import type { ReactNode } from "react";
+  ["payments/revenuecat/native/base/contexts/revenuecat-context.tsx.hbs", `import type { ReactNode } from "react";
 import {
   createContext,
   useCallback,
@@ -32443,7 +32245,7 @@ import {
   restoreAndCheckPro,
   setUserAttributes as setRevenueCatUserAttributes,
   syncAndCheckPro,
-} from "@/lib/revenue-cat";
+} from "@/lib/revenuecat";
 
 type UserAttributes = {
   email?: string;
@@ -32704,12 +32506,210 @@ export function RevenueCatProvider({ children }: RevenueCatProviderProps) {
   return <RevenueCatContext.Provider value={value}>{children}</RevenueCatContext.Provider>;
 }
 `],
+  ["payments/revenuecat/native/base/lib/revenuecat.ts.hbs", `import { Platform } from "react-native";
+import Purchases, {
+  type CustomerInfo,
+  LOG_LEVEL,
+  type PurchasesOffering,
+  type PurchasesPackage,
+} from "react-native-purchases";
+
+// RevenueCat SDK utility layer. Thin wrappers around \`react-native-purchases\`.
+// These are pure functions with no React state — they talk to the SDK directly.
+// In components, prefer the \`useRevenueCat()\` / \`useIsPro()\` hooks from
+// \`@/contexts/revenuecat-context\` instead of importing from this file.
+
+function normalizeEnvValue(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? normalized : undefined;
+}
+
+const iosApiKey = normalizeEnvValue(process.env.EXPO_PUBLIC_REVENUECAT_IOS_KEY);
+const androidApiKey = normalizeEnvValue(process.env.EXPO_PUBLIC_REVENUECAT_ANDROID_KEY);
+
+const proEntitlementId =
+  normalizeEnvValue(process.env.EXPO_PUBLIC_REVENUECAT_ENTITLEMENT_ID) ?? "pro";
+const preferredOfferingId = normalizeEnvValue(process.env.EXPO_PUBLIC_REVENUECAT_OFFERING_ID);
+
+export const PRO_ENTITLEMENT_IDS: readonly string[] = [proEntitlementId];
+
+let hasConfiguredRevenueCat = false;
+
+export type RevenueCatInitFailureReason = "unsupported_platform" | "missing_api_key";
+
+export type RevenueCatInitResult =
+  | { configured: true }
+  | { configured: false; reason: RevenueCatInitFailureReason };
+
+type RevenueCatPurchaseError = {
+  userCancelled?: boolean;
+};
+
+type CustomerInfoListener = (customerInfo: CustomerInfo) => void;
+
+type PurchasesWithRemoveListener = typeof Purchases & {
+  removeCustomerInfoUpdateListener?: (listener: CustomerInfoListener) => void;
+};
+
+export function hasProEntitlement(customerInfo: CustomerInfo | null): boolean {
+  if (!customerInfo) return false;
+
+  return PRO_ENTITLEMENT_IDS.some((id) => customerInfo.entitlements.active[id] !== undefined);
+}
+
+function hasPackages(offering: PurchasesOffering | null | undefined): offering is PurchasesOffering {
+  return !!offering && offering.availablePackages.length > 0;
+}
+
+function pickFirstOfferingWithPackages(
+  offeringsById: Record<string, PurchasesOffering>,
+): PurchasesOffering | null {
+  for (const offering of Object.values(offeringsById)) {
+    if (hasPackages(offering)) {
+      return offering;
+    }
+  }
+  return null;
+}
+
+/**
+ * One-time SDK initialization. Safe to call multiple times (no-ops after first).
+ * Only \`RevenueCatProvider\` should call this — it owns the SDK lifecycle.
+ */
+export async function configureRevenueCat(): Promise<RevenueCatInitResult> {
+  if (Platform.OS !== "ios" && Platform.OS !== "android") {
+    return { configured: false, reason: "unsupported_platform" };
+  }
+
+  if (hasConfiguredRevenueCat) {
+    return { configured: true };
+  }
+
+  const apiKey = Platform.OS === "ios" ? iosApiKey : androidApiKey;
+
+  if (!apiKey) {
+    return { configured: false, reason: "missing_api_key" };
+  }
+
+  Purchases.setLogLevel(__DEV__ ? LOG_LEVEL.WARN : LOG_LEVEL.ERROR);
+
+  Purchases.configure({ apiKey });
+
+  hasConfiguredRevenueCat = true;
+
+  return { configured: true };
+}
+
+/**
+ * Subscribe to real-time entitlement changes. Returns an unsubscribe function.
+ * Only \`RevenueCatProvider\` should use this directly.
+ */
+export function onCustomerInfoUpdated(listener: CustomerInfoListener): () => void {
+  Purchases.addCustomerInfoUpdateListener(listener);
+
+  return () => {
+    (Purchases as PurchasesWithRemoveListener).removeCustomerInfoUpdateListener?.(listener);
+  };
+}
+
+/** Fetch latest CustomerInfo and return current pro status. */
+export async function refreshProEntitlement(): Promise<boolean> {
+  const customerInfo = await Purchases.getCustomerInfo();
+  return hasProEntitlement(customerInfo);
+}
+
+/**
+ * Identify the user in RevenueCat via \`Purchases.logIn\` so purchases follow the
+ * account across devices. Pass a stable auth user id. Returns pro status.
+ */
+export async function identifyUser(userId: string): Promise<boolean> {
+  const { customerInfo } = await Purchases.logIn(userId);
+  return hasProEntitlement(customerInfo);
+}
+
+/** Log out the current user from RevenueCat (resets to an anonymous id). */
+export async function logOutUser(): Promise<void> {
+  await Purchases.logOut();
+}
+
+/** Set user attributes for tracking in the RevenueCat dashboard. */
+export async function setUserAttributes(attributes: {
+  email?: string;
+  displayName?: string;
+}): Promise<void> {
+  if (attributes.email) {
+    await Purchases.setEmail(attributes.email);
+  }
+  if (attributes.displayName) {
+    await Purchases.setDisplayName(attributes.displayName);
+  }
+}
+
+async function getOffering(): Promise<PurchasesOffering | null> {
+  const offerings = await Purchases.getOfferings();
+
+  if (preferredOfferingId) {
+    const preferredOffering = offerings.all[preferredOfferingId];
+    if (hasPackages(preferredOffering)) {
+      return preferredOffering;
+    }
+
+    if (__DEV__) {
+      console.warn(
+        \`[RevenueCat] Offering '\${preferredOfferingId}' was configured but has no available packages; falling back to current offering.\`,
+      );
+    }
+  }
+
+  if (hasPackages(offerings.current)) {
+    return offerings.current;
+  }
+
+  const fallbackOffering = pickFirstOfferingWithPackages(offerings.all);
+  if (fallbackOffering) {
+    return fallbackOffering;
+  }
+
+  return offerings.current ?? null;
+}
+
+/** Get available subscription packages from the resolved offering. */
+export async function getPackages(): Promise<PurchasesPackage[]> {
+  const offering = await getOffering();
+  return offering?.availablePackages ?? [];
+}
+
+/** Attempt a package purchase and return the resulting pro status. */
+export async function purchaseAndCheckPro(pack: PurchasesPackage): Promise<boolean> {
+  const { customerInfo } = await Purchases.purchasePackage(pack);
+  return hasProEntitlement(customerInfo);
+}
+
+/** Restore purchases from the App Store / Play Store. */
+export async function restoreAndCheckPro(): Promise<boolean> {
+  const customerInfo = await Purchases.restorePurchases();
+  return hasProEntitlement(customerInfo);
+}
+
+/** Force-sync local store state with RevenueCat servers. Debug / recovery only. */
+export async function syncAndCheckPro(): Promise<boolean> {
+  const { customerInfo } = await Purchases.syncPurchasesForResult();
+  return hasProEntitlement(customerInfo);
+}
+
+/** Check whether an error thrown during purchase is a user cancellation. */
+export function isPurchaseCancelledError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+
+  return (error as RevenueCatPurchaseError).userCancelled === true;
+}
+`],
   ["payments/revenuecat/native/unistyles/components/paywall-example.tsx.hbs", `import { useState } from "react";
 import { ActivityIndicator, Alert, Pressable, Text, View } from "react-native";
 import { StyleSheet } from "react-native-unistyles";
 import type { PurchasesPackage } from "react-native-purchases";
 
-import { useRevenueCat } from "@/providers/RevenueCatProvider";
+import { useRevenueCat } from "@/contexts/revenuecat-context";
 
 export function PaywallExample() {
   const { isPro, getPackages, purchasePackage, restorePurchases } = useRevenueCat();
@@ -32836,7 +32836,7 @@ const styles = StyleSheet.create((theme) => ({
   ["payments/revenuecat/native/unistyles/components/subscription-status-card.tsx.hbs", `import { Text, View } from "react-native";
 import { StyleSheet } from "react-native-unistyles";
 
-import { useRevenueCat } from "@/providers/RevenueCatProvider";
+import { useRevenueCat } from "@/contexts/revenuecat-context";
 
 export function SubscriptionStatusCard() {
   const { isPro, isConfigured } = useRevenueCat();
@@ -32884,7 +32884,7 @@ const styles = StyleSheet.create((theme) => ({
 import { ActivityIndicator, Alert, Pressable, Text, View } from "react-native";
 import type { PurchasesPackage } from "react-native-purchases";
 
-import { useRevenueCat } from "@/providers/RevenueCatProvider";
+import { useRevenueCat } from "@/contexts/revenuecat-context";
 
 export function PaywallExample() {
   const { isPro, getPackages, purchasePackage, restorePurchases } = useRevenueCat();
@@ -32983,7 +32983,7 @@ export function PaywallExample() {
 `],
   ["payments/revenuecat/native/uniwind/components/subscription-status-card.tsx.hbs", `import { Text, View } from "react-native";
 
-import { useRevenueCat } from "@/providers/RevenueCatProvider";
+import { useRevenueCat } from "@/contexts/revenuecat-context";
 
 export function SubscriptionStatusCard() {
   const { isPro, isConfigured } = useRevenueCat();

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -32030,7 +32030,7 @@ function SuccessPage() {
 import { components } from "./_generated/api";
 
 export const revenuecat = new RevenueCat(components.revenuecat, {
-  REVENUECAT_WEBHOOK_AUTH: process.env.REVENUECAT_WEBHOOK_AUTH ?? "",
+  REVENUECAT_WEBHOOK_AUTH: process.env.REVENUECAT_WEBHOOK_AUTH,
 });
 
 export const { hasEntitlement, isSubscriber, getActiveSubscriptions } = revenuecat.api();
@@ -32056,6 +32056,8 @@ export function PaywallExample() {
   const [packages, setPackages] = useState<PurchasesPackage[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [isPurchasing, setIsPurchasing] = useState(false);
+  const [isRestoring, setIsRestoring] = useState(false);
+  const isBusy = isPurchasing || isRestoring;
 
   const loadPackages = async () => {
     setIsLoading(true);
@@ -32067,12 +32069,24 @@ export function PaywallExample() {
   };
 
   const handlePurchase = async (pack: PurchasesPackage) => {
+    if (isBusy) return;
     setIsPurchasing(true);
     try {
       const success = await purchasePackage(pack);
       Alert.alert(success ? "You're now Premium!" : "Purchase not completed");
     } finally {
       setIsPurchasing(false);
+    }
+  };
+
+  const handleRestore = async () => {
+    if (isBusy) return;
+    setIsRestoring(true);
+    try {
+      const success = await restorePurchases();
+      Alert.alert(success ? "Purchases restored" : "No purchases to restore");
+    } finally {
+      setIsRestoring(false);
     }
   };
 
@@ -32104,7 +32118,7 @@ export function PaywallExample() {
             key={pack.identifier}
             style={styles.button}
             onPress={() => handlePurchase(pack)}
-            disabled={isPurchasing}
+            disabled={isBusy}
           >
             <Text style={styles.buttonText}>
               {pack.product.title} · {pack.product.priceString}
@@ -32113,8 +32127,10 @@ export function PaywallExample() {
         ))
       )}
 
-      <Pressable style={styles.secondary} onPress={restorePurchases}>
-        <Text style={styles.secondaryText}>Restore purchases</Text>
+      <Pressable style={styles.secondary} onPress={handleRestore} disabled={isBusy}>
+        <Text style={styles.secondaryText}>
+          {isRestoring ? "Restoring..." : "Restore purchases"}
+        </Text>
       </Pressable>
     </View>
   );
@@ -32216,13 +32232,13 @@ import Purchases, {
 // In components, prefer the \`useRevenueCat()\` / \`useIsPro()\` hooks from
 // \`@/providers/RevenueCatProvider\` instead of importing from this file.
 
-const iosApiKey = process.env.EXPO_PUBLIC_REVENUECAT_IOS_KEY ?? "";
-const androidApiKey = process.env.EXPO_PUBLIC_REVENUECAT_ANDROID_KEY ?? "";
-
 function normalizeEnvValue(value: string | undefined): string | undefined {
   const normalized = value?.trim();
   return normalized ? normalized : undefined;
 }
+
+const iosApiKey = normalizeEnvValue(process.env.EXPO_PUBLIC_REVENUECAT_IOS_KEY);
+const androidApiKey = normalizeEnvValue(process.env.EXPO_PUBLIC_REVENUECAT_ANDROID_KEY);
 
 const proEntitlementId =
   normalizeEnvValue(process.env.EXPO_PUBLIC_REVENUECAT_ENTITLEMENT_ID) ?? "pro";
@@ -32700,6 +32716,8 @@ export function PaywallExample() {
   const [packages, setPackages] = useState<PurchasesPackage[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [isPurchasing, setIsPurchasing] = useState(false);
+  const [isRestoring, setIsRestoring] = useState(false);
+  const isBusy = isPurchasing || isRestoring;
 
   const loadPackages = async () => {
     setIsLoading(true);
@@ -32711,12 +32729,24 @@ export function PaywallExample() {
   };
 
   const handlePurchase = async (pack: PurchasesPackage) => {
+    if (isBusy) return;
     setIsPurchasing(true);
     try {
       const success = await purchasePackage(pack);
       Alert.alert(success ? "You're now Premium!" : "Purchase not completed");
     } finally {
       setIsPurchasing(false);
+    }
+  };
+
+  const handleRestore = async () => {
+    if (isBusy) return;
+    setIsRestoring(true);
+    try {
+      const success = await restorePurchases();
+      Alert.alert(success ? "Purchases restored" : "No purchases to restore");
+    } finally {
+      setIsRestoring(false);
     }
   };
 
@@ -32748,7 +32778,7 @@ export function PaywallExample() {
             key={pack.identifier}
             style={styles.button}
             onPress={() => handlePurchase(pack)}
-            disabled={isPurchasing}
+            disabled={isBusy}
           >
             <Text style={styles.buttonText}>
               {pack.product.title} · {pack.product.priceString}
@@ -32757,8 +32787,10 @@ export function PaywallExample() {
         ))
       )}
 
-      <Pressable style={styles.secondary} onPress={restorePurchases}>
-        <Text style={styles.secondaryText}>Restore purchases</Text>
+      <Pressable style={styles.secondary} onPress={handleRestore} disabled={isBusy}>
+        <Text style={styles.secondaryText}>
+          {isRestoring ? "Restoring..." : "Restore purchases"}
+        </Text>
       </Pressable>
     </View>
   );
@@ -32859,6 +32891,8 @@ export function PaywallExample() {
   const [packages, setPackages] = useState<PurchasesPackage[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [isPurchasing, setIsPurchasing] = useState(false);
+  const [isRestoring, setIsRestoring] = useState(false);
+  const isBusy = isPurchasing || isRestoring;
 
   const loadPackages = async () => {
     setIsLoading(true);
@@ -32870,12 +32904,24 @@ export function PaywallExample() {
   };
 
   const handlePurchase = async (pack: PurchasesPackage) => {
+    if (isBusy) return;
     setIsPurchasing(true);
     try {
       const success = await purchasePackage(pack);
       Alert.alert(success ? "You're now Premium!" : "Purchase not completed");
     } finally {
       setIsPurchasing(false);
+    }
+  };
+
+  const handleRestore = async () => {
+    if (isBusy) return;
+    setIsRestoring(true);
+    try {
+      const success = await restorePurchases();
+      Alert.alert(success ? "Purchases restored" : "No purchases to restore");
+    } finally {
+      setIsRestoring(false);
     }
   };
 
@@ -32917,7 +32963,7 @@ export function PaywallExample() {
             key={pack.identifier}
             className="items-center rounded-xl bg-neutral-900 py-3 dark:bg-neutral-50"
             onPress={() => handlePurchase(pack)}
-            disabled={isPurchasing}
+            disabled={isBusy}
           >
             <Text className="font-semibold text-neutral-50 dark:text-neutral-900">
               {pack.product.title} · {pack.product.priceString}
@@ -32926,8 +32972,10 @@ export function PaywallExample() {
         ))
       )}
 
-      <Pressable className="items-center py-2" onPress={restorePurchases}>
-        <Text className="text-neutral-500 text-sm">Restore purchases</Text>
+      <Pressable className="items-center py-2" onPress={handleRestore} disabled={isBusy}>
+        <Text className="text-neutral-500 text-sm">
+          {isRestoring ? "Restoring..." : "Restore purchases"}
+        </Text>
       </Pressable>
     </View>
   );

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -5604,6 +5604,10 @@ import { NAV_THEME } from "@/lib/constants";
 import { authClient{{#if (eq payments "polar")}}, polarNativeClient{{/if}} } from "@/lib/auth-client";
 import { SignIn } from "@/components/sign-in";
 import { SignUp } from "@/components/sign-up";
+{{#if (eq payments "revenuecat")}}
+import { SubscriptionStatusCard } from "@/components/subscription-status-card";
+import { PaywallExample } from "@/components/paywall-example";
+{{/if}}
 {{#if (eq api "orpc")}}
 import { useQuery } from "@tanstack/react-query";
 import { queryClient, orpc } from "@/utils/orpc";
@@ -5791,6 +5795,11 @@ return (
         <SignUp />
       </>
       )}
+
+      {{#if (eq payments "revenuecat")}}
+      <SubscriptionStatusCard />
+      <PaywallExample />
+      {{/if}}
     </View>
   </ScrollView>
 </Container>
@@ -6410,6 +6419,10 @@ import { StyleSheet } from "react-native-unistyles";
 import { Container } from "@/components/container";
 import { SignIn } from "@/components/sign-in";
 import { SignUp } from "@/components/sign-up";
+{{#if (eq payments "revenuecat")}}
+import { SubscriptionStatusCard } from "@/components/subscription-status-card";
+import { PaywallExample } from "@/components/paywall-example";
+{{/if}}
 {{#if (eq api "orpc")}}
 import { useQuery } from "@tanstack/react-query";
 import { queryClient, orpc } from "@/utils/orpc";
@@ -6557,6 +6570,11 @@ export default function Home() {
               <SignUp />
             </>
           )}
+
+          {{#if (eq payments "revenuecat")}}
+          <SubscriptionStatusCard />
+          <PaywallExample />
+          {{/if}}
         </View>
       </ScrollView>
     </Container>
@@ -7151,6 +7169,10 @@ import { Ionicons } from "@expo/vector-icons";
 import { Card, Chip, useThemeColor } from "heroui-native";
 import { SignIn } from "@/components/sign-in";
 import { SignUp } from "@/components/sign-up";
+{{#if (eq payments "revenuecat")}}
+import { SubscriptionStatusCard } from "@/components/subscription-status-card";
+import { PaywallExample } from "@/components/paywall-example";
+{{/if}}
 {{#if (eq api "orpc")}}
 import { useQuery } from "@tanstack/react-query";
 import { queryClient, orpc } from "@/utils/orpc";
@@ -7322,6 +7344,13 @@ return (
     <SignUp />
   </>
   )}
+
+  {{#if (eq payments "revenuecat")}}
+  <View className="mt-6">
+    <SubscriptionStatusCard />
+    <PaywallExample />
+  </View>
+  {{/if}}
 </Container>
 );
 }
@@ -23889,6 +23918,10 @@ import { env } from "@{{projectName}}/env/native";
 import { Container } from "@/components/container";
 import { useColorScheme } from "@/lib/use-color-scheme";
 import { NAV_THEME } from "@/lib/constants";
+{{#if (eq payments "revenuecat")}}
+import { SubscriptionStatusCard } from "@/components/subscription-status-card";
+import { PaywallExample } from "@/components/paywall-example";
+{{/if}}
 {{#if (eq api "orpc")}}
 import { useQuery } from "@tanstack/react-query";
 import { orpc } from "@/utils/orpc";
@@ -24218,6 +24251,11 @@ return (
         <SignUp />
       </>
       )}
+      {{/if}}
+
+      {{#if (eq payments "revenuecat")}}
+      <SubscriptionStatusCard />
+      <PaywallExample />
       {{/if}}
     </View>
   </ScrollView>
@@ -25150,6 +25188,10 @@ import { env } from "@{{projectName}}/env/native";
 {{/if}}
 import { StyleSheet } from "react-native-unistyles";
 import { Container } from "@/components/container";
+{{#if (eq payments "revenuecat")}}
+import { SubscriptionStatusCard } from "@/components/subscription-status-card";
+import { PaywallExample } from "@/components/paywall-example";
+{{/if}}
 
 {{#if (eq api "orpc")}}
 import { useQuery } from "@tanstack/react-query";
@@ -25438,6 +25480,11 @@ export default function Home() {
             <SignUp />
           </>
         )}
+        {{/if}}
+
+        {{#if (eq payments "revenuecat")}}
+        <SubscriptionStatusCard />
+        <PaywallExample />
         {{/if}}
       </ScrollView>
     </Container>
@@ -26496,6 +26543,10 @@ import { api } from "@{{projectName}}/backend/convex/_generated/api";
 import { Ionicons } from "@expo/vector-icons";
 {{/unless}}
 import { Button, Chip, Separator, Spinner, Surface, useThemeColor } from "heroui-native";
+{{#if (eq payments "revenuecat")}}
+import { SubscriptionStatusCard } from "@/components/subscription-status-card";
+import { PaywallExample } from "@/components/paywall-example";
+{{/if}}
 
 export default function Home() {
 {{#if (eq api "orpc")}}
@@ -26751,6 +26802,13 @@ return (
     <SignUp />
   </View>
   )}
+  {{/if}}
+
+  {{#if (eq payments "revenuecat")}}
+  <View className="mt-5">
+    <SubscriptionStatusCard />
+    <PaywallExample />
+  </View>
   {{/if}}
 </Container>
 );
@@ -32046,12 +32104,17 @@ revenuecat.registerRoutes(http);
 export default http;
 `],
   ["payments/revenuecat/native/bare/components/paywall-example.tsx.hbs", `import { useState } from "react";
-import { ActivityIndicator, Alert, Pressable, StyleSheet, Text, View } from "react-native";
+import { Button, Column, Host, Text as ExpoUIText } from "@expo/ui";
+import { ActivityIndicator, Alert, StyleSheet, View } from "react-native";
 import type { PurchasesPackage } from "react-native-purchases";
 
+import { NAV_THEME } from "@/lib/constants";
+import { useColorScheme } from "@/lib/use-color-scheme";
 import { useRevenueCat } from "@/contexts/revenuecat-context";
 
 export function PaywallExample() {
+  const { colorScheme } = useColorScheme();
+  const theme = colorScheme === "dark" ? NAV_THEME.dark : NAV_THEME.light;
   const { isPro, getPackages, purchasePackage, restorePurchases } = useRevenueCat();
   const [packages, setPackages] = useState<PurchasesPackage[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -32092,130 +32155,128 @@ export function PaywallExample() {
 
   if (isPro) {
     return (
-      <View style={styles.card}>
-        <Text style={styles.title}>You're Premium</Text>
-        <Text style={styles.muted}>Thanks for your support — enjoy all features.</Text>
+      <View style={[styles.card, { backgroundColor: theme.card, borderColor: theme.border }]}>
+        <Host matchContents=\\{{ vertical: true }}>
+          <Column spacing={6}>
+            <ExpoUIText textStyle=\\{{ color: theme.text, fontSize: 16, fontWeight: "bold" }}>
+              You're Premium
+            </ExpoUIText>
+            <ExpoUIText textStyle=\\{{ color: theme.text, fontSize: 13 }} style=\\{{ opacity: 0.7 }}>
+              Thanks for your support — enjoy all features.
+            </ExpoUIText>
+          </Column>
+        </Host>
       </View>
     );
   }
 
   return (
-    <View style={styles.card}>
-      <Text style={styles.title}>Upgrade to Premium</Text>
-      <Text style={styles.muted}>Unlock all features.</Text>
+    <View style={[styles.card, { backgroundColor: theme.card, borderColor: theme.border }]}>
+      <Host style={styles.headerHost} matchContents=\\{{ vertical: true }}>
+        <Column spacing={6}>
+          <ExpoUIText textStyle=\\{{ color: theme.text, fontSize: 16, fontWeight: "bold" }}>
+            Upgrade to Premium
+          </ExpoUIText>
+          <ExpoUIText textStyle=\\{{ color: theme.text, fontSize: 13 }} style=\\{{ opacity: 0.7 }}>
+            Unlock all features.
+          </ExpoUIText>
+        </Column>
+      </Host>
 
-      {packages.length === 0 ? (
-        <Pressable style={styles.button} onPress={loadPackages} disabled={isLoading}>
-          {isLoading ? (
-            <ActivityIndicator color="#fafafa" />
-          ) : (
-            <Text style={styles.buttonText}>View plans</Text>
-          )}
-        </Pressable>
+      {isLoading ? (
+        <View style={styles.loadingRow}>
+          <ActivityIndicator color={theme.text} />
+        </View>
       ) : (
-        packages.map((pack) => (
-          <Pressable
-            key={pack.identifier}
-            style={styles.button}
-            onPress={() => handlePurchase(pack)}
-            disabled={isBusy}
-          >
-            <Text style={styles.buttonText}>
-              {pack.product.title} · {pack.product.priceString}
-            </Text>
-          </Pressable>
-        ))
+        <Host style={styles.actionsHost} matchContents=\\{{ vertical: true }}>
+          <Column spacing={8}>
+            {packages.length === 0 ? (
+              <Button label="View plans" onPress={loadPackages} />
+            ) : (
+              packages.map((pack) => (
+                <Button
+                  key={pack.identifier}
+                  label={\`\${pack.product.title} · \${pack.product.priceString}\`}
+                  variant="outlined"
+                  onPress={() => handlePurchase(pack)}
+                />
+              ))
+            )}
+            <Button
+              label={isRestoring ? "Restoring..." : "Restore purchases"}
+              variant="outlined"
+              onPress={handleRestore}
+            />
+          </Column>
+        </Host>
       )}
-
-      <Pressable style={styles.secondary} onPress={handleRestore} disabled={isBusy}>
-        <Text style={styles.secondaryText}>
-          {isRestoring ? "Restoring..." : "Restore purchases"}
-        </Text>
-      </Pressable>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
   card: {
-    gap: 12,
-    borderRadius: 16,
+    marginBottom: 16,
     padding: 16,
-    backgroundColor: "#f4f4f5",
+    borderWidth: 1,
+    borderRadius: 16,
   },
-  title: {
-    fontSize: 18,
-    fontWeight: "600",
-    color: "#18181b",
+  headerHost: {
+    marginBottom: 12,
   },
-  muted: {
-    fontSize: 14,
-    color: "#71717a",
+  actionsHost: {
+    marginTop: 4,
   },
-  button: {
+  loadingRow: {
     alignItems: "center",
-    borderRadius: 12,
     paddingVertical: 12,
-    backgroundColor: "#18181b",
-  },
-  buttonText: {
-    fontSize: 15,
-    fontWeight: "600",
-    color: "#fafafa",
-  },
-  secondary: {
-    alignItems: "center",
-    paddingVertical: 10,
-  },
-  secondaryText: {
-    fontSize: 14,
-    color: "#71717a",
   },
 });
 `],
-  ["payments/revenuecat/native/bare/components/subscription-status-card.tsx.hbs", `import { StyleSheet, Text, View } from "react-native";
+  ["payments/revenuecat/native/bare/components/subscription-status-card.tsx.hbs", `import { Column, Host, Text as ExpoUIText } from "@expo/ui";
+import { StyleSheet, View } from "react-native";
 
+import { NAV_THEME } from "@/lib/constants";
+import { useColorScheme } from "@/lib/use-color-scheme";
 import { useRevenueCat } from "@/contexts/revenuecat-context";
 
 export function SubscriptionStatusCard() {
+  const { colorScheme } = useColorScheme();
+  const theme = colorScheme === "dark" ? NAV_THEME.dark : NAV_THEME.light;
   const { isPro, isConfigured } = useRevenueCat();
 
   return (
-    <View style={styles.card}>
-      <Text style={styles.title}>Subscription</Text>
-      {!isConfigured ? (
-        <Text style={styles.muted}>
-          RevenueCat is not configured yet. Add your API keys in apps/native/.env.
-        </Text>
-      ) : isPro ? (
-        <Text style={styles.pro}>You're a Premium member 🎉</Text>
-      ) : (
-        <Text style={styles.muted}>You're on the free plan.</Text>
-      )}
+    <View style={[styles.card, { backgroundColor: theme.card, borderColor: theme.border }]}>
+      <Host matchContents=\\{{ vertical: true }}>
+        <Column spacing={6}>
+          <ExpoUIText textStyle=\\{{ color: theme.text, fontSize: 16, fontWeight: "bold" }}>
+            Subscription
+          </ExpoUIText>
+          {!isConfigured ? (
+            <ExpoUIText textStyle=\\{{ color: theme.text, fontSize: 13 }} style=\\{{ opacity: 0.7 }}>
+              RevenueCat is not configured yet. Add your API keys in apps/native/.env.
+            </ExpoUIText>
+          ) : isPro ? (
+            <ExpoUIText textStyle=\\{{ color: "#16a34a", fontSize: 14, fontWeight: "500" }}>
+              You're a Premium member 🎉
+            </ExpoUIText>
+          ) : (
+            <ExpoUIText textStyle=\\{{ color: theme.text, fontSize: 13 }} style=\\{{ opacity: 0.7 }}>
+              You're on the free plan.
+            </ExpoUIText>
+          )}
+        </Column>
+      </Host>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
   card: {
-    gap: 8,
-    borderRadius: 16,
+    marginBottom: 16,
     padding: 16,
-    backgroundColor: "#f4f4f5",
-  },
-  title: {
-    fontSize: 18,
-    fontWeight: "600",
-    color: "#18181b",
-  },
-  pro: {
-    fontSize: 15,
-    fontWeight: "500",
-    color: "#16a34a",
-  },
-  muted: {
-    fontSize: 14,
-    color: "#71717a",
+    borderWidth: 1,
+    borderRadius: 16,
   },
 });
 `],
@@ -32881,7 +32942,8 @@ const styles = StyleSheet.create((theme) => ({
 }));
 `],
   ["payments/revenuecat/native/uniwind/components/paywall-example.tsx.hbs", `import { useState } from "react";
-import { ActivityIndicator, Alert, Pressable, Text, View } from "react-native";
+import { Alert, View } from "react-native";
+import { Button, Card, Spinner } from "heroui-native";
 import type { PurchasesPackage } from "react-native-purchases";
 
 import { useRevenueCat } from "@/contexts/revenuecat-context";
@@ -32927,61 +32989,52 @@ export function PaywallExample() {
 
   if (isPro) {
     return (
-      <View className="gap-2 rounded-2xl bg-neutral-100 p-4 dark:bg-neutral-900">
-        <Text className="font-semibold text-lg text-neutral-900 dark:text-neutral-50">
-          You're Premium
-        </Text>
-        <Text className="text-neutral-500 text-sm">
+      <Card variant="secondary" className="mb-4 p-4">
+        <Card.Title className="mb-2">You're Premium</Card.Title>
+        <Card.Description>
           Thanks for your support — enjoy all features.
-        </Text>
-      </View>
+        </Card.Description>
+      </Card>
     );
   }
 
   return (
-    <View className="gap-3 rounded-2xl bg-neutral-100 p-4 dark:bg-neutral-900">
-      <Text className="font-semibold text-lg text-neutral-900 dark:text-neutral-50">
-        Upgrade to Premium
-      </Text>
-      <Text className="text-neutral-500 text-sm">Unlock all features.</Text>
+    <Card variant="secondary" className="mb-4 p-4">
+      <Card.Title className="mb-2">Upgrade to Premium</Card.Title>
+      <Card.Description className="mb-4">Unlock all features.</Card.Description>
 
-      {packages.length === 0 ? (
-        <Pressable
-          className="items-center rounded-xl bg-neutral-900 py-3 dark:bg-neutral-50"
-          onPress={loadPackages}
-          disabled={isLoading}
-        >
-          {isLoading ? (
-            <ActivityIndicator />
-          ) : (
-            <Text className="font-semibold text-neutral-50 dark:text-neutral-900">View plans</Text>
-          )}
-        </Pressable>
-      ) : (
-        packages.map((pack) => (
-          <Pressable
-            key={pack.identifier}
-            className="items-center rounded-xl bg-neutral-900 py-3 dark:bg-neutral-50"
-            onPress={() => handlePurchase(pack)}
-            disabled={isBusy}
-          >
-            <Text className="font-semibold text-neutral-50 dark:text-neutral-900">
-              {pack.product.title} · {pack.product.priceString}
-            </Text>
-          </Pressable>
-        ))
-      )}
+      <View className="gap-3">
+        {packages.length === 0 ? (
+          <Button onPress={loadPackages} isDisabled={isLoading}>
+            {isLoading ? <Spinner size="sm" color="default" /> : <Button.Label>View plans</Button.Label>}
+          </Button>
+        ) : (
+          packages.map((pack) => (
+            <Button
+              key={pack.identifier}
+              variant="secondary"
+              onPress={() => handlePurchase(pack)}
+              isDisabled={isBusy}
+            >
+              <Button.Label>
+                {pack.product.title} · {pack.product.priceString}
+              </Button.Label>
+            </Button>
+          ))
+        )}
 
-      <Pressable className="items-center py-2" onPress={handleRestore} disabled={isBusy}>
-        <Text className="text-neutral-500 text-sm">
-          {isRestoring ? "Restoring..." : "Restore purchases"}
-        </Text>
-      </Pressable>
-    </View>
+        <Button variant="ghost" onPress={handleRestore} isDisabled={isBusy}>
+          <Button.Label>
+            {isRestoring ? "Restoring..." : "Restore purchases"}
+          </Button.Label>
+        </Button>
+      </View>
+    </Card>
   );
 }
 `],
-  ["payments/revenuecat/native/uniwind/components/subscription-status-card.tsx.hbs", `import { Text, View } from "react-native";
+  ["payments/revenuecat/native/uniwind/components/subscription-status-card.tsx.hbs", `import { Text } from "react-native";
+import { Card } from "heroui-native";
 
 import { useRevenueCat } from "@/contexts/revenuecat-context";
 
@@ -32989,20 +33042,20 @@ export function SubscriptionStatusCard() {
   const { isPro, isConfigured } = useRevenueCat();
 
   return (
-    <View className="gap-2 rounded-2xl bg-neutral-100 p-4 dark:bg-neutral-900">
-      <Text className="font-semibold text-lg text-neutral-900 dark:text-neutral-50">
-        Subscription
-      </Text>
+    <Card variant="secondary" className="mb-4 p-4">
+      <Card.Title className="mb-2">Subscription</Card.Title>
       {!isConfigured ? (
-        <Text className="text-neutral-500 text-sm">
+        <Card.Description>
           RevenueCat is not configured yet. Add your API keys in apps/native/.env.
-        </Text>
+        </Card.Description>
       ) : isPro ? (
-        <Text className="font-medium text-base text-green-600">You're a Premium member 🎉</Text>
+        <Text className="text-success text-base font-medium">
+          You're a Premium member 🎉
+        </Text>
       ) : (
-        <Text className="text-neutral-500 text-sm">You're on the free plan.</Text>
+        <Card.Description>You're on the free plan.</Card.Description>
       )}
-    </View>
+    </Card>
   );
 }
 `]

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -2293,6 +2293,9 @@ import { httpAction } from "./_generated/server";
 {{#if (eq payments "polar")}}
 import { polar } from "./polar";
 {{/if}}
+{{#if (eq payments "revenuecat")}}
+import { revenuecat } from "./revenuecat";
+{{/if}}
 
 const http = httpRouter();
 
@@ -2336,6 +2339,10 @@ authComponent.registerRoutes(http, createAuth);
 {{#if (eq payments "polar")}}
 
 polar.registerRoutes(http);
+{{/if}}
+{{#if (eq payments "revenuecat")}}
+
+revenuecat.registerRoutes(http);
 {{/if}}
 
 export default http;
@@ -13967,6 +13974,9 @@ import betterAuth from "@convex-dev/better-auth/convex.config";
 {{#if (eq payments "polar")}}
 import polar from "@convex-dev/polar/convex.config.js";
 {{/if}}
+{{#if (eq payments "revenuecat")}}
+import revenuecat from "convex-revenuecat/convex.config";
+{{/if}}
 {{#if (includes examples "ai")}}
 import agent from "@convex-dev/agent/convex.config";
 {{/if}}
@@ -13977,6 +13987,9 @@ app.use(betterAuth);
 {{/if}}
 {{#if (eq payments "polar")}}
 app.use(polar);
+{{/if}}
+{{#if (eq payments "revenuecat")}}
+app.use(revenuecat);
 {{/if}}
 {{#if (includes examples "ai")}}
 app.use(agent);
@@ -23486,6 +23499,9 @@ import { queryClient } from "@/utils/orpc";
 import { NAV_THEME } from "@/lib/constants";
 import { useColorScheme } from "@/lib/use-color-scheme";
 import { StyleSheet } from "react-native";
+{{#if (eq payments "revenuecat")}}
+import { RevenueCatProvider } from "@/providers/RevenueCatProvider";
+{{/if}}
 
 const LIGHT_THEME = {
   ...DefaultTheme,
@@ -23533,6 +23549,9 @@ export default function RootLayout() {
 
   return (
     <>
+{{#if (eq payments "revenuecat")}}
+      <RevenueCatProvider>
+{{/if}}
       {{#if (eq backend "convex")}}
         {{#if (eq auth "clerk")}}
           <ClerkProvider tokenCache={tokenCache} publishableKey={env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY}>
@@ -23630,6 +23649,9 @@ export default function RootLayout() {
           {{/unless}}
         {{/if}}
       {{/if}}
+{{#if (eq payments "revenuecat")}}
+      </RevenueCatProvider>
+{{/if}}
     </>
   );
 }
@@ -24700,6 +24722,9 @@ import { Stack } from "expo-router";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { useUnistyles } from "react-native-unistyles";
 import { StatusBar } from "expo-status-bar";
+{{#if (eq payments "revenuecat")}}
+import { RevenueCatProvider } from "@/providers/RevenueCatProvider";
+{{/if}}
 
 export const unstable_settings = {
   initialRouteName: "(drawer)",
@@ -24731,6 +24756,9 @@ export default function RootLayout() {
   const { theme } = useUnistyles();
 
   return (
+{{#if (eq payments "revenuecat")}}
+    <RevenueCatProvider>
+{{/if}}
     {{#if (eq backend "convex")}}
     {{#if (eq auth "clerk")}}
     <ClerkProvider
@@ -24904,6 +24932,9 @@ export default function RootLayout() {
         {{/unless}}
       {{/if}}
     {{/if}}
+{{#if (eq payments "revenuecat")}}
+    </RevenueCatProvider>
+{{/if}}
   );
 }
 `],
@@ -26102,6 +26133,9 @@ import { HeroUINativeProvider } from "heroui-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { KeyboardProvider } from "react-native-keyboard-controller";
 import { AppThemeProvider } from "@/contexts/app-theme-context";
+{{#if (eq payments "revenuecat")}}
+import { RevenueCatProvider } from "@/providers/RevenueCatProvider";
+{{/if}}
 
 {{#if (eq api "trpc")}}
   import { queryClient } from "@/utils/trpc";
@@ -26150,6 +26184,9 @@ function StackLayout() {
 
 export default function Layout() {
   return (
+{{#if (eq payments "revenuecat")}}
+    <RevenueCatProvider>
+{{/if}}
     {{#if (eq backend "convex")}}
       {{#if (eq auth "clerk")}}
         <ClerkProvider tokenCache={tokenCache} publishableKey={env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY}>
@@ -26244,6 +26281,9 @@ export default function Layout() {
         {{/unless}}
       {{/if}}
     {{/if}}
+{{#if (eq payments "revenuecat")}}
+    </RevenueCatProvider>
+{{/if}}
   );
 }
 `],
@@ -31984,7 +32024,940 @@ function SuccessPage() {
 		<p>Checkout ID: {checkout_id}</p>
 	{/if}
 </div>
+`],
+  ["payments/revenuecat/convex/backend/convex/revenuecat.ts.hbs", `import { RevenueCat } from "convex-revenuecat";
+
+import { components } from "./_generated/api";
+
+export const revenuecat = new RevenueCat(components.revenuecat, {
+  REVENUECAT_WEBHOOK_AUTH: process.env.REVENUECAT_WEBHOOK_AUTH ?? "",
+});
+
+export const { hasEntitlement, isSubscriber, getActiveSubscriptions } = revenuecat.api();
+`],
+  ["payments/revenuecat/convex/no-better-auth/convex/http.ts.hbs", `import { httpRouter } from "convex/server";
+
+import { revenuecat } from "./revenuecat";
+
+const http = httpRouter();
+
+revenuecat.registerRoutes(http);
+
+export default http;
+`],
+  ["payments/revenuecat/native/bare/components/paywall-example.tsx.hbs", `import { useState } from "react";
+import { ActivityIndicator, Alert, Pressable, StyleSheet, Text, View } from "react-native";
+import type { PurchasesPackage } from "react-native-purchases";
+
+import { useRevenueCat } from "@/providers/RevenueCatProvider";
+
+export function PaywallExample() {
+  const { isPro, getPackages, purchasePackage, restorePurchases } = useRevenueCat();
+  const [packages, setPackages] = useState<PurchasesPackage[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isPurchasing, setIsPurchasing] = useState(false);
+
+  const loadPackages = async () => {
+    setIsLoading(true);
+    try {
+      setPackages(await getPackages());
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handlePurchase = async (pack: PurchasesPackage) => {
+    setIsPurchasing(true);
+    try {
+      const success = await purchasePackage(pack);
+      Alert.alert(success ? "You're now Premium!" : "Purchase not completed");
+    } finally {
+      setIsPurchasing(false);
+    }
+  };
+
+  if (isPro) {
+    return (
+      <View style={styles.card}>
+        <Text style={styles.title}>You're Premium</Text>
+        <Text style={styles.muted}>Thanks for your support — enjoy all features.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.card}>
+      <Text style={styles.title}>Upgrade to Premium</Text>
+      <Text style={styles.muted}>Unlock all features.</Text>
+
+      {packages.length === 0 ? (
+        <Pressable style={styles.button} onPress={loadPackages} disabled={isLoading}>
+          {isLoading ? (
+            <ActivityIndicator color="#fafafa" />
+          ) : (
+            <Text style={styles.buttonText}>View plans</Text>
+          )}
+        </Pressable>
+      ) : (
+        packages.map((pack) => (
+          <Pressable
+            key={pack.identifier}
+            style={styles.button}
+            onPress={() => handlePurchase(pack)}
+            disabled={isPurchasing}
+          >
+            <Text style={styles.buttonText}>
+              {pack.product.title} · {pack.product.priceString}
+            </Text>
+          </Pressable>
+        ))
+      )}
+
+      <Pressable style={styles.secondary} onPress={restorePurchases}>
+        <Text style={styles.secondaryText}>Restore purchases</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    gap: 12,
+    borderRadius: 16,
+    padding: 16,
+    backgroundColor: "#f4f4f5",
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: "600",
+    color: "#18181b",
+  },
+  muted: {
+    fontSize: 14,
+    color: "#71717a",
+  },
+  button: {
+    alignItems: "center",
+    borderRadius: 12,
+    paddingVertical: 12,
+    backgroundColor: "#18181b",
+  },
+  buttonText: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: "#fafafa",
+  },
+  secondary: {
+    alignItems: "center",
+    paddingVertical: 10,
+  },
+  secondaryText: {
+    fontSize: 14,
+    color: "#71717a",
+  },
+});
+`],
+  ["payments/revenuecat/native/bare/components/subscription-status-card.tsx.hbs", `import { StyleSheet, Text, View } from "react-native";
+
+import { useRevenueCat } from "@/providers/RevenueCatProvider";
+
+export function SubscriptionStatusCard() {
+  const { isPro, isConfigured } = useRevenueCat();
+
+  return (
+    <View style={styles.card}>
+      <Text style={styles.title}>Subscription</Text>
+      {!isConfigured ? (
+        <Text style={styles.muted}>
+          RevenueCat is not configured yet. Add your API keys in apps/native/.env.
+        </Text>
+      ) : isPro ? (
+        <Text style={styles.pro}>You're a Premium member 🎉</Text>
+      ) : (
+        <Text style={styles.muted}>You're on the free plan.</Text>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    gap: 8,
+    borderRadius: 16,
+    padding: 16,
+    backgroundColor: "#f4f4f5",
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: "600",
+    color: "#18181b",
+  },
+  pro: {
+    fontSize: 15,
+    fontWeight: "500",
+    color: "#16a34a",
+  },
+  muted: {
+    fontSize: 14,
+    color: "#71717a",
+  },
+});
+`],
+  ["payments/revenuecat/native/base/lib/revenue-cat/index.ts.hbs", `import { Platform } from "react-native";
+import Purchases, {
+  type CustomerInfo,
+  LOG_LEVEL,
+  type PurchasesOffering,
+  type PurchasesPackage,
+} from "react-native-purchases";
+
+// RevenueCat SDK utility layer. Thin wrappers around \`react-native-purchases\`.
+// These are pure functions with no React state — they talk to the SDK directly.
+// In components, prefer the \`useRevenueCat()\` / \`useIsPro()\` hooks from
+// \`@/providers/RevenueCatProvider\` instead of importing from this file.
+
+const iosApiKey = process.env.EXPO_PUBLIC_REVENUECAT_IOS_KEY ?? "";
+const androidApiKey = process.env.EXPO_PUBLIC_REVENUECAT_ANDROID_KEY ?? "";
+
+function normalizeEnvValue(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? normalized : undefined;
+}
+
+const proEntitlementId =
+  normalizeEnvValue(process.env.EXPO_PUBLIC_REVENUECAT_ENTITLEMENT_ID) ?? "pro";
+const preferredOfferingId = normalizeEnvValue(process.env.EXPO_PUBLIC_REVENUECAT_OFFERING_ID);
+
+export const PRO_ENTITLEMENT_IDS: readonly string[] = [proEntitlementId];
+
+let hasConfiguredRevenueCat = false;
+
+export type RevenueCatInitFailureReason = "unsupported_platform" | "missing_api_key";
+
+export type RevenueCatInitResult =
+  | { configured: true }
+  | { configured: false; reason: RevenueCatInitFailureReason };
+
+type RevenueCatPurchaseError = {
+  userCancelled?: boolean;
+};
+
+type CustomerInfoListener = (customerInfo: CustomerInfo) => void;
+
+type PurchasesWithRemoveListener = typeof Purchases & {
+  removeCustomerInfoUpdateListener?: (listener: CustomerInfoListener) => void;
+};
+
+export function hasProEntitlement(customerInfo: CustomerInfo | null): boolean {
+  if (!customerInfo) return false;
+
+  return PRO_ENTITLEMENT_IDS.some((id) => customerInfo.entitlements.active[id] !== undefined);
+}
+
+function hasPackages(offering: PurchasesOffering | null | undefined): offering is PurchasesOffering {
+  return !!offering && offering.availablePackages.length > 0;
+}
+
+function pickFirstOfferingWithPackages(
+  offeringsById: Record<string, PurchasesOffering>,
+): PurchasesOffering | null {
+  for (const offering of Object.values(offeringsById)) {
+    if (hasPackages(offering)) {
+      return offering;
+    }
+  }
+  return null;
+}
+
+/**
+ * One-time SDK initialization. Safe to call multiple times (no-ops after first).
+ * Only \`RevenueCatProvider\` should call this — it owns the SDK lifecycle.
+ */
+export async function configureRevenueCat(): Promise<RevenueCatInitResult> {
+  if (Platform.OS !== "ios" && Platform.OS !== "android") {
+    return { configured: false, reason: "unsupported_platform" };
+  }
+
+  if (hasConfiguredRevenueCat) {
+    return { configured: true };
+  }
+
+  const apiKey = Platform.OS === "ios" ? iosApiKey : androidApiKey;
+
+  if (!apiKey) {
+    return { configured: false, reason: "missing_api_key" };
+  }
+
+  Purchases.setLogLevel(__DEV__ ? LOG_LEVEL.WARN : LOG_LEVEL.ERROR);
+
+  Purchases.configure({ apiKey });
+
+  hasConfiguredRevenueCat = true;
+
+  return { configured: true };
+}
+
+/**
+ * Subscribe to real-time entitlement changes. Returns an unsubscribe function.
+ * Only \`RevenueCatProvider\` should use this directly.
+ */
+export function onCustomerInfoUpdated(listener: CustomerInfoListener): () => void {
+  Purchases.addCustomerInfoUpdateListener(listener);
+
+  return () => {
+    (Purchases as PurchasesWithRemoveListener).removeCustomerInfoUpdateListener?.(listener);
+  };
+}
+
+/** Fetch latest CustomerInfo and return current pro status. */
+export async function refreshProEntitlement(): Promise<boolean> {
+  const customerInfo = await Purchases.getCustomerInfo();
+  return hasProEntitlement(customerInfo);
+}
+
+/**
+ * Identify the user in RevenueCat via \`Purchases.logIn\` so purchases follow the
+ * account across devices. Pass a stable auth user id. Returns pro status.
+ */
+export async function identifyUser(userId: string): Promise<boolean> {
+  const { customerInfo } = await Purchases.logIn(userId);
+  return hasProEntitlement(customerInfo);
+}
+
+/** Log out the current user from RevenueCat (resets to an anonymous id). */
+export async function logOutUser(): Promise<void> {
+  await Purchases.logOut();
+}
+
+/** Set user attributes for tracking in the RevenueCat dashboard. */
+export async function setUserAttributes(attributes: {
+  email?: string;
+  displayName?: string;
+}): Promise<void> {
+  if (attributes.email) {
+    await Purchases.setEmail(attributes.email);
+  }
+  if (attributes.displayName) {
+    await Purchases.setDisplayName(attributes.displayName);
+  }
+}
+
+async function getOffering(): Promise<PurchasesOffering | null> {
+  const offerings = await Purchases.getOfferings();
+
+  if (preferredOfferingId) {
+    const preferredOffering = offerings.all[preferredOfferingId];
+    if (hasPackages(preferredOffering)) {
+      return preferredOffering;
+    }
+
+    if (__DEV__) {
+      console.warn(
+        \`[RevenueCat] Offering '\${preferredOfferingId}' was configured but has no available packages; falling back to current offering.\`,
+      );
+    }
+  }
+
+  if (hasPackages(offerings.current)) {
+    return offerings.current;
+  }
+
+  const fallbackOffering = pickFirstOfferingWithPackages(offerings.all);
+  if (fallbackOffering) {
+    return fallbackOffering;
+  }
+
+  return offerings.current ?? null;
+}
+
+/** Get available subscription packages from the resolved offering. */
+export async function getPackages(): Promise<PurchasesPackage[]> {
+  const offering = await getOffering();
+  return offering?.availablePackages ?? [];
+}
+
+/** Attempt a package purchase and return the resulting pro status. */
+export async function purchaseAndCheckPro(pack: PurchasesPackage): Promise<boolean> {
+  const { customerInfo } = await Purchases.purchasePackage(pack);
+  return hasProEntitlement(customerInfo);
+}
+
+/** Restore purchases from the App Store / Play Store. */
+export async function restoreAndCheckPro(): Promise<boolean> {
+  const customerInfo = await Purchases.restorePurchases();
+  return hasProEntitlement(customerInfo);
+}
+
+/** Force-sync local store state with RevenueCat servers. Debug / recovery only. */
+export async function syncAndCheckPro(): Promise<boolean> {
+  const { customerInfo } = await Purchases.syncPurchasesForResult();
+  return hasProEntitlement(customerInfo);
+}
+
+/** Check whether an error thrown during purchase is a user cancellation. */
+export function isPurchaseCancelledError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+
+  return (error as RevenueCatPurchaseError).userCancelled === true;
+}
+`],
+  ["payments/revenuecat/native/base/providers/RevenueCatProvider.tsx.hbs", `import type { ReactNode } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { AppState } from "react-native";
+import type { PurchasesPackage } from "react-native-purchases";
+
+import {
+  configureRevenueCat,
+  getPackages as getRevenueCatPackages,
+  hasProEntitlement,
+  identifyUser as identifyRevenueCatUser,
+  isPurchaseCancelledError,
+  logOutUser as logOutRevenueCatUser,
+  onCustomerInfoUpdated,
+  purchaseAndCheckPro,
+  type RevenueCatInitFailureReason,
+  refreshProEntitlement,
+  restoreAndCheckPro,
+  setUserAttributes as setRevenueCatUserAttributes,
+  syncAndCheckPro,
+} from "@/lib/revenue-cat";
+
+type UserAttributes = {
+  email?: string;
+  displayName?: string;
+};
+
+export type RevenueCatContextValue = {
+  isPro: boolean;
+  isConfigured: boolean;
+  refreshEntitlement: () => Promise<boolean>;
+  getPackages: () => Promise<PurchasesPackage[]>;
+  purchasePackage: (pack: PurchasesPackage) => Promise<boolean>;
+  restorePurchases: () => Promise<boolean>;
+  syncPurchases: () => Promise<boolean>;
+  identifyUser: (userId: string) => Promise<boolean>;
+  logOutUser: () => Promise<void>;
+  setUserAttributes: (attributes: UserAttributes) => Promise<void>;
+};
+
+type RevenueCatProviderProps = {
+  children: ReactNode;
+};
+
+const RevenueCatContext = createContext<RevenueCatContextValue | null>(null);
+
+export function useRevenueCat(): RevenueCatContextValue {
+  const context = useContext(RevenueCatContext);
+
+  if (!context) {
+    throw new Error("useRevenueCat must be used within RevenueCatProvider");
+  }
+
+  return context;
+}
+
+export function useIsPro(): boolean {
+  const context = useContext(RevenueCatContext);
+  return context?.isPro ?? false;
+}
+
+function logInitSkip(reason: RevenueCatInitFailureReason): void {
+  if (reason === "unsupported_platform") {
+    console.warn("[RevenueCat] Initialization skipped: unsupported platform");
+    return;
+  }
+
+  console.warn(
+    "[RevenueCat] Missing API key. Add EXPO_PUBLIC_REVENUECAT_IOS_KEY and EXPO_PUBLIC_REVENUECAT_ANDROID_KEY in apps/native/.env",
+  );
+}
+
+export function RevenueCatProvider({ children }: RevenueCatProviderProps) {
+  const [isConfigured, setIsConfigured] = useState(false);
+  const [isPro, setIsPro] = useState(false);
+
+  const refreshEntitlement = useCallback(async (): Promise<boolean> => {
+    if (!isConfigured) return false;
+    try {
+      const nextIsPro = await refreshProEntitlement();
+      setIsPro(nextIsPro);
+      return nextIsPro;
+    } catch (error) {
+      console.warn("[RevenueCat] Failed to refresh entitlement:", error);
+      return false;
+    }
+  }, [isConfigured]);
+
+  const getPackages = useCallback(async (): Promise<PurchasesPackage[]> => {
+    if (!isConfigured) return [];
+
+    try {
+      return await getRevenueCatPackages();
+    } catch (error) {
+      console.warn("[RevenueCat] Failed to fetch packages:", error);
+      return [];
+    }
+  }, [isConfigured]);
+
+  const purchasePackage = useCallback(
+    async (pack: PurchasesPackage): Promise<boolean> => {
+      if (!isConfigured) return false;
+
+      try {
+        const nextIsPro = await purchaseAndCheckPro(pack);
+        setIsPro(nextIsPro);
+        return nextIsPro;
+      } catch (error) {
+        if (isPurchaseCancelledError(error)) {
+          try {
+            const nextIsPro = await refreshProEntitlement();
+            setIsPro(nextIsPro);
+            return nextIsPro;
+          } catch (refreshError) {
+            console.warn(
+              "[RevenueCat] Failed to refresh entitlement after cancellation:",
+              refreshError,
+            );
+            return false;
+          }
+        }
+
+        console.warn("[RevenueCat] Purchase failed:", error);
+        return false;
+      }
+    },
+    [isConfigured],
+  );
+
+  const restorePurchases = useCallback(async (): Promise<boolean> => {
+    if (!isConfigured) return false;
+
+    try {
+      const nextIsPro = await restoreAndCheckPro();
+      setIsPro(nextIsPro);
+      return nextIsPro;
+    } catch (error) {
+      console.warn("[RevenueCat] Restore failed:", error);
+      return false;
+    }
+  }, [isConfigured]);
+
+  const syncPurchases = useCallback(async (): Promise<boolean> => {
+    if (!isConfigured) return false;
+
+    try {
+      const nextIsPro = await syncAndCheckPro();
+      setIsPro(nextIsPro);
+      return nextIsPro;
+    } catch (error) {
+      console.warn("[RevenueCat] Sync purchases failed:", error);
+      return false;
+    }
+  }, [isConfigured]);
+
+  const identifyUser = useCallback(
+    async (userId: string): Promise<boolean> => {
+      if (!isConfigured) return false;
+
+      try {
+        const nextIsPro = await identifyRevenueCatUser(userId);
+        setIsPro(nextIsPro);
+        return nextIsPro;
+      } catch (error) {
+        console.warn("[RevenueCat] Identify user failed:", error);
+        return false;
+      }
+    },
+    [isConfigured],
+  );
+
+  const logOutUser = useCallback(async (): Promise<void> => {
+    if (!isConfigured) return;
+
+    try {
+      await logOutRevenueCatUser();
+      setIsPro(false);
+    } catch (error) {
+      console.warn("[RevenueCat] Log out failed:", error);
+    }
+  }, [isConfigured]);
+
+  const setUserAttributes = useCallback(
+    async (attributes: UserAttributes): Promise<void> => {
+      if (!isConfigured) return;
+
+      try {
+        await setRevenueCatUserAttributes(attributes);
+      } catch (error) {
+        console.warn("[RevenueCat] Set attributes failed:", error);
+      }
+    },
+    [isConfigured],
+  );
+
+  useEffect(() => {
+    let isMounted = true;
+    let unsubscribe = () => {};
+
+    const initialize = async () => {
+      try {
+        const result = await configureRevenueCat();
+
+        if (!isMounted) return;
+
+        if (!result.configured) {
+          setIsConfigured(false);
+          logInitSkip(result.reason);
+          return;
+        }
+
+        setIsConfigured(true);
+
+        unsubscribe = onCustomerInfoUpdated((customerInfo) => {
+          if (!isMounted) return;
+          setIsPro(hasProEntitlement(customerInfo));
+        });
+
+        const nextIsPro = await refreshProEntitlement();
+        if (isMounted) {
+          setIsPro(nextIsPro);
+        }
+      } catch (error) {
+        console.warn("[RevenueCat] Initialization failed:", error);
+      }
+    };
+
+    initialize();
+
+    return () => {
+      isMounted = false;
+      unsubscribe();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isConfigured) return;
+
+    const subscription = AppState.addEventListener("change", (state) => {
+      if (state !== "active") return;
+
+      refreshEntitlement().catch((error) => {
+        console.warn("[RevenueCat] Foreground entitlement refresh failed:", error);
+      });
+    });
+
+    return () => {
+      subscription.remove();
+    };
+  }, [isConfigured, refreshEntitlement]);
+
+  const value = useMemo<RevenueCatContextValue>(
+    () => ({
+      isPro,
+      isConfigured,
+      refreshEntitlement,
+      getPackages,
+      purchasePackage,
+      restorePurchases,
+      syncPurchases,
+      identifyUser,
+      logOutUser,
+      setUserAttributes,
+    }),
+    [
+      isPro,
+      isConfigured,
+      refreshEntitlement,
+      getPackages,
+      purchasePackage,
+      restorePurchases,
+      syncPurchases,
+      identifyUser,
+      logOutUser,
+      setUserAttributes,
+    ],
+  );
+
+  return <RevenueCatContext.Provider value={value}>{children}</RevenueCatContext.Provider>;
+}
+`],
+  ["payments/revenuecat/native/unistyles/components/paywall-example.tsx.hbs", `import { useState } from "react";
+import { ActivityIndicator, Alert, Pressable, Text, View } from "react-native";
+import { StyleSheet } from "react-native-unistyles";
+import type { PurchasesPackage } from "react-native-purchases";
+
+import { useRevenueCat } from "@/providers/RevenueCatProvider";
+
+export function PaywallExample() {
+  const { isPro, getPackages, purchasePackage, restorePurchases } = useRevenueCat();
+  const [packages, setPackages] = useState<PurchasesPackage[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isPurchasing, setIsPurchasing] = useState(false);
+
+  const loadPackages = async () => {
+    setIsLoading(true);
+    try {
+      setPackages(await getPackages());
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handlePurchase = async (pack: PurchasesPackage) => {
+    setIsPurchasing(true);
+    try {
+      const success = await purchasePackage(pack);
+      Alert.alert(success ? "You're now Premium!" : "Purchase not completed");
+    } finally {
+      setIsPurchasing(false);
+    }
+  };
+
+  if (isPro) {
+    return (
+      <View style={styles.card}>
+        <Text style={styles.title}>You're Premium</Text>
+        <Text style={styles.muted}>Thanks for your support — enjoy all features.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.card}>
+      <Text style={styles.title}>Upgrade to Premium</Text>
+      <Text style={styles.muted}>Unlock all features.</Text>
+
+      {packages.length === 0 ? (
+        <Pressable style={styles.button} onPress={loadPackages} disabled={isLoading}>
+          {isLoading ? (
+            <ActivityIndicator color={styles.buttonText.color} />
+          ) : (
+            <Text style={styles.buttonText}>View plans</Text>
+          )}
+        </Pressable>
+      ) : (
+        packages.map((pack) => (
+          <Pressable
+            key={pack.identifier}
+            style={styles.button}
+            onPress={() => handlePurchase(pack)}
+            disabled={isPurchasing}
+          >
+            <Text style={styles.buttonText}>
+              {pack.product.title} · {pack.product.priceString}
+            </Text>
+          </Pressable>
+        ))
+      )}
+
+      <Pressable style={styles.secondary} onPress={restorePurchases}>
+        <Text style={styles.secondaryText}>Restore purchases</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  card: {
+    gap: theme.spacing.md,
+    borderRadius: theme.borderRadius.xl,
+    padding: theme.spacing.md,
+    backgroundColor: theme.colors.card,
+  },
+  title: {
+    fontSize: theme.fontSize.lg,
+    fontWeight: "600",
+    color: theme.colors.foreground,
+  },
+  muted: {
+    fontSize: theme.fontSize.sm,
+    color: theme.colors.mutedForeground,
+  },
+  button: {
+    alignItems: "center",
+    borderRadius: theme.borderRadius.lg,
+    paddingVertical: theme.spacing.sm,
+    backgroundColor: theme.colors.primary,
+  },
+  buttonText: {
+    fontSize: theme.fontSize.base,
+    fontWeight: "600",
+    color: theme.colors.primaryForeground,
+  },
+  secondary: {
+    alignItems: "center",
+    paddingVertical: theme.spacing.sm,
+  },
+  secondaryText: {
+    fontSize: theme.fontSize.sm,
+    color: theme.colors.mutedForeground,
+  },
+}));
+`],
+  ["payments/revenuecat/native/unistyles/components/subscription-status-card.tsx.hbs", `import { Text, View } from "react-native";
+import { StyleSheet } from "react-native-unistyles";
+
+import { useRevenueCat } from "@/providers/RevenueCatProvider";
+
+export function SubscriptionStatusCard() {
+  const { isPro, isConfigured } = useRevenueCat();
+
+  return (
+    <View style={styles.card}>
+      <Text style={styles.title}>Subscription</Text>
+      {!isConfigured ? (
+        <Text style={styles.muted}>
+          RevenueCat is not configured yet. Add your API keys in apps/native/.env.
+        </Text>
+      ) : isPro ? (
+        <Text style={styles.pro}>You're a Premium member 🎉</Text>
+      ) : (
+        <Text style={styles.muted}>You're on the free plan.</Text>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  card: {
+    gap: theme.spacing.sm,
+    borderRadius: theme.borderRadius.xl,
+    padding: theme.spacing.md,
+    backgroundColor: theme.colors.card,
+  },
+  title: {
+    fontSize: theme.fontSize.lg,
+    fontWeight: "600",
+    color: theme.colors.foreground,
+  },
+  pro: {
+    fontSize: theme.fontSize.base,
+    fontWeight: "500",
+    color: theme.colors.success,
+  },
+  muted: {
+    fontSize: theme.fontSize.sm,
+    color: theme.colors.mutedForeground,
+  },
+}));
+`],
+  ["payments/revenuecat/native/uniwind/components/paywall-example.tsx.hbs", `import { useState } from "react";
+import { ActivityIndicator, Alert, Pressable, Text, View } from "react-native";
+import type { PurchasesPackage } from "react-native-purchases";
+
+import { useRevenueCat } from "@/providers/RevenueCatProvider";
+
+export function PaywallExample() {
+  const { isPro, getPackages, purchasePackage, restorePurchases } = useRevenueCat();
+  const [packages, setPackages] = useState<PurchasesPackage[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isPurchasing, setIsPurchasing] = useState(false);
+
+  const loadPackages = async () => {
+    setIsLoading(true);
+    try {
+      setPackages(await getPackages());
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handlePurchase = async (pack: PurchasesPackage) => {
+    setIsPurchasing(true);
+    try {
+      const success = await purchasePackage(pack);
+      Alert.alert(success ? "You're now Premium!" : "Purchase not completed");
+    } finally {
+      setIsPurchasing(false);
+    }
+  };
+
+  if (isPro) {
+    return (
+      <View className="gap-2 rounded-2xl bg-neutral-100 p-4 dark:bg-neutral-900">
+        <Text className="font-semibold text-lg text-neutral-900 dark:text-neutral-50">
+          You're Premium
+        </Text>
+        <Text className="text-neutral-500 text-sm">
+          Thanks for your support — enjoy all features.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View className="gap-3 rounded-2xl bg-neutral-100 p-4 dark:bg-neutral-900">
+      <Text className="font-semibold text-lg text-neutral-900 dark:text-neutral-50">
+        Upgrade to Premium
+      </Text>
+      <Text className="text-neutral-500 text-sm">Unlock all features.</Text>
+
+      {packages.length === 0 ? (
+        <Pressable
+          className="items-center rounded-xl bg-neutral-900 py-3 dark:bg-neutral-50"
+          onPress={loadPackages}
+          disabled={isLoading}
+        >
+          {isLoading ? (
+            <ActivityIndicator />
+          ) : (
+            <Text className="font-semibold text-neutral-50 dark:text-neutral-900">View plans</Text>
+          )}
+        </Pressable>
+      ) : (
+        packages.map((pack) => (
+          <Pressable
+            key={pack.identifier}
+            className="items-center rounded-xl bg-neutral-900 py-3 dark:bg-neutral-50"
+            onPress={() => handlePurchase(pack)}
+            disabled={isPurchasing}
+          >
+            <Text className="font-semibold text-neutral-50 dark:text-neutral-900">
+              {pack.product.title} · {pack.product.priceString}
+            </Text>
+          </Pressable>
+        ))
+      )}
+
+      <Pressable className="items-center py-2" onPress={restorePurchases}>
+        <Text className="text-neutral-500 text-sm">Restore purchases</Text>
+      </Pressable>
+    </View>
+  );
+}
+`],
+  ["payments/revenuecat/native/uniwind/components/subscription-status-card.tsx.hbs", `import { Text, View } from "react-native";
+
+import { useRevenueCat } from "@/providers/RevenueCatProvider";
+
+export function SubscriptionStatusCard() {
+  const { isPro, isConfigured } = useRevenueCat();
+
+  return (
+    <View className="gap-2 rounded-2xl bg-neutral-100 p-4 dark:bg-neutral-900">
+      <Text className="font-semibold text-lg text-neutral-900 dark:text-neutral-50">
+        Subscription
+      </Text>
+      {!isConfigured ? (
+        <Text className="text-neutral-500 text-sm">
+          RevenueCat is not configured yet. Add your API keys in apps/native/.env.
+        </Text>
+      ) : isPro ? (
+        <Text className="font-medium text-base text-green-600">You're a Premium member 🎉</Text>
+      ) : (
+        <Text className="text-neutral-500 text-sm">You're on the free plan.</Text>
+      )}
+    </View>
+  );
+}
 `]
 ]);
 
-export const TEMPLATE_COUNT = 497;
+export const TEMPLATE_COUNT = 507;

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -2867,6 +2867,9 @@ import { httpAction } from "./_generated/server";
 {{#if (eq payments "polar")}}
 import { polar } from "./polar";
 {{/if}}
+{{#if (eq payments "revenuecat")}}
+import { revenuecat } from "./revenuecat";
+{{/if}}
 
 const http = httpRouter();
 
@@ -2910,6 +2913,10 @@ authComponent.registerRoutes(http, createAuth);
 {{#if (eq payments "polar")}}
 
 polar.registerRoutes(http);
+{{/if}}
+{{#if (eq payments "revenuecat")}}
+
+revenuecat.registerRoutes(http);
 {{/if}}
 
 export default http;
@@ -6190,6 +6197,10 @@ import { NAV_THEME } from "@/lib/constants";
 import { authClient{{#if (eq payments "polar")}}, polarNativeClient{{/if}} } from "@/lib/auth-client";
 import { SignIn } from "@/components/sign-in";
 import { SignUp } from "@/components/sign-up";
+{{#if (eq payments "revenuecat")}}
+import { SubscriptionStatusCard } from "@/components/subscription-status-card";
+import { PaywallExample } from "@/components/paywall-example";
+{{/if}}
 {{#if (eq api "orpc")}}
 import { useQuery } from "@tanstack/react-query";
 import { queryClient, orpc } from "@/utils/orpc";
@@ -6377,6 +6388,11 @@ return (
         <SignUp />
       </>
       )}
+
+      {{#if (eq payments "revenuecat")}}
+      <SubscriptionStatusCard />
+      <PaywallExample />
+      {{/if}}
     </View>
   </ScrollView>
 </Container>
@@ -6996,6 +7012,10 @@ import { StyleSheet } from "react-native-unistyles";
 import { Container } from "@/components/container";
 import { SignIn } from "@/components/sign-in";
 import { SignUp } from "@/components/sign-up";
+{{#if (eq payments "revenuecat")}}
+import { SubscriptionStatusCard } from "@/components/subscription-status-card";
+import { PaywallExample } from "@/components/paywall-example";
+{{/if}}
 {{#if (eq api "orpc")}}
 import { useQuery } from "@tanstack/react-query";
 import { queryClient, orpc } from "@/utils/orpc";
@@ -7143,6 +7163,11 @@ export default function Home() {
               <SignUp />
             </>
           )}
+
+          {{#if (eq payments "revenuecat")}}
+          <SubscriptionStatusCard />
+          <PaywallExample />
+          {{/if}}
         </View>
       </ScrollView>
     </Container>
@@ -7737,6 +7762,10 @@ import { Ionicons } from "@expo/vector-icons";
 import { Card, Chip, useThemeColor } from "heroui-native";
 import { SignIn } from "@/components/sign-in";
 import { SignUp } from "@/components/sign-up";
+{{#if (eq payments "revenuecat")}}
+import { SubscriptionStatusCard } from "@/components/subscription-status-card";
+import { PaywallExample } from "@/components/paywall-example";
+{{/if}}
 {{#if (eq api "orpc")}}
 import { useQuery } from "@tanstack/react-query";
 import { queryClient, orpc } from "@/utils/orpc";
@@ -7908,6 +7937,13 @@ return (
     <SignUp />
   </>
   )}
+
+  {{#if (eq payments "revenuecat")}}
+  <View className="mt-6">
+    <SubscriptionStatusCard />
+    <PaywallExample />
+  </View>
+  {{/if}}
 </Container>
 );
 }
@@ -14235,6 +14271,9 @@ import betterAuth from "@convex-dev/better-auth/convex.config";
 {{#if (eq payments "polar")}}
 import polar from "@convex-dev/polar/convex.config.js";
 {{/if}}
+{{#if (eq payments "revenuecat")}}
+import revenuecat from "convex-revenuecat/convex.config";
+{{/if}}
 {{#if (includes examples "ai")}}
 import agent from "@convex-dev/agent/convex.config";
 {{/if}}
@@ -14245,6 +14284,9 @@ app.use(betterAuth);
 {{/if}}
 {{#if (eq payments "polar")}}
 app.use(polar);
+{{/if}}
+{{#if (eq payments "revenuecat")}}
+app.use(revenuecat);
 {{/if}}
 {{#if (includes examples "ai")}}
 app.use(agent);
@@ -26414,6 +26456,9 @@ import { queryClient } from "@/utils/orpc";
 import { NAV_THEME } from "@/lib/constants";
 import { useColorScheme } from "@/lib/use-color-scheme";
 import { StyleSheet } from "react-native";
+{{#if (eq payments "revenuecat")}}
+import { RevenueCatProvider } from "@/contexts/revenuecat-context";
+{{/if}}
 
 const LIGHT_THEME = {
   ...DefaultTheme,
@@ -26461,6 +26506,9 @@ export default function RootLayout() {
 
   return (
     <>
+{{#if (eq payments "revenuecat")}}
+      <RevenueCatProvider>
+{{/if}}
       {{#if (eq backend "convex")}}
         {{#if (eq auth "clerk")}}
           <ClerkProvider tokenCache={tokenCache} publishableKey={env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY}>
@@ -26558,6 +26606,9 @@ export default function RootLayout() {
           {{/unless}}
         {{/if}}
       {{/if}}
+{{#if (eq payments "revenuecat")}}
+      </RevenueCatProvider>
+{{/if}}
     </>
   );
 }
@@ -26795,6 +26846,10 @@ import { env } from "@{{projectName}}/env/native";
 import { Container } from "@/components/container";
 import { useColorScheme } from "@/lib/use-color-scheme";
 import { NAV_THEME } from "@/lib/constants";
+{{#if (eq payments "revenuecat")}}
+import { SubscriptionStatusCard } from "@/components/subscription-status-card";
+import { PaywallExample } from "@/components/paywall-example";
+{{/if}}
 {{#if (eq api "orpc")}}
 import { useQuery } from "@tanstack/react-query";
 import { orpc } from "@/utils/orpc";
@@ -27124,6 +27179,11 @@ return (
         <SignUp />
       </>
       )}
+      {{/if}}
+
+      {{#if (eq payments "revenuecat")}}
+      <SubscriptionStatusCard />
+      <PaywallExample />
       {{/if}}
     </View>
   </ScrollView>
@@ -27654,6 +27714,9 @@ import { Stack } from "expo-router";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { useUnistyles } from "react-native-unistyles";
 import { StatusBar } from "expo-status-bar";
+{{#if (eq payments "revenuecat")}}
+import { RevenueCatProvider } from "@/contexts/revenuecat-context";
+{{/if}}
 
 export const unstable_settings = {
   initialRouteName: "(drawer)",
@@ -27685,6 +27748,9 @@ export default function RootLayout() {
   const { theme } = useUnistyles();
 
   return (
+{{#if (eq payments "revenuecat")}}
+    <RevenueCatProvider>
+{{/if}}
     {{#if (eq backend "convex")}}
     {{#if (eq auth "clerk")}}
     <ClerkProvider
@@ -27858,6 +27924,9 @@ export default function RootLayout() {
         {{/unless}}
       {{/if}}
     {{/if}}
+{{#if (eq payments "revenuecat")}}
+    </RevenueCatProvider>
+{{/if}}
   );
 }
 `],
@@ -28083,6 +28152,10 @@ import { env } from "@{{projectName}}/env/native";
 {{/if}}
 import { StyleSheet } from "react-native-unistyles";
 import { Container } from "@/components/container";
+{{#if (eq payments "revenuecat")}}
+import { SubscriptionStatusCard } from "@/components/subscription-status-card";
+import { PaywallExample } from "@/components/paywall-example";
+{{/if}}
 
 {{#if (eq api "orpc")}}
 import { useQuery } from "@tanstack/react-query";
@@ -28371,6 +28444,11 @@ export default function Home() {
             <SignUp />
           </>
         )}
+        {{/if}}
+
+        {{#if (eq payments "revenuecat")}}
+        <SubscriptionStatusCard />
+        <PaywallExample />
         {{/if}}
       </ScrollView>
     </Container>
@@ -29124,6 +29202,9 @@ import { HeroUINativeProvider } from "heroui-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { KeyboardProvider } from "react-native-keyboard-controller";
 import { AppThemeProvider } from "@/contexts/app-theme-context";
+{{#if (eq payments "revenuecat")}}
+import { RevenueCatProvider } from "@/contexts/revenuecat-context";
+{{/if}}
 
 {{#if (eq api "trpc")}}
   import { queryClient } from "@/utils/trpc";
@@ -29172,6 +29253,9 @@ function StackLayout() {
 
 export default function Layout() {
   return (
+{{#if (eq payments "revenuecat")}}
+    <RevenueCatProvider>
+{{/if}}
     {{#if (eq backend "convex")}}
       {{#if (eq auth "clerk")}}
         <ClerkProvider tokenCache={tokenCache} publishableKey={env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY}>
@@ -29266,6 +29350,9 @@ export default function Layout() {
         {{/unless}}
       {{/if}}
     {{/if}}
+{{#if (eq payments "revenuecat")}}
+    </RevenueCatProvider>
+{{/if}}
   );
 }
 `],
@@ -29478,6 +29565,10 @@ import { api } from "@{{projectName}}/backend/convex/_generated/api";
 import { Ionicons } from "@expo/vector-icons";
 {{/unless}}
 import { Button, Chip, Separator, Spinner, Surface, useThemeColor } from "heroui-native";
+{{#if (eq payments "revenuecat")}}
+import { SubscriptionStatusCard } from "@/components/subscription-status-card";
+import { PaywallExample } from "@/components/paywall-example";
+{{/if}}
 
 export default function Home() {
 {{#if (eq api "orpc")}}
@@ -29733,6 +29824,13 @@ return (
     <SignUp />
   </View>
   )}
+  {{/if}}
+
+  {{#if (eq payments "revenuecat")}}
+  <View className="mt-5">
+    <SubscriptionStatusCard />
+    <PaywallExample />
+  </View>
   {{/if}}
 </Container>
 );
@@ -35472,7 +35570,983 @@ export default function Success() {
 		<p>Checkout ID: {checkout_id}</p>
 	{/if}
 </div>
+`],
+  ["payments/revenuecat/convex/backend/convex/revenuecat.ts.hbs", `import { RevenueCat } from "convex-revenuecat";
+
+import { components } from "./_generated/api";
+
+export const revenuecat = new RevenueCat(components.revenuecat, {
+  REVENUECAT_WEBHOOK_AUTH: process.env.REVENUECAT_WEBHOOK_AUTH,
+});
+
+export const { hasEntitlement, isSubscriber, getActiveSubscriptions } = revenuecat.api();
+`],
+  ["payments/revenuecat/convex/no-better-auth/convex/http.ts.hbs", `import { httpRouter } from "convex/server";
+
+import { revenuecat } from "./revenuecat";
+
+const http = httpRouter();
+
+revenuecat.registerRoutes(http);
+
+export default http;
+`],
+  ["payments/revenuecat/native/bare/components/paywall-example.tsx.hbs", `import { useState } from "react";
+import { Button, Column, Host, Text as ExpoUIText } from "@expo/ui";
+import { ActivityIndicator, Alert, StyleSheet, View } from "react-native";
+import type { PurchasesPackage } from "react-native-purchases";
+
+import { NAV_THEME } from "@/lib/constants";
+import { useColorScheme } from "@/lib/use-color-scheme";
+import { useRevenueCat } from "@/contexts/revenuecat-context";
+
+export function PaywallExample() {
+  const { colorScheme } = useColorScheme();
+  const theme = colorScheme === "dark" ? NAV_THEME.dark : NAV_THEME.light;
+  const { isPro, getPackages, purchasePackage, restorePurchases } = useRevenueCat();
+  const [packages, setPackages] = useState<PurchasesPackage[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isPurchasing, setIsPurchasing] = useState(false);
+  const [isRestoring, setIsRestoring] = useState(false);
+  const isBusy = isPurchasing || isRestoring;
+
+  const loadPackages = async () => {
+    setIsLoading(true);
+    try {
+      setPackages(await getPackages());
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handlePurchase = async (pack: PurchasesPackage) => {
+    if (isBusy) return;
+    setIsPurchasing(true);
+    try {
+      const success = await purchasePackage(pack);
+      Alert.alert(success ? "You're now Premium!" : "Purchase not completed");
+    } finally {
+      setIsPurchasing(false);
+    }
+  };
+
+  const handleRestore = async () => {
+    if (isBusy) return;
+    setIsRestoring(true);
+    try {
+      const success = await restorePurchases();
+      Alert.alert(success ? "Purchases restored" : "No purchases to restore");
+    } finally {
+      setIsRestoring(false);
+    }
+  };
+
+  if (isPro) {
+    return (
+      <View style={[styles.card, { backgroundColor: theme.card, borderColor: theme.border }]}>
+        <Host matchContents=\\{{ vertical: true }}>
+          <Column spacing={6}>
+            <ExpoUIText textStyle=\\{{ color: theme.text, fontSize: 16, fontWeight: "bold" }}>
+              You're Premium
+            </ExpoUIText>
+            <ExpoUIText textStyle=\\{{ color: theme.text, fontSize: 13 }} style=\\{{ opacity: 0.7 }}>
+              Thanks for your support — enjoy all features.
+            </ExpoUIText>
+          </Column>
+        </Host>
+      </View>
+    );
+  }
+
+  return (
+    <View style={[styles.card, { backgroundColor: theme.card, borderColor: theme.border }]}>
+      <Host style={styles.headerHost} matchContents=\\{{ vertical: true }}>
+        <Column spacing={6}>
+          <ExpoUIText textStyle=\\{{ color: theme.text, fontSize: 16, fontWeight: "bold" }}>
+            Upgrade to Premium
+          </ExpoUIText>
+          <ExpoUIText textStyle=\\{{ color: theme.text, fontSize: 13 }} style=\\{{ opacity: 0.7 }}>
+            Unlock all features.
+          </ExpoUIText>
+        </Column>
+      </Host>
+
+      {isLoading ? (
+        <View style={styles.loadingRow}>
+          <ActivityIndicator color={theme.text} />
+        </View>
+      ) : (
+        <Host style={styles.actionsHost} matchContents=\\{{ vertical: true }}>
+          <Column spacing={8}>
+            {packages.length === 0 ? (
+              <Button label="View plans" onPress={loadPackages} />
+            ) : (
+              packages.map((pack) => (
+                <Button
+                  key={pack.identifier}
+                  label={\`\${pack.product.title} · \${pack.product.priceString}\`}
+                  variant="outlined"
+                  onPress={() => handlePurchase(pack)}
+                />
+              ))
+            )}
+            <Button
+              label={isRestoring ? "Restoring..." : "Restore purchases"}
+              variant="outlined"
+              onPress={handleRestore}
+            />
+          </Column>
+        </Host>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    marginBottom: 16,
+    padding: 16,
+    borderWidth: 1,
+    borderRadius: 16,
+  },
+  headerHost: {
+    marginBottom: 12,
+  },
+  actionsHost: {
+    marginTop: 4,
+  },
+  loadingRow: {
+    alignItems: "center",
+    paddingVertical: 12,
+  },
+});
+`],
+  ["payments/revenuecat/native/bare/components/subscription-status-card.tsx.hbs", `import { Column, Host, Text as ExpoUIText } from "@expo/ui";
+import { StyleSheet, View } from "react-native";
+
+import { NAV_THEME } from "@/lib/constants";
+import { useColorScheme } from "@/lib/use-color-scheme";
+import { useRevenueCat } from "@/contexts/revenuecat-context";
+
+export function SubscriptionStatusCard() {
+  const { colorScheme } = useColorScheme();
+  const theme = colorScheme === "dark" ? NAV_THEME.dark : NAV_THEME.light;
+  const { isPro, isConfigured } = useRevenueCat();
+
+  return (
+    <View style={[styles.card, { backgroundColor: theme.card, borderColor: theme.border }]}>
+      <Host matchContents=\\{{ vertical: true }}>
+        <Column spacing={6}>
+          <ExpoUIText textStyle=\\{{ color: theme.text, fontSize: 16, fontWeight: "bold" }}>
+            Subscription
+          </ExpoUIText>
+          {!isConfigured ? (
+            <ExpoUIText textStyle=\\{{ color: theme.text, fontSize: 13 }} style=\\{{ opacity: 0.7 }}>
+              RevenueCat is not configured yet. Add your API keys in apps/native/.env.
+            </ExpoUIText>
+          ) : isPro ? (
+            <ExpoUIText textStyle=\\{{ color: "#16a34a", fontSize: 14, fontWeight: "500" }}>
+              You're a Premium member 🎉
+            </ExpoUIText>
+          ) : (
+            <ExpoUIText textStyle=\\{{ color: theme.text, fontSize: 13 }} style=\\{{ opacity: 0.7 }}>
+              You're on the free plan.
+            </ExpoUIText>
+          )}
+        </Column>
+      </Host>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    marginBottom: 16,
+    padding: 16,
+    borderWidth: 1,
+    borderRadius: 16,
+  },
+});
+`],
+  ["payments/revenuecat/native/base/contexts/revenuecat-context.tsx.hbs", `import type { ReactNode } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { AppState } from "react-native";
+import type { PurchasesPackage } from "react-native-purchases";
+
+import {
+  configureRevenueCat,
+  getPackages as getRevenueCatPackages,
+  hasProEntitlement,
+  identifyUser as identifyRevenueCatUser,
+  isPurchaseCancelledError,
+  logOutUser as logOutRevenueCatUser,
+  onCustomerInfoUpdated,
+  purchaseAndCheckPro,
+  type RevenueCatInitFailureReason,
+  refreshProEntitlement,
+  restoreAndCheckPro,
+  setUserAttributes as setRevenueCatUserAttributes,
+  syncAndCheckPro,
+} from "@/lib/revenuecat";
+
+type UserAttributes = {
+  email?: string;
+  displayName?: string;
+};
+
+export type RevenueCatContextValue = {
+  isPro: boolean;
+  isConfigured: boolean;
+  refreshEntitlement: () => Promise<boolean>;
+  getPackages: () => Promise<PurchasesPackage[]>;
+  purchasePackage: (pack: PurchasesPackage) => Promise<boolean>;
+  restorePurchases: () => Promise<boolean>;
+  syncPurchases: () => Promise<boolean>;
+  identifyUser: (userId: string) => Promise<boolean>;
+  logOutUser: () => Promise<void>;
+  setUserAttributes: (attributes: UserAttributes) => Promise<void>;
+};
+
+type RevenueCatProviderProps = {
+  children: ReactNode;
+};
+
+const RevenueCatContext = createContext<RevenueCatContextValue | null>(null);
+
+export function useRevenueCat(): RevenueCatContextValue {
+  const context = useContext(RevenueCatContext);
+
+  if (!context) {
+    throw new Error("useRevenueCat must be used within RevenueCatProvider");
+  }
+
+  return context;
+}
+
+export function useIsPro(): boolean {
+  const context = useContext(RevenueCatContext);
+  return context?.isPro ?? false;
+}
+
+function logInitSkip(reason: RevenueCatInitFailureReason): void {
+  if (reason === "unsupported_platform") {
+    console.warn("[RevenueCat] Initialization skipped: unsupported platform");
+    return;
+  }
+
+  console.warn(
+    "[RevenueCat] Missing API key. Add EXPO_PUBLIC_REVENUECAT_IOS_KEY and EXPO_PUBLIC_REVENUECAT_ANDROID_KEY in apps/native/.env",
+  );
+}
+
+export function RevenueCatProvider({ children }: RevenueCatProviderProps) {
+  const [isConfigured, setIsConfigured] = useState(false);
+  const [isPro, setIsPro] = useState(false);
+
+  const refreshEntitlement = useCallback(async (): Promise<boolean> => {
+    if (!isConfigured) return false;
+    try {
+      const nextIsPro = await refreshProEntitlement();
+      setIsPro(nextIsPro);
+      return nextIsPro;
+    } catch (error) {
+      console.warn("[RevenueCat] Failed to refresh entitlement:", error);
+      return false;
+    }
+  }, [isConfigured]);
+
+  const getPackages = useCallback(async (): Promise<PurchasesPackage[]> => {
+    if (!isConfigured) return [];
+
+    try {
+      return await getRevenueCatPackages();
+    } catch (error) {
+      console.warn("[RevenueCat] Failed to fetch packages:", error);
+      return [];
+    }
+  }, [isConfigured]);
+
+  const purchasePackage = useCallback(
+    async (pack: PurchasesPackage): Promise<boolean> => {
+      if (!isConfigured) return false;
+
+      try {
+        const nextIsPro = await purchaseAndCheckPro(pack);
+        setIsPro(nextIsPro);
+        return nextIsPro;
+      } catch (error) {
+        if (isPurchaseCancelledError(error)) {
+          try {
+            const nextIsPro = await refreshProEntitlement();
+            setIsPro(nextIsPro);
+            return nextIsPro;
+          } catch (refreshError) {
+            console.warn(
+              "[RevenueCat] Failed to refresh entitlement after cancellation:",
+              refreshError,
+            );
+            return false;
+          }
+        }
+
+        console.warn("[RevenueCat] Purchase failed:", error);
+        return false;
+      }
+    },
+    [isConfigured],
+  );
+
+  const restorePurchases = useCallback(async (): Promise<boolean> => {
+    if (!isConfigured) return false;
+
+    try {
+      const nextIsPro = await restoreAndCheckPro();
+      setIsPro(nextIsPro);
+      return nextIsPro;
+    } catch (error) {
+      console.warn("[RevenueCat] Restore failed:", error);
+      return false;
+    }
+  }, [isConfigured]);
+
+  const syncPurchases = useCallback(async (): Promise<boolean> => {
+    if (!isConfigured) return false;
+
+    try {
+      const nextIsPro = await syncAndCheckPro();
+      setIsPro(nextIsPro);
+      return nextIsPro;
+    } catch (error) {
+      console.warn("[RevenueCat] Sync purchases failed:", error);
+      return false;
+    }
+  }, [isConfigured]);
+
+  const identifyUser = useCallback(
+    async (userId: string): Promise<boolean> => {
+      if (!isConfigured) return false;
+
+      try {
+        const nextIsPro = await identifyRevenueCatUser(userId);
+        setIsPro(nextIsPro);
+        return nextIsPro;
+      } catch (error) {
+        console.warn("[RevenueCat] Identify user failed:", error);
+        return false;
+      }
+    },
+    [isConfigured],
+  );
+
+  const logOutUser = useCallback(async (): Promise<void> => {
+    if (!isConfigured) return;
+
+    try {
+      await logOutRevenueCatUser();
+      setIsPro(false);
+    } catch (error) {
+      console.warn("[RevenueCat] Log out failed:", error);
+    }
+  }, [isConfigured]);
+
+  const setUserAttributes = useCallback(
+    async (attributes: UserAttributes): Promise<void> => {
+      if (!isConfigured) return;
+
+      try {
+        await setRevenueCatUserAttributes(attributes);
+      } catch (error) {
+        console.warn("[RevenueCat] Set attributes failed:", error);
+      }
+    },
+    [isConfigured],
+  );
+
+  useEffect(() => {
+    let isMounted = true;
+    let unsubscribe = () => {};
+
+    const initialize = async () => {
+      try {
+        const result = await configureRevenueCat();
+
+        if (!isMounted) return;
+
+        if (!result.configured) {
+          setIsConfigured(false);
+          logInitSkip(result.reason);
+          return;
+        }
+
+        setIsConfigured(true);
+
+        unsubscribe = onCustomerInfoUpdated((customerInfo) => {
+          if (!isMounted) return;
+          setIsPro(hasProEntitlement(customerInfo));
+        });
+
+        const nextIsPro = await refreshProEntitlement();
+        if (isMounted) {
+          setIsPro(nextIsPro);
+        }
+      } catch (error) {
+        console.warn("[RevenueCat] Initialization failed:", error);
+      }
+    };
+
+    initialize();
+
+    return () => {
+      isMounted = false;
+      unsubscribe();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isConfigured) return;
+
+    const subscription = AppState.addEventListener("change", (state) => {
+      if (state !== "active") return;
+
+      refreshEntitlement().catch((error) => {
+        console.warn("[RevenueCat] Foreground entitlement refresh failed:", error);
+      });
+    });
+
+    return () => {
+      subscription.remove();
+    };
+  }, [isConfigured, refreshEntitlement]);
+
+  const value = useMemo<RevenueCatContextValue>(
+    () => ({
+      isPro,
+      isConfigured,
+      refreshEntitlement,
+      getPackages,
+      purchasePackage,
+      restorePurchases,
+      syncPurchases,
+      identifyUser,
+      logOutUser,
+      setUserAttributes,
+    }),
+    [
+      isPro,
+      isConfigured,
+      refreshEntitlement,
+      getPackages,
+      purchasePackage,
+      restorePurchases,
+      syncPurchases,
+      identifyUser,
+      logOutUser,
+      setUserAttributes,
+    ],
+  );
+
+  return <RevenueCatContext.Provider value={value}>{children}</RevenueCatContext.Provider>;
+}
+`],
+  ["payments/revenuecat/native/base/lib/revenuecat.ts.hbs", `import { Platform } from "react-native";
+import Purchases, {
+  type CustomerInfo,
+  LOG_LEVEL,
+  type PurchasesOffering,
+  type PurchasesPackage,
+} from "react-native-purchases";
+
+// RevenueCat SDK utility layer. Thin wrappers around \`react-native-purchases\`.
+// These are pure functions with no React state — they talk to the SDK directly.
+// In components, prefer the \`useRevenueCat()\` / \`useIsPro()\` hooks from
+// \`@/contexts/revenuecat-context\` instead of importing from this file.
+
+function normalizeEnvValue(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? normalized : undefined;
+}
+
+const iosApiKey = normalizeEnvValue(process.env.EXPO_PUBLIC_REVENUECAT_IOS_KEY);
+const androidApiKey = normalizeEnvValue(process.env.EXPO_PUBLIC_REVENUECAT_ANDROID_KEY);
+
+const proEntitlementId =
+  normalizeEnvValue(process.env.EXPO_PUBLIC_REVENUECAT_ENTITLEMENT_ID) ?? "pro";
+const preferredOfferingId = normalizeEnvValue(process.env.EXPO_PUBLIC_REVENUECAT_OFFERING_ID);
+
+export const PRO_ENTITLEMENT_IDS: readonly string[] = [proEntitlementId];
+
+let hasConfiguredRevenueCat = false;
+
+export type RevenueCatInitFailureReason = "unsupported_platform" | "missing_api_key";
+
+export type RevenueCatInitResult =
+  | { configured: true }
+  | { configured: false; reason: RevenueCatInitFailureReason };
+
+type RevenueCatPurchaseError = {
+  userCancelled?: boolean;
+};
+
+type CustomerInfoListener = (customerInfo: CustomerInfo) => void;
+
+type PurchasesWithRemoveListener = typeof Purchases & {
+  removeCustomerInfoUpdateListener?: (listener: CustomerInfoListener) => void;
+};
+
+export function hasProEntitlement(customerInfo: CustomerInfo | null): boolean {
+  if (!customerInfo) return false;
+
+  return PRO_ENTITLEMENT_IDS.some((id) => customerInfo.entitlements.active[id] !== undefined);
+}
+
+function hasPackages(offering: PurchasesOffering | null | undefined): offering is PurchasesOffering {
+  return !!offering && offering.availablePackages.length > 0;
+}
+
+function pickFirstOfferingWithPackages(
+  offeringsById: Record<string, PurchasesOffering>,
+): PurchasesOffering | null {
+  for (const offering of Object.values(offeringsById)) {
+    if (hasPackages(offering)) {
+      return offering;
+    }
+  }
+  return null;
+}
+
+/**
+ * One-time SDK initialization. Safe to call multiple times (no-ops after first).
+ * Only \`RevenueCatProvider\` should call this — it owns the SDK lifecycle.
+ */
+export async function configureRevenueCat(): Promise<RevenueCatInitResult> {
+  if (Platform.OS !== "ios" && Platform.OS !== "android") {
+    return { configured: false, reason: "unsupported_platform" };
+  }
+
+  if (hasConfiguredRevenueCat) {
+    return { configured: true };
+  }
+
+  const apiKey = Platform.OS === "ios" ? iosApiKey : androidApiKey;
+
+  if (!apiKey) {
+    return { configured: false, reason: "missing_api_key" };
+  }
+
+  Purchases.setLogLevel(__DEV__ ? LOG_LEVEL.WARN : LOG_LEVEL.ERROR);
+
+  Purchases.configure({ apiKey });
+
+  hasConfiguredRevenueCat = true;
+
+  return { configured: true };
+}
+
+/**
+ * Subscribe to real-time entitlement changes. Returns an unsubscribe function.
+ * Only \`RevenueCatProvider\` should use this directly.
+ */
+export function onCustomerInfoUpdated(listener: CustomerInfoListener): () => void {
+  Purchases.addCustomerInfoUpdateListener(listener);
+
+  return () => {
+    (Purchases as PurchasesWithRemoveListener).removeCustomerInfoUpdateListener?.(listener);
+  };
+}
+
+/** Fetch latest CustomerInfo and return current pro status. */
+export async function refreshProEntitlement(): Promise<boolean> {
+  const customerInfo = await Purchases.getCustomerInfo();
+  return hasProEntitlement(customerInfo);
+}
+
+/**
+ * Identify the user in RevenueCat via \`Purchases.logIn\` so purchases follow the
+ * account across devices. Pass a stable auth user id. Returns pro status.
+ */
+export async function identifyUser(userId: string): Promise<boolean> {
+  const { customerInfo } = await Purchases.logIn(userId);
+  return hasProEntitlement(customerInfo);
+}
+
+/** Log out the current user from RevenueCat (resets to an anonymous id). */
+export async function logOutUser(): Promise<void> {
+  await Purchases.logOut();
+}
+
+/** Set user attributes for tracking in the RevenueCat dashboard. */
+export async function setUserAttributes(attributes: {
+  email?: string;
+  displayName?: string;
+}): Promise<void> {
+  if (attributes.email) {
+    await Purchases.setEmail(attributes.email);
+  }
+  if (attributes.displayName) {
+    await Purchases.setDisplayName(attributes.displayName);
+  }
+}
+
+async function getOffering(): Promise<PurchasesOffering | null> {
+  const offerings = await Purchases.getOfferings();
+
+  if (preferredOfferingId) {
+    const preferredOffering = offerings.all[preferredOfferingId];
+    if (hasPackages(preferredOffering)) {
+      return preferredOffering;
+    }
+
+    if (__DEV__) {
+      console.warn(
+        \`[RevenueCat] Offering '\${preferredOfferingId}' was configured but has no available packages; falling back to current offering.\`,
+      );
+    }
+  }
+
+  if (hasPackages(offerings.current)) {
+    return offerings.current;
+  }
+
+  const fallbackOffering = pickFirstOfferingWithPackages(offerings.all);
+  if (fallbackOffering) {
+    return fallbackOffering;
+  }
+
+  return offerings.current ?? null;
+}
+
+/** Get available subscription packages from the resolved offering. */
+export async function getPackages(): Promise<PurchasesPackage[]> {
+  const offering = await getOffering();
+  return offering?.availablePackages ?? [];
+}
+
+/** Attempt a package purchase and return the resulting pro status. */
+export async function purchaseAndCheckPro(pack: PurchasesPackage): Promise<boolean> {
+  const { customerInfo } = await Purchases.purchasePackage(pack);
+  return hasProEntitlement(customerInfo);
+}
+
+/** Restore purchases from the App Store / Play Store. */
+export async function restoreAndCheckPro(): Promise<boolean> {
+  const customerInfo = await Purchases.restorePurchases();
+  return hasProEntitlement(customerInfo);
+}
+
+/** Force-sync local store state with RevenueCat servers. Debug / recovery only. */
+export async function syncAndCheckPro(): Promise<boolean> {
+  const { customerInfo } = await Purchases.syncPurchasesForResult();
+  return hasProEntitlement(customerInfo);
+}
+
+/** Check whether an error thrown during purchase is a user cancellation. */
+export function isPurchaseCancelledError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+
+  return (error as RevenueCatPurchaseError).userCancelled === true;
+}
+`],
+  ["payments/revenuecat/native/unistyles/components/paywall-example.tsx.hbs", `import { useState } from "react";
+import { ActivityIndicator, Alert, Pressable, Text, View } from "react-native";
+import { StyleSheet } from "react-native-unistyles";
+import type { PurchasesPackage } from "react-native-purchases";
+
+import { useRevenueCat } from "@/contexts/revenuecat-context";
+
+export function PaywallExample() {
+  const { isPro, getPackages, purchasePackage, restorePurchases } = useRevenueCat();
+  const [packages, setPackages] = useState<PurchasesPackage[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isPurchasing, setIsPurchasing] = useState(false);
+  const [isRestoring, setIsRestoring] = useState(false);
+  const isBusy = isPurchasing || isRestoring;
+
+  const loadPackages = async () => {
+    setIsLoading(true);
+    try {
+      setPackages(await getPackages());
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handlePurchase = async (pack: PurchasesPackage) => {
+    if (isBusy) return;
+    setIsPurchasing(true);
+    try {
+      const success = await purchasePackage(pack);
+      Alert.alert(success ? "You're now Premium!" : "Purchase not completed");
+    } finally {
+      setIsPurchasing(false);
+    }
+  };
+
+  const handleRestore = async () => {
+    if (isBusy) return;
+    setIsRestoring(true);
+    try {
+      const success = await restorePurchases();
+      Alert.alert(success ? "Purchases restored" : "No purchases to restore");
+    } finally {
+      setIsRestoring(false);
+    }
+  };
+
+  if (isPro) {
+    return (
+      <View style={styles.card}>
+        <Text style={styles.title}>You're Premium</Text>
+        <Text style={styles.muted}>Thanks for your support — enjoy all features.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.card}>
+      <Text style={styles.title}>Upgrade to Premium</Text>
+      <Text style={styles.muted}>Unlock all features.</Text>
+
+      {packages.length === 0 ? (
+        <Pressable style={styles.button} onPress={loadPackages} disabled={isLoading}>
+          {isLoading ? (
+            <ActivityIndicator color={styles.buttonText.color} />
+          ) : (
+            <Text style={styles.buttonText}>View plans</Text>
+          )}
+        </Pressable>
+      ) : (
+        packages.map((pack) => (
+          <Pressable
+            key={pack.identifier}
+            style={styles.button}
+            onPress={() => handlePurchase(pack)}
+            disabled={isBusy}
+          >
+            <Text style={styles.buttonText}>
+              {pack.product.title} · {pack.product.priceString}
+            </Text>
+          </Pressable>
+        ))
+      )}
+
+      <Pressable style={styles.secondary} onPress={handleRestore} disabled={isBusy}>
+        <Text style={styles.secondaryText}>
+          {isRestoring ? "Restoring..." : "Restore purchases"}
+        </Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  card: {
+    gap: theme.spacing.md,
+    borderRadius: theme.borderRadius.xl,
+    padding: theme.spacing.md,
+    backgroundColor: theme.colors.card,
+  },
+  title: {
+    fontSize: theme.fontSize.lg,
+    fontWeight: "600",
+    color: theme.colors.foreground,
+  },
+  muted: {
+    fontSize: theme.fontSize.sm,
+    color: theme.colors.mutedForeground,
+  },
+  button: {
+    alignItems: "center",
+    borderRadius: theme.borderRadius.lg,
+    paddingVertical: theme.spacing.sm,
+    backgroundColor: theme.colors.primary,
+  },
+  buttonText: {
+    fontSize: theme.fontSize.base,
+    fontWeight: "600",
+    color: theme.colors.primaryForeground,
+  },
+  secondary: {
+    alignItems: "center",
+    paddingVertical: theme.spacing.sm,
+  },
+  secondaryText: {
+    fontSize: theme.fontSize.sm,
+    color: theme.colors.mutedForeground,
+  },
+}));
+`],
+  ["payments/revenuecat/native/unistyles/components/subscription-status-card.tsx.hbs", `import { Text, View } from "react-native";
+import { StyleSheet } from "react-native-unistyles";
+
+import { useRevenueCat } from "@/contexts/revenuecat-context";
+
+export function SubscriptionStatusCard() {
+  const { isPro, isConfigured } = useRevenueCat();
+
+  return (
+    <View style={styles.card}>
+      <Text style={styles.title}>Subscription</Text>
+      {!isConfigured ? (
+        <Text style={styles.muted}>
+          RevenueCat is not configured yet. Add your API keys in apps/native/.env.
+        </Text>
+      ) : isPro ? (
+        <Text style={styles.pro}>You're a Premium member 🎉</Text>
+      ) : (
+        <Text style={styles.muted}>You're on the free plan.</Text>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  card: {
+    gap: theme.spacing.sm,
+    borderRadius: theme.borderRadius.xl,
+    padding: theme.spacing.md,
+    backgroundColor: theme.colors.card,
+  },
+  title: {
+    fontSize: theme.fontSize.lg,
+    fontWeight: "600",
+    color: theme.colors.foreground,
+  },
+  pro: {
+    fontSize: theme.fontSize.base,
+    fontWeight: "500",
+    color: theme.colors.success,
+  },
+  muted: {
+    fontSize: theme.fontSize.sm,
+    color: theme.colors.mutedForeground,
+  },
+}));
+`],
+  ["payments/revenuecat/native/uniwind/components/paywall-example.tsx.hbs", `import { useState } from "react";
+import { Alert, View } from "react-native";
+import { Button, Card, Spinner } from "heroui-native";
+import type { PurchasesPackage } from "react-native-purchases";
+
+import { useRevenueCat } from "@/contexts/revenuecat-context";
+
+export function PaywallExample() {
+  const { isPro, getPackages, purchasePackage, restorePurchases } = useRevenueCat();
+  const [packages, setPackages] = useState<PurchasesPackage[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isPurchasing, setIsPurchasing] = useState(false);
+  const [isRestoring, setIsRestoring] = useState(false);
+  const isBusy = isPurchasing || isRestoring;
+
+  const loadPackages = async () => {
+    setIsLoading(true);
+    try {
+      setPackages(await getPackages());
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handlePurchase = async (pack: PurchasesPackage) => {
+    if (isBusy) return;
+    setIsPurchasing(true);
+    try {
+      const success = await purchasePackage(pack);
+      Alert.alert(success ? "You're now Premium!" : "Purchase not completed");
+    } finally {
+      setIsPurchasing(false);
+    }
+  };
+
+  const handleRestore = async () => {
+    if (isBusy) return;
+    setIsRestoring(true);
+    try {
+      const success = await restorePurchases();
+      Alert.alert(success ? "Purchases restored" : "No purchases to restore");
+    } finally {
+      setIsRestoring(false);
+    }
+  };
+
+  if (isPro) {
+    return (
+      <Card variant="secondary" className="mb-4 p-4">
+        <Card.Title className="mb-2">You're Premium</Card.Title>
+        <Card.Description>
+          Thanks for your support — enjoy all features.
+        </Card.Description>
+      </Card>
+    );
+  }
+
+  return (
+    <Card variant="secondary" className="mb-4 p-4">
+      <Card.Title className="mb-2">Upgrade to Premium</Card.Title>
+      <Card.Description className="mb-4">Unlock all features.</Card.Description>
+
+      <View className="gap-3">
+        {packages.length === 0 ? (
+          <Button onPress={loadPackages} isDisabled={isLoading}>
+            {isLoading ? <Spinner size="sm" color="default" /> : <Button.Label>View plans</Button.Label>}
+          </Button>
+        ) : (
+          packages.map((pack) => (
+            <Button
+              key={pack.identifier}
+              variant="secondary"
+              onPress={() => handlePurchase(pack)}
+              isDisabled={isBusy}
+            >
+              <Button.Label>
+                {pack.product.title} · {pack.product.priceString}
+              </Button.Label>
+            </Button>
+          ))
+        )}
+
+        <Button variant="ghost" onPress={handleRestore} isDisabled={isBusy}>
+          <Button.Label>
+            {isRestoring ? "Restoring..." : "Restore purchases"}
+          </Button.Label>
+        </Button>
+      </View>
+    </Card>
+  );
+}
+`],
+  ["payments/revenuecat/native/uniwind/components/subscription-status-card.tsx.hbs", `import { Text } from "react-native";
+import { Card } from "heroui-native";
+
+import { useRevenueCat } from "@/contexts/revenuecat-context";
+
+export function SubscriptionStatusCard() {
+  const { isPro, isConfigured } = useRevenueCat();
+
+  return (
+    <Card variant="secondary" className="mb-4 p-4">
+      <Card.Title className="mb-2">Subscription</Card.Title>
+      {!isConfigured ? (
+        <Card.Description>
+          RevenueCat is not configured yet. Add your API keys in apps/native/.env.
+        </Card.Description>
+      ) : isPro ? (
+        <Text className="text-success text-base font-medium">
+          You're a Premium member 🎉
+        </Text>
+      ) : (
+        <Card.Description>You're on the free plan.</Card.Description>
+      )}
+    </Card>
+  );
+}
 `]
 ]);
 
-export const TEMPLATE_COUNT = 529;
+export const TEMPLATE_COUNT = 539;

--- a/packages/template-generator/src/utils/add-deps.ts
+++ b/packages/template-generator/src/utils/add-deps.ts
@@ -124,6 +124,7 @@ export const dependencyVersionMap = {
   "@convex-dev/react-query": "^0.1.0",
   "@convex-dev/agent": "^0.3.2",
   "@convex-dev/polar": "^0.9.1",
+  "convex-revenuecat": "^0.3.2",
   "convex-svelte": "^0.0.12",
   "convex-nuxt": "0.1.5",
   "convex-vue": "^0.1.5",
@@ -170,6 +171,8 @@ export const dependencyVersionMap = {
   "@polar-sh/sdk": "^0.47.1",
   "@stripe/react-stripe-js": "^4.0.2",
   "@stripe/stripe-js": "^7.9.0",
+
+  "react-native-purchases": "^9.10.5",
 
   evlog: "^2.18.1",
 } as const;

--- a/packages/template-generator/src/utils/add-deps.ts
+++ b/packages/template-generator/src/utils/add-deps.ts
@@ -130,6 +130,7 @@ export const dependencyVersionMap = {
   "@convex-dev/react-query": "^0.1.0",
   "@convex-dev/agent": "^0.7.1",
   "@convex-dev/polar": "^0.9.2",
+  "convex-revenuecat": "^0.3.2",
   "convex-svelte": "^0.14.0",
   "convex-nuxt": "0.1.5",
   "convex-vue": "^0.1.5",
@@ -186,6 +187,8 @@ export const dependencyVersionMap = {
   "@polar-sh/sdk": "^0.47.0",
   "@stripe/react-stripe-js": "^6.9.0",
   "@stripe/stripe-js": "^9.15.0",
+
+  "react-native-purchases": "^10.9.0",
 
   evlog: "^2.28.1",
 } as const;

--- a/packages/template-generator/templates/auth/better-auth/convex/backend/convex/http.ts.hbs
+++ b/packages/template-generator/templates/auth/better-auth/convex/backend/convex/http.ts.hbs
@@ -6,6 +6,9 @@ import { httpAction } from "./_generated/server";
 {{#if (eq payments "polar")}}
 import { polar } from "./polar";
 {{/if}}
+{{#if (eq payments "revenuecat")}}
+import { revenuecat } from "./revenuecat";
+{{/if}}
 
 const http = httpRouter();
 
@@ -49,6 +52,10 @@ authComponent.registerRoutes(http, createAuth);
 {{#if (eq payments "polar")}}
 
 polar.registerRoutes(http);
+{{/if}}
+{{#if (eq payments "revenuecat")}}
+
+revenuecat.registerRoutes(http);
 {{/if}}
 
 export default http;

--- a/packages/template-generator/templates/auth/better-auth/native/bare/app/(drawer)/index.tsx.hbs
+++ b/packages/template-generator/templates/auth/better-auth/native/bare/app/(drawer)/index.tsx.hbs
@@ -11,6 +11,10 @@ import { NAV_THEME } from "@/lib/constants";
 import { authClient{{#if (eq payments "polar")}}, polarNativeClient{{/if}} } from "@/lib/auth-client";
 import { SignIn } from "@/components/sign-in";
 import { SignUp } from "@/components/sign-up";
+{{#if (eq payments "revenuecat")}}
+import { SubscriptionStatusCard } from "@/components/subscription-status-card";
+import { PaywallExample } from "@/components/paywall-example";
+{{/if}}
 {{#if (eq api "orpc")}}
 import { useQuery } from "@tanstack/react-query";
 import { queryClient, orpc } from "@/utils/orpc";
@@ -198,6 +202,11 @@ return (
         <SignUp />
       </>
       )}
+
+      {{#if (eq payments "revenuecat")}}
+      <SubscriptionStatusCard />
+      <PaywallExample />
+      {{/if}}
     </View>
   </ScrollView>
 </Container>

--- a/packages/template-generator/templates/auth/better-auth/native/unistyles/app/(drawer)/index.tsx.hbs
+++ b/packages/template-generator/templates/auth/better-auth/native/unistyles/app/(drawer)/index.tsx.hbs
@@ -10,6 +10,10 @@ import { StyleSheet } from "react-native-unistyles";
 import { Container } from "@/components/container";
 import { SignIn } from "@/components/sign-in";
 import { SignUp } from "@/components/sign-up";
+{{#if (eq payments "revenuecat")}}
+import { SubscriptionStatusCard } from "@/components/subscription-status-card";
+import { PaywallExample } from "@/components/paywall-example";
+{{/if}}
 {{#if (eq api "orpc")}}
 import { useQuery } from "@tanstack/react-query";
 import { queryClient, orpc } from "@/utils/orpc";
@@ -157,6 +161,11 @@ export default function Home() {
               <SignUp />
             </>
           )}
+
+          {{#if (eq payments "revenuecat")}}
+          <SubscriptionStatusCard />
+          <PaywallExample />
+          {{/if}}
         </View>
       </ScrollView>
     </Container>

--- a/packages/template-generator/templates/auth/better-auth/native/uniwind/app/(drawer)/index.tsx.hbs
+++ b/packages/template-generator/templates/auth/better-auth/native/uniwind/app/(drawer)/index.tsx.hbs
@@ -10,6 +10,10 @@ import { Ionicons } from "@expo/vector-icons";
 import { Card, Chip, useThemeColor } from "heroui-native";
 import { SignIn } from "@/components/sign-in";
 import { SignUp } from "@/components/sign-up";
+{{#if (eq payments "revenuecat")}}
+import { SubscriptionStatusCard } from "@/components/subscription-status-card";
+import { PaywallExample } from "@/components/paywall-example";
+{{/if}}
 {{#if (eq api "orpc")}}
 import { useQuery } from "@tanstack/react-query";
 import { queryClient, orpc } from "@/utils/orpc";
@@ -181,6 +185,13 @@ return (
     <SignUp />
   </>
   )}
+
+  {{#if (eq payments "revenuecat")}}
+  <View className="mt-6">
+    <SubscriptionStatusCard />
+    <PaywallExample />
+  </View>
+  {{/if}}
 </Container>
 );
 }

--- a/packages/template-generator/templates/backend/convex/packages/backend/convex/convex.config.ts.hbs
+++ b/packages/template-generator/templates/backend/convex/packages/backend/convex/convex.config.ts.hbs
@@ -5,6 +5,9 @@ import betterAuth from "@convex-dev/better-auth/convex.config";
 {{#if (eq payments "polar")}}
 import polar from "@convex-dev/polar/convex.config.js";
 {{/if}}
+{{#if (eq payments "revenuecat")}}
+import revenuecat from "convex-revenuecat/convex.config";
+{{/if}}
 {{#if (includes examples "ai")}}
 import agent from "@convex-dev/agent/convex.config";
 {{/if}}
@@ -15,6 +18,9 @@ app.use(betterAuth);
 {{/if}}
 {{#if (eq payments "polar")}}
 app.use(polar);
+{{/if}}
+{{#if (eq payments "revenuecat")}}
+app.use(revenuecat);
 {{/if}}
 {{#if (includes examples "ai")}}
 app.use(agent);

--- a/packages/template-generator/templates/frontend/native/bare/app/(drawer)/index.tsx.hbs
+++ b/packages/template-generator/templates/frontend/native/bare/app/(drawer)/index.tsx.hbs
@@ -8,6 +8,10 @@ import { env } from "@{{projectName}}/env/native";
 import { Container } from "@/components/container";
 import { useColorScheme } from "@/lib/use-color-scheme";
 import { NAV_THEME } from "@/lib/constants";
+{{#if (eq payments "revenuecat")}}
+import { SubscriptionStatusCard } from "@/components/subscription-status-card";
+import { PaywallExample } from "@/components/paywall-example";
+{{/if}}
 {{#if (eq api "orpc")}}
 import { useQuery } from "@tanstack/react-query";
 import { orpc } from "@/utils/orpc";
@@ -337,6 +341,11 @@ return (
         <SignUp />
       </>
       )}
+      {{/if}}
+
+      {{#if (eq payments "revenuecat")}}
+      <SubscriptionStatusCard />
+      <PaywallExample />
       {{/if}}
     </View>
   </ScrollView>

--- a/packages/template-generator/templates/frontend/native/bare/app/_layout.tsx.hbs
+++ b/packages/template-generator/templates/frontend/native/bare/app/_layout.tsx.hbs
@@ -45,6 +45,9 @@ import { queryClient } from "@/utils/orpc";
 import { NAV_THEME } from "@/lib/constants";
 import { useColorScheme } from "@/lib/use-color-scheme";
 import { StyleSheet } from "react-native";
+{{#if (eq payments "revenuecat")}}
+import { RevenueCatProvider } from "@/contexts/revenuecat-context";
+{{/if}}
 
 const LIGHT_THEME = {
   ...DefaultTheme,
@@ -92,6 +95,9 @@ export default function RootLayout() {
 
   return (
     <>
+{{#if (eq payments "revenuecat")}}
+      <RevenueCatProvider>
+{{/if}}
       {{#if (eq backend "convex")}}
         {{#if (eq auth "clerk")}}
           <ClerkProvider tokenCache={tokenCache} publishableKey={env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY}>
@@ -189,6 +195,9 @@ export default function RootLayout() {
           {{/unless}}
         {{/if}}
       {{/if}}
+{{#if (eq payments "revenuecat")}}
+      </RevenueCatProvider>
+{{/if}}
     </>
   );
 }

--- a/packages/template-generator/templates/frontend/native/bare/app/_layout.tsx.hbs
+++ b/packages/template-generator/templates/frontend/native/bare/app/_layout.tsx.hbs
@@ -45,6 +45,9 @@ import { queryClient } from "@/utils/orpc";
 import { NAV_THEME } from "@/lib/constants";
 import { useColorScheme } from "@/lib/use-color-scheme";
 import { StyleSheet } from "react-native";
+{{#if (eq payments "revenuecat")}}
+import { RevenueCatProvider } from "@/providers/RevenueCatProvider";
+{{/if}}
 
 const LIGHT_THEME = {
   ...DefaultTheme,
@@ -92,6 +95,9 @@ export default function RootLayout() {
 
   return (
     <>
+{{#if (eq payments "revenuecat")}}
+      <RevenueCatProvider>
+{{/if}}
       {{#if (eq backend "convex")}}
         {{#if (eq auth "clerk")}}
           <ClerkProvider tokenCache={tokenCache} publishableKey={env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY}>
@@ -189,6 +195,9 @@ export default function RootLayout() {
           {{/unless}}
         {{/if}}
       {{/if}}
+{{#if (eq payments "revenuecat")}}
+      </RevenueCatProvider>
+{{/if}}
     </>
   );
 }

--- a/packages/template-generator/templates/frontend/native/bare/app/_layout.tsx.hbs
+++ b/packages/template-generator/templates/frontend/native/bare/app/_layout.tsx.hbs
@@ -46,7 +46,7 @@ import { NAV_THEME } from "@/lib/constants";
 import { useColorScheme } from "@/lib/use-color-scheme";
 import { StyleSheet } from "react-native";
 {{#if (eq payments "revenuecat")}}
-import { RevenueCatProvider } from "@/providers/RevenueCatProvider";
+import { RevenueCatProvider } from "@/contexts/revenuecat-context";
 {{/if}}
 
 const LIGHT_THEME = {

--- a/packages/template-generator/templates/frontend/native/unistyles/app/(drawer)/index.tsx.hbs
+++ b/packages/template-generator/templates/frontend/native/unistyles/app/(drawer)/index.tsx.hbs
@@ -6,6 +6,10 @@ import { env } from "@{{projectName}}/env/native";
 {{/if}}
 import { StyleSheet } from "react-native-unistyles";
 import { Container } from "@/components/container";
+{{#if (eq payments "revenuecat")}}
+import { SubscriptionStatusCard } from "@/components/subscription-status-card";
+import { PaywallExample } from "@/components/paywall-example";
+{{/if}}
 
 {{#if (eq api "orpc")}}
 import { useQuery } from "@tanstack/react-query";
@@ -294,6 +298,11 @@ export default function Home() {
             <SignUp />
           </>
         )}
+        {{/if}}
+
+        {{#if (eq payments "revenuecat")}}
+        <SubscriptionStatusCard />
+        <PaywallExample />
         {{/if}}
       </ScrollView>
     </Container>

--- a/packages/template-generator/templates/frontend/native/unistyles/app/(drawer)/index.tsx.hbs
+++ b/packages/template-generator/templates/frontend/native/unistyles/app/(drawer)/index.tsx.hbs
@@ -8,6 +8,10 @@ import { env } from "@{{projectName}}/env/native";
 {{/if}}
 import { StyleSheet } from "react-native-unistyles";
 import { Container } from "@/components/container";
+{{#if (eq payments "revenuecat")}}
+import { SubscriptionStatusCard } from "@/components/subscription-status-card";
+import { PaywallExample } from "@/components/paywall-example";
+{{/if}}
 
 {{#if (eq api "orpc")}}
 import { useQuery } from "@tanstack/react-query";
@@ -296,6 +300,11 @@ export default function Home() {
             <SignUp />
           </>
         )}
+        {{/if}}
+
+        {{#if (eq payments "revenuecat")}}
+        <SubscriptionStatusCard />
+        <PaywallExample />
         {{/if}}
       </ScrollView>
     </Container>

--- a/packages/template-generator/templates/frontend/native/unistyles/app/_layout.tsx.hbs
+++ b/packages/template-generator/templates/frontend/native/unistyles/app/_layout.tsx.hbs
@@ -41,7 +41,7 @@ import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { useUnistyles } from "react-native-unistyles";
 import { StatusBar } from "expo-status-bar";
 {{#if (eq payments "revenuecat")}}
-import { RevenueCatProvider } from "@/providers/RevenueCatProvider";
+import { RevenueCatProvider } from "@/contexts/revenuecat-context";
 {{/if}}
 
 export const unstable_settings = {

--- a/packages/template-generator/templates/frontend/native/unistyles/app/_layout.tsx.hbs
+++ b/packages/template-generator/templates/frontend/native/unistyles/app/_layout.tsx.hbs
@@ -40,6 +40,9 @@ import { Stack } from "expo-router";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { useUnistyles } from "react-native-unistyles";
 import { StatusBar } from "expo-status-bar";
+{{#if (eq payments "revenuecat")}}
+import { RevenueCatProvider } from "@/providers/RevenueCatProvider";
+{{/if}}
 
 export const unstable_settings = {
   initialRouteName: "(drawer)",
@@ -71,6 +74,9 @@ export default function RootLayout() {
   const { theme } = useUnistyles();
 
   return (
+{{#if (eq payments "revenuecat")}}
+    <RevenueCatProvider>
+{{/if}}
     {{#if (eq backend "convex")}}
     {{#if (eq auth "clerk")}}
     <ClerkProvider
@@ -244,5 +250,8 @@ export default function RootLayout() {
         {{/unless}}
       {{/if}}
     {{/if}}
+{{#if (eq payments "revenuecat")}}
+    </RevenueCatProvider>
+{{/if}}
   );
 }

--- a/packages/template-generator/templates/frontend/native/unistyles/app/_layout.tsx.hbs
+++ b/packages/template-generator/templates/frontend/native/unistyles/app/_layout.tsx.hbs
@@ -41,6 +41,9 @@ import { Stack } from "expo-router";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { useUnistyles } from "react-native-unistyles";
 import { StatusBar } from "expo-status-bar";
+{{#if (eq payments "revenuecat")}}
+import { RevenueCatProvider } from "@/contexts/revenuecat-context";
+{{/if}}
 
 export const unstable_settings = {
   initialRouteName: "(drawer)",
@@ -72,6 +75,9 @@ export default function RootLayout() {
   const { theme } = useUnistyles();
 
   return (
+{{#if (eq payments "revenuecat")}}
+    <RevenueCatProvider>
+{{/if}}
     {{#if (eq backend "convex")}}
     {{#if (eq auth "clerk")}}
     <ClerkProvider
@@ -245,5 +251,8 @@ export default function RootLayout() {
         {{/unless}}
       {{/if}}
     {{/if}}
+{{#if (eq payments "revenuecat")}}
+    </RevenueCatProvider>
+{{/if}}
   );
 }

--- a/packages/template-generator/templates/frontend/native/uniwind/app/(drawer)/index.tsx.hbs
+++ b/packages/template-generator/templates/frontend/native/uniwind/app/(drawer)/index.tsx.hbs
@@ -37,6 +37,10 @@ import { api } from "@{{projectName}}/backend/convex/_generated/api";
 import { Ionicons } from "@expo/vector-icons";
 {{/unless}}
 import { Button, Chip, Separator, Spinner, Surface, useThemeColor } from "heroui-native";
+{{#if (eq payments "revenuecat")}}
+import { SubscriptionStatusCard } from "@/components/subscription-status-card";
+import { PaywallExample } from "@/components/paywall-example";
+{{/if}}
 
 export default function Home() {
 {{#if (eq api "orpc")}}
@@ -292,6 +296,13 @@ return (
     <SignUp />
   </View>
   )}
+  {{/if}}
+
+  {{#if (eq payments "revenuecat")}}
+  <View className="mt-5">
+    <SubscriptionStatusCard />
+    <PaywallExample />
+  </View>
   {{/if}}
 </Container>
 );

--- a/packages/template-generator/templates/frontend/native/uniwind/app/_layout.tsx.hbs
+++ b/packages/template-generator/templates/frontend/native/uniwind/app/_layout.tsx.hbs
@@ -41,7 +41,7 @@ import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { KeyboardProvider } from "react-native-keyboard-controller";
 import { AppThemeProvider } from "@/contexts/app-theme-context";
 {{#if (eq payments "revenuecat")}}
-import { RevenueCatProvider } from "@/providers/RevenueCatProvider";
+import { RevenueCatProvider } from "@/contexts/revenuecat-context";
 {{/if}}
 
 {{#if (eq api "trpc")}}

--- a/packages/template-generator/templates/frontend/native/uniwind/app/_layout.tsx.hbs
+++ b/packages/template-generator/templates/frontend/native/uniwind/app/_layout.tsx.hbs
@@ -40,6 +40,9 @@ import { HeroUINativeProvider } from "heroui-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { KeyboardProvider } from "react-native-keyboard-controller";
 import { AppThemeProvider } from "@/contexts/app-theme-context";
+{{#if (eq payments "revenuecat")}}
+import { RevenueCatProvider } from "@/providers/RevenueCatProvider";
+{{/if}}
 
 {{#if (eq api "trpc")}}
   import { queryClient } from "@/utils/trpc";
@@ -88,6 +91,9 @@ function StackLayout() {
 
 export default function Layout() {
   return (
+{{#if (eq payments "revenuecat")}}
+    <RevenueCatProvider>
+{{/if}}
     {{#if (eq backend "convex")}}
       {{#if (eq auth "clerk")}}
         <ClerkProvider tokenCache={tokenCache} publishableKey={env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY}>
@@ -182,5 +188,8 @@ export default function Layout() {
         {{/unless}}
       {{/if}}
     {{/if}}
+{{#if (eq payments "revenuecat")}}
+    </RevenueCatProvider>
+{{/if}}
   );
 }

--- a/packages/template-generator/templates/frontend/native/uniwind/app/_layout.tsx.hbs
+++ b/packages/template-generator/templates/frontend/native/uniwind/app/_layout.tsx.hbs
@@ -40,6 +40,9 @@ import { HeroUINativeProvider } from "heroui-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { KeyboardProvider } from "react-native-keyboard-controller";
 import { AppThemeProvider } from "@/contexts/app-theme-context";
+{{#if (eq payments "revenuecat")}}
+import { RevenueCatProvider } from "@/contexts/revenuecat-context";
+{{/if}}
 
 {{#if (eq api "trpc")}}
   import { queryClient } from "@/utils/trpc";
@@ -88,6 +91,9 @@ function StackLayout() {
 
 export default function Layout() {
   return (
+{{#if (eq payments "revenuecat")}}
+    <RevenueCatProvider>
+{{/if}}
     {{#if (eq backend "convex")}}
       {{#if (eq auth "clerk")}}
         <ClerkProvider tokenCache={tokenCache} publishableKey={env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY}>
@@ -182,5 +188,8 @@ export default function Layout() {
         {{/unless}}
       {{/if}}
     {{/if}}
+{{#if (eq payments "revenuecat")}}
+    </RevenueCatProvider>
+{{/if}}
   );
 }

--- a/packages/template-generator/templates/payments/revenuecat/convex/backend/convex/revenuecat.ts.hbs
+++ b/packages/template-generator/templates/payments/revenuecat/convex/backend/convex/revenuecat.ts.hbs
@@ -1,0 +1,9 @@
+import { RevenueCat } from "convex-revenuecat";
+
+import { components } from "./_generated/api";
+
+export const revenuecat = new RevenueCat(components.revenuecat, {
+  REVENUECAT_WEBHOOK_AUTH: process.env.REVENUECAT_WEBHOOK_AUTH,
+});
+
+export const { hasEntitlement, isSubscriber, getActiveSubscriptions } = revenuecat.api();

--- a/packages/template-generator/templates/payments/revenuecat/convex/backend/convex/revenuecat.ts.hbs
+++ b/packages/template-generator/templates/payments/revenuecat/convex/backend/convex/revenuecat.ts.hbs
@@ -3,7 +3,7 @@ import { RevenueCat } from "convex-revenuecat";
 import { components } from "./_generated/api";
 
 export const revenuecat = new RevenueCat(components.revenuecat, {
-  REVENUECAT_WEBHOOK_AUTH: process.env.REVENUECAT_WEBHOOK_AUTH ?? "",
+  REVENUECAT_WEBHOOK_AUTH: process.env.REVENUECAT_WEBHOOK_AUTH,
 });
 
 export const { hasEntitlement, isSubscriber, getActiveSubscriptions } = revenuecat.api();

--- a/packages/template-generator/templates/payments/revenuecat/convex/backend/convex/revenuecat.ts.hbs
+++ b/packages/template-generator/templates/payments/revenuecat/convex/backend/convex/revenuecat.ts.hbs
@@ -1,0 +1,9 @@
+import { RevenueCat } from "convex-revenuecat";
+
+import { components } from "./_generated/api";
+
+export const revenuecat = new RevenueCat(components.revenuecat, {
+  REVENUECAT_WEBHOOK_AUTH: process.env.REVENUECAT_WEBHOOK_AUTH ?? "",
+});
+
+export const { hasEntitlement, isSubscriber, getActiveSubscriptions } = revenuecat.api();

--- a/packages/template-generator/templates/payments/revenuecat/convex/no-better-auth/convex/http.ts.hbs
+++ b/packages/template-generator/templates/payments/revenuecat/convex/no-better-auth/convex/http.ts.hbs
@@ -1,0 +1,9 @@
+import { httpRouter } from "convex/server";
+
+import { revenuecat } from "./revenuecat";
+
+const http = httpRouter();
+
+revenuecat.registerRoutes(http);
+
+export default http;

--- a/packages/template-generator/templates/payments/revenuecat/native/bare/components/paywall-example.tsx.hbs
+++ b/packages/template-generator/templates/payments/revenuecat/native/bare/components/paywall-example.tsx.hbs
@@ -1,10 +1,15 @@
 import { useState } from "react";
-import { ActivityIndicator, Alert, Pressable, StyleSheet, Text, View } from "react-native";
+import { Button, Column, Host, Text as ExpoUIText } from "@expo/ui";
+import { ActivityIndicator, Alert, StyleSheet, View } from "react-native";
 import type { PurchasesPackage } from "react-native-purchases";
 
+import { NAV_THEME } from "@/lib/constants";
+import { useColorScheme } from "@/lib/use-color-scheme";
 import { useRevenueCat } from "@/contexts/revenuecat-context";
 
 export function PaywallExample() {
+  const { colorScheme } = useColorScheme();
+  const theme = colorScheme === "dark" ? NAV_THEME.dark : NAV_THEME.light;
   const { isPro, getPackages, purchasePackage, restorePurchases } = useRevenueCat();
   const [packages, setPackages] = useState<PurchasesPackage[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -45,83 +50,80 @@ export function PaywallExample() {
 
   if (isPro) {
     return (
-      <View style={styles.card}>
-        <Text style={styles.title}>You're Premium</Text>
-        <Text style={styles.muted}>Thanks for your support — enjoy all features.</Text>
+      <View style={[styles.card, { backgroundColor: theme.card, borderColor: theme.border }]}>
+        <Host matchContents=\{{ vertical: true }}>
+          <Column spacing={6}>
+            <ExpoUIText textStyle=\{{ color: theme.text, fontSize: 16, fontWeight: "bold" }}>
+              You're Premium
+            </ExpoUIText>
+            <ExpoUIText textStyle=\{{ color: theme.text, fontSize: 13 }} style=\{{ opacity: 0.7 }}>
+              Thanks for your support — enjoy all features.
+            </ExpoUIText>
+          </Column>
+        </Host>
       </View>
     );
   }
 
   return (
-    <View style={styles.card}>
-      <Text style={styles.title}>Upgrade to Premium</Text>
-      <Text style={styles.muted}>Unlock all features.</Text>
+    <View style={[styles.card, { backgroundColor: theme.card, borderColor: theme.border }]}>
+      <Host style={styles.headerHost} matchContents=\{{ vertical: true }}>
+        <Column spacing={6}>
+          <ExpoUIText textStyle=\{{ color: theme.text, fontSize: 16, fontWeight: "bold" }}>
+            Upgrade to Premium
+          </ExpoUIText>
+          <ExpoUIText textStyle=\{{ color: theme.text, fontSize: 13 }} style=\{{ opacity: 0.7 }}>
+            Unlock all features.
+          </ExpoUIText>
+        </Column>
+      </Host>
 
-      {packages.length === 0 ? (
-        <Pressable style={styles.button} onPress={loadPackages} disabled={isLoading}>
-          {isLoading ? (
-            <ActivityIndicator color="#fafafa" />
-          ) : (
-            <Text style={styles.buttonText}>View plans</Text>
-          )}
-        </Pressable>
+      {isLoading ? (
+        <View style={styles.loadingRow}>
+          <ActivityIndicator color={theme.text} />
+        </View>
       ) : (
-        packages.map((pack) => (
-          <Pressable
-            key={pack.identifier}
-            style={styles.button}
-            onPress={() => handlePurchase(pack)}
-            disabled={isBusy}
-          >
-            <Text style={styles.buttonText}>
-              {pack.product.title} · {pack.product.priceString}
-            </Text>
-          </Pressable>
-        ))
+        <Host style={styles.actionsHost} matchContents=\{{ vertical: true }}>
+          <Column spacing={8}>
+            {packages.length === 0 ? (
+              <Button label="View plans" onPress={loadPackages} />
+            ) : (
+              packages.map((pack) => (
+                <Button
+                  key={pack.identifier}
+                  label={`${pack.product.title} · ${pack.product.priceString}`}
+                  variant="outlined"
+                  onPress={() => handlePurchase(pack)}
+                />
+              ))
+            )}
+            <Button
+              label={isRestoring ? "Restoring..." : "Restore purchases"}
+              variant="outlined"
+              onPress={handleRestore}
+            />
+          </Column>
+        </Host>
       )}
-
-      <Pressable style={styles.secondary} onPress={handleRestore} disabled={isBusy}>
-        <Text style={styles.secondaryText}>
-          {isRestoring ? "Restoring..." : "Restore purchases"}
-        </Text>
-      </Pressable>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
   card: {
-    gap: 12,
-    borderRadius: 16,
+    marginBottom: 16,
     padding: 16,
-    backgroundColor: "#f4f4f5",
+    borderWidth: 1,
+    borderRadius: 16,
   },
-  title: {
-    fontSize: 18,
-    fontWeight: "600",
-    color: "#18181b",
+  headerHost: {
+    marginBottom: 12,
   },
-  muted: {
-    fontSize: 14,
-    color: "#71717a",
+  actionsHost: {
+    marginTop: 4,
   },
-  button: {
+  loadingRow: {
     alignItems: "center",
-    borderRadius: 12,
     paddingVertical: 12,
-    backgroundColor: "#18181b",
-  },
-  buttonText: {
-    fontSize: 15,
-    fontWeight: "600",
-    color: "#fafafa",
-  },
-  secondary: {
-    alignItems: "center",
-    paddingVertical: 10,
-  },
-  secondaryText: {
-    fontSize: 14,
-    color: "#71717a",
   },
 });

--- a/packages/template-generator/templates/payments/revenuecat/native/bare/components/paywall-example.tsx.hbs
+++ b/packages/template-generator/templates/payments/revenuecat/native/bare/components/paywall-example.tsx.hbs
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { ActivityIndicator, Alert, Pressable, StyleSheet, Text, View } from "react-native";
 import type { PurchasesPackage } from "react-native-purchases";
 
-import { useRevenueCat } from "@/providers/RevenueCatProvider";
+import { useRevenueCat } from "@/contexts/revenuecat-context";
 
 export function PaywallExample() {
   const { isPro, getPackages, purchasePackage, restorePurchases } = useRevenueCat();

--- a/packages/template-generator/templates/payments/revenuecat/native/bare/components/paywall-example.tsx.hbs
+++ b/packages/template-generator/templates/payments/revenuecat/native/bare/components/paywall-example.tsx.hbs
@@ -1,0 +1,129 @@
+import { useState } from "react";
+import { Button, Column, Host, Text as ExpoUIText } from "@expo/ui";
+import { ActivityIndicator, Alert, StyleSheet, View } from "react-native";
+import type { PurchasesPackage } from "react-native-purchases";
+
+import { NAV_THEME } from "@/lib/constants";
+import { useColorScheme } from "@/lib/use-color-scheme";
+import { useRevenueCat } from "@/contexts/revenuecat-context";
+
+export function PaywallExample() {
+  const { colorScheme } = useColorScheme();
+  const theme = colorScheme === "dark" ? NAV_THEME.dark : NAV_THEME.light;
+  const { isPro, getPackages, purchasePackage, restorePurchases } = useRevenueCat();
+  const [packages, setPackages] = useState<PurchasesPackage[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isPurchasing, setIsPurchasing] = useState(false);
+  const [isRestoring, setIsRestoring] = useState(false);
+  const isBusy = isPurchasing || isRestoring;
+
+  const loadPackages = async () => {
+    setIsLoading(true);
+    try {
+      setPackages(await getPackages());
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handlePurchase = async (pack: PurchasesPackage) => {
+    if (isBusy) return;
+    setIsPurchasing(true);
+    try {
+      const success = await purchasePackage(pack);
+      Alert.alert(success ? "You're now Premium!" : "Purchase not completed");
+    } finally {
+      setIsPurchasing(false);
+    }
+  };
+
+  const handleRestore = async () => {
+    if (isBusy) return;
+    setIsRestoring(true);
+    try {
+      const success = await restorePurchases();
+      Alert.alert(success ? "Purchases restored" : "No purchases to restore");
+    } finally {
+      setIsRestoring(false);
+    }
+  };
+
+  if (isPro) {
+    return (
+      <View style={[styles.card, { backgroundColor: theme.card, borderColor: theme.border }]}>
+        <Host matchContents=\{{ vertical: true }}>
+          <Column spacing={6}>
+            <ExpoUIText textStyle=\{{ color: theme.text, fontSize: 16, fontWeight: "bold" }}>
+              You're Premium
+            </ExpoUIText>
+            <ExpoUIText textStyle=\{{ color: theme.text, fontSize: 13 }} style=\{{ opacity: 0.7 }}>
+              Thanks for your support — enjoy all features.
+            </ExpoUIText>
+          </Column>
+        </Host>
+      </View>
+    );
+  }
+
+  return (
+    <View style={[styles.card, { backgroundColor: theme.card, borderColor: theme.border }]}>
+      <Host style={styles.headerHost} matchContents=\{{ vertical: true }}>
+        <Column spacing={6}>
+          <ExpoUIText textStyle=\{{ color: theme.text, fontSize: 16, fontWeight: "bold" }}>
+            Upgrade to Premium
+          </ExpoUIText>
+          <ExpoUIText textStyle=\{{ color: theme.text, fontSize: 13 }} style=\{{ opacity: 0.7 }}>
+            Unlock all features.
+          </ExpoUIText>
+        </Column>
+      </Host>
+
+      {isLoading ? (
+        <View style={styles.loadingRow}>
+          <ActivityIndicator color={theme.text} />
+        </View>
+      ) : (
+        <Host style={styles.actionsHost} matchContents=\{{ vertical: true }}>
+          <Column spacing={8}>
+            {packages.length === 0 ? (
+              <Button label="View plans" onPress={loadPackages} />
+            ) : (
+              packages.map((pack) => (
+                <Button
+                  key={pack.identifier}
+                  label={`${pack.product.title} · ${pack.product.priceString}`}
+                  variant="outlined"
+                  onPress={() => handlePurchase(pack)}
+                />
+              ))
+            )}
+            <Button
+              label={isRestoring ? "Restoring..." : "Restore purchases"}
+              variant="outlined"
+              onPress={handleRestore}
+            />
+          </Column>
+        </Host>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    marginBottom: 16,
+    padding: 16,
+    borderWidth: 1,
+    borderRadius: 16,
+  },
+  headerHost: {
+    marginBottom: 12,
+  },
+  actionsHost: {
+    marginTop: 4,
+  },
+  loadingRow: {
+    alignItems: "center",
+    paddingVertical: 12,
+  },
+});

--- a/packages/template-generator/templates/payments/revenuecat/native/bare/components/paywall-example.tsx.hbs
+++ b/packages/template-generator/templates/payments/revenuecat/native/bare/components/paywall-example.tsx.hbs
@@ -1,0 +1,111 @@
+import { useState } from "react";
+import { ActivityIndicator, Alert, Pressable, StyleSheet, Text, View } from "react-native";
+import type { PurchasesPackage } from "react-native-purchases";
+
+import { useRevenueCat } from "@/providers/RevenueCatProvider";
+
+export function PaywallExample() {
+  const { isPro, getPackages, purchasePackage, restorePurchases } = useRevenueCat();
+  const [packages, setPackages] = useState<PurchasesPackage[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isPurchasing, setIsPurchasing] = useState(false);
+
+  const loadPackages = async () => {
+    setIsLoading(true);
+    try {
+      setPackages(await getPackages());
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handlePurchase = async (pack: PurchasesPackage) => {
+    setIsPurchasing(true);
+    try {
+      const success = await purchasePackage(pack);
+      Alert.alert(success ? "You're now Premium!" : "Purchase not completed");
+    } finally {
+      setIsPurchasing(false);
+    }
+  };
+
+  if (isPro) {
+    return (
+      <View style={styles.card}>
+        <Text style={styles.title}>You're Premium</Text>
+        <Text style={styles.muted}>Thanks for your support — enjoy all features.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.card}>
+      <Text style={styles.title}>Upgrade to Premium</Text>
+      <Text style={styles.muted}>Unlock all features.</Text>
+
+      {packages.length === 0 ? (
+        <Pressable style={styles.button} onPress={loadPackages} disabled={isLoading}>
+          {isLoading ? (
+            <ActivityIndicator color="#fafafa" />
+          ) : (
+            <Text style={styles.buttonText}>View plans</Text>
+          )}
+        </Pressable>
+      ) : (
+        packages.map((pack) => (
+          <Pressable
+            key={pack.identifier}
+            style={styles.button}
+            onPress={() => handlePurchase(pack)}
+            disabled={isPurchasing}
+          >
+            <Text style={styles.buttonText}>
+              {pack.product.title} · {pack.product.priceString}
+            </Text>
+          </Pressable>
+        ))
+      )}
+
+      <Pressable style={styles.secondary} onPress={restorePurchases}>
+        <Text style={styles.secondaryText}>Restore purchases</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    gap: 12,
+    borderRadius: 16,
+    padding: 16,
+    backgroundColor: "#f4f4f5",
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: "600",
+    color: "#18181b",
+  },
+  muted: {
+    fontSize: 14,
+    color: "#71717a",
+  },
+  button: {
+    alignItems: "center",
+    borderRadius: 12,
+    paddingVertical: 12,
+    backgroundColor: "#18181b",
+  },
+  buttonText: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: "#fafafa",
+  },
+  secondary: {
+    alignItems: "center",
+    paddingVertical: 10,
+  },
+  secondaryText: {
+    fontSize: 14,
+    color: "#71717a",
+  },
+});

--- a/packages/template-generator/templates/payments/revenuecat/native/bare/components/paywall-example.tsx.hbs
+++ b/packages/template-generator/templates/payments/revenuecat/native/bare/components/paywall-example.tsx.hbs
@@ -9,6 +9,8 @@ export function PaywallExample() {
   const [packages, setPackages] = useState<PurchasesPackage[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [isPurchasing, setIsPurchasing] = useState(false);
+  const [isRestoring, setIsRestoring] = useState(false);
+  const isBusy = isPurchasing || isRestoring;
 
   const loadPackages = async () => {
     setIsLoading(true);
@@ -20,12 +22,24 @@ export function PaywallExample() {
   };
 
   const handlePurchase = async (pack: PurchasesPackage) => {
+    if (isBusy) return;
     setIsPurchasing(true);
     try {
       const success = await purchasePackage(pack);
       Alert.alert(success ? "You're now Premium!" : "Purchase not completed");
     } finally {
       setIsPurchasing(false);
+    }
+  };
+
+  const handleRestore = async () => {
+    if (isBusy) return;
+    setIsRestoring(true);
+    try {
+      const success = await restorePurchases();
+      Alert.alert(success ? "Purchases restored" : "No purchases to restore");
+    } finally {
+      setIsRestoring(false);
     }
   };
 
@@ -57,7 +71,7 @@ export function PaywallExample() {
             key={pack.identifier}
             style={styles.button}
             onPress={() => handlePurchase(pack)}
-            disabled={isPurchasing}
+            disabled={isBusy}
           >
             <Text style={styles.buttonText}>
               {pack.product.title} · {pack.product.priceString}
@@ -66,8 +80,10 @@ export function PaywallExample() {
         ))
       )}
 
-      <Pressable style={styles.secondary} onPress={restorePurchases}>
-        <Text style={styles.secondaryText}>Restore purchases</Text>
+      <Pressable style={styles.secondary} onPress={handleRestore} disabled={isBusy}>
+        <Text style={styles.secondaryText}>
+          {isRestoring ? "Restoring..." : "Restore purchases"}
+        </Text>
       </Pressable>
     </View>
   );

--- a/packages/template-generator/templates/payments/revenuecat/native/bare/components/subscription-status-card.tsx.hbs
+++ b/packages/template-generator/templates/payments/revenuecat/native/bare/components/subscription-status-card.tsx.hbs
@@ -1,45 +1,46 @@
-import { StyleSheet, Text, View } from "react-native";
+import { Column, Host, Text as ExpoUIText } from "@expo/ui";
+import { StyleSheet, View } from "react-native";
 
+import { NAV_THEME } from "@/lib/constants";
+import { useColorScheme } from "@/lib/use-color-scheme";
 import { useRevenueCat } from "@/contexts/revenuecat-context";
 
 export function SubscriptionStatusCard() {
+  const { colorScheme } = useColorScheme();
+  const theme = colorScheme === "dark" ? NAV_THEME.dark : NAV_THEME.light;
   const { isPro, isConfigured } = useRevenueCat();
 
   return (
-    <View style={styles.card}>
-      <Text style={styles.title}>Subscription</Text>
-      {!isConfigured ? (
-        <Text style={styles.muted}>
-          RevenueCat is not configured yet. Add your API keys in apps/native/.env.
-        </Text>
-      ) : isPro ? (
-        <Text style={styles.pro}>You're a Premium member 🎉</Text>
-      ) : (
-        <Text style={styles.muted}>You're on the free plan.</Text>
-      )}
+    <View style={[styles.card, { backgroundColor: theme.card, borderColor: theme.border }]}>
+      <Host matchContents=\{{ vertical: true }}>
+        <Column spacing={6}>
+          <ExpoUIText textStyle=\{{ color: theme.text, fontSize: 16, fontWeight: "bold" }}>
+            Subscription
+          </ExpoUIText>
+          {!isConfigured ? (
+            <ExpoUIText textStyle=\{{ color: theme.text, fontSize: 13 }} style=\{{ opacity: 0.7 }}>
+              RevenueCat is not configured yet. Add your API keys in apps/native/.env.
+            </ExpoUIText>
+          ) : isPro ? (
+            <ExpoUIText textStyle=\{{ color: "#16a34a", fontSize: 14, fontWeight: "500" }}>
+              You're a Premium member 🎉
+            </ExpoUIText>
+          ) : (
+            <ExpoUIText textStyle=\{{ color: theme.text, fontSize: 13 }} style=\{{ opacity: 0.7 }}>
+              You're on the free plan.
+            </ExpoUIText>
+          )}
+        </Column>
+      </Host>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
   card: {
-    gap: 8,
-    borderRadius: 16,
+    marginBottom: 16,
     padding: 16,
-    backgroundColor: "#f4f4f5",
-  },
-  title: {
-    fontSize: 18,
-    fontWeight: "600",
-    color: "#18181b",
-  },
-  pro: {
-    fontSize: 15,
-    fontWeight: "500",
-    color: "#16a34a",
-  },
-  muted: {
-    fontSize: 14,
-    color: "#71717a",
+    borderWidth: 1,
+    borderRadius: 16,
   },
 });

--- a/packages/template-generator/templates/payments/revenuecat/native/bare/components/subscription-status-card.tsx.hbs
+++ b/packages/template-generator/templates/payments/revenuecat/native/bare/components/subscription-status-card.tsx.hbs
@@ -1,6 +1,6 @@
 import { StyleSheet, Text, View } from "react-native";
 
-import { useRevenueCat } from "@/providers/RevenueCatProvider";
+import { useRevenueCat } from "@/contexts/revenuecat-context";
 
 export function SubscriptionStatusCard() {
   const { isPro, isConfigured } = useRevenueCat();

--- a/packages/template-generator/templates/payments/revenuecat/native/bare/components/subscription-status-card.tsx.hbs
+++ b/packages/template-generator/templates/payments/revenuecat/native/bare/components/subscription-status-card.tsx.hbs
@@ -1,0 +1,46 @@
+import { Column, Host, Text as ExpoUIText } from "@expo/ui";
+import { StyleSheet, View } from "react-native";
+
+import { NAV_THEME } from "@/lib/constants";
+import { useColorScheme } from "@/lib/use-color-scheme";
+import { useRevenueCat } from "@/contexts/revenuecat-context";
+
+export function SubscriptionStatusCard() {
+  const { colorScheme } = useColorScheme();
+  const theme = colorScheme === "dark" ? NAV_THEME.dark : NAV_THEME.light;
+  const { isPro, isConfigured } = useRevenueCat();
+
+  return (
+    <View style={[styles.card, { backgroundColor: theme.card, borderColor: theme.border }]}>
+      <Host matchContents=\{{ vertical: true }}>
+        <Column spacing={6}>
+          <ExpoUIText textStyle=\{{ color: theme.text, fontSize: 16, fontWeight: "bold" }}>
+            Subscription
+          </ExpoUIText>
+          {!isConfigured ? (
+            <ExpoUIText textStyle=\{{ color: theme.text, fontSize: 13 }} style=\{{ opacity: 0.7 }}>
+              RevenueCat is not configured yet. Add your API keys in apps/native/.env.
+            </ExpoUIText>
+          ) : isPro ? (
+            <ExpoUIText textStyle=\{{ color: "#16a34a", fontSize: 14, fontWeight: "500" }}>
+              You're a Premium member 🎉
+            </ExpoUIText>
+          ) : (
+            <ExpoUIText textStyle=\{{ color: theme.text, fontSize: 13 }} style=\{{ opacity: 0.7 }}>
+              You're on the free plan.
+            </ExpoUIText>
+          )}
+        </Column>
+      </Host>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    marginBottom: 16,
+    padding: 16,
+    borderWidth: 1,
+    borderRadius: 16,
+  },
+});

--- a/packages/template-generator/templates/payments/revenuecat/native/bare/components/subscription-status-card.tsx.hbs
+++ b/packages/template-generator/templates/payments/revenuecat/native/bare/components/subscription-status-card.tsx.hbs
@@ -1,0 +1,45 @@
+import { StyleSheet, Text, View } from "react-native";
+
+import { useRevenueCat } from "@/providers/RevenueCatProvider";
+
+export function SubscriptionStatusCard() {
+  const { isPro, isConfigured } = useRevenueCat();
+
+  return (
+    <View style={styles.card}>
+      <Text style={styles.title}>Subscription</Text>
+      {!isConfigured ? (
+        <Text style={styles.muted}>
+          RevenueCat is not configured yet. Add your API keys in apps/native/.env.
+        </Text>
+      ) : isPro ? (
+        <Text style={styles.pro}>You're a Premium member 🎉</Text>
+      ) : (
+        <Text style={styles.muted}>You're on the free plan.</Text>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    gap: 8,
+    borderRadius: 16,
+    padding: 16,
+    backgroundColor: "#f4f4f5",
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: "600",
+    color: "#18181b",
+  },
+  pro: {
+    fontSize: 15,
+    fontWeight: "500",
+    color: "#16a34a",
+  },
+  muted: {
+    fontSize: 14,
+    color: "#71717a",
+  },
+});

--- a/packages/template-generator/templates/payments/revenuecat/native/base/contexts/revenuecat-context.tsx.hbs
+++ b/packages/template-generator/templates/payments/revenuecat/native/base/contexts/revenuecat-context.tsx.hbs
@@ -1,0 +1,286 @@
+import type { ReactNode } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { AppState } from "react-native";
+import type { PurchasesPackage } from "react-native-purchases";
+
+import {
+  configureRevenueCat,
+  getPackages as getRevenueCatPackages,
+  hasProEntitlement,
+  identifyUser as identifyRevenueCatUser,
+  isPurchaseCancelledError,
+  logOutUser as logOutRevenueCatUser,
+  onCustomerInfoUpdated,
+  purchaseAndCheckPro,
+  type RevenueCatInitFailureReason,
+  refreshProEntitlement,
+  restoreAndCheckPro,
+  setUserAttributes as setRevenueCatUserAttributes,
+  syncAndCheckPro,
+} from "@/lib/revenuecat";
+
+type UserAttributes = {
+  email?: string;
+  displayName?: string;
+};
+
+export type RevenueCatContextValue = {
+  isPro: boolean;
+  isConfigured: boolean;
+  refreshEntitlement: () => Promise<boolean>;
+  getPackages: () => Promise<PurchasesPackage[]>;
+  purchasePackage: (pack: PurchasesPackage) => Promise<boolean>;
+  restorePurchases: () => Promise<boolean>;
+  syncPurchases: () => Promise<boolean>;
+  identifyUser: (userId: string) => Promise<boolean>;
+  logOutUser: () => Promise<void>;
+  setUserAttributes: (attributes: UserAttributes) => Promise<void>;
+};
+
+type RevenueCatProviderProps = {
+  children: ReactNode;
+};
+
+const RevenueCatContext = createContext<RevenueCatContextValue | null>(null);
+
+export function useRevenueCat(): RevenueCatContextValue {
+  const context = useContext(RevenueCatContext);
+
+  if (!context) {
+    throw new Error("useRevenueCat must be used within RevenueCatProvider");
+  }
+
+  return context;
+}
+
+export function useIsPro(): boolean {
+  const context = useContext(RevenueCatContext);
+  return context?.isPro ?? false;
+}
+
+function logInitSkip(reason: RevenueCatInitFailureReason): void {
+  if (reason === "unsupported_platform") {
+    console.warn("[RevenueCat] Initialization skipped: unsupported platform");
+    return;
+  }
+
+  console.warn(
+    "[RevenueCat] Missing API key. Add EXPO_PUBLIC_REVENUECAT_IOS_KEY and EXPO_PUBLIC_REVENUECAT_ANDROID_KEY in apps/native/.env",
+  );
+}
+
+export function RevenueCatProvider({ children }: RevenueCatProviderProps) {
+  const [isConfigured, setIsConfigured] = useState(false);
+  const [isPro, setIsPro] = useState(false);
+
+  const refreshEntitlement = useCallback(async (): Promise<boolean> => {
+    if (!isConfigured) return false;
+    try {
+      const nextIsPro = await refreshProEntitlement();
+      setIsPro(nextIsPro);
+      return nextIsPro;
+    } catch (error) {
+      console.warn("[RevenueCat] Failed to refresh entitlement:", error);
+      return false;
+    }
+  }, [isConfigured]);
+
+  const getPackages = useCallback(async (): Promise<PurchasesPackage[]> => {
+    if (!isConfigured) return [];
+
+    try {
+      return await getRevenueCatPackages();
+    } catch (error) {
+      console.warn("[RevenueCat] Failed to fetch packages:", error);
+      return [];
+    }
+  }, [isConfigured]);
+
+  const purchasePackage = useCallback(
+    async (pack: PurchasesPackage): Promise<boolean> => {
+      if (!isConfigured) return false;
+
+      try {
+        const nextIsPro = await purchaseAndCheckPro(pack);
+        setIsPro(nextIsPro);
+        return nextIsPro;
+      } catch (error) {
+        if (isPurchaseCancelledError(error)) {
+          try {
+            const nextIsPro = await refreshProEntitlement();
+            setIsPro(nextIsPro);
+            return nextIsPro;
+          } catch (refreshError) {
+            console.warn(
+              "[RevenueCat] Failed to refresh entitlement after cancellation:",
+              refreshError,
+            );
+            return false;
+          }
+        }
+
+        console.warn("[RevenueCat] Purchase failed:", error);
+        return false;
+      }
+    },
+    [isConfigured],
+  );
+
+  const restorePurchases = useCallback(async (): Promise<boolean> => {
+    if (!isConfigured) return false;
+
+    try {
+      const nextIsPro = await restoreAndCheckPro();
+      setIsPro(nextIsPro);
+      return nextIsPro;
+    } catch (error) {
+      console.warn("[RevenueCat] Restore failed:", error);
+      return false;
+    }
+  }, [isConfigured]);
+
+  const syncPurchases = useCallback(async (): Promise<boolean> => {
+    if (!isConfigured) return false;
+
+    try {
+      const nextIsPro = await syncAndCheckPro();
+      setIsPro(nextIsPro);
+      return nextIsPro;
+    } catch (error) {
+      console.warn("[RevenueCat] Sync purchases failed:", error);
+      return false;
+    }
+  }, [isConfigured]);
+
+  const identifyUser = useCallback(
+    async (userId: string): Promise<boolean> => {
+      if (!isConfigured) return false;
+
+      try {
+        const nextIsPro = await identifyRevenueCatUser(userId);
+        setIsPro(nextIsPro);
+        return nextIsPro;
+      } catch (error) {
+        console.warn("[RevenueCat] Identify user failed:", error);
+        return false;
+      }
+    },
+    [isConfigured],
+  );
+
+  const logOutUser = useCallback(async (): Promise<void> => {
+    if (!isConfigured) return;
+
+    try {
+      await logOutRevenueCatUser();
+      setIsPro(false);
+    } catch (error) {
+      console.warn("[RevenueCat] Log out failed:", error);
+    }
+  }, [isConfigured]);
+
+  const setUserAttributes = useCallback(
+    async (attributes: UserAttributes): Promise<void> => {
+      if (!isConfigured) return;
+
+      try {
+        await setRevenueCatUserAttributes(attributes);
+      } catch (error) {
+        console.warn("[RevenueCat] Set attributes failed:", error);
+      }
+    },
+    [isConfigured],
+  );
+
+  useEffect(() => {
+    let isMounted = true;
+    let unsubscribe = () => {};
+
+    const initialize = async () => {
+      try {
+        const result = await configureRevenueCat();
+
+        if (!isMounted) return;
+
+        if (!result.configured) {
+          setIsConfigured(false);
+          logInitSkip(result.reason);
+          return;
+        }
+
+        setIsConfigured(true);
+
+        unsubscribe = onCustomerInfoUpdated((customerInfo) => {
+          if (!isMounted) return;
+          setIsPro(hasProEntitlement(customerInfo));
+        });
+
+        const nextIsPro = await refreshProEntitlement();
+        if (isMounted) {
+          setIsPro(nextIsPro);
+        }
+      } catch (error) {
+        console.warn("[RevenueCat] Initialization failed:", error);
+      }
+    };
+
+    initialize();
+
+    return () => {
+      isMounted = false;
+      unsubscribe();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isConfigured) return;
+
+    const subscription = AppState.addEventListener("change", (state) => {
+      if (state !== "active") return;
+
+      refreshEntitlement().catch((error) => {
+        console.warn("[RevenueCat] Foreground entitlement refresh failed:", error);
+      });
+    });
+
+    return () => {
+      subscription.remove();
+    };
+  }, [isConfigured, refreshEntitlement]);
+
+  const value = useMemo<RevenueCatContextValue>(
+    () => ({
+      isPro,
+      isConfigured,
+      refreshEntitlement,
+      getPackages,
+      purchasePackage,
+      restorePurchases,
+      syncPurchases,
+      identifyUser,
+      logOutUser,
+      setUserAttributes,
+    }),
+    [
+      isPro,
+      isConfigured,
+      refreshEntitlement,
+      getPackages,
+      purchasePackage,
+      restorePurchases,
+      syncPurchases,
+      identifyUser,
+      logOutUser,
+      setUserAttributes,
+    ],
+  );
+
+  return <RevenueCatContext.Provider value={value}>{children}</RevenueCatContext.Provider>;
+}

--- a/packages/template-generator/templates/payments/revenuecat/native/base/contexts/revenuecat-context.tsx.hbs
+++ b/packages/template-generator/templates/payments/revenuecat/native/base/contexts/revenuecat-context.tsx.hbs
@@ -24,7 +24,7 @@ import {
   restoreAndCheckPro,
   setUserAttributes as setRevenueCatUserAttributes,
   syncAndCheckPro,
-} from "@/lib/revenue-cat";
+} from "@/lib/revenuecat";
 
 type UserAttributes = {
   email?: string;

--- a/packages/template-generator/templates/payments/revenuecat/native/base/lib/revenue-cat/index.ts.hbs
+++ b/packages/template-generator/templates/payments/revenuecat/native/base/lib/revenue-cat/index.ts.hbs
@@ -11,13 +11,13 @@ import Purchases, {
 // In components, prefer the `useRevenueCat()` / `useIsPro()` hooks from
 // `@/providers/RevenueCatProvider` instead of importing from this file.
 
-const iosApiKey = process.env.EXPO_PUBLIC_REVENUECAT_IOS_KEY ?? "";
-const androidApiKey = process.env.EXPO_PUBLIC_REVENUECAT_ANDROID_KEY ?? "";
-
 function normalizeEnvValue(value: string | undefined): string | undefined {
   const normalized = value?.trim();
   return normalized ? normalized : undefined;
 }
+
+const iosApiKey = normalizeEnvValue(process.env.EXPO_PUBLIC_REVENUECAT_IOS_KEY);
+const androidApiKey = normalizeEnvValue(process.env.EXPO_PUBLIC_REVENUECAT_ANDROID_KEY);
 
 const proEntitlementId =
   normalizeEnvValue(process.env.EXPO_PUBLIC_REVENUECAT_ENTITLEMENT_ID) ?? "pro";

--- a/packages/template-generator/templates/payments/revenuecat/native/base/lib/revenue-cat/index.ts.hbs
+++ b/packages/template-generator/templates/payments/revenuecat/native/base/lib/revenue-cat/index.ts.hbs
@@ -1,0 +1,197 @@
+import { Platform } from "react-native";
+import Purchases, {
+  type CustomerInfo,
+  LOG_LEVEL,
+  type PurchasesOffering,
+  type PurchasesPackage,
+} from "react-native-purchases";
+
+// RevenueCat SDK utility layer. Thin wrappers around `react-native-purchases`.
+// These are pure functions with no React state — they talk to the SDK directly.
+// In components, prefer the `useRevenueCat()` / `useIsPro()` hooks from
+// `@/providers/RevenueCatProvider` instead of importing from this file.
+
+const iosApiKey = process.env.EXPO_PUBLIC_REVENUECAT_IOS_KEY ?? "";
+const androidApiKey = process.env.EXPO_PUBLIC_REVENUECAT_ANDROID_KEY ?? "";
+
+function normalizeEnvValue(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? normalized : undefined;
+}
+
+const proEntitlementId =
+  normalizeEnvValue(process.env.EXPO_PUBLIC_REVENUECAT_ENTITLEMENT_ID) ?? "pro";
+const preferredOfferingId = normalizeEnvValue(process.env.EXPO_PUBLIC_REVENUECAT_OFFERING_ID);
+
+export const PRO_ENTITLEMENT_IDS: readonly string[] = [proEntitlementId];
+
+let hasConfiguredRevenueCat = false;
+
+export type RevenueCatInitFailureReason = "unsupported_platform" | "missing_api_key";
+
+export type RevenueCatInitResult =
+  | { configured: true }
+  | { configured: false; reason: RevenueCatInitFailureReason };
+
+type RevenueCatPurchaseError = {
+  userCancelled?: boolean;
+};
+
+type CustomerInfoListener = (customerInfo: CustomerInfo) => void;
+
+type PurchasesWithRemoveListener = typeof Purchases & {
+  removeCustomerInfoUpdateListener?: (listener: CustomerInfoListener) => void;
+};
+
+export function hasProEntitlement(customerInfo: CustomerInfo | null): boolean {
+  if (!customerInfo) return false;
+
+  return PRO_ENTITLEMENT_IDS.some((id) => customerInfo.entitlements.active[id] !== undefined);
+}
+
+function hasPackages(offering: PurchasesOffering | null | undefined): offering is PurchasesOffering {
+  return !!offering && offering.availablePackages.length > 0;
+}
+
+function pickFirstOfferingWithPackages(
+  offeringsById: Record<string, PurchasesOffering>,
+): PurchasesOffering | null {
+  for (const offering of Object.values(offeringsById)) {
+    if (hasPackages(offering)) {
+      return offering;
+    }
+  }
+  return null;
+}
+
+/**
+ * One-time SDK initialization. Safe to call multiple times (no-ops after first).
+ * Only `RevenueCatProvider` should call this — it owns the SDK lifecycle.
+ */
+export async function configureRevenueCat(): Promise<RevenueCatInitResult> {
+  if (Platform.OS !== "ios" && Platform.OS !== "android") {
+    return { configured: false, reason: "unsupported_platform" };
+  }
+
+  if (hasConfiguredRevenueCat) {
+    return { configured: true };
+  }
+
+  const apiKey = Platform.OS === "ios" ? iosApiKey : androidApiKey;
+
+  if (!apiKey) {
+    return { configured: false, reason: "missing_api_key" };
+  }
+
+  Purchases.setLogLevel(__DEV__ ? LOG_LEVEL.WARN : LOG_LEVEL.ERROR);
+
+  Purchases.configure({ apiKey });
+
+  hasConfiguredRevenueCat = true;
+
+  return { configured: true };
+}
+
+/**
+ * Subscribe to real-time entitlement changes. Returns an unsubscribe function.
+ * Only `RevenueCatProvider` should use this directly.
+ */
+export function onCustomerInfoUpdated(listener: CustomerInfoListener): () => void {
+  Purchases.addCustomerInfoUpdateListener(listener);
+
+  return () => {
+    (Purchases as PurchasesWithRemoveListener).removeCustomerInfoUpdateListener?.(listener);
+  };
+}
+
+/** Fetch latest CustomerInfo and return current pro status. */
+export async function refreshProEntitlement(): Promise<boolean> {
+  const customerInfo = await Purchases.getCustomerInfo();
+  return hasProEntitlement(customerInfo);
+}
+
+/**
+ * Identify the user in RevenueCat via `Purchases.logIn` so purchases follow the
+ * account across devices. Pass a stable auth user id. Returns pro status.
+ */
+export async function identifyUser(userId: string): Promise<boolean> {
+  const { customerInfo } = await Purchases.logIn(userId);
+  return hasProEntitlement(customerInfo);
+}
+
+/** Log out the current user from RevenueCat (resets to an anonymous id). */
+export async function logOutUser(): Promise<void> {
+  await Purchases.logOut();
+}
+
+/** Set user attributes for tracking in the RevenueCat dashboard. */
+export async function setUserAttributes(attributes: {
+  email?: string;
+  displayName?: string;
+}): Promise<void> {
+  if (attributes.email) {
+    await Purchases.setEmail(attributes.email);
+  }
+  if (attributes.displayName) {
+    await Purchases.setDisplayName(attributes.displayName);
+  }
+}
+
+async function getOffering(): Promise<PurchasesOffering | null> {
+  const offerings = await Purchases.getOfferings();
+
+  if (preferredOfferingId) {
+    const preferredOffering = offerings.all[preferredOfferingId];
+    if (hasPackages(preferredOffering)) {
+      return preferredOffering;
+    }
+
+    if (__DEV__) {
+      console.warn(
+        `[RevenueCat] Offering '${preferredOfferingId}' was configured but has no available packages; falling back to current offering.`,
+      );
+    }
+  }
+
+  if (hasPackages(offerings.current)) {
+    return offerings.current;
+  }
+
+  const fallbackOffering = pickFirstOfferingWithPackages(offerings.all);
+  if (fallbackOffering) {
+    return fallbackOffering;
+  }
+
+  return offerings.current ?? null;
+}
+
+/** Get available subscription packages from the resolved offering. */
+export async function getPackages(): Promise<PurchasesPackage[]> {
+  const offering = await getOffering();
+  return offering?.availablePackages ?? [];
+}
+
+/** Attempt a package purchase and return the resulting pro status. */
+export async function purchaseAndCheckPro(pack: PurchasesPackage): Promise<boolean> {
+  const { customerInfo } = await Purchases.purchasePackage(pack);
+  return hasProEntitlement(customerInfo);
+}
+
+/** Restore purchases from the App Store / Play Store. */
+export async function restoreAndCheckPro(): Promise<boolean> {
+  const customerInfo = await Purchases.restorePurchases();
+  return hasProEntitlement(customerInfo);
+}
+
+/** Force-sync local store state with RevenueCat servers. Debug / recovery only. */
+export async function syncAndCheckPro(): Promise<boolean> {
+  const { customerInfo } = await Purchases.syncPurchasesForResult();
+  return hasProEntitlement(customerInfo);
+}
+
+/** Check whether an error thrown during purchase is a user cancellation. */
+export function isPurchaseCancelledError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+
+  return (error as RevenueCatPurchaseError).userCancelled === true;
+}

--- a/packages/template-generator/templates/payments/revenuecat/native/base/lib/revenuecat.ts.hbs
+++ b/packages/template-generator/templates/payments/revenuecat/native/base/lib/revenuecat.ts.hbs
@@ -9,7 +9,7 @@ import Purchases, {
 // RevenueCat SDK utility layer. Thin wrappers around `react-native-purchases`.
 // These are pure functions with no React state — they talk to the SDK directly.
 // In components, prefer the `useRevenueCat()` / `useIsPro()` hooks from
-// `@/providers/RevenueCatProvider` instead of importing from this file.
+// `@/contexts/revenuecat-context` instead of importing from this file.
 
 function normalizeEnvValue(value: string | undefined): string | undefined {
   const normalized = value?.trim();

--- a/packages/template-generator/templates/payments/revenuecat/native/base/lib/revenuecat.ts.hbs
+++ b/packages/template-generator/templates/payments/revenuecat/native/base/lib/revenuecat.ts.hbs
@@ -1,0 +1,197 @@
+import { Platform } from "react-native";
+import Purchases, {
+  type CustomerInfo,
+  LOG_LEVEL,
+  type PurchasesOffering,
+  type PurchasesPackage,
+} from "react-native-purchases";
+
+// RevenueCat SDK utility layer. Thin wrappers around `react-native-purchases`.
+// These are pure functions with no React state — they talk to the SDK directly.
+// In components, prefer the `useRevenueCat()` / `useIsPro()` hooks from
+// `@/contexts/revenuecat-context` instead of importing from this file.
+
+function normalizeEnvValue(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? normalized : undefined;
+}
+
+const iosApiKey = normalizeEnvValue(process.env.EXPO_PUBLIC_REVENUECAT_IOS_KEY);
+const androidApiKey = normalizeEnvValue(process.env.EXPO_PUBLIC_REVENUECAT_ANDROID_KEY);
+
+const proEntitlementId =
+  normalizeEnvValue(process.env.EXPO_PUBLIC_REVENUECAT_ENTITLEMENT_ID) ?? "pro";
+const preferredOfferingId = normalizeEnvValue(process.env.EXPO_PUBLIC_REVENUECAT_OFFERING_ID);
+
+export const PRO_ENTITLEMENT_IDS: readonly string[] = [proEntitlementId];
+
+let hasConfiguredRevenueCat = false;
+
+export type RevenueCatInitFailureReason = "unsupported_platform" | "missing_api_key";
+
+export type RevenueCatInitResult =
+  | { configured: true }
+  | { configured: false; reason: RevenueCatInitFailureReason };
+
+type RevenueCatPurchaseError = {
+  userCancelled?: boolean;
+};
+
+type CustomerInfoListener = (customerInfo: CustomerInfo) => void;
+
+type PurchasesWithRemoveListener = typeof Purchases & {
+  removeCustomerInfoUpdateListener?: (listener: CustomerInfoListener) => void;
+};
+
+export function hasProEntitlement(customerInfo: CustomerInfo | null): boolean {
+  if (!customerInfo) return false;
+
+  return PRO_ENTITLEMENT_IDS.some((id) => customerInfo.entitlements.active[id] !== undefined);
+}
+
+function hasPackages(offering: PurchasesOffering | null | undefined): offering is PurchasesOffering {
+  return !!offering && offering.availablePackages.length > 0;
+}
+
+function pickFirstOfferingWithPackages(
+  offeringsById: Record<string, PurchasesOffering>,
+): PurchasesOffering | null {
+  for (const offering of Object.values(offeringsById)) {
+    if (hasPackages(offering)) {
+      return offering;
+    }
+  }
+  return null;
+}
+
+/**
+ * One-time SDK initialization. Safe to call multiple times (no-ops after first).
+ * Only `RevenueCatProvider` should call this — it owns the SDK lifecycle.
+ */
+export async function configureRevenueCat(): Promise<RevenueCatInitResult> {
+  if (Platform.OS !== "ios" && Platform.OS !== "android") {
+    return { configured: false, reason: "unsupported_platform" };
+  }
+
+  if (hasConfiguredRevenueCat) {
+    return { configured: true };
+  }
+
+  const apiKey = Platform.OS === "ios" ? iosApiKey : androidApiKey;
+
+  if (!apiKey) {
+    return { configured: false, reason: "missing_api_key" };
+  }
+
+  Purchases.setLogLevel(__DEV__ ? LOG_LEVEL.WARN : LOG_LEVEL.ERROR);
+
+  Purchases.configure({ apiKey });
+
+  hasConfiguredRevenueCat = true;
+
+  return { configured: true };
+}
+
+/**
+ * Subscribe to real-time entitlement changes. Returns an unsubscribe function.
+ * Only `RevenueCatProvider` should use this directly.
+ */
+export function onCustomerInfoUpdated(listener: CustomerInfoListener): () => void {
+  Purchases.addCustomerInfoUpdateListener(listener);
+
+  return () => {
+    (Purchases as PurchasesWithRemoveListener).removeCustomerInfoUpdateListener?.(listener);
+  };
+}
+
+/** Fetch latest CustomerInfo and return current pro status. */
+export async function refreshProEntitlement(): Promise<boolean> {
+  const customerInfo = await Purchases.getCustomerInfo();
+  return hasProEntitlement(customerInfo);
+}
+
+/**
+ * Identify the user in RevenueCat via `Purchases.logIn` so purchases follow the
+ * account across devices. Pass a stable auth user id. Returns pro status.
+ */
+export async function identifyUser(userId: string): Promise<boolean> {
+  const { customerInfo } = await Purchases.logIn(userId);
+  return hasProEntitlement(customerInfo);
+}
+
+/** Log out the current user from RevenueCat (resets to an anonymous id). */
+export async function logOutUser(): Promise<void> {
+  await Purchases.logOut();
+}
+
+/** Set user attributes for tracking in the RevenueCat dashboard. */
+export async function setUserAttributes(attributes: {
+  email?: string;
+  displayName?: string;
+}): Promise<void> {
+  if (attributes.email) {
+    await Purchases.setEmail(attributes.email);
+  }
+  if (attributes.displayName) {
+    await Purchases.setDisplayName(attributes.displayName);
+  }
+}
+
+async function getOffering(): Promise<PurchasesOffering | null> {
+  const offerings = await Purchases.getOfferings();
+
+  if (preferredOfferingId) {
+    const preferredOffering = offerings.all[preferredOfferingId];
+    if (hasPackages(preferredOffering)) {
+      return preferredOffering;
+    }
+
+    if (__DEV__) {
+      console.warn(
+        `[RevenueCat] Offering '${preferredOfferingId}' was configured but has no available packages; falling back to current offering.`,
+      );
+    }
+  }
+
+  if (hasPackages(offerings.current)) {
+    return offerings.current;
+  }
+
+  const fallbackOffering = pickFirstOfferingWithPackages(offerings.all);
+  if (fallbackOffering) {
+    return fallbackOffering;
+  }
+
+  return offerings.current ?? null;
+}
+
+/** Get available subscription packages from the resolved offering. */
+export async function getPackages(): Promise<PurchasesPackage[]> {
+  const offering = await getOffering();
+  return offering?.availablePackages ?? [];
+}
+
+/** Attempt a package purchase and return the resulting pro status. */
+export async function purchaseAndCheckPro(pack: PurchasesPackage): Promise<boolean> {
+  const { customerInfo } = await Purchases.purchasePackage(pack);
+  return hasProEntitlement(customerInfo);
+}
+
+/** Restore purchases from the App Store / Play Store. */
+export async function restoreAndCheckPro(): Promise<boolean> {
+  const customerInfo = await Purchases.restorePurchases();
+  return hasProEntitlement(customerInfo);
+}
+
+/** Force-sync local store state with RevenueCat servers. Debug / recovery only. */
+export async function syncAndCheckPro(): Promise<boolean> {
+  const { customerInfo } = await Purchases.syncPurchasesForResult();
+  return hasProEntitlement(customerInfo);
+}
+
+/** Check whether an error thrown during purchase is a user cancellation. */
+export function isPurchaseCancelledError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+
+  return (error as RevenueCatPurchaseError).userCancelled === true;
+}

--- a/packages/template-generator/templates/payments/revenuecat/native/base/providers/RevenueCatProvider.tsx.hbs
+++ b/packages/template-generator/templates/payments/revenuecat/native/base/providers/RevenueCatProvider.tsx.hbs
@@ -1,0 +1,286 @@
+import type { ReactNode } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { AppState } from "react-native";
+import type { PurchasesPackage } from "react-native-purchases";
+
+import {
+  configureRevenueCat,
+  getPackages as getRevenueCatPackages,
+  hasProEntitlement,
+  identifyUser as identifyRevenueCatUser,
+  isPurchaseCancelledError,
+  logOutUser as logOutRevenueCatUser,
+  onCustomerInfoUpdated,
+  purchaseAndCheckPro,
+  type RevenueCatInitFailureReason,
+  refreshProEntitlement,
+  restoreAndCheckPro,
+  setUserAttributes as setRevenueCatUserAttributes,
+  syncAndCheckPro,
+} from "@/lib/revenue-cat";
+
+type UserAttributes = {
+  email?: string;
+  displayName?: string;
+};
+
+export type RevenueCatContextValue = {
+  isPro: boolean;
+  isConfigured: boolean;
+  refreshEntitlement: () => Promise<boolean>;
+  getPackages: () => Promise<PurchasesPackage[]>;
+  purchasePackage: (pack: PurchasesPackage) => Promise<boolean>;
+  restorePurchases: () => Promise<boolean>;
+  syncPurchases: () => Promise<boolean>;
+  identifyUser: (userId: string) => Promise<boolean>;
+  logOutUser: () => Promise<void>;
+  setUserAttributes: (attributes: UserAttributes) => Promise<void>;
+};
+
+type RevenueCatProviderProps = {
+  children: ReactNode;
+};
+
+const RevenueCatContext = createContext<RevenueCatContextValue | null>(null);
+
+export function useRevenueCat(): RevenueCatContextValue {
+  const context = useContext(RevenueCatContext);
+
+  if (!context) {
+    throw new Error("useRevenueCat must be used within RevenueCatProvider");
+  }
+
+  return context;
+}
+
+export function useIsPro(): boolean {
+  const context = useContext(RevenueCatContext);
+  return context?.isPro ?? false;
+}
+
+function logInitSkip(reason: RevenueCatInitFailureReason): void {
+  if (reason === "unsupported_platform") {
+    console.warn("[RevenueCat] Initialization skipped: unsupported platform");
+    return;
+  }
+
+  console.warn(
+    "[RevenueCat] Missing API key. Add EXPO_PUBLIC_REVENUECAT_IOS_KEY and EXPO_PUBLIC_REVENUECAT_ANDROID_KEY in apps/native/.env",
+  );
+}
+
+export function RevenueCatProvider({ children }: RevenueCatProviderProps) {
+  const [isConfigured, setIsConfigured] = useState(false);
+  const [isPro, setIsPro] = useState(false);
+
+  const refreshEntitlement = useCallback(async (): Promise<boolean> => {
+    if (!isConfigured) return false;
+    try {
+      const nextIsPro = await refreshProEntitlement();
+      setIsPro(nextIsPro);
+      return nextIsPro;
+    } catch (error) {
+      console.warn("[RevenueCat] Failed to refresh entitlement:", error);
+      return false;
+    }
+  }, [isConfigured]);
+
+  const getPackages = useCallback(async (): Promise<PurchasesPackage[]> => {
+    if (!isConfigured) return [];
+
+    try {
+      return await getRevenueCatPackages();
+    } catch (error) {
+      console.warn("[RevenueCat] Failed to fetch packages:", error);
+      return [];
+    }
+  }, [isConfigured]);
+
+  const purchasePackage = useCallback(
+    async (pack: PurchasesPackage): Promise<boolean> => {
+      if (!isConfigured) return false;
+
+      try {
+        const nextIsPro = await purchaseAndCheckPro(pack);
+        setIsPro(nextIsPro);
+        return nextIsPro;
+      } catch (error) {
+        if (isPurchaseCancelledError(error)) {
+          try {
+            const nextIsPro = await refreshProEntitlement();
+            setIsPro(nextIsPro);
+            return nextIsPro;
+          } catch (refreshError) {
+            console.warn(
+              "[RevenueCat] Failed to refresh entitlement after cancellation:",
+              refreshError,
+            );
+            return false;
+          }
+        }
+
+        console.warn("[RevenueCat] Purchase failed:", error);
+        return false;
+      }
+    },
+    [isConfigured],
+  );
+
+  const restorePurchases = useCallback(async (): Promise<boolean> => {
+    if (!isConfigured) return false;
+
+    try {
+      const nextIsPro = await restoreAndCheckPro();
+      setIsPro(nextIsPro);
+      return nextIsPro;
+    } catch (error) {
+      console.warn("[RevenueCat] Restore failed:", error);
+      return false;
+    }
+  }, [isConfigured]);
+
+  const syncPurchases = useCallback(async (): Promise<boolean> => {
+    if (!isConfigured) return false;
+
+    try {
+      const nextIsPro = await syncAndCheckPro();
+      setIsPro(nextIsPro);
+      return nextIsPro;
+    } catch (error) {
+      console.warn("[RevenueCat] Sync purchases failed:", error);
+      return false;
+    }
+  }, [isConfigured]);
+
+  const identifyUser = useCallback(
+    async (userId: string): Promise<boolean> => {
+      if (!isConfigured) return false;
+
+      try {
+        const nextIsPro = await identifyRevenueCatUser(userId);
+        setIsPro(nextIsPro);
+        return nextIsPro;
+      } catch (error) {
+        console.warn("[RevenueCat] Identify user failed:", error);
+        return false;
+      }
+    },
+    [isConfigured],
+  );
+
+  const logOutUser = useCallback(async (): Promise<void> => {
+    if (!isConfigured) return;
+
+    try {
+      await logOutRevenueCatUser();
+      setIsPro(false);
+    } catch (error) {
+      console.warn("[RevenueCat] Log out failed:", error);
+    }
+  }, [isConfigured]);
+
+  const setUserAttributes = useCallback(
+    async (attributes: UserAttributes): Promise<void> => {
+      if (!isConfigured) return;
+
+      try {
+        await setRevenueCatUserAttributes(attributes);
+      } catch (error) {
+        console.warn("[RevenueCat] Set attributes failed:", error);
+      }
+    },
+    [isConfigured],
+  );
+
+  useEffect(() => {
+    let isMounted = true;
+    let unsubscribe = () => {};
+
+    const initialize = async () => {
+      try {
+        const result = await configureRevenueCat();
+
+        if (!isMounted) return;
+
+        if (!result.configured) {
+          setIsConfigured(false);
+          logInitSkip(result.reason);
+          return;
+        }
+
+        setIsConfigured(true);
+
+        unsubscribe = onCustomerInfoUpdated((customerInfo) => {
+          if (!isMounted) return;
+          setIsPro(hasProEntitlement(customerInfo));
+        });
+
+        const nextIsPro = await refreshProEntitlement();
+        if (isMounted) {
+          setIsPro(nextIsPro);
+        }
+      } catch (error) {
+        console.warn("[RevenueCat] Initialization failed:", error);
+      }
+    };
+
+    initialize();
+
+    return () => {
+      isMounted = false;
+      unsubscribe();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isConfigured) return;
+
+    const subscription = AppState.addEventListener("change", (state) => {
+      if (state !== "active") return;
+
+      refreshEntitlement().catch((error) => {
+        console.warn("[RevenueCat] Foreground entitlement refresh failed:", error);
+      });
+    });
+
+    return () => {
+      subscription.remove();
+    };
+  }, [isConfigured, refreshEntitlement]);
+
+  const value = useMemo<RevenueCatContextValue>(
+    () => ({
+      isPro,
+      isConfigured,
+      refreshEntitlement,
+      getPackages,
+      purchasePackage,
+      restorePurchases,
+      syncPurchases,
+      identifyUser,
+      logOutUser,
+      setUserAttributes,
+    }),
+    [
+      isPro,
+      isConfigured,
+      refreshEntitlement,
+      getPackages,
+      purchasePackage,
+      restorePurchases,
+      syncPurchases,
+      identifyUser,
+      logOutUser,
+      setUserAttributes,
+    ],
+  );
+
+  return <RevenueCatContext.Provider value={value}>{children}</RevenueCatContext.Provider>;
+}

--- a/packages/template-generator/templates/payments/revenuecat/native/unistyles/components/paywall-example.tsx.hbs
+++ b/packages/template-generator/templates/payments/revenuecat/native/unistyles/components/paywall-example.tsx.hbs
@@ -1,0 +1,112 @@
+import { useState } from "react";
+import { ActivityIndicator, Alert, Pressable, Text, View } from "react-native";
+import { StyleSheet } from "react-native-unistyles";
+import type { PurchasesPackage } from "react-native-purchases";
+
+import { useRevenueCat } from "@/providers/RevenueCatProvider";
+
+export function PaywallExample() {
+  const { isPro, getPackages, purchasePackage, restorePurchases } = useRevenueCat();
+  const [packages, setPackages] = useState<PurchasesPackage[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isPurchasing, setIsPurchasing] = useState(false);
+
+  const loadPackages = async () => {
+    setIsLoading(true);
+    try {
+      setPackages(await getPackages());
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handlePurchase = async (pack: PurchasesPackage) => {
+    setIsPurchasing(true);
+    try {
+      const success = await purchasePackage(pack);
+      Alert.alert(success ? "You're now Premium!" : "Purchase not completed");
+    } finally {
+      setIsPurchasing(false);
+    }
+  };
+
+  if (isPro) {
+    return (
+      <View style={styles.card}>
+        <Text style={styles.title}>You're Premium</Text>
+        <Text style={styles.muted}>Thanks for your support — enjoy all features.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.card}>
+      <Text style={styles.title}>Upgrade to Premium</Text>
+      <Text style={styles.muted}>Unlock all features.</Text>
+
+      {packages.length === 0 ? (
+        <Pressable style={styles.button} onPress={loadPackages} disabled={isLoading}>
+          {isLoading ? (
+            <ActivityIndicator color={styles.buttonText.color} />
+          ) : (
+            <Text style={styles.buttonText}>View plans</Text>
+          )}
+        </Pressable>
+      ) : (
+        packages.map((pack) => (
+          <Pressable
+            key={pack.identifier}
+            style={styles.button}
+            onPress={() => handlePurchase(pack)}
+            disabled={isPurchasing}
+          >
+            <Text style={styles.buttonText}>
+              {pack.product.title} · {pack.product.priceString}
+            </Text>
+          </Pressable>
+        ))
+      )}
+
+      <Pressable style={styles.secondary} onPress={restorePurchases}>
+        <Text style={styles.secondaryText}>Restore purchases</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  card: {
+    gap: theme.spacing.md,
+    borderRadius: theme.borderRadius.xl,
+    padding: theme.spacing.md,
+    backgroundColor: theme.colors.card,
+  },
+  title: {
+    fontSize: theme.fontSize.lg,
+    fontWeight: "600",
+    color: theme.colors.foreground,
+  },
+  muted: {
+    fontSize: theme.fontSize.sm,
+    color: theme.colors.mutedForeground,
+  },
+  button: {
+    alignItems: "center",
+    borderRadius: theme.borderRadius.lg,
+    paddingVertical: theme.spacing.sm,
+    backgroundColor: theme.colors.primary,
+  },
+  buttonText: {
+    fontSize: theme.fontSize.base,
+    fontWeight: "600",
+    color: theme.colors.primaryForeground,
+  },
+  secondary: {
+    alignItems: "center",
+    paddingVertical: theme.spacing.sm,
+  },
+  secondaryText: {
+    fontSize: theme.fontSize.sm,
+    color: theme.colors.mutedForeground,
+  },
+}));

--- a/packages/template-generator/templates/payments/revenuecat/native/unistyles/components/paywall-example.tsx.hbs
+++ b/packages/template-generator/templates/payments/revenuecat/native/unistyles/components/paywall-example.tsx.hbs
@@ -1,0 +1,128 @@
+import { useState } from "react";
+import { ActivityIndicator, Alert, Pressable, Text, View } from "react-native";
+import { StyleSheet } from "react-native-unistyles";
+import type { PurchasesPackage } from "react-native-purchases";
+
+import { useRevenueCat } from "@/contexts/revenuecat-context";
+
+export function PaywallExample() {
+  const { isPro, getPackages, purchasePackage, restorePurchases } = useRevenueCat();
+  const [packages, setPackages] = useState<PurchasesPackage[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isPurchasing, setIsPurchasing] = useState(false);
+  const [isRestoring, setIsRestoring] = useState(false);
+  const isBusy = isPurchasing || isRestoring;
+
+  const loadPackages = async () => {
+    setIsLoading(true);
+    try {
+      setPackages(await getPackages());
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handlePurchase = async (pack: PurchasesPackage) => {
+    if (isBusy) return;
+    setIsPurchasing(true);
+    try {
+      const success = await purchasePackage(pack);
+      Alert.alert(success ? "You're now Premium!" : "Purchase not completed");
+    } finally {
+      setIsPurchasing(false);
+    }
+  };
+
+  const handleRestore = async () => {
+    if (isBusy) return;
+    setIsRestoring(true);
+    try {
+      const success = await restorePurchases();
+      Alert.alert(success ? "Purchases restored" : "No purchases to restore");
+    } finally {
+      setIsRestoring(false);
+    }
+  };
+
+  if (isPro) {
+    return (
+      <View style={styles.card}>
+        <Text style={styles.title}>You're Premium</Text>
+        <Text style={styles.muted}>Thanks for your support — enjoy all features.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.card}>
+      <Text style={styles.title}>Upgrade to Premium</Text>
+      <Text style={styles.muted}>Unlock all features.</Text>
+
+      {packages.length === 0 ? (
+        <Pressable style={styles.button} onPress={loadPackages} disabled={isLoading}>
+          {isLoading ? (
+            <ActivityIndicator color={styles.buttonText.color} />
+          ) : (
+            <Text style={styles.buttonText}>View plans</Text>
+          )}
+        </Pressable>
+      ) : (
+        packages.map((pack) => (
+          <Pressable
+            key={pack.identifier}
+            style={styles.button}
+            onPress={() => handlePurchase(pack)}
+            disabled={isBusy}
+          >
+            <Text style={styles.buttonText}>
+              {pack.product.title} · {pack.product.priceString}
+            </Text>
+          </Pressable>
+        ))
+      )}
+
+      <Pressable style={styles.secondary} onPress={handleRestore} disabled={isBusy}>
+        <Text style={styles.secondaryText}>
+          {isRestoring ? "Restoring..." : "Restore purchases"}
+        </Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  card: {
+    gap: theme.spacing.md,
+    borderRadius: theme.borderRadius.xl,
+    padding: theme.spacing.md,
+    backgroundColor: theme.colors.card,
+  },
+  title: {
+    fontSize: theme.fontSize.lg,
+    fontWeight: "600",
+    color: theme.colors.foreground,
+  },
+  muted: {
+    fontSize: theme.fontSize.sm,
+    color: theme.colors.mutedForeground,
+  },
+  button: {
+    alignItems: "center",
+    borderRadius: theme.borderRadius.lg,
+    paddingVertical: theme.spacing.sm,
+    backgroundColor: theme.colors.primary,
+  },
+  buttonText: {
+    fontSize: theme.fontSize.base,
+    fontWeight: "600",
+    color: theme.colors.primaryForeground,
+  },
+  secondary: {
+    alignItems: "center",
+    paddingVertical: theme.spacing.sm,
+  },
+  secondaryText: {
+    fontSize: theme.fontSize.sm,
+    color: theme.colors.mutedForeground,
+  },
+}));

--- a/packages/template-generator/templates/payments/revenuecat/native/unistyles/components/paywall-example.tsx.hbs
+++ b/packages/template-generator/templates/payments/revenuecat/native/unistyles/components/paywall-example.tsx.hbs
@@ -3,7 +3,7 @@ import { ActivityIndicator, Alert, Pressable, Text, View } from "react-native";
 import { StyleSheet } from "react-native-unistyles";
 import type { PurchasesPackage } from "react-native-purchases";
 
-import { useRevenueCat } from "@/providers/RevenueCatProvider";
+import { useRevenueCat } from "@/contexts/revenuecat-context";
 
 export function PaywallExample() {
   const { isPro, getPackages, purchasePackage, restorePurchases } = useRevenueCat();

--- a/packages/template-generator/templates/payments/revenuecat/native/unistyles/components/paywall-example.tsx.hbs
+++ b/packages/template-generator/templates/payments/revenuecat/native/unistyles/components/paywall-example.tsx.hbs
@@ -10,6 +10,8 @@ export function PaywallExample() {
   const [packages, setPackages] = useState<PurchasesPackage[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [isPurchasing, setIsPurchasing] = useState(false);
+  const [isRestoring, setIsRestoring] = useState(false);
+  const isBusy = isPurchasing || isRestoring;
 
   const loadPackages = async () => {
     setIsLoading(true);
@@ -21,12 +23,24 @@ export function PaywallExample() {
   };
 
   const handlePurchase = async (pack: PurchasesPackage) => {
+    if (isBusy) return;
     setIsPurchasing(true);
     try {
       const success = await purchasePackage(pack);
       Alert.alert(success ? "You're now Premium!" : "Purchase not completed");
     } finally {
       setIsPurchasing(false);
+    }
+  };
+
+  const handleRestore = async () => {
+    if (isBusy) return;
+    setIsRestoring(true);
+    try {
+      const success = await restorePurchases();
+      Alert.alert(success ? "Purchases restored" : "No purchases to restore");
+    } finally {
+      setIsRestoring(false);
     }
   };
 
@@ -58,7 +72,7 @@ export function PaywallExample() {
             key={pack.identifier}
             style={styles.button}
             onPress={() => handlePurchase(pack)}
-            disabled={isPurchasing}
+            disabled={isBusy}
           >
             <Text style={styles.buttonText}>
               {pack.product.title} · {pack.product.priceString}
@@ -67,8 +81,10 @@ export function PaywallExample() {
         ))
       )}
 
-      <Pressable style={styles.secondary} onPress={restorePurchases}>
-        <Text style={styles.secondaryText}>Restore purchases</Text>
+      <Pressable style={styles.secondary} onPress={handleRestore} disabled={isBusy}>
+        <Text style={styles.secondaryText}>
+          {isRestoring ? "Restoring..." : "Restore purchases"}
+        </Text>
       </Pressable>
     </View>
   );

--- a/packages/template-generator/templates/payments/revenuecat/native/unistyles/components/subscription-status-card.tsx.hbs
+++ b/packages/template-generator/templates/payments/revenuecat/native/unistyles/components/subscription-status-card.tsx.hbs
@@ -1,7 +1,7 @@
 import { Text, View } from "react-native";
 import { StyleSheet } from "react-native-unistyles";
 
-import { useRevenueCat } from "@/providers/RevenueCatProvider";
+import { useRevenueCat } from "@/contexts/revenuecat-context";
 
 export function SubscriptionStatusCard() {
   const { isPro, isConfigured } = useRevenueCat();

--- a/packages/template-generator/templates/payments/revenuecat/native/unistyles/components/subscription-status-card.tsx.hbs
+++ b/packages/template-generator/templates/payments/revenuecat/native/unistyles/components/subscription-status-card.tsx.hbs
@@ -1,0 +1,46 @@
+import { Text, View } from "react-native";
+import { StyleSheet } from "react-native-unistyles";
+
+import { useRevenueCat } from "@/providers/RevenueCatProvider";
+
+export function SubscriptionStatusCard() {
+  const { isPro, isConfigured } = useRevenueCat();
+
+  return (
+    <View style={styles.card}>
+      <Text style={styles.title}>Subscription</Text>
+      {!isConfigured ? (
+        <Text style={styles.muted}>
+          RevenueCat is not configured yet. Add your API keys in apps/native/.env.
+        </Text>
+      ) : isPro ? (
+        <Text style={styles.pro}>You're a Premium member 🎉</Text>
+      ) : (
+        <Text style={styles.muted}>You're on the free plan.</Text>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  card: {
+    gap: theme.spacing.sm,
+    borderRadius: theme.borderRadius.xl,
+    padding: theme.spacing.md,
+    backgroundColor: theme.colors.card,
+  },
+  title: {
+    fontSize: theme.fontSize.lg,
+    fontWeight: "600",
+    color: theme.colors.foreground,
+  },
+  pro: {
+    fontSize: theme.fontSize.base,
+    fontWeight: "500",
+    color: theme.colors.success,
+  },
+  muted: {
+    fontSize: theme.fontSize.sm,
+    color: theme.colors.mutedForeground,
+  },
+}));

--- a/packages/template-generator/templates/payments/revenuecat/native/unistyles/components/subscription-status-card.tsx.hbs
+++ b/packages/template-generator/templates/payments/revenuecat/native/unistyles/components/subscription-status-card.tsx.hbs
@@ -1,0 +1,46 @@
+import { Text, View } from "react-native";
+import { StyleSheet } from "react-native-unistyles";
+
+import { useRevenueCat } from "@/contexts/revenuecat-context";
+
+export function SubscriptionStatusCard() {
+  const { isPro, isConfigured } = useRevenueCat();
+
+  return (
+    <View style={styles.card}>
+      <Text style={styles.title}>Subscription</Text>
+      {!isConfigured ? (
+        <Text style={styles.muted}>
+          RevenueCat is not configured yet. Add your API keys in apps/native/.env.
+        </Text>
+      ) : isPro ? (
+        <Text style={styles.pro}>You're a Premium member 🎉</Text>
+      ) : (
+        <Text style={styles.muted}>You're on the free plan.</Text>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  card: {
+    gap: theme.spacing.sm,
+    borderRadius: theme.borderRadius.xl,
+    padding: theme.spacing.md,
+    backgroundColor: theme.colors.card,
+  },
+  title: {
+    fontSize: theme.fontSize.lg,
+    fontWeight: "600",
+    color: theme.colors.foreground,
+  },
+  pro: {
+    fontSize: theme.fontSize.base,
+    fontWeight: "500",
+    color: theme.colors.success,
+  },
+  muted: {
+    fontSize: theme.fontSize.sm,
+    color: theme.colors.mutedForeground,
+  },
+}));

--- a/packages/template-generator/templates/payments/revenuecat/native/uniwind/components/paywall-example.tsx.hbs
+++ b/packages/template-generator/templates/payments/revenuecat/native/uniwind/components/paywall-example.tsx.hbs
@@ -9,6 +9,8 @@ export function PaywallExample() {
   const [packages, setPackages] = useState<PurchasesPackage[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [isPurchasing, setIsPurchasing] = useState(false);
+  const [isRestoring, setIsRestoring] = useState(false);
+  const isBusy = isPurchasing || isRestoring;
 
   const loadPackages = async () => {
     setIsLoading(true);
@@ -20,12 +22,24 @@ export function PaywallExample() {
   };
 
   const handlePurchase = async (pack: PurchasesPackage) => {
+    if (isBusy) return;
     setIsPurchasing(true);
     try {
       const success = await purchasePackage(pack);
       Alert.alert(success ? "You're now Premium!" : "Purchase not completed");
     } finally {
       setIsPurchasing(false);
+    }
+  };
+
+  const handleRestore = async () => {
+    if (isBusy) return;
+    setIsRestoring(true);
+    try {
+      const success = await restorePurchases();
+      Alert.alert(success ? "Purchases restored" : "No purchases to restore");
+    } finally {
+      setIsRestoring(false);
     }
   };
 
@@ -67,7 +81,7 @@ export function PaywallExample() {
             key={pack.identifier}
             className="items-center rounded-xl bg-neutral-900 py-3 dark:bg-neutral-50"
             onPress={() => handlePurchase(pack)}
-            disabled={isPurchasing}
+            disabled={isBusy}
           >
             <Text className="font-semibold text-neutral-50 dark:text-neutral-900">
               {pack.product.title} · {pack.product.priceString}
@@ -76,8 +90,10 @@ export function PaywallExample() {
         ))
       )}
 
-      <Pressable className="items-center py-2" onPress={restorePurchases}>
-        <Text className="text-neutral-500 text-sm">Restore purchases</Text>
+      <Pressable className="items-center py-2" onPress={handleRestore} disabled={isBusy}>
+        <Text className="text-neutral-500 text-sm">
+          {isRestoring ? "Restoring..." : "Restore purchases"}
+        </Text>
       </Pressable>
     </View>
   );

--- a/packages/template-generator/templates/payments/revenuecat/native/uniwind/components/paywall-example.tsx.hbs
+++ b/packages/template-generator/templates/payments/revenuecat/native/uniwind/components/paywall-example.tsx.hbs
@@ -1,0 +1,84 @@
+import { useState } from "react";
+import { ActivityIndicator, Alert, Pressable, Text, View } from "react-native";
+import type { PurchasesPackage } from "react-native-purchases";
+
+import { useRevenueCat } from "@/providers/RevenueCatProvider";
+
+export function PaywallExample() {
+  const { isPro, getPackages, purchasePackage, restorePurchases } = useRevenueCat();
+  const [packages, setPackages] = useState<PurchasesPackage[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isPurchasing, setIsPurchasing] = useState(false);
+
+  const loadPackages = async () => {
+    setIsLoading(true);
+    try {
+      setPackages(await getPackages());
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handlePurchase = async (pack: PurchasesPackage) => {
+    setIsPurchasing(true);
+    try {
+      const success = await purchasePackage(pack);
+      Alert.alert(success ? "You're now Premium!" : "Purchase not completed");
+    } finally {
+      setIsPurchasing(false);
+    }
+  };
+
+  if (isPro) {
+    return (
+      <View className="gap-2 rounded-2xl bg-neutral-100 p-4 dark:bg-neutral-900">
+        <Text className="font-semibold text-lg text-neutral-900 dark:text-neutral-50">
+          You're Premium
+        </Text>
+        <Text className="text-neutral-500 text-sm">
+          Thanks for your support — enjoy all features.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View className="gap-3 rounded-2xl bg-neutral-100 p-4 dark:bg-neutral-900">
+      <Text className="font-semibold text-lg text-neutral-900 dark:text-neutral-50">
+        Upgrade to Premium
+      </Text>
+      <Text className="text-neutral-500 text-sm">Unlock all features.</Text>
+
+      {packages.length === 0 ? (
+        <Pressable
+          className="items-center rounded-xl bg-neutral-900 py-3 dark:bg-neutral-50"
+          onPress={loadPackages}
+          disabled={isLoading}
+        >
+          {isLoading ? (
+            <ActivityIndicator />
+          ) : (
+            <Text className="font-semibold text-neutral-50 dark:text-neutral-900">View plans</Text>
+          )}
+        </Pressable>
+      ) : (
+        packages.map((pack) => (
+          <Pressable
+            key={pack.identifier}
+            className="items-center rounded-xl bg-neutral-900 py-3 dark:bg-neutral-50"
+            onPress={() => handlePurchase(pack)}
+            disabled={isPurchasing}
+          >
+            <Text className="font-semibold text-neutral-50 dark:text-neutral-900">
+              {pack.product.title} · {pack.product.priceString}
+            </Text>
+          </Pressable>
+        ))
+      )}
+
+      <Pressable className="items-center py-2" onPress={restorePurchases}>
+        <Text className="text-neutral-500 text-sm">Restore purchases</Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/packages/template-generator/templates/payments/revenuecat/native/uniwind/components/paywall-example.tsx.hbs
+++ b/packages/template-generator/templates/payments/revenuecat/native/uniwind/components/paywall-example.tsx.hbs
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { ActivityIndicator, Alert, Pressable, Text, View } from "react-native";
 import type { PurchasesPackage } from "react-native-purchases";
 
-import { useRevenueCat } from "@/providers/RevenueCatProvider";
+import { useRevenueCat } from "@/contexts/revenuecat-context";
 
 export function PaywallExample() {
   const { isPro, getPackages, purchasePackage, restorePurchases } = useRevenueCat();

--- a/packages/template-generator/templates/payments/revenuecat/native/uniwind/components/paywall-example.tsx.hbs
+++ b/packages/template-generator/templates/payments/revenuecat/native/uniwind/components/paywall-example.tsx.hbs
@@ -1,0 +1,91 @@
+import { useState } from "react";
+import { Alert, View } from "react-native";
+import { Button, Card, Spinner } from "heroui-native";
+import type { PurchasesPackage } from "react-native-purchases";
+
+import { useRevenueCat } from "@/contexts/revenuecat-context";
+
+export function PaywallExample() {
+  const { isPro, getPackages, purchasePackage, restorePurchases } = useRevenueCat();
+  const [packages, setPackages] = useState<PurchasesPackage[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isPurchasing, setIsPurchasing] = useState(false);
+  const [isRestoring, setIsRestoring] = useState(false);
+  const isBusy = isPurchasing || isRestoring;
+
+  const loadPackages = async () => {
+    setIsLoading(true);
+    try {
+      setPackages(await getPackages());
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handlePurchase = async (pack: PurchasesPackage) => {
+    if (isBusy) return;
+    setIsPurchasing(true);
+    try {
+      const success = await purchasePackage(pack);
+      Alert.alert(success ? "You're now Premium!" : "Purchase not completed");
+    } finally {
+      setIsPurchasing(false);
+    }
+  };
+
+  const handleRestore = async () => {
+    if (isBusy) return;
+    setIsRestoring(true);
+    try {
+      const success = await restorePurchases();
+      Alert.alert(success ? "Purchases restored" : "No purchases to restore");
+    } finally {
+      setIsRestoring(false);
+    }
+  };
+
+  if (isPro) {
+    return (
+      <Card variant="secondary" className="mb-4 p-4">
+        <Card.Title className="mb-2">You're Premium</Card.Title>
+        <Card.Description>
+          Thanks for your support — enjoy all features.
+        </Card.Description>
+      </Card>
+    );
+  }
+
+  return (
+    <Card variant="secondary" className="mb-4 p-4">
+      <Card.Title className="mb-2">Upgrade to Premium</Card.Title>
+      <Card.Description className="mb-4">Unlock all features.</Card.Description>
+
+      <View className="gap-3">
+        {packages.length === 0 ? (
+          <Button onPress={loadPackages} isDisabled={isLoading}>
+            {isLoading ? <Spinner size="sm" color="default" /> : <Button.Label>View plans</Button.Label>}
+          </Button>
+        ) : (
+          packages.map((pack) => (
+            <Button
+              key={pack.identifier}
+              variant="secondary"
+              onPress={() => handlePurchase(pack)}
+              isDisabled={isBusy}
+            >
+              <Button.Label>
+                {pack.product.title} · {pack.product.priceString}
+              </Button.Label>
+            </Button>
+          ))
+        )}
+
+        <Button variant="ghost" onPress={handleRestore} isDisabled={isBusy}>
+          <Button.Label>
+            {isRestoring ? "Restoring..." : "Restore purchases"}
+          </Button.Label>
+        </Button>
+      </View>
+    </Card>
+  );
+}

--- a/packages/template-generator/templates/payments/revenuecat/native/uniwind/components/paywall-example.tsx.hbs
+++ b/packages/template-generator/templates/payments/revenuecat/native/uniwind/components/paywall-example.tsx.hbs
@@ -1,5 +1,6 @@
 import { useState } from "react";
-import { ActivityIndicator, Alert, Pressable, Text, View } from "react-native";
+import { Alert, View } from "react-native";
+import { Button, Card, Spinner } from "heroui-native";
 import type { PurchasesPackage } from "react-native-purchases";
 
 import { useRevenueCat } from "@/contexts/revenuecat-context";
@@ -45,56 +46,46 @@ export function PaywallExample() {
 
   if (isPro) {
     return (
-      <View className="gap-2 rounded-2xl bg-neutral-100 p-4 dark:bg-neutral-900">
-        <Text className="font-semibold text-lg text-neutral-900 dark:text-neutral-50">
-          You're Premium
-        </Text>
-        <Text className="text-neutral-500 text-sm">
+      <Card variant="secondary" className="mb-4 p-4">
+        <Card.Title className="mb-2">You're Premium</Card.Title>
+        <Card.Description>
           Thanks for your support — enjoy all features.
-        </Text>
-      </View>
+        </Card.Description>
+      </Card>
     );
   }
 
   return (
-    <View className="gap-3 rounded-2xl bg-neutral-100 p-4 dark:bg-neutral-900">
-      <Text className="font-semibold text-lg text-neutral-900 dark:text-neutral-50">
-        Upgrade to Premium
-      </Text>
-      <Text className="text-neutral-500 text-sm">Unlock all features.</Text>
+    <Card variant="secondary" className="mb-4 p-4">
+      <Card.Title className="mb-2">Upgrade to Premium</Card.Title>
+      <Card.Description className="mb-4">Unlock all features.</Card.Description>
 
-      {packages.length === 0 ? (
-        <Pressable
-          className="items-center rounded-xl bg-neutral-900 py-3 dark:bg-neutral-50"
-          onPress={loadPackages}
-          disabled={isLoading}
-        >
-          {isLoading ? (
-            <ActivityIndicator />
-          ) : (
-            <Text className="font-semibold text-neutral-50 dark:text-neutral-900">View plans</Text>
-          )}
-        </Pressable>
-      ) : (
-        packages.map((pack) => (
-          <Pressable
-            key={pack.identifier}
-            className="items-center rounded-xl bg-neutral-900 py-3 dark:bg-neutral-50"
-            onPress={() => handlePurchase(pack)}
-            disabled={isBusy}
-          >
-            <Text className="font-semibold text-neutral-50 dark:text-neutral-900">
-              {pack.product.title} · {pack.product.priceString}
-            </Text>
-          </Pressable>
-        ))
-      )}
+      <View className="gap-3">
+        {packages.length === 0 ? (
+          <Button onPress={loadPackages} isDisabled={isLoading}>
+            {isLoading ? <Spinner size="sm" color="default" /> : <Button.Label>View plans</Button.Label>}
+          </Button>
+        ) : (
+          packages.map((pack) => (
+            <Button
+              key={pack.identifier}
+              variant="secondary"
+              onPress={() => handlePurchase(pack)}
+              isDisabled={isBusy}
+            >
+              <Button.Label>
+                {pack.product.title} · {pack.product.priceString}
+              </Button.Label>
+            </Button>
+          ))
+        )}
 
-      <Pressable className="items-center py-2" onPress={handleRestore} disabled={isBusy}>
-        <Text className="text-neutral-500 text-sm">
-          {isRestoring ? "Restoring..." : "Restore purchases"}
-        </Text>
-      </Pressable>
-    </View>
+        <Button variant="ghost" onPress={handleRestore} isDisabled={isBusy}>
+          <Button.Label>
+            {isRestoring ? "Restoring..." : "Restore purchases"}
+          </Button.Label>
+        </Button>
+      </View>
+    </Card>
   );
 }

--- a/packages/template-generator/templates/payments/revenuecat/native/uniwind/components/subscription-status-card.tsx.hbs
+++ b/packages/template-generator/templates/payments/revenuecat/native/uniwind/components/subscription-status-card.tsx.hbs
@@ -1,6 +1,6 @@
 import { Text, View } from "react-native";
 
-import { useRevenueCat } from "@/providers/RevenueCatProvider";
+import { useRevenueCat } from "@/contexts/revenuecat-context";
 
 export function SubscriptionStatusCard() {
   const { isPro, isConfigured } = useRevenueCat();

--- a/packages/template-generator/templates/payments/revenuecat/native/uniwind/components/subscription-status-card.tsx.hbs
+++ b/packages/template-generator/templates/payments/revenuecat/native/uniwind/components/subscription-status-card.tsx.hbs
@@ -1,0 +1,25 @@
+import { Text } from "react-native";
+import { Card } from "heroui-native";
+
+import { useRevenueCat } from "@/contexts/revenuecat-context";
+
+export function SubscriptionStatusCard() {
+  const { isPro, isConfigured } = useRevenueCat();
+
+  return (
+    <Card variant="secondary" className="mb-4 p-4">
+      <Card.Title className="mb-2">Subscription</Card.Title>
+      {!isConfigured ? (
+        <Card.Description>
+          RevenueCat is not configured yet. Add your API keys in apps/native/.env.
+        </Card.Description>
+      ) : isPro ? (
+        <Text className="text-success text-base font-medium">
+          You're a Premium member 🎉
+        </Text>
+      ) : (
+        <Card.Description>You're on the free plan.</Card.Description>
+      )}
+    </Card>
+  );
+}

--- a/packages/template-generator/templates/payments/revenuecat/native/uniwind/components/subscription-status-card.tsx.hbs
+++ b/packages/template-generator/templates/payments/revenuecat/native/uniwind/components/subscription-status-card.tsx.hbs
@@ -1,4 +1,5 @@
-import { Text, View } from "react-native";
+import { Text } from "react-native";
+import { Card } from "heroui-native";
 
 import { useRevenueCat } from "@/contexts/revenuecat-context";
 
@@ -6,19 +7,19 @@ export function SubscriptionStatusCard() {
   const { isPro, isConfigured } = useRevenueCat();
 
   return (
-    <View className="gap-2 rounded-2xl bg-neutral-100 p-4 dark:bg-neutral-900">
-      <Text className="font-semibold text-lg text-neutral-900 dark:text-neutral-50">
-        Subscription
-      </Text>
+    <Card variant="secondary" className="mb-4 p-4">
+      <Card.Title className="mb-2">Subscription</Card.Title>
       {!isConfigured ? (
-        <Text className="text-neutral-500 text-sm">
+        <Card.Description>
           RevenueCat is not configured yet. Add your API keys in apps/native/.env.
-        </Text>
+        </Card.Description>
       ) : isPro ? (
-        <Text className="font-medium text-base text-green-600">You're a Premium member 🎉</Text>
+        <Text className="text-success text-base font-medium">
+          You're a Premium member 🎉
+        </Text>
       ) : (
-        <Text className="text-neutral-500 text-sm">You're on the free plan.</Text>
+        <Card.Description>You're on the free plan.</Card.Description>
       )}
-    </View>
+    </Card>
   );
 }

--- a/packages/template-generator/templates/payments/revenuecat/native/uniwind/components/subscription-status-card.tsx.hbs
+++ b/packages/template-generator/templates/payments/revenuecat/native/uniwind/components/subscription-status-card.tsx.hbs
@@ -1,0 +1,24 @@
+import { Text, View } from "react-native";
+
+import { useRevenueCat } from "@/providers/RevenueCatProvider";
+
+export function SubscriptionStatusCard() {
+  const { isPro, isConfigured } = useRevenueCat();
+
+  return (
+    <View className="gap-2 rounded-2xl bg-neutral-100 p-4 dark:bg-neutral-900">
+      <Text className="font-semibold text-lg text-neutral-900 dark:text-neutral-50">
+        Subscription
+      </Text>
+      {!isConfigured ? (
+        <Text className="text-neutral-500 text-sm">
+          RevenueCat is not configured yet. Add your API keys in apps/native/.env.
+        </Text>
+      ) : isPro ? (
+        <Text className="font-medium text-base text-green-600">You're a Premium member 🎉</Text>
+      ) : (
+        <Text className="text-neutral-500 text-sm">You're on the free plan.</Text>
+      )}
+    </View>
+  );
+}

--- a/packages/types/src/schemas.ts
+++ b/packages/types/src/schemas.ts
@@ -91,7 +91,7 @@ export const AuthSchema = z
   .enum(["better-auth", "clerk", "none"])
   .describe("Authentication provider");
 
-export const PaymentsSchema = z.enum(["polar", "none"]).describe("Payments provider");
+export const PaymentsSchema = z.enum(["polar", "revenuecat", "none"]).describe("Payments provider");
 
 export const WebDeploySchema = z.enum(["cloudflare", "docker", "none"]).describe("Web deployment");
 

--- a/packages/types/src/schemas.ts
+++ b/packages/types/src/schemas.ts
@@ -159,6 +159,7 @@ export const McpServerSchema = z
     "clerk",
     "expo",
     "polar",
+    "revenuecat",
   ])
   .describe("MCP server to install");
 

--- a/packages/types/src/schemas.ts
+++ b/packages/types/src/schemas.ts
@@ -91,7 +91,7 @@ export const AuthSchema = z
   .enum(["better-auth", "clerk", "none"])
   .describe("Authentication provider");
 
-export const PaymentsSchema = z.enum(["polar", "none"]).describe("Payments provider");
+export const PaymentsSchema = z.enum(["polar", "revenuecat", "none"]).describe("Payments provider");
 
 export const WebDeploySchema = z
   .enum(["cloudflare", "prisma", "docker", "vercel", "none"])
@@ -162,6 +162,7 @@ export const McpServerSchema = z
     "clerk",
     "expo",
     "polar",
+    "revenuecat",
   ])
   .describe("MCP server to install");
 


### PR DESCRIPTION
## What

Adds **RevenueCat** as a `payments` provider for in-app purchases on native (Expo / React Native) apps.

Polar covers web subscriptions through Better-Auth. There is currently no option for mobile in-app purchases, which is a different billing model: the stores own the transaction, and subscription state lives outside your backend. RevenueCat fills that gap.

Unlike Polar, RevenueCat is **native-gated** and **auth-agnostic**:

- Offered only when a native frontend (`native-bare` / `native-uniwind` / `native-unistyles`) is selected, with any backend except `none`.
- **Convex backend** wires the [`convex-revenuecat`](https://www.convex.dev/components/ramonclaudio-convex-revenuecat) component: `app.use(revenuecat)` in `convex.config.ts`, a webhook via `registerRoutes` (`POST /webhooks/revenuecat`), and a `revenuecat.ts` client exposing `hasEntitlement` / `isSubscriber` / `getActiveSubscriptions`.
- **Other backends** get the `react-native-purchases` SDK integration only, since RevenueCat hosts subscription state.

## How it works

- **Schema / prompt / validation**: `revenuecat` added to `PaymentsSchema`. The prompt offers it when a native frontend is present, and `validatePaymentsCompatibility` errors if it is selected without one. Matrix oracle and cases updated with `payments-revenuecat-requires-native-frontend`.
- **Template handler**: restructured so the native branch and the Convex component are processed without changing Polar's behavior. The Convex webhook is appended to the Better-Auth `http.ts` when present, and a standalone `http.ts` is generated for Convex + Clerk/none so the Better-Auth routes are never clobbered.
- **Native scaffolding** (all three variants): a shared auth-agnostic `RevenueCatProvider` plus a `lib/revenuecat` SDK layer, with `subscription-status-card` and `paywall-example` components written in each variant's own UI kit (StyleSheet / heroui-native / unistyles) and mounted on the drawer home screen. The provider is mounted via a conditional wrap in each `app/_layout.tsx`.
- **Env**: native `.env` gets `EXPO_PUBLIC_REVENUECAT_IOS_KEY` / `_ANDROID_KEY` / `_ENTITLEMENT_ID`. Convex `.env.local` gets `REVENUECAT_WEBHOOK_AUTH` with setup comments.
- **Post-install + MCP**: setup instructions print when the provider is selected, and the RevenueCat MCP server is added to the recommended set.
- **Web stack-builder**: RevenueCat added to `apps/web` with a native-frontend constraint, mirroring how Polar gates on Better-Auth.

Native code is based on [`0rtbo/convexpo-revenuecat`](https://github.com/0rtbo/convexpo-revenuecat), adapted to this project's conventions. The reference's `user-context` coupling and identity auto-sync were dropped to keep the provider auth-agnostic, and the example components are SDK/provider-based rather than tied to a specific Convex `subscriptions` module.

## Testing

Verified on the rebase against `main` at 3.42.2:

- CLI test suite: **1039 pass / 0 fail** (42 skipped).
- `BTS_MATRIX_MODE=smoke` matrix: **291 combinations checked, 184 valid / 107 invalid, all matching the oracle**, covering revenuecat across all native variants and Convex with and without Better-Auth, plus invalid combos rejected by the right rule.
- `oxfmt` and `oxlint` clean across the repo.
- `tsc --noEmit` clean in `apps/cli` and `packages/template-generator`.

## Notes for maintainers

Two things need your call:

1. **R2 icon is missing.** `apps/web/src/lib/constant.ts` points at `r2.better-t-stack.dev/icons/revenuecat.svg`, which currently returns 404. It follows the existing `polar.svg` convention, so it resolves as soon as the asset is uploaded, but only you can upload to the bucket. Happy to switch it to an empty `icon` if you would rather merge before uploading.
2. **Pinned versions.** `convex-revenuecat` is pinned to `^0.3.2`, which is the API the templates are written against and still the latest release. `react-native-purchases` is on `^10.9.0`; v10's only breaking change is an Android minSdk bump from 21 to 23, which Expo already exceeds, and none of the SDK calls used here changed.

This branch was rebased onto latest `main` and squashed to a single commit, so the earlier review threads on the old commits are marked outdated. The webhook-secret fix Codex flagged is included.

---

Changes authored with Claude Code (Opus 5).
