### PR TITLE
feat(template-generator): update Astro template to v7

### DIFF
--- a/packages/template-generator/src/processors/deploy-deps.ts
+++ b/packages/template-generator/src/processors/deploy-deps.ts
@@ -86,7 +86,12 @@ export function processDeployDeps(vfs: VirtualFileSystem, config: ProjectConfig)
         vfs,
         packagePath: webPkgPath,
         dependencies: ["@astrojs/node"],
-        devDependencies: ["alchemy", "@astrojs/cloudflare", "@cloudflare/workers-types"],
+        devDependencies: [
+          "alchemy",
+          "@astrojs/cloudflare",
+          "wrangler",
+          "@cloudflare/workers-types",
+        ],
       });
     } else if (
       frontend.includes("tanstack-router") ||

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -23169,7 +23169,7 @@ export default defineConfig({
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^6.0.1"
+    "astro": "^7.0.0"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.18",

--- a/packages/template-generator/src/utils/add-deps.ts
+++ b/packages/template-generator/src/utils/add-deps.ts
@@ -146,15 +146,15 @@ export const dependencyVersionMap = {
   "@tanstack/solid-query-devtools": "^5.99.1",
   "@tanstack/solid-router-devtools": "^1.166.13",
 
-  wrangler: "^4.77.0",
+  wrangler: "^4.103.0",
   "@cloudflare/vite-plugin": "^1.17.1",
   "@opennextjs/cloudflare": "^1.17.3",
   "nitro-cloudflare-dev": "^0.2.2",
   "@sveltejs/adapter-cloudflare": "^7.2.8",
   "@sveltejs/adapter-node": "^5.5.4",
-  "@cloudflare/workers-types": "^4.20251213.0",
-  "@astrojs/cloudflare": "^13.0.1",
-  "@astrojs/node": "^10.0.0-beta.9",
+  "@cloudflare/workers-types": "^4.20260621.1",
+  "@astrojs/cloudflare": "^14.0.0",
+  "@astrojs/node": "^11.0.0",
 
   alchemy: "^0.91.2",
 

--- a/packages/template-generator/src/utils/generated-ignore-patterns.ts
+++ b/packages/template-generator/src/utils/generated-ignore-patterns.ts
@@ -23,6 +23,7 @@ const FRONTEND_GENERATED_PATTERNS = {
     "apps/native/ios/**",
     "apps/native/android/**",
   ],
+  none: [],
 } as const satisfies Partial<Record<ProjectConfig["frontend"][number], readonly string[]>>;
 
 const SERVER_BUILD_BACKENDS = ["hono", "express", "fastify", "elysia"] as const;

--- a/packages/template-generator/templates/frontend/astro/package.json.hbs
+++ b/packages/template-generator/templates/frontend/astro/package.json.hbs
@@ -10,7 +10,7 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^6.0.1"
+    "astro": "^7.0.0"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.18",


### PR DESCRIPTION
## Summary

- Update the generated Astro web template to Astro 7.
- Bump official Astro adapter dependencies for Node and Cloudflare deploy targets.
- Add Wrangler to Astro Cloudflare web deploy dependencies to satisfy the new adapter peer requirements.
- Regenerate embedded templates and fix the `frontend: ["none"]` generated-ignore-pattern type case surfaced during validation.

## Validation

- `bun run check`
- `cd packages/template-generator && bun run typecheck`
- `cd packages/template-generator && bun run build`
- Generated 12 Astro-related scaffold combinations and ran `bun install`, `bun run build`, and `bun run check-types` for each.
- Ran browser smoke checks against generated Astro apps with dev servers and headless Chromium:
  - home page renders
  - oRPC status reaches `Connected`
  - todo pages can create and toggle todos
  - Better Auth non-Polar flows can sign up and reach the dashboard
  - Cloudflare self, Docker server, Astro + native companion, and evlog self variants boot and render

Note: the Better Auth + Polar runtime smoke was limited to boot/API validation with dummy Polar env values. Full signup requires a real `POLAR_ACCESS_TOKEN` because the generated Polar integration performs live Polar-backed work during signup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wrangler is now included as a deployment dependency for Astro projects on Cloudflare.
  * Added explicit support for the "none" frontend option in template generation.

* **Updates**
  * Upgraded Astro template from version 6.0.1 to 7.0.0.
  * Updated Cloudflare Workers types, Wrangler, and related Astro integration packages to latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->