### PR TITLE
feat(web): custom display label for sponsor website links

### DIFF
--- a/apps/web/src/app/(home)/_components/sponsors-section.tsx
+++ b/apps/web/src/app/(home)/_components/sponsors-section.tsx
@@ -5,8 +5,8 @@ import { useState } from "react";
 import { FaGithub } from "react-icons/fa6";
 
 import {
-  formatSponsorUrl,
   getSponsorUrl,
+  getSponsorUrlLabel,
   isLifetimeSpecialSponsor,
   shouldShowLifetimeTotal,
 } from "@/lib/sponsor-utils";
@@ -130,7 +130,7 @@ export default function SponsorsSection({ sponsorsData }: { sponsorsData: Sponso
                                   className="group flex items-center gap-2 text-muted-foreground text-xs transition-colors hover:text-primary"
                                 >
                                   <Globe className="size-3" />
-                                  <span className="truncate">{formatSponsorUrl(sponsorUrl)}</span>
+                                  <span className="truncate">{getSponsorUrlLabel(entry)}</span>
                                 </a>
                               )}
                             </div>
@@ -211,7 +211,7 @@ export default function SponsorsSection({ sponsorsData }: { sponsorsData: Sponso
                                   className="group flex items-center gap-2 text-muted-foreground text-xs transition-colors hover:text-primary"
                                 >
                                   <Globe className="size-3" />
-                                  <span className="truncate">{formatSponsorUrl(sponsorUrl)}</span>
+                                  <span className="truncate">{getSponsorUrlLabel(entry)}</span>
                                 </a>
                               )}
                             </div>
@@ -325,7 +325,7 @@ export default function SponsorsSection({ sponsorsData }: { sponsorsData: Sponso
                                     className="group flex items-center gap-2 text-muted-foreground/70 text-xs transition-colors hover:text-muted-foreground"
                                   >
                                     <Globe className="size-3" />
-                                    <span className="truncate">{formatSponsorUrl(sponsorUrl)}</span>
+                                    <span className="truncate">{getSponsorUrlLabel(entry)}</span>
                                   </a>
                                 )}
                               </div>

--- a/apps/web/src/app/(home)/new/_components/special-sponsors-panel.tsx
+++ b/apps/web/src/app/(home)/new/_components/special-sponsors-panel.tsx
@@ -5,7 +5,7 @@ import Image from "next/image";
 import { FaGithub } from "react-icons/fa6";
 
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
-import { formatSponsorUrl, getSponsorUrl, shouldShowLifetimeTotal } from "@/lib/sponsor-utils";
+import { getSponsorUrl, getSponsorUrlLabel, shouldShowLifetimeTotal } from "@/lib/sponsor-utils";
 import type { Sponsor } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
@@ -109,7 +109,7 @@ export function SpecialSponsorsPanel({ sponsors, compact = false }: SpecialSpons
                         className="group flex items-center gap-2 text-muted-foreground text-xs transition-colors hover:text-primary"
                       >
                         <Globe className="h-3.5 w-3.5" />
-                        <span className="truncate">{formatSponsorUrl(sponsorUrl)}</span>
+                        <span className="truncate">{getSponsorUrlLabel(entry)}</span>
                       </a>
                     ) : null}
                   </div>

--- a/apps/web/src/components/special-sponsor-banner.tsx
+++ b/apps/web/src/components/special-sponsor-banner.tsx
@@ -3,7 +3,7 @@ import Image from "next/image";
 import { FaGithub } from "react-icons/fa6";
 
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
-import { formatSponsorUrl, getSponsorUrl, shouldShowLifetimeTotal } from "@/lib/sponsor-utils";
+import { getSponsorUrl, getSponsorUrlLabel, shouldShowLifetimeTotal } from "@/lib/sponsor-utils";
 import { fetchSponsors } from "@/lib/sponsors";
 
 export async function SpecialSponsorBanner() {
@@ -95,7 +95,7 @@ export async function SpecialSponsorBanner() {
                             className="group flex items-center gap-2 text-muted-foreground text-xs transition-colors hover:text-primary"
                           >
                             <Globe className="h-4 w-4" />
-                            <span className="truncate">{formatSponsorUrl(sponsorUrl)}</span>
+                            <span className="truncate">{getSponsorUrlLabel(entry)}</span>
                           </a>
                         ) : null}
                       </div>

--- a/apps/web/src/lib/sponsor-utils.ts
+++ b/apps/web/src/lib/sponsor-utils.ts
@@ -31,3 +31,11 @@ export const getSponsorUrl = (sponsor: Sponsor): string => {
 export const formatSponsorUrl = (url: string): string => {
   return url?.replace(/^https?:\/\//, "")?.replace(/\/$/, "");
 };
+
+// Text shown for a sponsor's website link. Uses websiteLabel when provided
+// (so the display can differ from the actual link, e.g. a redirect URL),
+// otherwise falls back to the formatted website/GitHub URL.
+export const getSponsorUrlLabel = (sponsor: Sponsor): string => {
+  const label = sponsor.websiteLabel?.trim();
+  return label || formatSponsorUrl(getSponsorUrl(sponsor));
+};

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -31,6 +31,10 @@ export type Sponsor = {
   githubId: string;
   avatarUrl: string;
   websiteUrl?: string | null;
+  // Optional display text for the website link. When set, show this label
+  // instead of the URL while still linking to websiteUrl (e.g. show
+  // "CodeRabbit.ai" but link to a redirect URL).
+  websiteLabel?: string | null;
   githubUrl: string;
   tierName: string;
   totalProcessedAmount: number;


### PR DESCRIPTION
## What

Adds an optional `websiteLabel` field to the `Sponsor` type and a `getSponsorUrlLabel` helper, so a sponsor's website link can display custom text while still linking to `websiteUrl`.

## Why

CodeRabbit asked to keep their displayed URL as **CodeRabbit.ai** while the link points to a redirect (`coderabbit.link/btstack`). Previously the visible text was always derived from `websiteUrl`, so a redirect link would show the redirect host instead of the brand URL.

## Behavior

- When `websiteLabel` is set on a sponsor, the card shows that label as the link text.
- When it's absent, it falls back to the existing formatted URL — no change for any current sponsor.

Applied across all three sponsor link render sites: `sponsors-section`, `special-sponsor-banner`, and `special-sponsors-panel`.

The sponsor data itself (`websiteLabel`) is produced by the sponsorkit generator via its override file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sponsor website links can now show a custom display label when available.
  * Sponsor cards and banners use clearer, more consistent link text for sponsor websites.

* **Bug Fixes**
  * Improved fallback labeling for sponsor links so displayed text is cleaner and easier to read.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->