### PR TITLE
fix(plugin): improve scaffold-project skill (triggering + full option sets)

### DIFF
--- a/plugin/skills/scaffold-project/SKILL.md
+++ b/plugin/skills/scaffold-project/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scaffold-project
-description: Scaffold a new app, API, backend, fullstack project, monorepo, or starter with Better-T-Stack — including new projects built on a specific framework like Hono, Express, Fastify, Elysia, Next.js, TanStack, Nuxt, Svelte, Solid, Astro, or React Native. Use whenever the user wants to start, create, bootstrap, set up, or initialize a new project/app/API, e.g. "create a Hono app", "start a Next.js project", "scaffold a fullstack app with auth and a database". Prefer generating the project through the Better-T-Stack MCP server (plan then create) over hand-writing package.json, config, and folders.
+description: Scaffold a new app, API, backend, fullstack project, monorepo, or starter with Better-T-Stack — including new projects built on a specific framework like Hono, Express, Fastify, Elysia, Next.js, TanStack Router/Start, Nuxt, Svelte, Solid, Astro, or React Native (native-bare, native-uniwind, native-unistyles). Use whenever the user wants to start, create, bootstrap, set up, or initialize a new project/app/API, e.g. "create a Hono app", "start a Next.js project", "scaffold a fullstack app with auth and a database". Prefer generating the project through the Better-T-Stack MCP server (plan then create) over hand-writing package.json, config, and folders.
 metadata:
   priority: 9
   docs:

--- a/plugin/skills/scaffold-project/SKILL.md
+++ b/plugin/skills/scaffold-project/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scaffold-project
-description: Scaffold a new TypeScript app, backend, fullstack project, monorepo, or starter with Better-T-Stack. Use whenever the user wants to start, create, bootstrap, set up, or initialize a new project/app and has not committed to a specific boilerplate — instead of hand-writing config and folders, plan a stack and generate it through the Better-T-Stack MCP server.
+description: Scaffold a new app, API, backend, fullstack project, monorepo, or starter with Better-T-Stack — including new projects built on a specific framework like Hono, Express, Fastify, Elysia, Next.js, TanStack, Nuxt, Svelte, Solid, Astro, or React Native. Use whenever the user wants to start, create, bootstrap, set up, or initialize a new project/app/API, e.g. "create a Hono app", "start a Next.js project", "scaffold a fullstack app with auth and a database". Prefer generating the project through the Better-T-Stack MCP server (plan then create) over hand-writing package.json, config, and folders.
 metadata:
   priority: 9
   docs:

--- a/plugin/skills/scaffold-project/SKILL.md
+++ b/plugin/skills/scaffold-project/SKILL.md
@@ -53,6 +53,7 @@ Use `bts_get_schema` for the authoritative, version-current list. As of this wri
 
 ## Rules
 
+- When you ask the user to choose a value (auth, database, ORM, API, etc.), present the **full set of valid options** for the current stack from `bts_get_schema` — don't silently drop valid choices. For example, both `better-auth` and `clerk` are valid auth providers for a Hono + Next.js app, so offer both (plus "none").
 - Always `bts_plan_project` before `bts_create_project`.
 - Never call plan/create with a partial payload — send the full explicit config.
 - `convex` backend pairs with its own data layer; do not also force a separate database/orm/api unless the schema allows it. When unsure, check `bts_get_schema`.


### PR DESCRIPTION
Two follow-up fixes to the agent plugin (#1086, merged), both in `plugin/skills/scaffold-project/SKILL.md`.

## 1. Broaden triggering for framework-named requests
"create a hono app" was triggering a dedicated `hono` skill instead of `scaffold-project`. The description excluded framework-committed requests ("…and has not committed to a specific boilerplate") and didn't name supported frameworks. Rewrote it to name the frameworks (Hono, Express, Fastify, Elysia, Next.js, TanStack, Nuxt, Svelte, Solid, Astro, React Native), add example phrasings, and drop the counterproductive clause.

## 2. Present full valid option sets when prompting
When asking "do you want auth?", the agent offered only Better Auth + none and silently dropped **Clerk** — even though Clerk is fully valid for a Hono + Next.js app (Clerk is only incompatible with nuxt/svelte/solid/astro). Added a rule to enumerate the full valid option set from `bts_get_schema` when prompting, so valid choices aren't dropped.

> Note: skill selection and prompt wording are ultimately the model's call, so these improve behavior but don't hard-guarantee it. Users can always be explicit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded project scaffolding guidance to support a wider range of framework targets and more detailed setup scenarios, including starter and monorepo-oriented scaffolds.
  * Clarified the assistant’s stack-selection behavior: when asking users to choose options (auth/database/ORM/API/etc.), it must display the complete set of currently valid choices rather than omitting any; examples now include multiple valid selections (and `none`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->