### PR TITLE
fix: report correct dev port (3001) for tanstack-router

### DIFF
--- a/apps/cli/src/helpers/core/post-installation.ts
+++ b/apps/cli/src/helpers/core/post-installation.ts
@@ -127,11 +127,10 @@ export async function displayPostInstallInstructions(
     frontend?.includes("native-unistyles");
 
   const hasReactRouter = frontend?.includes("react-router");
-  const hasTanStackRouter = frontend?.includes("tanstack-router");
   const hasSvelte = frontend?.includes("svelte");
   const hasAstro = frontend?.includes("astro");
-  const webPort =
-    hasReactRouter || hasTanStackRouter || hasSvelte ? "5173" : hasAstro ? "4321" : "3001";
+  // TanStack Router/Start, Next, Nuxt and Solid all dev on 3001; only React Router and SvelteKit use Vite's default 5173.
+  const webPort = hasReactRouter || hasSvelte ? "5173" : hasAstro ? "4321" : "3001";
 
   const betterAuthConvexInstructions =
     isConvex && config.auth === "better-auth"

--- a/packages/template-generator/src/processors/readme-generator.ts
+++ b/packages/template-generator/src/processors/readme-generator.ts
@@ -167,7 +167,6 @@ function generateReadmeContent(options: ProjectConfig): string {
 
   const isConvex = backend === "convex";
   const hasReactRouter = frontend.includes("react-router");
-  const hasTanStackRouter = frontend.includes("tanstack-router");
   const hasNative = hasNativeFrontend(frontend);
   const hasReactWeb = frontend.some((f) =>
     ["tanstack-router", "react-router", "tanstack-start", "next"].includes(f),
@@ -175,8 +174,8 @@ function generateReadmeContent(options: ProjectConfig): string {
   const hasSvelte = frontend.includes("svelte");
   const hasAstro = frontend.includes("astro");
   const packageManagerRunCmd = `${packageManager} run`;
-  const webPort =
-    hasReactRouter || hasTanStackRouter || hasSvelte ? "5173" : hasAstro ? "4321" : "3001";
+  // TanStack Router/Start, Next, Nuxt and Solid all dev on 3001; only React Router and SvelteKit use Vite's default 5173.
+  const webPort = hasReactRouter || hasSvelte ? "5173" : hasAstro ? "4321" : "3001";
 
   const stackDescription = generateStackDescription(frontend, backend, api, isConvex);
 


### PR DESCRIPTION
## Problem

The README generator (`packages/template-generator/src/processors/readme-generator.ts`) and the CLI post-install note (`apps/cli/src/helpers/core/post-installation.ts`) share a `webPort` formula that bucketed **`tanstack-router` under `5173`**:

```ts
hasReactRouter || hasTanStackRouter || hasSvelte ? "5173" : hasAstro ? "4321" : "3001"
```

But the tanstack-router template's `vite.config.ts` sets `server.port: 3001` (added in #1006). So both the generated README ("Frontend: http://localhost:5173") and the post-install "Your project will be available at" note told users the wrong URL — the dev server actually runs on **`3001`**.

Every other place in the codebase already treats tanstack-router as `3001`:
- the tanstack-router `vite.config.ts` (`server.port: 3001`)
- the electrobun `DEV_SERVER_PORT` template
- all CORS / site-URL logic in `env-vars.ts`

The two docs generators were the only outliers.

## Fix

Remove `tanstack-router` from the `5173` bucket so it falls through to `3001`, in both files (and drop the now-unused `hasTanStackRouter` local):

```diff
- hasReactRouter || hasTanStackRouter || hasSvelte ? "5173" : hasAstro ? "4321" : "3001"
+ hasReactRouter || hasSvelte ? "5173" : hasAstro ? "4321" : "3001"
```

Final mapping (now consistent across the whole repo):
- React Router & SvelteKit → `5173`
- Astro → `4321`
- everything else (TanStack Router/Start, Next, Nuxt, Solid) → `3001`

## Verification
- `bun test test/readme.test.ts` → 5 pass / 0 fail
- `tsc` clean for the edited files (pre-existing unrelated errors in `compatibility-rules.ts` only)
- Cross-checked all other paths/commands shared between the README generator and post-install note (env-file paths, Clerk setup, Convex `.env.local`, oRPC Scalar UI routes, DB commands, Docker/Alchemy deploy) — those already match and are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the local web server port shown in post-install instructions so it better matches the selected frontend stack.
  * React Router and Svelte-based projects now point to the expected default port, while other stacks use the appropriate fallback.
  * Improved guidance for users setting up apps with different frontend frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->