### PR TITLE
fix(cli): approve pnpm build scripts for generated stacks

### DIFF
--- a/apps/cli/test/pnpm-workspace.test.ts
+++ b/apps/cli/test/pnpm-workspace.test.ts
@@ -97,6 +97,27 @@ describe("pnpm workspace", () => {
     });
   });
 
+  it("adds esbuild approval for Vite+ stacks", async () => {
+    const workspace = await readPnpmWorkspace({
+      projectName: "pnpm-svelte-vite-plus",
+      frontend: ["svelte"],
+      backend: "self",
+      runtime: "none",
+      api: "orpc",
+      database: "sqlite",
+      orm: "drizzle",
+      auth: "better-auth",
+      payments: "none",
+      addons: ["evlog", "husky", "oxlint", "ultracite", "vite-plus"],
+      examples: ["none"],
+      dbSetup: "none",
+      webDeploy: "none",
+      serverDeploy: "none",
+    });
+
+    expect(workspace.allowBuilds).toEqual({ esbuild: true });
+  });
+
   it("adds only the React UI approval when no other build-script deps are expected", async () => {
     const workspace = await readPnpmWorkspace({
       projectName: "pnpm-react-ui",
@@ -116,6 +137,55 @@ describe("pnpm workspace", () => {
     });
 
     expect(workspace.allowBuilds).toEqual({ msw: true });
+  });
+
+  it("adds build approvals for a plain Next.js frontend", async () => {
+    const workspace = await readPnpmWorkspace({
+      projectName: "pnpm-next-ui",
+      frontend: ["next"],
+      backend: "none",
+      runtime: "none",
+      api: "none",
+      database: "none",
+      orm: "none",
+      auth: "none",
+      payments: "none",
+      addons: ["none"],
+      examples: ["none"],
+      dbSetup: "none",
+      webDeploy: "none",
+      serverDeploy: "none",
+    });
+
+    expect(workspace.allowBuilds).toEqual({
+      msw: true,
+      sharp: true,
+    });
+  });
+
+  it("adds build approvals for a plain Nuxt frontend", async () => {
+    const workspace = await readPnpmWorkspace({
+      projectName: "pnpm-nuxt-ui",
+      frontend: ["nuxt"],
+      backend: "none",
+      runtime: "none",
+      api: "none",
+      database: "none",
+      orm: "none",
+      auth: "none",
+      payments: "none",
+      addons: ["none"],
+      examples: ["none"],
+      dbSetup: "none",
+      webDeploy: "none",
+      serverDeploy: "none",
+    });
+
+    expect(workspace.allowBuilds).toEqual({
+      esbuild: true,
+      "@parcel/watcher": true,
+      "vue-demi": true,
+    });
   });
 
   it("adds build approvals for native Expo stacks", async () => {

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -23071,12 +23071,12 @@ declare module "cloudflare:workers" {
   ["extras/pnpm-workspace.yaml.hbs", `packages:
   - "apps/*"
   - "packages/*"
-{{#if (or (eq runtime "node") (eq webDeploy "cloudflare") (eq serverDeploy "cloudflare") (eq webDeploy "docker") (eq serverDeploy "docker") (eq orm "prisma") (includes addons "lefthook") (includes addons "nx") (includes addons "pwa") (includes frontend "tanstack-router") (includes frontend "react-router") (includes frontend "tanstack-start") (includes frontend "next") (includes frontend "nuxt") (includes frontend "native-bare") (includes frontend "native-uniwind") (includes frontend "native-unistyles"))}}
+{{#if (or (eq runtime "node") (eq webDeploy "cloudflare") (eq serverDeploy "cloudflare") (eq webDeploy "docker") (eq serverDeploy "docker") (eq orm "prisma") (includes addons "lefthook") (includes addons "nx") (includes addons "pwa") (includes addons "vite-plus") (includes frontend "tanstack-router") (includes frontend "react-router") (includes frontend "tanstack-start") (includes frontend "next") (includes frontend "nuxt") (includes frontend "native-bare") (includes frontend "native-uniwind") (includes frontend "native-unistyles"))}}
 
 # pnpm 11 blocks dependency lifecycle scripts unless they are approved here.
 # Entries are scoped to packages this generated stack can pull in.
 allowBuilds:
-{{#if (or (eq runtime "node") (eq webDeploy "cloudflare") (eq serverDeploy "cloudflare") (eq webDeploy "docker") (eq serverDeploy "docker") (includes frontend "tanstack-start"))}}
+{{#if (or (eq runtime "node") (eq webDeploy "cloudflare") (eq serverDeploy "cloudflare") (eq webDeploy "docker") (eq serverDeploy "docker") (includes addons "vite-plus") (includes frontend "tanstack-start") (includes frontend "nuxt"))}}
   esbuild: true
 {{/if}}
 {{#if (or (includes frontend "tanstack-router") (includes frontend "react-router") (includes frontend "tanstack-start") (includes frontend "next"))}}
@@ -23089,7 +23089,7 @@ allowBuilds:
   "@parcel/watcher": true
   vue-demi: true
 {{/if}}
-{{#if (or (eq webDeploy "cloudflare") (eq serverDeploy "cloudflare") (eq webDeploy "docker") (includes addons "pwa"))}}
+{{#if (or (eq webDeploy "cloudflare") (eq serverDeploy "cloudflare") (eq webDeploy "docker") (includes addons "pwa") (includes frontend "next"))}}
   sharp: true
 {{/if}}
 {{#if (or (eq webDeploy "cloudflare") (eq serverDeploy "cloudflare"))}}

--- a/packages/template-generator/templates/extras/pnpm-workspace.yaml.hbs
+++ b/packages/template-generator/templates/extras/pnpm-workspace.yaml.hbs
@@ -1,12 +1,12 @@
 packages:
   - "apps/*"
   - "packages/*"
-{{#if (or (eq runtime "node") (eq webDeploy "cloudflare") (eq serverDeploy "cloudflare") (eq webDeploy "docker") (eq serverDeploy "docker") (eq orm "prisma") (includes addons "lefthook") (includes addons "nx") (includes addons "pwa") (includes frontend "tanstack-router") (includes frontend "react-router") (includes frontend "tanstack-start") (includes frontend "next") (includes frontend "nuxt") (includes frontend "native-bare") (includes frontend "native-uniwind") (includes frontend "native-unistyles"))}}
+{{#if (or (eq runtime "node") (eq webDeploy "cloudflare") (eq serverDeploy "cloudflare") (eq webDeploy "docker") (eq serverDeploy "docker") (eq orm "prisma") (includes addons "lefthook") (includes addons "nx") (includes addons "pwa") (includes addons "vite-plus") (includes frontend "tanstack-router") (includes frontend "react-router") (includes frontend "tanstack-start") (includes frontend "next") (includes frontend "nuxt") (includes frontend "native-bare") (includes frontend "native-uniwind") (includes frontend "native-unistyles"))}}
 
 # pnpm 11 blocks dependency lifecycle scripts unless they are approved here.
 # Entries are scoped to packages this generated stack can pull in.
 allowBuilds:
-{{#if (or (eq runtime "node") (eq webDeploy "cloudflare") (eq serverDeploy "cloudflare") (eq webDeploy "docker") (eq serverDeploy "docker") (includes frontend "tanstack-start"))}}
+{{#if (or (eq runtime "node") (eq webDeploy "cloudflare") (eq serverDeploy "cloudflare") (eq webDeploy "docker") (eq serverDeploy "docker") (includes addons "vite-plus") (includes frontend "tanstack-start") (includes frontend "nuxt"))}}
   esbuild: true
 {{/if}}
 {{#if (or (includes frontend "tanstack-router") (includes frontend "react-router") (includes frontend "tanstack-start") (includes frontend "next"))}}
@@ -19,7 +19,7 @@ allowBuilds:
   "@parcel/watcher": true
   vue-demi: true
 {{/if}}
-{{#if (or (eq webDeploy "cloudflare") (eq serverDeploy "cloudflare") (eq webDeploy "docker") (includes addons "pwa"))}}
+{{#if (or (eq webDeploy "cloudflare") (eq serverDeploy "cloudflare") (eq webDeploy "docker") (includes addons "pwa") (includes frontend "next"))}}
   sharp: true
 {{/if}}
 {{#if (or (eq webDeploy "cloudflare") (eq serverDeploy "cloudflare"))}}


### PR DESCRIPTION
## Summary

- Adds missing pnpm `allowBuilds` coverage for generated Vite+, Nuxt, and Next.js stacks.
- Regenerates the embedded template map so published scaffolds include the updated `pnpm-workspace.yaml` template.
- Adds regression tests for Vite+, plain Next.js, and plain Nuxt approval output.

## Root Cause

pnpm 11 blocks dependency lifecycle scripts unless they are approved in `pnpm-workspace.yaml`. The template already knew about the relevant package names, but a few stack conditions were too narrow: Vite+ stacks need `esbuild`, plain Nuxt needs `esbuild`, and plain Next.js needs `sharp`.

## Validation

- `bun test apps/cli/test/pnpm-workspace.test.ts`
- `bun run check`
- Fresh generated plain Nuxt project: `pnpm install` completes without ignored-build errors
- Fresh generated plain Next.js project: `pnpm install` completes without ignored-build errors
- Covering-matrix union install confirmed the known approval package set: `esbuild`, `msw`, `msgpackr-extract`, `@parcel/watcher`, `vue-demi`, `sharp`, `workerd`, `@prisma/engines`, `prisma`, `lefthook`, `nx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for `pnpm-workspace.yaml` generation across Vite+, Next.js, and Nuxt stack configurations.

* **Bug Fixes**
  * Refined build permission settings for different project configurations to optimize dependency build handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->