### PR TITLE
feat(skills): recommend the deploy-to-vercel skill for Vercel deploys

### DIFF
--- a/apps/cli/src/helpers/addons/skills-setup.ts
+++ b/apps/cli/src/helpers/addons/skills-setup.ts
@@ -142,11 +142,19 @@ function hasNativeFrontend(frontend: ProjectConfig["frontend"]): boolean {
 
 function getRecommendedSourceKeys(config: ProjectConfig): SourceKey[] {
   const sources: SourceKey[] = [];
-  const { frontend, backend, dbSetup, auth, examples, addons, orm } = config;
+  const { frontend, backend, dbSetup, auth, examples, addons, orm, webDeploy, serverDeploy } =
+    config;
 
   if (hasReactBasedFrontend(frontend)) {
     sources.push("vercel-labs/agent-skills");
     sources.push("shadcn/ui");
+  }
+
+  if (
+    (webDeploy === "vercel" || serverDeploy === "vercel") &&
+    !sources.includes("vercel-labs/agent-skills")
+  ) {
+    sources.push("vercel-labs/agent-skills");
   }
 
   if (frontend.includes("next")) {
@@ -226,13 +234,19 @@ function getRecommendedSourceKeys(config: ProjectConfig): SourceKey[] {
 
 const CURATED_SKILLS_BY_SOURCE: Record<SourceKey, (config: ProjectConfig) => string[]> = {
   "vercel-labs/agent-skills": (config) => {
-    const skills = [
-      "web-design-guidelines",
-      "vercel-composition-patterns",
-      "vercel-react-best-practices",
-    ];
+    const skills: string[] = [];
+    if (hasReactBasedFrontend(config.frontend)) {
+      skills.push(
+        "web-design-guidelines",
+        "vercel-composition-patterns",
+        "vercel-react-best-practices",
+      );
+    }
     if (hasNativeFrontend(config.frontend)) {
       skills.push("vercel-react-native-skills");
+    }
+    if (config.webDeploy === "vercel" || config.serverDeploy === "vercel") {
+      skills.push("deploy-to-vercel");
     }
     return skills;
   },


### PR DESCRIPTION
Adds Vercel's deployment skill to the skills addon recommendations.

## What

- `vercel-labs/agent-skills` is now recommended whenever `webDeploy` or `serverDeploy` is `vercel` (previously only for react-based frontends), and its curated list includes `deploy-to-vercel` for those stacks
- React-specific skills from that source (`web-design-guidelines`, `vercel-composition-patterns`, `vercel-react-best-practices`) are now gated behind a react frontend, so a svelte/nuxt/astro + Vercel project gets the deploy skill without react guidance

## Skill selection (verified against vercel.com/docs/agent-resources/skills)

Checked the actual `SKILL.md` frontmatter in `vercel-labs/agent-skills` — the `--skill` identifiers are the frontmatter names, not the docs display names:

| Docs name | Real skill name | Included? |
|---|---|---|
| vercel-deploy | `deploy-to-vercel` (v3.0.0) | ✅ matches our deploy flow exactly |
| vercel-cli | `vercel-cli-with-tokens` | ❌ token-based headless auth; scaffolds use interactive login + generated scripts |
| autoship | separate repo | ❌ npm release automation, unrelated to scaffolded apps |

Full suite 652 pass, lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recommended skill suggestions so Vercel deployment-related skills now appear for more project types, not just React-based frontends.
  * Refined skill recommendations to show web design and mobile-specific skills only when they match the project setup.
  * Added a Vercel deployment skill when deployment settings indicate Vercel, making setup guidance more relevant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->