### PR TITLE
feat(opencode): native opencode plugin + MCP docs

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -279,6 +279,12 @@ export function createBtsCli(): ReturnType<typeof createCli> {
 // Re-export Result type from better-result for programmatic API consumers
 export { Result } from "better-result";
 
+// Re-export stack guidance so non-MCP integrations (e.g. the opencode plugin) share one source
+export { getStackGuidance } from "./stack-guidance";
+
+// Re-export the bts.jsonc reader so integrations can detect/inspect existing projects
+export { readBtsConfig } from "./utils/bts-config";
+
 /**
  * Error types that can be returned from create/createVirtual
  */

--- a/apps/cli/src/mcp.ts
+++ b/apps/cli/src/mcp.ts
@@ -3,6 +3,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import z from "zod";
 
 import { add, create, type SchemaName, SchemaNameSchema, getSchemaResult } from "./index";
+import { getStackGuidance } from "./stack-guidance";
 import {
   AddInputSchema,
   AddonOptionsSchema,
@@ -117,64 +118,6 @@ function getMcpInstallTimeoutMessage(packageManager: string) {
     "Dependency installation can exceed common MCP client request timeouts and cause the connection to close before the tool returns.",
     `Scaffold the project first, then run \`${packageManager} install\` in the generated project directory from a terminal.`,
   ].join(" ");
-}
-
-function getStackGuidance() {
-  return {
-    workflow: [
-      "Call bts_get_schema or bts_get_stack_guidance before constructing a config if the request is ambiguous.",
-      "For project creation, build a full explicit config before calling bts_plan_project.",
-      "Always call bts_plan_project before bts_create_project.",
-      "Only call bts_create_project after the plan succeeds and matches the user's intent.",
-      "Use bts_plan_addons before bts_add_addons for existing projects.",
-    ],
-    createContract: {
-      requiresExplicitFields: [
-        "projectName",
-        "frontend",
-        "backend",
-        "runtime",
-        "database",
-        "orm",
-        "api",
-        "auth",
-        "payments",
-        "addons",
-        "examples",
-        "git",
-        "packageManager",
-        "install",
-        "dbSetup",
-        "webDeploy",
-        "serverDeploy",
-      ],
-      optionalFields: ["addonOptions", "dbSetupOptions", "directoryConflict"],
-      rule: "Do not call bts_plan_project or bts_create_project with a partial payload. MCP project creation requires the full explicit stack config.",
-    },
-    fieldNotes: {
-      frontend:
-        "frontend is for app surfaces only. Choose explicit app targets such as next, react-router, tanstack-router, native-bare, native-uniwind, or native-unistyles.",
-      addons: "addons must be an explicit array. Use [] when no addons are requested.",
-      examples: "examples must be an explicit array. Use [] when no examples are requested.",
-      dbSetup:
-        "dbSetup is always required. Use 'none' when no managed database provisioning is requested.",
-      webDeploy:
-        "webDeploy is always required. Use 'none' when no web deployment target is requested.",
-      serverDeploy:
-        "serverDeploy is always required. Use 'none' when no server deployment target is requested.",
-      packageManager:
-        "packageManager is always required because installation and reproducible commands depend on it.",
-      install:
-        "install is always required. For MCP project creation, prefer false because many clients enforce request timeouts around long-running dependency installs.",
-      git: "git is always required. Set it to true or false explicitly instead of relying on defaults.",
-    },
-    ambiguityRules: [
-      "If the user request leaves major stack choices unspecified, stop and resolve them before calling bts_plan_project.",
-      "Do not infer extra app surfaces, addons, examples, or provisioning choices from a template name or styling preference.",
-      "If the user wants the smallest valid stack, still send the full config with explicit 'none', [] , true, or false values where appropriate.",
-      "For MCP execution, scaffold with install=false and let the user or agent run dependency installation separately from a terminal session.",
-    ],
-  };
 }
 
 export function createBtsMcpServer() {

--- a/apps/cli/src/stack-guidance.ts
+++ b/apps/cli/src/stack-guidance.ts
@@ -1,0 +1,60 @@
+// Static guidance for choosing a valid Better T Stack configuration.
+// Kept dependency-free so it can be shared by the MCP server and other
+// integrations (e.g. the opencode plugin) without pulling in the MCP SDK.
+export function getStackGuidance() {
+  return {
+    workflow: [
+      "Call bts_get_schema or bts_get_stack_guidance before constructing a config if the request is ambiguous.",
+      "For project creation, build a full explicit config before calling bts_plan_project.",
+      "Always call bts_plan_project before bts_create_project.",
+      "Only call bts_create_project after the plan succeeds and matches the user's intent.",
+      "Use bts_plan_addons before bts_add_addons for existing projects.",
+    ],
+    createContract: {
+      requiresExplicitFields: [
+        "projectName",
+        "frontend",
+        "backend",
+        "runtime",
+        "database",
+        "orm",
+        "api",
+        "auth",
+        "payments",
+        "addons",
+        "examples",
+        "git",
+        "packageManager",
+        "install",
+        "dbSetup",
+        "webDeploy",
+        "serverDeploy",
+      ],
+      optionalFields: ["addonOptions", "dbSetupOptions", "directoryConflict"],
+      rule: "Do not call bts_plan_project or bts_create_project with a partial payload. MCP project creation requires the full explicit stack config.",
+    },
+    fieldNotes: {
+      frontend:
+        "frontend is for app surfaces only. Choose explicit app targets such as next, react-router, tanstack-router, native-bare, native-uniwind, or native-unistyles.",
+      addons: "addons must be an explicit array. Use [] when no addons are requested.",
+      examples: "examples must be an explicit array. Use [] when no examples are requested.",
+      dbSetup:
+        "dbSetup is always required. Use 'none' when no managed database provisioning is requested.",
+      webDeploy:
+        "webDeploy is always required. Use 'none' when no web deployment target is requested.",
+      serverDeploy:
+        "serverDeploy is always required. Use 'none' when no server deployment target is requested.",
+      packageManager:
+        "packageManager is always required because installation and reproducible commands depend on it.",
+      install:
+        "install is always required. For MCP project creation, prefer false because many clients enforce request timeouts around long-running dependency installs.",
+      git: "git is always required. Set it to true or false explicitly instead of relying on defaults.",
+    },
+    ambiguityRules: [
+      "If the user request leaves major stack choices unspecified, stop and resolve them before calling bts_plan_project.",
+      "Do not infer extra app surfaces, addons, examples, or provisioning choices from a template name or styling preference.",
+      "If the user wants the smallest valid stack, still send the full config with explicit 'none', [] , true, or false values where appropriate.",
+      "For MCP execution, scaffold with install=false and let the user or agent run dependency installation separately from a terminal session.",
+    ],
+  };
+}

--- a/apps/web/content/docs/cli/agent-workflows.mdx
+++ b/apps/web/content/docs/cli/agent-workflows.mdx
@@ -212,11 +212,28 @@ args = ["-y", "create-better-t-stack@latest", "mcp"]
 
 ### opencode
 
-Add the MCP server, then ask for a project in chat:
+opencode has no plugin marketplace, but it supports the MCP server natively. Add it interactively:
 
 ```bash
-npx -y add-mcp@latest "npx -y create-better-t-stack@latest mcp"   # choose "opencode"
+opencode mcp add
 ```
+
+…and enter name `better-t-stack`, type `local`, command `npx -y create-better-t-stack@latest mcp`. Or add it to `opencode.json` directly:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "better-t-stack": {
+      "type": "local",
+      "command": ["npx", "-y", "create-better-t-stack@latest", "mcp"],
+      "enabled": true
+    }
+  }
+}
+```
+
+The two skills use the same `SKILL.md` format opencode reads — drop `scaffold-project` and `add-to-project` into `~/.config/opencode/skills/` (or `.opencode/skills/`) for the same proactive scaffolding.
 
 ### Other agents
 

--- a/apps/web/content/docs/cli/agent-workflows.mdx
+++ b/apps/web/content/docs/cli/agent-workflows.mdx
@@ -212,7 +212,20 @@ args = ["-y", "create-better-t-stack@latest", "mcp"]
 
 ### opencode
 
-opencode has no plugin marketplace, but it supports the MCP server natively. Add it interactively:
+The fastest path is the native opencode plugin, [`@better-t-stack/opencode`](https://www.npmjs.com/package/@better-t-stack/opencode). Add one line to `opencode.json` (or `~/.config/opencode/opencode.json`):
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["@better-t-stack/opencode"]
+}
+```
+
+opencode installs it on startup. It registers the `bts_*` tools natively **and** makes the agent Better-T-Stack aware — inside a project (with a `bts.jsonc`) it surfaces the stack and steers toward `bts_add_addons`; elsewhere it points at the scaffold tools. Then just ask for a project in chat.
+
+#### MCP server (alternative)
+
+opencode also supports the MCP server directly. Add it interactively:
 
 ```bash
 opencode mcp add

--- a/bun.lock
+++ b/bun.lock
@@ -141,6 +141,22 @@
         "create-better-t-stack": "^3.28.0",
       },
     },
+    "packages/opencode-plugin": {
+      "name": "@better-t-stack/opencode",
+      "version": "3.35.0",
+      "dependencies": {
+        "@better-t-stack/types": "workspace:*",
+        "create-better-t-stack": "workspace:*",
+      },
+      "devDependencies": {
+        "@opencode-ai/plugin": "1.14.48",
+        "tsdown": "^0.22.0",
+        "typescript": "^6.0.3",
+      },
+      "peerDependencies": {
+        "@opencode-ai/plugin": ">=1",
+      },
+    },
     "packages/template-generator": {
       "name": "@better-t-stack/template-generator",
       "version": "3.35.0",
@@ -232,6 +248,8 @@
     "@base-ui/utils": ["@base-ui/utils@0.2.8", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@floating-ui/utils": "^0.2.11", "reselect": "^5.1.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-jvOi+c+ftGlGotNcKnzPVg2IhCaDTB6/6R3JeqdjdXktuAJi3wKH9T7+svuaKh1mmfVU11UWzUZVH74JDfi/wQ=="],
 
     "@better-t-stack/backend": ["@better-t-stack/backend@workspace:packages/backend"],
+
+    "@better-t-stack/opencode": ["@better-t-stack/opencode@workspace:packages/opencode-plugin"],
 
     "@better-t-stack/template-generator": ["@better-t-stack/template-generator@workspace:packages/template-generator"],
 
@@ -433,6 +451,18 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="],
+
+    "@msgpackr-extract/msgpackr-extract-darwin-x64": ["@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm": ["@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4", "", { "os": "linux", "cpu": "arm" }, "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm64": ["@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-x64": ["@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ=="],
+
+    "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4", "", { "os": "win32", "cpu": "x64" }, "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ=="],
+
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
     "@next/env": ["@next/env@16.2.6", "", {}, "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw=="],
@@ -516,6 +546,10 @@
     "@octokit/webhooks": ["@octokit/webhooks@13.9.1", "", { "dependencies": { "@octokit/openapi-webhooks-types": "11.0.0", "@octokit/request-error": "^6.1.7", "@octokit/webhooks-methods": "^5.1.1" } }, "sha512-Nss2b4Jyn4wB3EAqAPJypGuCJFalz/ZujKBQQ5934To7Xw9xjf4hkr/EAByxQY7hp7MKd790bWGz7XYSTsHmaw=="],
 
     "@octokit/webhooks-methods": ["@octokit/webhooks-methods@5.1.1", "", {}, "sha512-NGlEHZDseJTCj8TMMFehzwa9g7On4KJMPVHDSrHxCQumL6uSQR8wIkP/qesv52fXqV1BPf4pTxwtS31ldAt9Xg=="],
+
+    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.14.48", "", { "dependencies": { "@opencode-ai/sdk": "1.14.48", "effect": "4.0.0-beta.59", "zod": "4.1.8" }, "peerDependencies": { "@opentui/core": ">=0.2.6", "@opentui/keymap": ">=0.2.6", "@opentui/solid": ">=0.2.6" }, "optionalPeers": ["@opentui/core", "@opentui/keymap", "@opentui/solid"] }, "sha512-pb2ywByzn4i35WWJquEYyb8lDC/ph1PLXT+heucJN6Y9U/oeSw98JQV93IG7M6BUBks6MKD3DGDJdQfyD6x0rA=="],
+
+    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.14.48", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-wKM86jCzV/ZApyWrdm3uP8XdWcS0LMbu3FV+OWz1ChiGGg1wiIWNGMJs5CY8/QX2/rUuZrd1Q1DqvdamZ0zLeg=="],
 
     "@orama/orama": ["@orama/orama@3.1.18", "", {}, "sha512-a61ljmRVVyG5MC/698C8/FfFDw5a8LOIvyOLW5fztgUXqUpc1jOfQzOitSCbge657OgXXThmY3Tk8fpiDb4UcA=="],
 
@@ -1259,6 +1293,8 @@
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
+    "effect": ["effect@4.0.0-beta.59", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.6.0", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.9", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^13.0.0", "yaml": "^2.8.3" } }, "sha512-xyUDLeHSe8d6lWGOvR6Fgn2HL6gYeTZ/S4Jzk9uc4ZUxMPPsNZlNXrvk0C7/utQFzeX7uAWcVnG2BjbA0SRoAA=="],
+
     "electron-to-chromium": ["electron-to-chromium@1.5.307", "", {}, "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg=="],
 
     "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
@@ -1375,6 +1411,8 @@
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
+    "fast-check": ["fast-check@4.8.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg=="],
+
     "fast-content-type-parse": ["fast-content-type-parse@2.0.1", "", {}, "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
@@ -1404,6 +1442,8 @@
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "find-my-way-ts": ["find-my-way-ts@0.1.6", "", {}, "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA=="],
 
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
@@ -1549,6 +1589,8 @@
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
+    "ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
+
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
 
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
@@ -1682,6 +1724,8 @@
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
     "kind-of": ["kind-of@6.0.3", "", {}, "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="],
+
+    "kubernetes-types": ["kubernetes-types@1.30.0", "", {}, "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q=="],
 
     "language-subtag-registry": ["language-subtag-registry@0.3.23", "", {}, "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ=="],
 
@@ -1907,6 +1951,12 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "msgpackr": ["msgpackr@1.12.1", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.2" } }, "sha512-4EUH9tQHnMmEgzW/MdAP0KIfa1T9AF+htl0ffe2n5vb2EKn9y2co8ccpgWko6S52Jy1PQZKwRnx5/KkYjtd9MQ=="],
+
+    "msgpackr-extract": ["msgpackr-extract@3.0.4", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw=="],
+
+    "multipasta": ["multipasta@0.2.7", "", {}, "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA=="],
+
     "nano": ["nano@10.1.4", "", { "dependencies": { "axios": "^1.7.4", "node-abort-controller": "^3.1.1", "qs": "^6.13.0" } }, "sha512-bJOFIPLExIbF6mljnfExXX9Cub4W0puhDjVMp+qV40xl/DBvgKao7St4+6/GB6EoHZap7eFnrnx4mnp5KYgwJA=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
@@ -1930,6 +1980,8 @@
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "node-fetch-native": ["node-fetch-native@1.6.7", "", {}, "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q=="],
+
+    "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
 
     "node-releases": ["node-releases@2.0.36", "", {}, "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA=="],
 
@@ -2062,6 +2114,8 @@
     "publint": ["publint@0.3.21", "", { "dependencies": { "@publint/pack": "^0.1.4", "package-manager-detector": "^1.6.0", "picocolors": "^1.1.1", "sade": "^1.8.1" }, "bin": { "publint": "src/cli.js" } }, "sha512-OqejcnMV6E9zel2oCrUOJEiiFkGiAAni0A6ibfQNh1k9Gu5z4F+Yso8lllam7AzmV6Do0vp7u3UpZNRBwuXaHQ=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "pure-rand": ["pure-rand@8.4.1", "", {}, "sha512-c58R2+SPFcSIPXoU834QN/KPDDOSd8sXcSrqf6e83Me6Rrp1EYkxukkjXMVrKvKaADs1SOyNkWdfvLf6zY8qLQ=="],
 
     "qrcode": ["qrcode@1.5.4", "", { "dependencies": { "dijkstrajs": "^1.0.1", "pngjs": "^5.0.0", "yargs": "^15.3.1" }, "bin": { "qrcode": "bin/qrcode" } }, "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg=="],
 
@@ -2315,6 +2369,8 @@
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
+    "toml": ["toml@4.1.1", "", {}, "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw=="],
+
     "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
     "tree-dump": ["tree-dump@1.1.0", "", { "peerDependencies": { "tslib": "2" } }, "sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA=="],
@@ -2406,6 +2462,8 @@
     "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
+    "uuid": ["uuid@13.0.2", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
@@ -2526,6 +2584,8 @@
     "@mdx-js/mdx/source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
     "@modelcontextprotocol/sdk/zod": ["zod@4.4.2", "", {}, "sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw=="],
+
+    "@opencode-ai/plugin/zod": ["zod@4.1.8", "", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
 
     "@reduxjs/toolkit/immer": ["immer@11.1.4", "", {}, "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw=="],
 

--- a/packages/opencode-plugin/README.md
+++ b/packages/opencode-plugin/README.md
@@ -1,0 +1,43 @@
+# @better-t-stack/opencode
+
+An [opencode](https://opencode.ai) plugin that lets your AI agent scaffold and extend projects with [Better-T-Stack](https://better-t-stack.dev) — natively, with no MCP server to wire up.
+
+## What it does
+
+- **Registers native opencode tools** that mirror the Better-T-Stack MCP:
+  - `bts_get_stack_guidance`, `bts_get_schema` — discover valid options
+  - `bts_plan_project`, `bts_create_project` — plan then generate a project
+  - `bts_plan_addons`, `bts_add_addons` — plan then add addons to an existing project
+- **Makes the agent Better-T-Stack aware.** It injects context into the system prompt: inside a Better-T-Stack project (a `bts.jsonc` is present) it surfaces the current stack and steers the agent to extend it with `bts_add_addons`; elsewhere it points the agent at the scaffold tools for new projects.
+
+## Install
+
+Add it to your opencode config (`opencode.json` or `~/.config/opencode/opencode.json`):
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["@better-t-stack/opencode"]
+}
+```
+
+opencode installs the package automatically on startup. Then just ask:
+
+> "create a fullstack app with Next, Hono, Postgres and Better Auth"
+
+The agent plans a valid stack and generates it. Dependencies are not installed automatically — run your package manager's `install` in the new project afterwards.
+
+## Workflow
+
+1. `bts_get_stack_guidance` / `bts_get_schema` for valid options (when the request is ambiguous)
+2. `bts_plan_project` (dry run) — confirm the resolved stack
+3. `bts_create_project` — generate (no install)
+4. For existing projects: `bts_plan_addons` → `bts_add_addons`
+
+## Alternative: MCP server
+
+Prefer MCP? Better-T-Stack also ships a stdio MCP server that works in opencode (`opencode mcp add` → `npx -y create-better-t-stack@latest mcp`). This plugin is the native opencode alternative, with the added system-prompt awareness.
+
+## License
+
+MIT

--- a/packages/opencode-plugin/package.json
+++ b/packages/opencode-plugin/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@better-t-stack/opencode",
+  "version": "3.35.0",
+  "description": "OpenCode plugin that scaffolds and extends projects with Better-T-Stack",
+  "keywords": [
+    "ai-agent",
+    "better-t-stack",
+    "opencode",
+    "opencode-plugin",
+    "scaffold",
+    "typescript"
+  ],
+  "homepage": "https://better-t-stack.dev",
+  "license": "MIT",
+  "author": "Aman Varshney",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AmanVarshney01/create-better-t-stack.git",
+    "directory": "packages/opencode-plugin"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "default": "./dist/index.mjs"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "check-types": "tsc --noEmit",
+    "prepublishOnly": "bun run build"
+  },
+  "dependencies": {
+    "@better-t-stack/types": "^3.35.0",
+    "create-better-t-stack": "^3.35.0"
+  },
+  "devDependencies": {
+    "@opencode-ai/plugin": "1.14.48",
+    "tsdown": "^0.22.0",
+    "typescript": "^6.0.3"
+  },
+  "peerDependencies": {
+    "@opencode-ai/plugin": ">=1"
+  }
+}

--- a/packages/opencode-plugin/src/index.ts
+++ b/packages/opencode-plugin/src/index.ts
@@ -1,0 +1,254 @@
+import {
+  ADDONS_VALUES,
+  API_VALUES,
+  AUTH_VALUES,
+  BACKEND_VALUES,
+  DATABASE_SETUP_VALUES,
+  DATABASE_VALUES,
+  DIRECTORY_CONFLICT_VALUES,
+  EXAMPLES_VALUES,
+  FRONTEND_VALUES,
+  ORM_VALUES,
+  PACKAGE_MANAGER_VALUES,
+  PAYMENTS_VALUES,
+  RUNTIME_VALUES,
+  SERVER_DEPLOY_VALUES,
+  WEB_DEPLOY_VALUES,
+} from "@better-t-stack/types";
+import { tool, type Plugin } from "@opencode-ai/plugin";
+import {
+  add,
+  create,
+  getSchemaResult,
+  getStackGuidance,
+  readBtsConfig,
+} from "create-better-t-stack";
+
+// Use opencode's bundled zod (via tool.schema) so arg schemas match the host runtime.
+const z = tool.schema;
+const enumOf = (values: readonly string[]) => z.enum(values as [string, ...string[]]);
+
+function ok(data: unknown): string {
+  return JSON.stringify({ ok: true, data }, null, 2);
+}
+
+function fail(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return JSON.stringify({ ok: false, error: message }, null, 2);
+}
+
+// Shared explicit project-config args. Enum values come from @better-t-stack/types,
+// so the option set always tracks the CLI.
+const projectConfigArgs = {
+  frontend: z
+    .array(enumOf(FRONTEND_VALUES))
+    .describe("App surfaces (not styling). Use [] for none, e.g. an API-only project."),
+  backend: enumOf(BACKEND_VALUES),
+  runtime: enumOf(RUNTIME_VALUES),
+  database: enumOf(DATABASE_VALUES),
+  orm: enumOf(ORM_VALUES),
+  api: enumOf(API_VALUES),
+  auth: enumOf(AUTH_VALUES),
+  payments: enumOf(PAYMENTS_VALUES),
+  addons: z.array(enumOf(ADDONS_VALUES)).describe("Use [] when no addons are requested."),
+  examples: z.array(enumOf(EXAMPLES_VALUES)).describe("Use [] when no examples are requested."),
+  git: z.boolean(),
+  packageManager: enumOf(PACKAGE_MANAGER_VALUES),
+  dbSetup: enumOf(DATABASE_SETUP_VALUES).describe("Use 'none' when no DB provisioning is wanted."),
+  webDeploy: enumOf(WEB_DEPLOY_VALUES),
+  serverDeploy: enumOf(SERVER_DEPLOY_VALUES),
+  directoryConflict: enumOf(DIRECTORY_CONFLICT_VALUES).optional(),
+  addonOptions: z.any().optional().describe("Nested addon options (see bts_get_schema)."),
+  dbSetupOptions: z
+    .any()
+    .optional()
+    .describe("Nested database-setup options (see bts_get_schema)."),
+};
+
+const addonArgs = {
+  projectDir: z.string().describe("Path to the existing Better-T-Stack project"),
+  addons: z.array(enumOf(ADDONS_VALUES)).describe("Addons to install"),
+  packageManager: enumOf(PACKAGE_MANAGER_VALUES).optional(),
+  addonOptions: z.any().optional().describe("Nested addon options (see bts_get_schema)."),
+};
+
+// Build a short system-prompt note so the agent is Better-T-Stack aware: inside a
+// BTS project it knows the stack and to extend via the addon tools; elsewhere it
+// knows the scaffold tools exist. Computed once at plugin load for the workspace.
+async function buildSystemContext(directory: string): Promise<string> {
+  let config: Awaited<ReturnType<typeof readBtsConfig>> = null;
+  try {
+    config = await readBtsConfig(directory);
+  } catch {
+    config = null;
+  }
+
+  if (config) {
+    const parts: string[] = [];
+    if (Array.isArray(config.frontend) && config.frontend.length) {
+      parts.push(`frontend [${config.frontend.join(", ")}]`);
+    }
+    if (config.backend) parts.push(`backend ${config.backend}`);
+    if (config.runtime) parts.push(`runtime ${config.runtime}`);
+    if (config.database && config.database !== "none") parts.push(`database ${config.database}`);
+    if (config.orm && config.orm !== "none") parts.push(`orm ${config.orm}`);
+    if (config.api && config.api !== "none") parts.push(`api ${config.api}`);
+    if (config.auth && config.auth !== "none") parts.push(`auth ${config.auth}`);
+    if (Array.isArray(config.addons) && config.addons.length) {
+      parts.push(`addons [${config.addons.join(", ")}]`);
+    }
+    const stack = parts.length ? ` Stack: ${parts.join(", ")}.` : "";
+    return [
+      `This workspace is a Better-T-Stack project (bts.jsonc present).${stack}`,
+      "When the user wants to add tooling or features (PWA, docs, linters, task runners, the MCP addon, etc.), use the bts_add_addons tool — call bts_plan_addons first — instead of wiring it by hand.",
+      "To scaffold a brand-new project, use bts_plan_project then bts_create_project.",
+    ].join(" ");
+  }
+
+  return [
+    "Better-T-Stack tools are available to scaffold new end-to-end type-safe projects.",
+    "When the user wants to start, create, or bootstrap a new app/API/fullstack project, prefer bts_plan_project then bts_create_project (use bts_get_schema / bts_get_stack_guidance for valid options) over hand-writing project config and folders.",
+  ].join(" ");
+}
+
+/**
+ * Better-T-Stack opencode plugin.
+ *
+ * Registers native opencode tools that plan and generate end-to-end type-safe
+ * projects with Better-T-Stack (mirroring the official MCP server), and injects
+ * Better-T-Stack awareness into the system prompt so the agent reaches for the
+ * right tools — scaffolding new projects, or extending the current one via addons.
+ *
+ * The agent should call bts_plan_project before bts_create_project, and
+ * bts_plan_addons before bts_add_addons.
+ */
+export const BetterTStackPlugin: Plugin = async ({ directory }) => {
+  const systemContext = await buildSystemContext(directory);
+
+  return {
+    "experimental.chat.system.transform": async (_input, output) => {
+      output.system.push(systemContext);
+    },
+    tool: {
+      bts_get_stack_guidance: tool({
+        description:
+          "Read guidance for choosing a valid Better-T-Stack configuration: the full explicit config the create tools expect, field semantics, and ambiguity rules. Use this first when a request is ambiguous.",
+        args: {},
+        async execute() {
+          try {
+            return ok(getStackGuidance());
+          } catch (error) {
+            return fail(error);
+          }
+        },
+      }),
+
+      bts_get_schema: tool({
+        description:
+          "Inspect Better-T-Stack CLI and input schemas (the exact allowed values for every field). Use together with bts_get_stack_guidance before planning when any part of the request is ambiguous.",
+        args: {
+          name: z
+            .string()
+            .optional()
+            .describe(
+              "Schema name (e.g. createInput, addInput, projectConfig). Defaults to 'all'.",
+            ),
+        },
+        async execute({ name }) {
+          try {
+            return ok(getSchemaResult((name ?? "all") as never));
+          } catch (error) {
+            return fail(error);
+          }
+        },
+      }),
+
+      bts_plan_project: tool({
+        description:
+          "Validate and preview a Better-T-Stack project without writing files or provisioning resources (dry run). Always call this before bts_create_project. Provide a full explicit config; use 'none', [], and booleans rather than omitting fields.",
+        args: {
+          projectName: z.string().describe("Project name or relative path"),
+          ...projectConfigArgs,
+        },
+        async execute({ projectName, ...config }) {
+          try {
+            const result = await create(projectName, {
+              ...(config as Record<string, unknown>),
+              dryRun: true,
+              disableAnalytics: true,
+            });
+            return result.isErr() ? fail(result.error) : ok(result.value);
+          } catch (error) {
+            return fail(error);
+          }
+        },
+      }),
+
+      bts_create_project: tool({
+        description:
+          "Create a Better-T-Stack project on disk. Call only after bts_plan_project succeeds and matches the user's intent. Dependencies are NOT installed — tell the user to run their package manager's install in the new project directory afterwards.",
+        args: {
+          projectName: z.string().describe("Project name or relative path"),
+          ...projectConfigArgs,
+        },
+        async execute({ projectName, ...config }) {
+          try {
+            const result = await create(projectName, {
+              ...(config as Record<string, unknown>),
+              install: false,
+              disableAnalytics: true,
+            });
+            return result.isErr() ? fail(result.error) : ok(result.value);
+          } catch (error) {
+            return fail(error);
+          }
+        },
+      }),
+
+      bts_plan_addons: tool({
+        description:
+          "Validate and preview addon installation for an existing Better-T-Stack project without writing files (dry run). Always call this before bts_add_addons.",
+        args: addonArgs,
+        async execute({ projectDir, addons, packageManager, addonOptions }) {
+          try {
+            const result = await add({
+              projectDir,
+              addons: addons as never,
+              packageManager: packageManager as never,
+              addonOptions: addonOptions as never,
+              install: false,
+              dryRun: true,
+            });
+            return result?.success
+              ? ok(result)
+              : fail(result?.error ?? "Failed to plan addon installation");
+          } catch (error) {
+            return fail(error);
+          }
+        },
+      }),
+
+      bts_add_addons: tool({
+        description:
+          "Install addons into an existing Better-T-Stack project. Call only after bts_plan_addons succeeds and the planned changes match the user's intent. Dependencies are NOT installed.",
+        args: addonArgs,
+        async execute({ projectDir, addons, packageManager, addonOptions }) {
+          try {
+            const result = await add({
+              projectDir,
+              addons: addons as never,
+              packageManager: packageManager as never,
+              addonOptions: addonOptions as never,
+              install: false,
+            });
+            return result?.success ? ok(result) : fail(result?.error ?? "Failed to add addons");
+          } catch (error) {
+            return fail(error);
+          }
+        },
+      }),
+    },
+  };
+};
+
+export default BetterTStackPlugin;

--- a/packages/opencode-plugin/tsconfig.json
+++ b/packages/opencode-plugin/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/opencode-plugin/tsdown.config.ts
+++ b/packages/opencode-plugin/tsdown.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  clean: true,
+  shims: true,
+  outDir: "dist",
+  dts: true,
+});

--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -11,6 +11,10 @@ const TEMPLATE_GENERATOR_PACKAGE_JSON_PATH = join(
   process.cwd(),
   "packages/template-generator/package.json",
 );
+const OPENCODE_PLUGIN_PACKAGE_JSON_PATH = join(
+  process.cwd(),
+  "packages/opencode-plugin/package.json",
+);
 // Plugin manifests track the CLI version so the installable plugin stays in lockstep with the tool it wraps.
 const PLUGIN_MANIFEST_PATHS = [
   join(process.cwd(), "plugin/.claude-plugin/plugin.json"),
@@ -129,6 +133,18 @@ async function main(): Promise<void> {
     `${JSON.stringify(templateGeneratorPackageJson, null, 2)}\n`,
   );
 
+  // Update opencode plugin package version and its bts dependency versions
+  const opencodePluginPackageJson = JSON.parse(
+    await readFile(OPENCODE_PLUGIN_PACKAGE_JSON_PATH, "utf-8"),
+  );
+  opencodePluginPackageJson.version = newVersion;
+  opencodePluginPackageJson.dependencies["create-better-t-stack"] = `^${newVersion}`;
+  opencodePluginPackageJson.dependencies["@better-t-stack/types"] = `^${newVersion}`;
+  await writeFile(
+    OPENCODE_PLUGIN_PACKAGE_JSON_PATH,
+    `${JSON.stringify(opencodePluginPackageJson, null, 2)}\n`,
+  );
+
   // Keep the installable plugin manifests in sync with the CLI version.
   for (const manifestPath of PLUGIN_MANIFEST_PATHS) {
     const pluginManifest = JSON.parse(await readFile(manifestPath, "utf-8"));
@@ -138,7 +154,7 @@ async function main(): Promise<void> {
 
   await $`bun install`;
   await $`bun run build:cli`;
-  await $`git add apps/cli/package.json packages/create-bts/package.json packages/types/package.json packages/template-generator/package.json plugin/.claude-plugin/plugin.json plugin/.codex-plugin/plugin.json bun.lock`;
+  await $`git add apps/cli/package.json packages/create-bts/package.json packages/types/package.json packages/template-generator/package.json packages/opencode-plugin/package.json plugin/.claude-plugin/plugin.json plugin/.codex-plugin/plugin.json bun.lock`;
   await $`git commit -m "chore(release): ${newVersion}"`;
 
   // Push the release branch
@@ -157,6 +173,7 @@ This PR bumps the version to \`${newVersion}\`.
 - Updated \`create-bts\` to v${newVersion}
 - Updated \`@better-t-stack/types\` to v${newVersion}
 - Updated \`@better-t-stack/template-generator\` to v${newVersion}
+- Updated \`@better-t-stack/opencode\` to v${newVersion}
 - Updated the agent plugin manifests (Claude Code + Codex) to v${newVersion}
 
 ### Preview Release


### PR DESCRIPTION
Full opencode support for Better-T-Stack — a native plugin plus documented MCP setup.

## 1. `@better-t-stack/opencode` plugin (new package)
`packages/opencode-plugin` — a real opencode plugin (not just MCP):
- Registers the `bts_*` tools via opencode's `tool()` API (get_stack_guidance, get_schema, plan/create project, plan/add addons), reusing the CLI's `create`/`add`/`getSchemaResult`/`getStackGuidance` and the same option enums from `@better-t-stack/types`.
- Uses `experimental.chat.system.transform` to make the agent **Better-T-Stack aware**: in a `bts.jsonc` project it surfaces the stack and steers toward `bts_add_addons`; elsewhere it points at the scaffold tools.
- One-line install: `"plugin": ["@better-t-stack/opencode"]`.

Refactor: extracted `getStackGuidance` into a standalone module and exported it + `readBtsConfig` from `create-better-t-stack` (so the plugin shares one source without pulling in the MCP SDK / circular init). Wired the package into the release bump script.

## 2. opencode docs
Documents the plugin (primary) and the MCP server (`opencode mcp add` / `opencode.json`) alternative.

## Verified
- **Plugin logic**: 14/14 — loads, registers all 6 tools + the system hook, injects project-aware context, every tool executes (incl. real on-disk create + addon flow), guardrails reject bad combos.
- **Real opencode load**: opencode loaded the plugin and gemini-3-flash ran `bts_get_stack_guidance` → `bts_get_schema` → `bts_plan_project` with a valid config, creating zero files.
- Full monorepo build + typecheck pass.

## Remaining
`npm publish` of `@better-t-stack/opencode` (needs maintainer npm auth) — or it ships on the next release via the bump/release flow.