### PR TITLE
fix(cli): retry skills installs and surface the failure reason

### DIFF
--- a/apps/cli/src/helpers/addons/skills-setup.ts
+++ b/apps/cli/src/helpers/addons/skills-setup.ts
@@ -490,23 +490,34 @@ export async function setupSkills(
   const runner = getPackageRunnerPrefix(packageManager);
   const globalFlags = scope === "global" ? ["-g"] : [];
 
+  const runSkillsAdd = async (source: string, skills: string[]) => {
+    const args = [
+      ...runner,
+      "skills@latest",
+      "add",
+      source,
+      ...globalFlags,
+      "--skill",
+      ...skills,
+      "--agent",
+      ...selectedAgents,
+      "-y",
+    ];
+    await $({ cwd: projectDir, env: { CI: "true" } })`${args}`;
+  };
+
+  const failedSources: string[] = [];
+
   // Install skills grouped by source (project scope, no -g flag)
   for (const [source, skills] of Object.entries(skillsBySource)) {
     const installResult = await Result.tryPromise({
       try: async () => {
-        const args = [
-          ...runner,
-          "skills@latest",
-          "add",
-          source,
-          ...globalFlags,
-          "--skill",
-          ...skills,
-          "--agent",
-          ...selectedAgents,
-          "-y",
-        ];
-        await $({ cwd: projectDir, env: { CI: "true" } })`${args}`;
+        try {
+          await runSkillsAdd(source, skills);
+        } catch {
+          // clone failures on large skill repos are usually transient
+          await runSkillsAdd(source, skills);
+        }
       },
       catch: (e) =>
         new AddonSetupError({
@@ -517,11 +528,45 @@ export async function setupSkills(
     });
 
     if (installResult.isErr()) {
-      cliLog.warn(pc.yellow(`Warning: Could not install skills from ${source}`));
+      failedSources.push(source);
+      const reason = getInstallFailureReason(installResult.error.cause);
+      cliLog.warn(
+        pc.yellow(
+          `Warning: Could not install skills from ${source}${reason ? ` (${reason})` : ""}`,
+        ),
+      );
     }
   }
 
-  installSpinner.stop("Skills installed");
+  installSpinner.stop(
+    failedSources.length > 0 ? "Skills installed (some sources failed)" : "Skills installed",
+  );
+
+  if (failedSources.length > 0) {
+    const retryCommands = failedSources
+      .map((source) => `  ${[...runner, "skills", "add", source].join(" ")}`)
+      .join("\n");
+    cliLog.info(`Retry the failed sources manually inside the project:\n${retryCommands}`);
+  }
 
   return Result.ok(undefined);
+}
+
+const ANSI_ESCAPE = String.fromCharCode(27);
+
+function stripAnsi(text: string): string {
+  return text
+    .split(ANSI_ESCAPE)
+    .map((chunk) => chunk.replace(/^\[[0-9;]*m/u, ""))
+    .join("");
+}
+
+function getInstallFailureReason(cause: unknown): string | undefined {
+  if (!cause || typeof cause !== "object") return undefined;
+  const { stderr, stdout } = cause as { stderr?: string; stdout?: string };
+  const lines = stripAnsi(`${stderr ?? ""}\n${stdout ?? ""}`)
+    .split("\n")
+    .map((line) => line.replace(/^[\s\u2500-\u25FF|]+/u, "").trim())
+    .filter((line) => /failed|error|invalid/iu.test(line));
+  return lines.at(0)?.slice(0, 200) || undefined;
 }


### PR DESCRIPTION
## Problem (#1096)

Users hit `Warning: Could not install skills from shadcn/ui` (and `vercel-labs/next-skills`, `heroui-inc/heroui`, `expo/skills`) during scaffolding, with no indication of why.

Diagnosis (ran the `skills` CLI manually against these sources): the failures are **transient git-clone failures** on the larger skill repos — the same command run again seconds later succeeds. The addon compounded the problem:
- it gave up after a single attempt, and
- the warning swallowed the underlying error entirely (the `AddonSetupError` message was never shown).

## Fix

- retry each source once before warning
- extract the skills CLI's actual failure line (ANSI-stripped, e.g. `Failed to clone repository`) and include it in the warning
- after setup, print ready-to-run `bunx skills add <source>` commands for any sources that still failed, so users can finish installing without re-scaffolding

## Verified

- scaffolded `tanstack-router + hono + turborepo + skills` with this branch: all 6 curated skills install into `.agents/skills/` + `skills-lock.json`, agents wired
- reason extraction tested against a real failing `skills add` run
- `bun run check` clean, all 106 addon tests pass

Note: the `tui@undefined` / `typescript ^5` npm ERESOLVE at the end of the issue log is a separate OpenTUI-addon peer-dependency problem, not covered here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved skill installation error handling with clearer warnings when a source fails.
  * Added more helpful failure details by showing readable error messages when available.
  * Updated the CLI to show retry commands for any failed installs, making recovery easier.
  * Refined the final install status message so it better reflects partial failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->