### PR TITLE
feat: add Descope authentication provider

### DIFF
--- a/apps/cli/src/helpers/core/post-installation.ts
+++ b/apps/cli/src/helpers/core/post-installation.ts
@@ -113,6 +113,8 @@ export async function displayPostInstallInstructions(
     : "";
   const clerkInstructions =
     config.auth === "clerk" ? getClerkInstructions(frontend || [], backend, api) : "";
+  const descopeInstructions =
+    config.auth === "descope" ? getDescopeInstructions(frontend || [], backend) : "";
   const alchemyDeployInstructions = getAlchemyDeployInstructions(
     runCmd,
     webDeploy,
@@ -233,6 +235,7 @@ export async function displayPostInstallInstructions(
   if (pwaInstructions) output += `\n${pwaInstructions.trim()}\n`;
   if (starlightInstructions) output += `\n${starlightInstructions.trim()}\n`;
   if (clerkInstructions) output += `\n${clerkInstructions.trim()}\n`;
+  if (descopeInstructions) output += `\n${descopeInstructions.trim()}\n`;
   if (betterAuthConvexInstructions) output += `\n${betterAuthConvexInstructions.trim()}\n`;
   if (polarInstructions) output += `\n${polarInstructions.trim()}\n`;
   // Deploy steps come last so env sync happens after auth/payment keys exist
@@ -571,6 +574,50 @@ function getClerkInstructions(frontend: Frontend[], backend: Backend, api: Proje
     `${pc.bold("Clerk Authentication Setup:")}`,
     `${pc.cyan("•")} Follow the guide: ${pc.underline(getClerkQuickstartUrl(frontend))}`,
     ...getClerkInstructionLines(frontend, backend, api).map((line) => `${pc.cyan("•")} ${line}`),
+  ];
+
+  return lines.join("\n");
+}
+
+function getDescopeQuickstartUrl(frontend: Frontend[]) {
+  if (frontend.includes("next")) {
+    return "https://docs.descope.com/getting-started/nextjs";
+  }
+  if (frontend.includes("react-router") || frontend.includes("tanstack-router")) {
+    return "https://docs.descope.com/getting-started/react";
+  }
+
+  return "https://docs.descope.com/getting-started";
+}
+
+function getDescopeInstructionLines(frontend: Frontend[], backend: Backend) {
+  const lines: string[] = [];
+
+  lines.push(
+    "Get your Project ID from the Descope Console: https://app.descope.com/settings/project",
+  );
+
+  if (frontend.includes("next")) {
+    lines.push("Set NEXT_PUBLIC_DESCOPE_PROJECT_ID in apps/web/.env");
+  }
+
+  if (frontend.some((value) => ["react-router", "tanstack-router"].includes(value))) {
+    lines.push("Set VITE_DESCOPE_PROJECT_ID in apps/web/.env");
+  }
+
+  if (backend !== "none") {
+    const serverEnvPath = backend === "self" ? "apps/web/.env" : "apps/server/.env";
+    lines.push(`Set DESCOPE_PROJECT_ID in ${serverEnvPath} for server-side session validation`);
+  }
+
+  return lines;
+}
+
+function getDescopeInstructions(frontend: Frontend[], backend: Backend) {
+  const lines = [
+    `${pc.bold("Descope Authentication Setup:")}`,
+    `${pc.cyan("•")} Follow the guide: ${pc.underline(getDescopeQuickstartUrl(frontend))}`,
+    ...getDescopeInstructionLines(frontend, backend).map((line) => `${pc.cyan("•")} ${line}`),
   ];
 
   return lines.join("\n");

--- a/apps/cli/src/helpers/core/post-installation.ts
+++ b/apps/cli/src/helpers/core/post-installation.ts
@@ -605,6 +605,17 @@ function getDescopeInstructionLines(frontend: Frontend[], backend: Backend) {
     lines.push("Set VITE_DESCOPE_PROJECT_ID in apps/web/.env");
   }
 
+  if (backend === "convex") {
+    lines.push(
+      'Create an "AWS API Gateway" User JWT template in the Descope Console (Project Settings → JWT Templates)',
+      "Apply it under Project Settings → Session Management → User JWT Token Format, then Save (this makes the token `iss` a full URL and adds an `aud` claim — Convex needs both)",
+      "Sign out and back in so a fresh token is minted with the new template",
+      "In the Convex dashboard (or via `npx convex env set`), set DESCOPE_PROJECT_ID to your Descope Project ID",
+      "See https://docs.descope.com/sessions/validation/jwt-authorizers/aws-jwt-authorizer",
+    );
+    return lines;
+  }
+
   if (backend !== "none") {
     const serverEnvPath = backend === "self" ? "apps/web/.env" : "apps/server/.env";
     lines.push(`Set DESCOPE_PROJECT_ID in ${serverEnvPath} for server-side session validation`);

--- a/apps/cli/src/prompts/auth.ts
+++ b/apps/cli/src/prompts/auth.ts
@@ -42,7 +42,9 @@ export function getAvailableAuthProviders(
     options.push("clerk");
   }
 
-  if (backend !== "convex" && hasDescopeCompatibleFrontends) {
+  if (hasDescopeCompatibleFrontends) {
+    // Descope supports Next.js, TanStack Router, and React Router across all
+    // backends, including Convex.
     options.push("descope");
   }
 

--- a/apps/cli/src/prompts/auth.ts
+++ b/apps/cli/src/prompts/auth.ts
@@ -24,6 +24,10 @@ export function getAvailableAuthProviders(
     ].includes(f),
   );
 
+  const hasDescopeCompatibleFrontends = frontend.some((f) =>
+    ["react-router", "tanstack-router", "next"].includes(f),
+  );
+
   const options: Auth[] = [];
 
   if (backend === "convex") {
@@ -36,6 +40,10 @@ export function getAvailableAuthProviders(
 
   if (hasClerkCompatibleFrontends) {
     options.push("clerk");
+  }
+
+  if (backend !== "convex" && hasDescopeCompatibleFrontends) {
+    options.push("descope");
   }
 
   if (options.length === 0) {
@@ -71,6 +79,12 @@ export async function getAuthChoice(
           value: "clerk",
           label: "Clerk",
           hint: "More than auth, Complete User Management",
+        };
+      case "descope":
+        return {
+          value: "descope",
+          label: "Descope",
+          hint: "drag-and-drop auth flows and user management",
         };
       default:
         return { value: "none", label: "None", hint: "No auth" };

--- a/apps/cli/src/utils/compatibility-rules.ts
+++ b/apps/cli/src/utils/compatibility-rules.ts
@@ -236,7 +236,7 @@ export function isFrontendAllowedWithBackend(
   }
 
   if (auth === "descope") {
-    if (backend === "convex") return false;
+    // Descope supports these frontends across all backends, including Convex.
     const compatibleFrontends = ["react-router", "tanstack-router", "next"];
     if (!compatibleFrontends.includes(frontend)) return false;
   }

--- a/apps/cli/src/utils/compatibility-rules.ts
+++ b/apps/cli/src/utils/compatibility-rules.ts
@@ -235,6 +235,12 @@ export function isFrontendAllowedWithBackend(
     if (incompatibleFrontends.includes(frontend)) return false;
   }
 
+  if (auth === "descope") {
+    if (backend === "convex") return false;
+    const compatibleFrontends = ["react-router", "tanstack-router", "next"];
+    if (!compatibleFrontends.includes(frontend)) return false;
+  }
+
   return true;
 }
 

--- a/apps/cli/src/utils/compatibility-rules.ts
+++ b/apps/cli/src/utils/compatibility-rules.ts
@@ -237,7 +237,9 @@ export function isFrontendAllowedWithBackend(
 
   if (auth === "descope") {
     // Descope supports these frontends across all backends, including Convex.
-    const compatibleFrontends = ["react-router", "tanstack-router", "next"];
+    // "none" is allowed for parity with validateBackendConstraints (which permits
+    // no web frontend) and with how Clerk handles frontend validation.
+    const compatibleFrontends = ["react-router", "tanstack-router", "next", "none"];
     if (!compatibleFrontends.includes(frontend)) return false;
   }
 

--- a/apps/cli/src/utils/config-validation.ts
+++ b/apps/cli/src/utils/config-validation.ts
@@ -404,23 +404,18 @@ export function validateBackendConstraints(
     }
   }
 
-  if (config.auth === "descope") {
-    if (config.backend === "convex") {
+  if (config.auth === "descope" && config.frontend) {
+    // Descope supports Next.js, TanStack Router, and React Router across all
+    // backends, including Convex.
+    const incompatibleFrontends = config.frontend.filter(
+      (f) => f !== "none" && !["react-router", "tanstack-router", "next"].includes(f),
+    );
+    if (incompatibleFrontends.length > 0) {
       return validationErr(
-        "Descope authentication is not compatible with the Convex backend. Please choose a different backend or auth provider.",
+        `Descope authentication is not compatible with the following frontends: ${incompatibleFrontends.join(
+          ", ",
+        )}. Descope currently supports Next.js, TanStack Router, and React Router. Please choose a different frontend or auth provider.`,
       );
-    }
-    if (config.frontend) {
-      const incompatibleFrontends = config.frontend.filter(
-        (f) => f !== "none" && !["react-router", "tanstack-router", "next"].includes(f),
-      );
-      if (incompatibleFrontends.length > 0) {
-        return validationErr(
-          `Descope authentication is not compatible with the following frontends: ${incompatibleFrontends.join(
-            ", ",
-          )}. Descope currently supports Next.js, TanStack Router, and React Router. Please choose a different frontend or auth provider.`,
-        );
-      }
     }
   }
 

--- a/apps/cli/src/utils/config-validation.ts
+++ b/apps/cli/src/utils/config-validation.ts
@@ -404,6 +404,26 @@ export function validateBackendConstraints(
     }
   }
 
+  if (config.auth === "descope") {
+    if (config.backend === "convex") {
+      return validationErr(
+        "Descope authentication is not compatible with the Convex backend. Please choose a different backend or auth provider.",
+      );
+    }
+    if (config.frontend) {
+      const incompatibleFrontends = config.frontend.filter(
+        (f) => f !== "none" && !["react-router", "tanstack-router", "next"].includes(f),
+      );
+      if (incompatibleFrontends.length > 0) {
+        return validationErr(
+          `Descope authentication is not compatible with the following frontends: ${incompatibleFrontends.join(
+            ", ",
+          )}. Descope currently supports Next.js, TanStack Router, and React Router. Please choose a different frontend or auth provider.`,
+        );
+      }
+    }
+  }
+
   if (
     providedFlags.has("backend") &&
     backend &&

--- a/apps/cli/test/descope-matrix.test.ts
+++ b/apps/cli/test/descope-matrix.test.ts
@@ -13,8 +13,13 @@ describe("Descope auth provider option", () => {
     }
   });
 
-  it("is not offered for the Convex backend or unsupported frontends", () => {
-    expect(getAvailableAuthProviders("convex", ["next"])).not.toContain("descope");
+  it("is offered for the Convex backend with all supported frontends", () => {
+    for (const frontend of ["next", "react-router", "tanstack-router"] as const) {
+      expect(getAvailableAuthProviders("convex", [frontend])).toContain("descope");
+    }
+  });
+
+  it("is not offered for unsupported frontends", () => {
     for (const frontend of ["svelte", "nuxt", "solid", "astro", "tanstack-start"] as const) {
       expect(getAvailableAuthProviders("hono", [frontend])).not.toContain("descope");
     }
@@ -193,7 +198,94 @@ describe("Descope matrix", () => {
     expect(failures).toEqual([]);
   }, 30_000);
 
-  it("should reject Descope with the Convex backend", async () => {
+  const convexFrontends = ["next", "react-router", "tanstack-router"] as const;
+  for (const frontend of convexFrontends) {
+    it(`should generate Descope with the Convex backend on ${frontend}`, async () => {
+      const config = {
+        projectName: `descope-convex-${frontend}`,
+        frontend: [frontend],
+        backend: "convex" as const,
+        runtime: "none" as const,
+        database: "none" as const,
+        orm: "none" as const,
+        auth: "descope" as const,
+        api: "none" as const,
+        addons: ["none" as const],
+        examples: ["none" as const],
+        dbSetup: "none" as const,
+        webDeploy: "none" as const,
+        serverDeploy: "none" as const,
+        install: false,
+        git: false,
+        packageManager: "bun" as const,
+        payments: "none" as const,
+      };
+
+      expect(validateConfigCompatibility(config).isOk()).toBe(true);
+
+      const result = await createVirtual(config);
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) return;
+
+      const files = collectFiles(result.value.root, result.value.root.path);
+
+      // Convex backend trusts Descope as an AWS API Gateway compliant JWT issuer.
+      const authConfig = files.get("packages/backend/convex/auth.config.ts");
+      expect(authConfig).toContain("https://api.descope.com/");
+      expect(authConfig).toContain("DESCOPE_PROJECT_ID");
+
+      // Private Convex query gating on the authenticated identity.
+      expect(files.get("packages/backend/convex/privateData.ts")).toContain("getUserIdentity");
+
+      // Descope → Convex auth bridge hook, using the right SDK per frontend.
+      const authBridge = files.get("apps/web/src/utils/convex-descope-auth.ts");
+      expect(authBridge).toContain("useAuthFromDescope");
+      expect(authBridge).toContain(
+        frontend === "next" ? "@descope/nextjs-sdk/client" : "@descope/react-sdk",
+      );
+
+      // The Convex client is wired to the Descope auth bridge.
+      const wiringFile =
+        frontend === "next"
+          ? "apps/web/src/components/providers.tsx"
+          : frontend === "tanstack-router"
+            ? "apps/web/src/main.tsx"
+            : "apps/web/src/root.tsx";
+      const wiring = files.get(wiringFile);
+      expect(wiring).toContain("ConvexProviderWithAuth");
+      expect(wiring).toContain("useAuthFromDescope");
+
+      // Descope AuthProvider wraps the app (layout.tsx for Next.js, the wiring
+      // file itself for the Vite frameworks).
+      const authProviderFile =
+        frontend === "next" ? files.get("apps/web/src/app/layout.tsx") : wiring;
+      expect(authProviderFile).toContain("AuthProvider");
+
+      // Web app depends on the correct Descope SDK and public project id env var.
+      if (frontend === "next") {
+        expect(files.get("apps/web/package.json")).toContain("@descope/nextjs-sdk");
+        expect(files.get("packages/env/src/web.ts")).toContain("NEXT_PUBLIC_DESCOPE_PROJECT_ID");
+      } else {
+        expect(files.get("apps/web/package.json")).toContain("@descope/react-sdk");
+        const webEnv = files.get("packages/env/src/web.ts");
+        expect(webEnv).toContain("VITE_DESCOPE_PROJECT_ID");
+        // Vite SPA (Descope forces ssr:false) evaluates env client-side where
+        // `process` is undefined, so the skipValidation check must be guarded.
+        expect(webEnv).toContain('typeof process !== "undefined"');
+      }
+
+      // Dashboard reads the private Convex query.
+      const dashboardPath =
+        frontend === "next"
+          ? "apps/web/src/app/dashboard/page.tsx"
+          : frontend === "tanstack-router"
+            ? "apps/web/src/routes/_auth/dashboard.tsx"
+            : "apps/web/src/routes/dashboard.tsx";
+      expect(files.get(dashboardPath)).toContain("api.privateData.get");
+    }, 30_000);
+  }
+
+  it("should reject Descope + Convex with an unsupported frontend (tanstack-start)", async () => {
     const result = await runTRPCTest({
       projectName: "descope-convex-fail",
       auth: "descope",
@@ -202,7 +294,7 @@ describe("Descope matrix", () => {
       database: "none",
       orm: "none",
       api: "none",
-      frontend: ["next"],
+      frontend: ["tanstack-start"],
       addons: ["none"],
       examples: ["none"],
       dbSetup: "none",
@@ -211,7 +303,7 @@ describe("Descope matrix", () => {
       expectError: true,
     });
 
-    expectError(result, "not compatible with the Convex backend");
+    expectError(result, "Descope authentication is not compatible");
   });
 
   const unsupportedFrontends = ["svelte", "nuxt", "solid", "astro", "tanstack-start"] as const;

--- a/apps/cli/test/descope-matrix.test.ts
+++ b/apps/cli/test/descope-matrix.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from "bun:test";
+
+import { createVirtual } from "../src/index";
+import { getAvailableAuthProviders } from "../src/prompts/auth";
+import { validateConfigCompatibility } from "../src/validation";
+import { collectFiles } from "./setup";
+import { expectError, runTRPCTest } from "./test-utils";
+
+describe("Descope auth provider option", () => {
+  it("is offered for compatible frontends on a non-Convex backend", () => {
+    for (const frontend of ["next", "react-router", "tanstack-router"] as const) {
+      expect(getAvailableAuthProviders("hono", [frontend])).toContain("descope");
+    }
+  });
+
+  it("is not offered for the Convex backend or unsupported frontends", () => {
+    expect(getAvailableAuthProviders("convex", ["next"])).not.toContain("descope");
+    for (const frontend of ["svelte", "nuxt", "solid", "astro", "tanstack-start"] as const) {
+      expect(getAvailableAuthProviders("hono", [frontend])).not.toContain("descope");
+    }
+  });
+
+  it("appears exactly once alongside a single None entry", () => {
+    // Guards against the provider falling through to the default "None" label.
+    const providers = getAvailableAuthProviders("hono", ["next"]);
+    expect(providers.filter((p) => p === "descope")).toHaveLength(1);
+    expect(providers.filter((p) => p === "none")).toHaveLength(1);
+  });
+});
+
+const standardBackends = [
+  { backend: "hono", runtime: "bun" },
+  { backend: "hono", runtime: "node" },
+  { backend: "express", runtime: "node" },
+  { backend: "fastify", runtime: "node" },
+  { backend: "elysia", runtime: "bun" },
+] as const;
+
+// Descope currently supports Next.js, React Router, and TanStack Router.
+const webFrontends = ["next", "react-router", "tanstack-router"] as const;
+const apiOptions = ["trpc", "orpc", "none"] as const;
+
+function webSdkFor(frontend: string) {
+  return frontend === "next" ? "@descope/nextjs-sdk" : "@descope/react-sdk";
+}
+
+function webEnvVarFor(frontend: string) {
+  return frontend === "next" ? "NEXT_PUBLIC_DESCOPE_PROJECT_ID" : "VITE_DESCOPE_PROJECT_ID";
+}
+
+describe("Descope matrix", () => {
+  it("should generate every supported Descope combination", async () => {
+    const combos = [
+      ...standardBackends.flatMap((pair) =>
+        webFrontends.flatMap((frontend) =>
+          apiOptions.map((api) => ({
+            backend: pair.backend,
+            runtime: pair.runtime,
+            frontend,
+            api,
+          })),
+        ),
+      ),
+      // Fullstack (self) backend only supports Next.js among Descope frontends.
+      ...apiOptions.map((api) => ({
+        backend: "self",
+        runtime: "none",
+        frontend: "next",
+        api,
+      })),
+    ];
+
+    const failures: string[] = [];
+
+    for (const [index, combo] of combos.entries()) {
+      const label = `${combo.backend}/${combo.runtime}/${combo.frontend}/${combo.api}`;
+      const hasApi = combo.api !== "none";
+      const config = {
+        projectName: `descope-matrix-${index}`,
+        frontend: [combo.frontend],
+        backend: combo.backend,
+        runtime: combo.runtime,
+        database: hasApi ? "sqlite" : "none",
+        orm: hasApi ? "drizzle" : "none",
+        auth: "descope" as const,
+        api: combo.api,
+        addons: ["none"] as const,
+        examples: ["none"] as const,
+        dbSetup: "none" as const,
+        webDeploy: "none" as const,
+        serverDeploy: "none" as const,
+        install: false,
+        git: false,
+        packageManager: "bun" as const,
+        payments: "none" as const,
+      };
+
+      const validation = validateConfigCompatibility(config);
+      if (validation.isErr()) {
+        failures.push(`${label}: unexpected validation error: ${validation.error.message}`);
+        continue;
+      }
+
+      const result = await createVirtual(config);
+      if (result.isErr()) {
+        failures.push(`${label}: generation failed: ${result.error.message}`);
+        continue;
+      }
+
+      const files = collectFiles(result.value.root, result.value.root.path);
+
+      // Correct SDK dependency for the chosen frontend.
+      const webPackage = files.get("apps/web/package.json");
+      if (!webPackage?.includes(webSdkFor(combo.frontend))) {
+        failures.push(`${label}: web package.json missing ${webSdkFor(combo.frontend)}`);
+      }
+
+      // Client-side token helper is always generated.
+      const authHelper = files.get("apps/web/src/utils/descope-auth.ts");
+      if (!authHelper?.includes("getDescopeAuthToken")) {
+        failures.push(`${label}: missing getDescopeAuthToken helper`);
+      }
+
+      // Web env exposes the public project id.
+      const webEnv = files.get("packages/env/src/web.ts");
+      if (!webEnv?.includes(webEnvVarFor(combo.frontend))) {
+        failures.push(`${label}: web env missing ${webEnvVarFor(combo.frontend)}`);
+      }
+
+      // Server-side validation is wired into the API context when an API is present.
+      if (hasApi) {
+        const context = files.get("packages/api/src/context.ts");
+        if (!context?.includes("validateDescopeSession")) {
+          failures.push(`${label}: context.ts missing validateDescopeSession`);
+        }
+        if (!context?.includes("@descope/node-sdk")) {
+          failures.push(`${label}: context.ts missing @descope/node-sdk import`);
+        }
+      }
+
+      // Server env carries the project id (self backend keeps it in the web app env).
+      const serverEnvPath =
+        combo.backend === "self" ? "packages/env/src/web.ts" : "packages/env/src/server.ts";
+      if (!files.get(serverEnvPath)?.includes("DESCOPE_PROJECT_ID")) {
+        failures.push(`${label}: ${serverEnvPath} missing DESCOPE_PROJECT_ID`);
+      }
+      // API contexts import DESCOPE_PROJECT_ID from env/server, so server.ts
+      // must carry it whenever an API is present (incl. the self backend).
+      if (hasApi && !files.get("packages/env/src/server.ts")?.includes("DESCOPE_PROJECT_ID")) {
+        failures.push(`${label}: server.ts missing DESCOPE_PROJECT_ID`);
+      }
+
+      if (combo.frontend === "next") {
+        const signIn = files.get("apps/web/src/app/sign-in/page.tsx");
+        if (!signIn?.includes('flowId="sign-up-or-in"')) {
+          failures.push(`${label}: missing Next.js sign-in page with Descope flow`);
+        }
+
+        const proxy = files.get("apps/web/src/proxy.ts");
+        if (!proxy?.includes("authMiddleware")) {
+          failures.push(`${label}: missing Descope authMiddleware in proxy.ts`);
+        }
+        if (!proxy?.includes("publicRoutes")) {
+          failures.push(`${label}: proxy.ts missing publicRoutes configuration`);
+        }
+
+        const layout = files.get("apps/web/src/app/layout.tsx");
+        if (!layout?.includes("AuthProvider")) {
+          failures.push(`${label}: layout.tsx missing Descope AuthProvider`);
+        }
+      }
+
+      if (combo.frontend === "react-router") {
+        const dashboard = files.get("apps/web/src/routes/dashboard.tsx");
+        if (!dashboard?.includes("@descope/react-sdk")) {
+          failures.push(`${label}: react-router dashboard missing @descope/react-sdk`);
+        }
+      }
+
+      if (combo.frontend === "tanstack-router") {
+        const authRoute = files.get("apps/web/src/routes/_auth/route.tsx");
+        if (!authRoute?.includes('flowId="sign-up-or-in"')) {
+          failures.push(`${label}: tanstack-router _auth route missing Descope flow`);
+        }
+        const main = files.get("apps/web/src/main.tsx");
+        if (!main?.includes("AuthProvider")) {
+          failures.push(`${label}: main.tsx missing Descope AuthProvider`);
+        }
+      }
+    }
+
+    expect(combos).toHaveLength(48);
+    expect(failures).toEqual([]);
+  }, 30_000);
+
+  it("should reject Descope with the Convex backend", async () => {
+    const result = await runTRPCTest({
+      projectName: "descope-convex-fail",
+      auth: "descope",
+      backend: "convex",
+      runtime: "none",
+      database: "none",
+      orm: "none",
+      api: "none",
+      frontend: ["next"],
+      addons: ["none"],
+      examples: ["none"],
+      dbSetup: "none",
+      webDeploy: "none",
+      serverDeploy: "none",
+      expectError: true,
+    });
+
+    expectError(result, "not compatible with the Convex backend");
+  });
+
+  const unsupportedFrontends = ["svelte", "nuxt", "solid", "astro", "tanstack-start"] as const;
+  for (const frontend of unsupportedFrontends) {
+    it(`should reject Descope with ${frontend}`, async () => {
+      const result = await runTRPCTest({
+        projectName: `descope-${frontend}-fail`,
+        auth: "descope",
+        backend: "hono",
+        runtime: "bun",
+        database: "none",
+        orm: "none",
+        api: "none",
+        frontend: [frontend],
+        addons: ["none"],
+        examples: ["none"],
+        dbSetup: "none",
+        webDeploy: "none",
+        serverDeploy: "none",
+        expectError: true,
+      });
+
+      expectError(result, "Descope authentication is not compatible");
+    });
+  }
+});

--- a/apps/cli/test/descope-matrix.test.ts
+++ b/apps/cli/test/descope-matrix.test.ts
@@ -261,14 +261,12 @@ describe("Descope matrix", () => {
         frontend === "next" ? files.get("apps/web/src/app/layout.tsx") : wiring;
       expect(authProviderFile).toContain("AuthProvider");
 
-      // Web app depends on the correct Descope SDK and public project id env var.
-      if (frontend === "next") {
-        expect(files.get("apps/web/package.json")).toContain("@descope/nextjs-sdk");
-        expect(files.get("packages/env/src/web.ts")).toContain("NEXT_PUBLIC_DESCOPE_PROJECT_ID");
-      } else {
-        expect(files.get("apps/web/package.json")).toContain("@descope/react-sdk");
-        const webEnv = files.get("packages/env/src/web.ts");
-        expect(webEnv).toContain("VITE_DESCOPE_PROJECT_ID");
+      // Web app depends on the correct Descope SDK and public project id env var
+      // (reusing the shared per-frontend helpers so this can't diverge).
+      expect(files.get("apps/web/package.json")).toContain(webSdkFor(frontend));
+      const webEnv = files.get("packages/env/src/web.ts");
+      expect(webEnv).toContain(webEnvVarFor(frontend));
+      if (frontend !== "next") {
         // Vite SPA (Descope forces ssr:false) evaluates env client-side where
         // `process` is undefined, so the skipValidation check must be guarded.
         expect(webEnv).toContain('typeof process !== "undefined"');

--- a/apps/web/content/docs/cli/compatibility.mdx
+++ b/apps/web/content/docs/cli/compatibility.mdx
@@ -228,7 +228,7 @@ Clerk authentication requires:
 Descope authentication requires:
 
 - Supported frontends: `next`, `react-router`, and `tanstack-router`
-- Supported backends: any backend except Convex (Hono, Express, Fastify, Elysia, or fullstack `self`)
+- Supported backends: any backend including Convex (Hono, Express, Fastify, Elysia, fullstack `self`, or Convex)
 
 ### Payments Requirements
 
@@ -256,8 +256,11 @@ create-better-t-stack --auth clerk --backend self --frontend astro
 # ✅ Valid - Descope with React Router
 create-better-t-stack --auth descope --backend hono --frontend react-router
 
-# ❌ Invalid - Descope with Convex
+# ✅ Valid - Descope with Convex
 create-better-t-stack --auth descope --backend convex --frontend next
+
+# ✅ Valid - Descope with Convex on TanStack Router
+create-better-t-stack --auth descope --backend convex --frontend tanstack-router
 ```
 
 ## Example Compatibility

--- a/apps/web/content/docs/cli/compatibility.mdx
+++ b/apps/web/content/docs/cli/compatibility.mdx
@@ -223,6 +223,13 @@ Clerk authentication requires:
 - Fullstack (`--backend self`) support with Next.js or TanStack Start
 - Not compatible with Nuxt, Svelte, Solid, or Astro
 
+### Descope Requirements
+
+Descope authentication requires:
+
+- Supported frontends: `next`, `react-router`, and `tanstack-router`
+- Supported backends: any backend except Convex (Hono, Express, Fastify, Elysia, or fullstack `self`)
+
 ### Payments Requirements
 
 Polar payments require:
@@ -245,6 +252,12 @@ create-better-t-stack --auth clerk --backend self --frontend next
 
 # ❌ Invalid - Clerk with Astro
 create-better-t-stack --auth clerk --backend self --frontend astro
+
+# ✅ Valid - Descope with React Router
+create-better-t-stack --auth descope --backend hono --frontend react-router
+
+# ❌ Invalid - Descope with Convex
+create-better-t-stack --auth descope --backend convex --frontend next
 ```
 
 ## Example Compatibility

--- a/apps/web/content/docs/cli/index.mdx
+++ b/apps/web/content/docs/cli/index.mdx
@@ -34,7 +34,7 @@ create-better-t-stack [project-directory] [options]
 - `--database <type>`: `none`, `sqlite`, `postgres`, `mysql`, `mongodb`
 - `--orm <type>`: `none`, `drizzle`, `prisma`, `mongoose`
 - `--api <type>`: `none`, `trpc`, `orpc`
-- `--auth <provider>`: `better-auth`, `clerk`, `none` (see [Options](/docs/cli/options#authentication))
+- `--auth <provider>`: `better-auth`, `clerk`, `descope`, `none` (see [Options](/docs/cli/options#authentication))
 - `--payments <provider>`: `polar`, `none`
 - `--db-setup <setup>`: `none`, `turso`, `d1`, `neon`, `supabase`, `prisma-postgres`, `planetscale`, `mongodb-atlas`, `docker`
 - `--examples <types...>`: `none`, `todo`, `ai`

--- a/apps/web/content/docs/cli/options.mdx
+++ b/apps/web/content/docs/cli/options.mdx
@@ -263,11 +263,13 @@ Choose authentication provider:
 
 - `better-auth`: Better-Auth authentication (default)
 - `clerk`: Clerk authentication
+- `descope`: Descope authentication
 - `none`: No authentication
 
 ```bash
 create-better-t-stack --auth better-auth
 create-better-t-stack --auth clerk
+create-better-t-stack --auth descope
 create-better-t-stack --auth none
 ```
 
@@ -278,6 +280,7 @@ create-better-t-stack --auth none
 - with `--backend convex`, `better-auth` supports `react-router`, `tanstack-router`, `tanstack-start`, `next`, and native Expo frontends
 - `clerk` requires a compatible frontend
 - Supported Clerk backends: `convex`, `hono`, `express`, `fastify`, `elysia`, and `self` with Next.js or TanStack Start
+- `descope` supports the `next`, `react-router`, and `tanstack-router` frontends and is not compatible with the Convex backend
 - Authentication is automatically set to `none` when using `--backend none`
 
 ## Payments

--- a/apps/web/content/docs/cli/options.mdx
+++ b/apps/web/content/docs/cli/options.mdx
@@ -280,7 +280,7 @@ create-better-t-stack --auth none
 - with `--backend convex`, `better-auth` supports `react-router`, `tanstack-router`, `tanstack-start`, `next`, and native Expo frontends
 - `clerk` requires a compatible frontend
 - Supported Clerk backends: `convex`, `hono`, `express`, `fastify`, `elysia`, and `self` with Next.js or TanStack Start
-- `descope` supports the `next`, `react-router`, and `tanstack-router` frontends and is not compatible with the Convex backend
+- `descope` supports the `next`, `react-router`, and `tanstack-router` frontends across all backends, including Convex
 - Authentication is automatically set to `none` when using `--backend none`
 
 ## Payments

--- a/apps/web/content/docs/index.mdx
+++ b/apps/web/content/docs/index.mdx
@@ -105,7 +105,7 @@ See the full list in the [CLI Reference](/docs/cli). Key flags:
 - `--database`: sqlite, postgres, mysql, mongodb, none
 - `--orm`: drizzle, prisma, mongoose, none
 - `--api`: trpc, orpc, none
-- `--auth`: better-auth, clerk, none
+- `--auth`: better-auth, clerk, descope, none
 - `--payments`: polar, none
 - `--addons`: turborepo, nx, vite-plus, pwa, tauri, electrobun, biome, lefthook, husky, starlight, fumadocs, ultracite, oxlint, mcp, opentui, wxt, skills, evlog, none
 - `--examples`: todo, ai, none

--- a/apps/web/public/descope.svg
+++ b/apps/web/public/descope.svg
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="194.7px" height="215.2px" viewBox="0 0 194.7 215.2" style="enable-background:new 0 0 194.7 215.2;" xml:space="preserve"
+	>
+<style type="text/css">
+	.st0{fill:url(#SVGID_1_);}
+	.st1{fill:url(#SVGID_00000004519561486438896460000001266960168497785022_);}
+	.st2{fill:url(#SVGID_00000049204468076180615810000015113731544435055266_);}
+	.st3{fill:url(#SVGID_00000116951257355544416270000003794629356563808950_);}
+</style>
+<g>
+	<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="68.3919" y1="222.1531" x2="185.0265" y2="41.0264">
+		<stop  offset="1.481436e-07" style="stop-color:#0083B5"/>
+		<stop  offset="0.4173" style="stop-color:#00FFFF"/>
+		<stop  offset="0.9952" style="stop-color:#6FF12D"/>
+	</linearGradient>
+	<path class="st0" d="M129.8,174.7c7.6-1.6,14-4.8,19.2-9.7c7.7-7.3,8.8-17.1,8.8-29.4V80.7c0-12.3-1.1-22.1-8.8-29.4
+		c-5.2-4.9-11.6-8.1-19.2-9.7V15.4c12.5,1.8,22.9,6.5,31,14.2c10.6,10,19.9,23.5,19.9,40.5v75c0,17-9.3,30.5-19.9,40.5
+		c-8.1,7.7-18.5,12.4-31,14.2V174.7z"/>
+
+		<linearGradient id="SVGID_00000040544740507634666800000017273841385603649669_" gradientUnits="userSpaceOnUse" x1="5.037" y1="181.3564" x2="121.6716" y2="0.2297">
+		<stop  offset="1.481436e-07" style="stop-color:#0083B5"/>
+		<stop  offset="0.4173" style="stop-color:#00FFFF"/>
+		<stop  offset="0.9952" style="stop-color:#6FF12D"/>
+	</linearGradient>
+	<path style="fill:url(#SVGID_00000040544740507634666800000017273841385603649669_);" d="M33.9,29.6c8.1-7.7,18.5-12.4,31-14.2
+		v26.3c-7.6,1.6-14,4.8-19.2,9.7c-7.7,7.3-8.8,17-8.8,29.2v55.1c0,12.3,1.1,22.1,8.8,29.4c5.2,4.9,11.6,8.1,19.2,9.7v25.1
+		c-12.5-1.8-22.9-6.5-31-14.2c-10.6-10-19.9-23.5-19.9-40.5V69.8C13.9,53,23.2,39.6,33.9,29.6z"/>
+	<g>
+
+			<linearGradient id="SVGID_00000060713993868866928010000000698955780952733088_" gradientUnits="userSpaceOnUse" x1="22.0278" y1="192.2974" x2="138.6624" y2="11.1707">
+			<stop  offset="1.481436e-07" style="stop-color:#0083B5"/>
+			<stop  offset="0.4173" style="stop-color:#00FFFF"/>
+			<stop  offset="0.9952" style="stop-color:#6FF12D"/>
+		</linearGradient>
+		<path style="fill:url(#SVGID_00000060713993868866928010000000698955780952733088_);" d="M120.2,87.8l8.5-13.7l-17.8-9.4
+			l-7.5,14.2c-1.1,2.1-3.1,3.3-5.5,3.3c-2.3,0-4.4-1.2-5.5-3.3L85,64.7L67.3,74l12.3,19.7L120.2,87.8z"/>
+
+			<linearGradient id="SVGID_00000115475840050352750520000000840372054167564949_" gradientUnits="userSpaceOnUse" x1="37.9651" y1="202.5601" x2="154.5998" y2="21.4334">
+			<stop  offset="1.481436e-07" style="stop-color:#0083B5"/>
+			<stop  offset="0.4173" style="stop-color:#00FFFF"/>
+			<stop  offset="0.9952" style="stop-color:#6FF12D"/>
+		</linearGradient>
+		<path style="fill:url(#SVGID_00000115475840050352750520000000840372054167564949_);" d="M142.4,97.7l-87.8,0.8v17.7l27.5-0.1
+			l-14.8,23.8l17.7,9.3l7.5-14.2c1.1-2.1,3.1-3.3,5.5-3.3c2.3,0,4.4,1.2,5.5,3.3l7.5,14.2l17.8-9.4l-12-19.3L93.7,116l48.7-0.2V97.7
+			z"/>
+	</g>
+</g>
+</svg>

--- a/apps/web/src/app/(home)/new/_components/tech-icon.tsx
+++ b/apps/web/src/app/(home)/new/_components/tech-icon.tsx
@@ -16,7 +16,7 @@ export function TechIcon({
 
   if (!icon) return null;
 
-  if (!icon.startsWith("https://")) {
+  if (!icon.startsWith("https://") && !icon.startsWith("/")) {
     return <span className={cn("inline-flex items-center text-lg", className)}>{icon}</span>;
   }
 

--- a/apps/web/src/app/(home)/new/_components/utils.ts
+++ b/apps/web/src/app/(home)/new/_components/utils.ts
@@ -77,6 +77,12 @@ const hasConvexBetterAuthCompatibleFrontend = (webFrontend: string[], nativeFron
 const convexBetterAuthFrontendRequirementMessage =
   "Better-Auth with Convex requires React Router, TanStack Router, TanStack Start, Next.js, or React Native";
 
+const descopeFrontendRequirementMessage =
+  "Descope requires Next.js, React Router, or TanStack Router, and is not compatible with the Convex backend";
+
+export const hasDescopeCompatibleFrontend = (webFrontend: string[]) =>
+  webFrontend.some((f) => ["react-router", "tanstack-router", "next"].includes(f));
+
 export const hasClerkCompatibleFrontend = (webFrontend: string[], nativeFrontend: string[]) =>
   webFrontend.some((f) =>
     ["react-router", "tanstack-router", "tanstack-start", "next"].includes(f),
@@ -611,6 +617,17 @@ export const analyzeStackCompatibility = (stack: StackState): CompatibilityResul
     }
   }
 
+  if (nextStack.auth === "descope") {
+    if (nextStack.backend === "convex" || !hasDescopeCompatibleFrontend(nextStack.webFrontend)) {
+      nextStack.auth = "none";
+      changed = true;
+      changes.push({
+        category: "auth",
+        message: `Auth set to 'None' (${descopeFrontendRequirementMessage})`,
+      });
+    }
+  }
+
   // ============================================
   // PAYMENTS CONSTRAINTS
   // ============================================
@@ -1116,6 +1133,14 @@ export const getDisabledReason = (
       }
       if (!hasClerkCompatibleFrontend(currentStack.webFrontend, currentStack.nativeFrontend)) {
         return clerkFrontendRequirementMessage;
+      }
+    }
+    if (optionId === "descope") {
+      if (
+        currentStack.backend === "convex" ||
+        !hasDescopeCompatibleFrontend(currentStack.webFrontend)
+      ) {
+        return descopeFrontendRequirementMessage;
       }
     }
   }

--- a/apps/web/src/app/(home)/new/_components/utils.ts
+++ b/apps/web/src/app/(home)/new/_components/utils.ts
@@ -78,10 +78,15 @@ const convexBetterAuthFrontendRequirementMessage =
   "Better-Auth with Convex requires React Router, TanStack Router, TanStack Start, Next.js, or React Native";
 
 const descopeFrontendRequirementMessage =
-  "Descope requires Next.js, React Router, or TanStack Router, and is not compatible with the Convex backend";
+  "Descope requires Next.js, React Router, or TanStack Router";
 
 export const hasDescopeCompatibleFrontend = (webFrontend: string[]) =>
   webFrontend.some((f) => ["react-router", "tanstack-router", "next"].includes(f));
+
+// Descope supports Next.js, TanStack Router, and React Router across all
+// backends, including Convex.
+export const isDescopeAllowed = (_backend: string, webFrontend: string[]) =>
+  hasDescopeCompatibleFrontend(webFrontend);
 
 export const hasClerkCompatibleFrontend = (webFrontend: string[], nativeFrontend: string[]) =>
   webFrontend.some((f) =>
@@ -618,7 +623,7 @@ export const analyzeStackCompatibility = (stack: StackState): CompatibilityResul
   }
 
   if (nextStack.auth === "descope") {
-    if (nextStack.backend === "convex" || !hasDescopeCompatibleFrontend(nextStack.webFrontend)) {
+    if (!isDescopeAllowed(nextStack.backend, nextStack.webFrontend)) {
       nextStack.auth = "none";
       changed = true;
       changes.push({
@@ -1136,10 +1141,7 @@ export const getDisabledReason = (
       }
     }
     if (optionId === "descope") {
-      if (
-        currentStack.backend === "convex" ||
-        !hasDescopeCompatibleFrontend(currentStack.webFrontend)
-      ) {
+      if (!isDescopeAllowed(currentStack.backend, currentStack.webFrontend)) {
         return descopeFrontendRequirementMessage;
       }
     }

--- a/apps/web/src/components/ui/tech-badge.tsx
+++ b/apps/web/src/components/ui/tech-badge.tsx
@@ -52,7 +52,7 @@ function TechIcon({ icon, name, className }: { icon: string; name: string; class
 
   if (!icon) return null;
 
-  if (!icon.startsWith("https://")) {
+  if (!icon.startsWith("https://") && !icon.startsWith("/")) {
     return <span className={cn("inline-flex items-center text-lg", className)}>{icon}</span>;
   }
 

--- a/apps/web/src/lib/constant.ts
+++ b/apps/web/src/lib/constant.ts
@@ -474,6 +474,13 @@ export const TECH_OPTIONS: Record<
       color: "from-blue-400 to-blue-600",
     },
     {
+      id: "descope",
+      name: "Descope",
+      description: "Drag-and-drop authentication and user management",
+      icon: "/descope.svg",
+      color: "from-teal-400 to-teal-600",
+    },
+    {
       id: "none",
       name: "No Auth",
       description: "Skip authentication",

--- a/packages/template-generator/src/processors/auth-deps.ts
+++ b/packages/template-generator/src/processors/auth-deps.ts
@@ -58,6 +58,17 @@ function processConvexAuthDeps(vfs: VirtualFileSystem, config: ProjectConfig): v
     if (nativeExists && hasNative) {
       addPackageDependency({ vfs, packagePath: nativePath, dependencies: ["@clerk/expo"] });
     }
+  } else if (auth === "descope") {
+    // Descope + Convex supports Next.js, TanStack Router, and React Router.
+    // Convex's `ConvexProviderWithAuth` ships with the `convex` package, so no
+    // extra backend dependency is needed.
+    if (webExists) {
+      if (hasNextJs) {
+        addPackageDependency({ vfs, packagePath: webPath, dependencies: ["@descope/nextjs-sdk"] });
+      } else if (hasReactRouter || hasTanStackRouter) {
+        addPackageDependency({ vfs, packagePath: webPath, dependencies: ["@descope/react-sdk"] });
+      }
+    }
   } else if (auth === "better-auth") {
     if (backendExists) {
       addPackageDependency({

--- a/packages/template-generator/src/processors/auth-deps.ts
+++ b/packages/template-generator/src/processors/auth-deps.ts
@@ -201,6 +201,26 @@ function processStandardAuthDeps(vfs: VirtualFileSystem, config: ProjectConfig):
         addPackageDependency({ vfs, packagePath: serverPath, dependencies: ["@clerk/fastify"] });
       }
     }
+  } else if (auth === "descope") {
+    if (webExists) {
+      if (hasNextJs) {
+        addPackageDependency({
+          vfs,
+          packagePath: webPath,
+          dependencies: ["@descope/nextjs-sdk"],
+        });
+      } else if (hasReactRouter || hasTanStackRouter) {
+        addPackageDependency({ vfs, packagePath: webPath, dependencies: ["@descope/react-sdk"] });
+      }
+    }
+
+    if (apiExists) {
+      addPackageDependency({ vfs, packagePath: apiPath, dependencies: ["@descope/node-sdk"] });
+    }
+
+    if (serverExists) {
+      addPackageDependency({ vfs, packagePath: serverPath, dependencies: ["@descope/node-sdk"] });
+    }
   } else if (auth === "better-auth") {
     if (authExists) {
       const authDependencies: AvailableDependencies[] = ["better-auth"];

--- a/packages/template-generator/src/template-handlers/auth.ts
+++ b/packages/template-generator/src/template-handlers/auth.ts
@@ -75,6 +75,31 @@ export async function processAuthTemplates(
     return;
   }
 
+  if (config.backend === "convex" && authProvider === "descope") {
+    processTemplatesFromPrefix(
+      vfs,
+      templates,
+      "auth/descope/convex/backend",
+      "packages/backend",
+      config,
+    );
+
+    // Descope + Convex supports Next.js, TanStack Router, and React Router.
+    const reactFramework = config.frontend.find((f) =>
+      ["next", "tanstack-router", "react-router"].includes(f),
+    );
+    if (reactFramework) {
+      processTemplatesFromPrefix(
+        vfs,
+        templates,
+        `auth/descope/convex/web/react/${reactFramework}`,
+        "apps/web",
+        config,
+      );
+    }
+    return;
+  }
+
   if (config.backend === "convex" && authProvider === "better-auth") {
     processTemplatesFromPrefix(
       vfs,

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -836,6 +836,23 @@ async function authenticateClerkRequest(request: Request): Promise<ClerkContextA
 {{/if}}
 {{/if}}
 
+{{#if (eq auth "descope")}}
+import DescopeClient from "@descope/node-sdk";
+import { env } from "@{{projectName}}/env/server";
+
+const descopeClient = DescopeClient({ projectId: env.DESCOPE_PROJECT_ID });
+
+async function validateDescopeSession(authHeader: string | null | undefined) {
+	if (!authHeader) return null;
+	const token = authHeader.replace(/^Bearer\\s+/i, "");
+	try {
+		return await descopeClient.validateSession(token);
+	} catch {
+		return null;
+	}
+}
+{{/if}}
+
 {{#if (and (eq backend 'self') (includes frontend "next"))}}
 import type { NextRequest } from "next/server";
 {{#if (eq auth "better-auth")}}
@@ -860,6 +877,12 @@ export async function createContext({{#if (eq auth "none")}}_req{{else}}req{{/if
 	return {
 		auth: clerkAuth,
 		session: null,
+	};
+{{else if (eq auth "descope")}}
+	const session = await validateDescopeSession(req.headers.get("authorization"));
+	return {
+		auth: null,
+		session,
 	};
 {{else}}
 	return {
@@ -1026,6 +1049,12 @@ export async function createContext({{#if (eq auth "none")}}_options{{else}}{ co
 		auth: clerkAuth,
 		session: null,
 	};
+{{else if (eq auth "descope")}}
+	const session = await validateDescopeSession(context.req.header("Authorization"));
+	return {
+		auth: null,
+		session,
+	};
 {{else}}
 	return {
 		auth: null,
@@ -1058,6 +1087,12 @@ export async function createContext({{#if (eq auth "none")}}_options{{else}}{ co
 	return {
 		auth: clerkAuth,
 		session: null,
+	};
+{{else if (eq auth "descope")}}
+	const session = await validateDescopeSession(context.request.headers.get("authorization"));
+	return {
+		auth: null,
+		session,
 	};
 {{else}}
 	return {
@@ -1095,6 +1130,12 @@ export async function createContext({{#if (eq auth "none")}}_opts{{else}}opts{{/
 		auth: clerkAuth,
 		session: null,
 	};
+{{else if (eq auth "descope")}}
+	const session = await validateDescopeSession(opts.req.headers.authorization);
+	return {
+		auth: null,
+		session,
+	};
 {{else}}
 	return {
 		auth: null,
@@ -1129,6 +1170,12 @@ export async function createContext(req: {{#if (eq auth "clerk")}}Parameters<typ
 		auth: clerkAuth,
 		session: null,
 	};
+{{else if (eq auth "descope")}}
+	const session = await validateDescopeSession(req.authorization);
+	return {
+		auth: null,
+		session,
+	};
 {{else}}
 	void req;
 	return {
@@ -1149,17 +1196,26 @@ export async function createContext() {
 
 export type Context = Awaited<ReturnType<typeof createContext>>;
 `],
-  ["api/orpc/server/src/index.ts.hbs", `import { {{#if (or (eq auth "better-auth") (eq auth "clerk"))}}ORPCError, {{/if}}os } from "@orpc/server";
+  ["api/orpc/server/src/index.ts.hbs", `import { {{#if (or (eq auth "better-auth") (eq auth "clerk") (eq auth "descope"))}}ORPCError, {{/if}}os } from "@orpc/server";
 import type { Context } from "./context";
 
 export const o = os.$context<Context>();
 
 export const publicProcedure = o;
 
-{{#if (or (eq auth "better-auth") (eq auth "clerk"))}}
+{{#if (or (eq auth "better-auth") (eq auth "clerk") (eq auth "descope"))}}
 const requireAuth = o.middleware(async ({ context, next }) => {
   {{#if (eq auth "better-auth")}}
   if (!context.session?.user) {
+    throw new ORPCError("UNAUTHORIZED");
+  }
+  return next({
+    context: {
+      session: context.session,
+    },
+  });
+  {{else if (eq auth "descope")}}
+  if (!context.session) {
     throw new ORPCError("UNAUTHORIZED");
   }
   return next({
@@ -1408,6 +1464,9 @@ import { env } from "@{{projectName}}/env/web";
 {{#if (eq auth "clerk")}}
 import { getClerkAuthToken } from "@/utils/clerk-auth";
 {{/if}}
+{{#if (eq auth "descope")}}
+import { getDescopeAuthToken } from "@/utils/descope-auth";
+{{/if}}
 {{/if}}
 
 export function createQueryClient() {
@@ -1514,6 +1573,15 @@ export const link = new RPCLink({
 		const token = await getClerkAuthToken();
 		return token ? { Authorization: \`Bearer \${token}\` } : {};
 		{{/if}}
+	},
+{{/if}}
+{{#if (eq auth "descope")}}
+	headers: () => {
+		{{#if (includes frontend "next")}}
+		if (typeof window === "undefined") return {};
+		{{/if}}
+		const token = getDescopeAuthToken();
+		return token ? { Authorization: \`Bearer \${token}\` } : {};
 	},
 {{/if}}
 {{#if (eq auth "better-auth")}}
@@ -1801,6 +1869,23 @@ async function authenticateClerkRequest(request: Request): Promise<ClerkContextA
 }
 {{/if}}
 
+{{#if (eq auth "descope")}}
+import DescopeClient from "@descope/node-sdk";
+import { env } from "@{{projectName}}/env/server";
+
+const descopeClient = DescopeClient({ projectId: env.DESCOPE_PROJECT_ID });
+
+async function validateDescopeSession(authHeader: string | null | undefined) {
+	if (!authHeader) return null;
+	const token = authHeader.replace(/^Bearer\\s+/i, "");
+	try {
+		return await descopeClient.validateSession(token);
+	} catch {
+		return null;
+	}
+}
+{{/if}}
+
 {{#if (and (eq backend 'self') (includes frontend "next"))}}
 import type { NextRequest } from "next/server";
 {{#if (eq auth "better-auth")}}
@@ -1811,7 +1896,7 @@ import { auth } from "@{{projectName}}/auth";
 {{/if}}
 {{/if}}
 
-export async function createContext({{#if (eq auth "none")}}_req{{else}}req{{/if}}: NextRequest){{#if (eq auth "clerk")}}: Promise<ClerkRequestContext>{{/if}} {
+export async function createContext({{#if (or (eq auth "none"))}}_req{{else}}req{{/if}}: NextRequest){{#if (eq auth "clerk")}}: Promise<ClerkRequestContext>{{/if}} {
 {{#if (eq auth "better-auth")}}
 	const session = await {{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}createAuth(){{else}}auth{{/if}}.api.getSession({
 		headers: req.headers,
@@ -1825,6 +1910,12 @@ export async function createContext({{#if (eq auth "none")}}_req{{else}}req{{/if
 	return {
 		auth: clerkAuth,
 		session: null,
+	};
+{{else if (eq auth "descope")}}
+	const session = await validateDescopeSession(req.headers.get("authorization"));
+	return {
+		auth: null,
+		session,
 	};
 {{else}}
 	return {
@@ -1843,7 +1934,7 @@ import { auth } from "@{{projectName}}/auth";
 {{/if}}
 {{/if}}
 
-export async function createContext({{#if (eq auth "none")}}_options{{else}}{ req }{{/if}}: { req: Request }){{#if (eq auth "clerk")}}: Promise<ClerkRequestContext>{{/if}} {
+export async function createContext({{#if (or (eq auth "none") (eq auth "descope"))}}_options{{else}}{ req }{{/if}}: { req: Request }){{#if (eq auth "clerk")}}: Promise<ClerkRequestContext>{{/if}} {
 {{#if (eq auth "better-auth")}}
 	const session = await {{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}createAuth(){{else}}auth{{/if}}.api.getSession({
 		headers: req.headers,
@@ -1895,6 +1986,12 @@ export async function createContext({{#if (eq auth "none")}}_options{{else}}{ co
 		auth: clerkAuth,
 		session: null,
 	};
+{{else if (eq auth "descope")}}
+	const session = await validateDescopeSession(context.req.header("Authorization"));
+	return {
+		auth: null,
+		session,
+	};
 {{else}}
 	return {
 		auth: null,
@@ -1928,6 +2025,12 @@ export async function createContext({{#if (eq auth "none")}}_options{{else}}{ co
 		auth: clerkAuth,
 		session: null,
 	};
+{{else if (eq auth "descope")}}
+	const session = await validateDescopeSession(context.request.headers.get("authorization"));
+	return {
+		auth: null,
+		session,
+	};
 {{else}}
 	return {
 		auth: null,
@@ -1959,6 +2062,12 @@ export async function createContext({{#if (eq auth "none")}}_opts{{else}}opts{{/
 	return {
 		auth: clerkAuth,
 		session: null,
+	};
+{{else if (eq auth "descope")}}
+	const session = await validateDescopeSession(opts.req.headers.authorization);
+	return {
+		auth: null,
+		session,
 	};
 {{else}}
 	return {
@@ -1992,6 +2101,12 @@ export async function createContext({ req }: CreateFastifyContextOptions){{#if (
 		auth: clerkAuth,
 		session: null,
 	};
+{{else if (eq auth "descope")}}
+	const session = await validateDescopeSession(req.headers.authorization);
+	return {
+		auth: null,
+		session,
+	};
 {{else}}
 	void req;
 	return {
@@ -2012,7 +2127,7 @@ export async function createContext() {
 
 export type Context = Awaited<ReturnType<typeof createContext>>;
 `],
-  ["api/trpc/server/src/index.ts.hbs", `import { initTRPC{{#if (or (eq auth "better-auth") (eq auth "clerk"))}}, TRPCError{{/if}} } from "@trpc/server";
+  ["api/trpc/server/src/index.ts.hbs", `import { initTRPC{{#if (or (eq auth "better-auth") (eq auth "clerk") (eq auth "descope"))}}, TRPCError{{/if}} } from "@trpc/server";
 import type { Context } from "./context";
 
 export const t = initTRPC.context<Context>().create();
@@ -2021,9 +2136,9 @@ export const router = t.router;
 
 export const publicProcedure = t.procedure;
 
-{{#if (or (eq auth "better-auth") (eq auth "clerk"))}}
+{{#if (or (eq auth "better-auth") (eq auth "clerk") (eq auth "descope"))}}
 export const protectedProcedure = t.procedure.use(({ ctx, next }) => {
-  {{#if (eq auth "better-auth")}}
+  {{#if (or (eq auth "better-auth") (eq auth "descope"))}}
   if (!ctx.session) {
     throw new TRPCError({
       code: "UNAUTHORIZED",
@@ -2043,7 +2158,7 @@ export const protectedProcedure = t.procedure.use(({ ctx, next }) => {
   return next({
     ctx: {
       ...ctx,
-      {{#if (eq auth "better-auth")}}
+      {{#if (or (eq auth "better-auth") (eq auth "descope"))}}
       session: ctx.session,
       {{else}}
       auth: ctx.auth,
@@ -2054,7 +2169,7 @@ export const protectedProcedure = t.procedure.use(({ ctx, next }) => {
 {{/if}}
 `],
   ["api/trpc/server/src/routers/index.ts.hbs", `{{#if (eq api "orpc")}}
-import { {{#if (eq auth "better-auth")}}protectedProcedure, {{/if}}publicProcedure } from "../index";
+import { {{#if (or (eq auth "better-auth") (eq auth "descope"))}}protectedProcedure, {{/if}}publicProcedure } from "../index";
 import type { RouterClient } from "@orpc/server";
 {{#if (includes examples "todo")}}
 import { todoRouter } from "./todo";
@@ -2071,6 +2186,13 @@ export const appRouter = {
       user: context.session?.user,
     };
   }),
+  {{else if (eq auth "descope")}}
+  privateData: protectedProcedure.handler(({ context }) => {
+    return {
+      message: "This is private",
+      userId: context.session?.token?.sub,
+    };
+  }),
   {{/if}}
   {{#if (includes examples "todo")}}
   todo: todoRouter,
@@ -2080,7 +2202,7 @@ export type AppRouter = typeof appRouter;
 export type AppRouterClient = RouterClient<typeof appRouter>;
 {{else if (eq api "trpc")}}
 import {
-  {{#if (or (eq auth "better-auth") (eq auth "clerk"))}}protectedProcedure, {{/if}}publicProcedure,
+  {{#if (or (eq auth "better-auth") (eq auth "clerk") (eq auth "descope"))}}protectedProcedure, {{/if}}publicProcedure,
   router,
 } from "../index";
 {{#if (includes examples "todo")}}
@@ -2091,12 +2213,14 @@ export const appRouter = router({
   healthCheck: publicProcedure.query(() => {
     return "OK";
   }),
-  {{#if (or (eq auth "better-auth") (eq auth "clerk"))}}
+  {{#if (or (eq auth "better-auth") (eq auth "clerk") (eq auth "descope"))}}
   privateData: protectedProcedure.query(({ ctx }) => {
     return {
       message: "This is private",
       {{#if (eq auth "better-auth")}}
       user: ctx.session.user,
+      {{else if (eq auth "descope")}}
+      userId: ctx.session.token.sub,
       {{else}}
       userId: ctx.auth.userId,
       {{/if}}
@@ -2137,6 +2261,9 @@ import { env } from "@{{projectName}}/env/web";
 {{#if (eq auth "clerk")}}
 import { getClerkAuthToken } from "@/utils/clerk-auth";
 {{/if}}
+{{#if (eq auth "descope")}}
+import { getDescopeAuthToken } from "@/utils/descope-auth";
+{{/if}}
 
 export const queryClient = new QueryClient({
 	queryCache: new QueryCache({
@@ -2175,6 +2302,13 @@ const trpcClient = createTRPCClient<AppRouter>({
 				return token ? { Authorization: \`Bearer \${token}\` } : {};
 			},
 {{/if}}
+{{#if (eq auth "descope")}}
+			headers: () => {
+				if (typeof window === "undefined") return {};
+				const token = getDescopeAuthToken();
+				return token ? { Authorization: \`Bearer \${token}\` } : {};
+			},
+{{/if}}
 {{#if (eq auth "better-auth")}}
 			fetch(url, options) {
 				return fetch(url, {
@@ -2209,6 +2343,9 @@ import { env } from "@{{projectName}}/env/web";
 {{#if (eq auth "clerk")}}
 import { getClerkAuthToken } from "@/utils/clerk-auth";
 {{/if}}
+{{#if (eq auth "descope")}}
+import { getDescopeAuthToken } from "@/utils/descope-auth";
+{{/if}}
 
 {{> getServerUrl}}
 
@@ -2234,6 +2371,12 @@ export const trpcClient = createTRPCClient<AppRouter>({
 {{#if (eq auth "clerk")}}
 			headers: async () => {
 				const token = await getClerkAuthToken();
+				return token ? { Authorization: \`Bearer \${token}\` } : {};
+			},
+{{/if}}
+{{#if (eq auth "descope")}}
+			headers: () => {
+				const token = getDescopeAuthToken();
 				return token ? { Authorization: \`Bearer \${token}\` } : {};
 			},
 {{/if}}
@@ -13951,6 +14094,243 @@ export const startInstance = createStart(() => {
 		requestMiddleware: [clerkMiddleware()],
 	}
 })
+`],
+  ["auth/descope/web/react/base/src/utils/descope-auth.ts.hbs", `{{#if (includes frontend "next")}}
+import { getSessionToken } from "@descope/nextjs-sdk/client";
+{{else}}
+import { getSessionToken } from "@descope/react-sdk";
+{{/if}}
+
+export function getDescopeAuthToken(): string | null {
+	return getSessionToken() || null;
+}
+`],
+  ["auth/descope/web/react/next/src/app/dashboard/page.tsx.hbs", `"use client";
+
+{{#if (eq api "orpc")}}
+import { useQuery } from "@tanstack/react-query";
+import { orpc } from "@/utils/orpc";
+{{/if}}
+{{#if (eq api "trpc")}}
+import { useQuery } from "@tanstack/react-query";
+import { trpc } from "@/utils/trpc";
+{{/if}}
+import { Descope } from "@descope/nextjs-sdk";
+import { useDescope, useSession, useUser } from "@descope/nextjs-sdk/client";
+
+export default function Dashboard() {
+  const { isAuthenticated, isSessionLoading } = useSession();
+  const { user } = useUser();
+  const sdk = useDescope();
+  const displayName = user?.name || user?.email || user?.loginIds?.[0] || "User";
+  {{#if (eq api "orpc")}}
+  const privateData = useQuery({
+    ...orpc.privateData.queryOptions(),
+    enabled: isAuthenticated,
+  });
+  {{/if}}
+  {{#if (eq api "trpc")}}
+  const privateData = useQuery({
+    ...trpc.privateData.queryOptions(),
+    enabled: isAuthenticated,
+  });
+  {{/if}}
+
+  if (isSessionLoading) {
+    return <div className="p-6">Loading...</div>;
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <div className="mx-auto max-w-md p-6">
+        <Descope flowId="sign-up-or-in" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4 p-6">
+      <h1 className="text-2xl font-semibold">Dashboard</h1>
+      <p>Welcome {displayName}</p>
+      {{#if (or (eq api "orpc") (eq api "trpc"))}}
+      <p>API: {privateData.data?.message}</p>
+      {{/if}}
+      <button
+        type="button"
+        className="rounded-md border px-3 py-1"
+        onClick={() => sdk.logout()}
+      >
+        Sign out
+      </button>
+    </div>
+  );
+}
+`],
+  ["auth/descope/web/react/next/src/app/sign-in/page.tsx.hbs", `"use client";
+
+import { Descope } from "@descope/nextjs-sdk";
+import { useRouter } from "next/navigation";
+
+export default function SignInPage() {
+	const router = useRouter();
+
+	return (
+		<div className="mx-auto max-w-md p-6">
+			<Descope
+				flowId="sign-up-or-in"
+				onSuccess={() => {
+					router.push("/dashboard");
+				}}
+			/>
+		</div>
+	);
+}
+`],
+  ["auth/descope/web/react/next/src/proxy.ts.hbs", `import { authMiddleware } from "@descope/nextjs-sdk/server";
+
+export default authMiddleware({
+	projectId: process.env.NEXT_PUBLIC_DESCOPE_PROJECT_ID,
+	// Route unauthenticated users to the sign-in flow
+	redirectUrl: "/sign-in",
+	// Routes that do not require authentication
+	publicRoutes: ["/", "/sign-in"],
+});
+
+export const config = {
+	matcher: [
+		// Skip Next.js internals and all static files, unless found in search params
+		"/((?!_next|[^?]*\\\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
+		// Always run for API routes
+		"/(api|trpc)(.*)",
+	],
+};
+`],
+  ["auth/descope/web/react/react-router/src/routes/dashboard.tsx.hbs", `{{#if (eq api "orpc")}}
+import { useQuery } from "@tanstack/react-query";
+import { orpc } from "@/utils/orpc";
+{{/if}}
+{{#if (eq api "trpc")}}
+import { useQuery } from "@tanstack/react-query";
+import { trpc } from "@/utils/trpc";
+{{/if}}
+import { Descope, useDescope, useSession, useUser } from "@descope/react-sdk";
+
+export default function Dashboard() {
+  const { isAuthenticated, isSessionLoading } = useSession();
+  const { user } = useUser();
+  const sdk = useDescope();
+  const displayName = user?.name || user?.email || user?.loginIds?.[0] || "User";
+  {{#if (eq api "orpc")}}
+  const privateData = useQuery({
+    ...orpc.privateData.queryOptions(),
+    enabled: isAuthenticated,
+  });
+  {{/if}}
+  {{#if (eq api "trpc")}}
+  const privateData = useQuery({
+    ...trpc.privateData.queryOptions(),
+    enabled: isAuthenticated,
+  });
+  {{/if}}
+
+  if (isSessionLoading) {
+    return <div className="p-6">Loading...</div>;
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <div className="mx-auto max-w-md p-6">
+        <Descope flowId="sign-up-or-in" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4 p-6">
+      <h1 className="text-2xl font-semibold">Dashboard</h1>
+      <p>Welcome {displayName}</p>
+      {{#if (or (eq api "orpc") (eq api "trpc"))}}
+      <p>API: {privateData.data?.message}</p>
+      {{/if}}
+      <button
+        type="button"
+        className="rounded-md border px-3 py-1"
+        onClick={() => sdk.logout()}
+      >
+        Sign out
+      </button>
+    </div>
+  );
+}
+`],
+  ["auth/descope/web/react/tanstack-router/src/routes/_auth/dashboard.tsx.hbs", `{{#if (eq api "orpc")}}
+import { useQuery } from "@tanstack/react-query";
+import { orpc } from "@/utils/orpc";
+{{/if}}
+{{#if (eq api "trpc")}}
+import { useQuery } from "@tanstack/react-query";
+import { trpc } from "@/utils/trpc";
+{{/if}}
+import { useDescope, useUser } from "@descope/react-sdk";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/_auth/dashboard")({
+	component: RouteComponent,
+});
+
+function RouteComponent() {
+	const { user } = useUser();
+	const sdk = useDescope();
+	const displayName = user?.name || user?.email || user?.loginIds?.[0] || "User";
+	{{#if (eq api "orpc")}}
+	const privateData = useQuery(orpc.privateData.queryOptions());
+	{{/if}}
+	{{#if (eq api "trpc")}}
+	const privateData = useQuery(trpc.privateData.queryOptions());
+	{{/if}}
+
+	return (
+		<div className="space-y-4 p-6">
+			<h1 className="text-2xl font-semibold">Dashboard</h1>
+			<p>Welcome {displayName}</p>
+			{{#if (or (eq api "orpc") (eq api "trpc"))}}
+			<p>API: {privateData.data?.message}</p>
+			{{/if}}
+			<button
+				type="button"
+				className="rounded-md border px-3 py-1"
+				onClick={() => sdk.logout()}
+			>
+				Sign out
+			</button>
+		</div>
+	);
+}
+`],
+  ["auth/descope/web/react/tanstack-router/src/routes/_auth/route.tsx.hbs", `import { Descope, useSession } from "@descope/react-sdk";
+import { Outlet, createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/_auth")({
+	component: AuthLayout,
+});
+
+function AuthLayout() {
+	const { isAuthenticated, isSessionLoading } = useSession();
+
+	if (isSessionLoading) {
+		return <div className="p-6">Loading...</div>;
+	}
+
+	if (!isAuthenticated) {
+		return (
+			<div className="mx-auto max-w-md p-6">
+				<Descope flowId="sign-up-or-in" />
+			</div>
+		);
+	}
+
+	return <Outlet />;
+}
 `],
   ["backend/convex/packages/backend/_gitignore", `
 .env.local
@@ -29859,6 +30239,8 @@ export default config;
 import { Geist, Geist_Mono } from "next/font/google";
 import "../index.css";
 {{#if (eq auth "clerk")}}import { ClerkProvider } from "@clerk/nextjs";
+{{/if}}{{#if (eq auth "descope")}}import { AuthProvider } from "@descope/nextjs-sdk";
+import { env } from "@{{projectName}}/env/web";
 {{/if}}{{#if (and (eq backend "convex") (eq auth "better-auth"))}}
 import { getToken } from "@/lib/auth-server";
 {{/if}}
@@ -29920,7 +30302,14 @@ export default function RootLayout({
 							{children}
 						</div>
 					</Providers>
-				</ClerkProvider>{{else}}<Providers>
+				</ClerkProvider>{{else if (eq auth "descope")}}<AuthProvider projectId={env.NEXT_PUBLIC_DESCOPE_PROJECT_ID}>
+					<Providers>
+						<div className="grid grid-rows-[auto_1fr] h-svh">
+							<Header />
+							{children}
+						</div>
+					</Providers>
+				</AuthProvider>{{else}}<Providers>
 					<div className="grid grid-rows-[auto_1fr] h-svh">
 						<Header />
 						{children}
@@ -30267,6 +30656,9 @@ export default {
 {{#if (or (includes addons "tauri") (includes addons "electrobun"))}}
   // Desktop addons package static web assets; SSR output cannot be bundled
   ssr: false,
+{{else if (eq auth "descope")}}
+  // Descope's SDK is client-only; render as a SPA so its AuthProvider/hooks work
+  ssr: false,
 {{/if}}
   appDirectory: "src",
 } satisfies Config;
@@ -30334,10 +30726,15 @@ import { clerkMiddleware, rootAuthLoader } from "@clerk/react-router/server";
 import { useEffect } from "react";
 import { setClerkAuthTokenGetter } from "@/utils/clerk-auth";
 {{/if}}
+{{#if (or (eq backend "convex") (eq auth "descope"))}}
+import { env } from "@{{projectName}}/env/web";
+{{/if}}
+{{#if (eq auth "descope")}}
+import { AuthProvider } from "@descope/react-sdk";
+{{/if}}
 
 {{#if (eq backend "convex")}}
 import { ConvexReactClient } from "convex/react";
-import { env } from "@{{projectName}}/env/web";
   {{#if (eq auth "clerk")}}
 import { ConvexProviderWithClerk } from "convex/react-clerk";
   {{else if (eq auth "better-auth")}}
@@ -30527,6 +30924,59 @@ export default function App({ loaderData }: Route.ComponentProps) {
       </ThemeProvider>
       {{/if}}
     </ClerkProvider>
+  );
+}
+{{else if (eq auth "descope")}}
+export default function App() {
+  return (
+    <AuthProvider projectId={env.VITE_DESCOPE_PROJECT_ID}>
+      {{#if (eq api "orpc")}}
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="dark"
+          disableTransitionOnChange
+          storageKey="vite-ui-theme"
+        >
+          <div className="grid grid-rows-[auto_1fr] h-svh">
+            <Header />
+            <Outlet />
+          </div>
+          <Toaster richColors />
+        </ThemeProvider>
+        <ReactQueryDevtools position="bottom" buttonPosition="bottom-right" />
+      </QueryClientProvider>
+      {{else if (eq api "trpc")}}
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="dark"
+          disableTransitionOnChange
+          storageKey="vite-ui-theme"
+        >
+          <div className="grid grid-rows-[auto_1fr] h-svh">
+            <Header />
+            <Outlet />
+          </div>
+          <Toaster richColors />
+        </ThemeProvider>
+        <ReactQueryDevtools position="bottom" buttonPosition="bottom-right" />
+      </QueryClientProvider>
+      {{else}}
+      <ThemeProvider
+        attribute="class"
+        defaultTheme="dark"
+        disableTransitionOnChange
+        storageKey="vite-ui-theme"
+      >
+        <div className="grid grid-rows-[auto_1fr] h-svh">
+          <Header />
+          <Outlet />
+        </div>
+        <Toaster richColors />
+      </ThemeProvider>
+      {{/if}}
+    </AuthProvider>
   );
 }
 {{else if (eq api "orpc")}}
@@ -30862,11 +31312,14 @@ import { routeTree } from "./routeTree.gen";
   import { QueryClientProvider } from "@tanstack/react-query";
   import { queryClient, trpc } from "./utils/trpc";
 {{/if}}
-{{#if (or (eq backend "convex") (eq auth "clerk"))}}
+{{#if (or (eq backend "convex") (eq auth "clerk") (eq auth "descope"))}}
   import { env } from "@{{projectName}}/env/web";
 {{/if}}
 {{#if (eq auth "clerk")}}
   import { ClerkProvider{{#if (or (eq backend "convex") (ne api "none"))}}, useAuth{{/if}} } from "@clerk/react";
+{{/if}}
+{{#if (eq auth "descope")}}
+  import { AuthProvider } from "@descope/react-sdk";
 {{/if}}
 {{#if (eq backend "convex")}}
   import { ConvexReactClient } from "convex/react";
@@ -30913,6 +31366,12 @@ const router = createRouter({
           {children}
         </QueryClientProvider>
       </ClerkProvider>
+      {{else if (eq auth "descope")}}
+      <AuthProvider projectId={env.VITE_DESCOPE_PROJECT_ID}>
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      </AuthProvider>
       {{else}}
       <QueryClientProvider client={queryClient}>
         {children}
@@ -30931,6 +31390,12 @@ const router = createRouter({
           {children}
         </QueryClientProvider>
       </ClerkProvider>
+      {{else if (eq auth "descope")}}
+      <AuthProvider projectId={env.VITE_DESCOPE_PROJECT_ID}>
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      </AuthProvider>
       {{else}}
       <QueryClientProvider client={queryClient}>
         {children}
@@ -30961,6 +31426,11 @@ const router = createRouter({
   context: {},
   Wrap: function WrapComponent({ children }: { children: React.ReactNode }) {
     return <ClerkProvider publishableKey={env.VITE_CLERK_PUBLISHABLE_KEY}>{children}</ClerkProvider>;
+  },
+  {{else if (eq auth "descope")}}
+  context: {},
+  Wrap: function WrapComponent({ children }: { children: React.ReactNode }) {
+    return <AuthProvider projectId={env.VITE_DESCOPE_PROJECT_ID}>{children}</AuthProvider>;
   },
   {{else}}
   context: {},
@@ -31932,7 +32402,7 @@ import UserMenu from "./user-menu";
 export default function Header() {
   const links = [
     { to: "/", label: "Home" },
-    {{#if (or (eq auth "better-auth") (eq auth "clerk"))}}
+    {{#if (or (eq auth "better-auth") (eq auth "clerk") (eq auth "descope"))}}
       { to: "/dashboard", label: "Dashboard" },
     {{/if}}
     {{#if (includes examples "todo")}}
@@ -32927,6 +33397,9 @@ export const env = createEnv({
 		CLERK_PUBLISHABLE_KEY: z.string().min(1),
 {{/if}}
 {{/if}}
+{{#if (eq auth "descope")}}
+		DESCOPE_PROJECT_ID: z.string().min(1),
+{{/if}}
 {{#if (eq payments "polar")}}
 		POLAR_ACCESS_TOKEN: z.string().min(1),
 		POLAR_SUCCESS_URL: z.url(),
@@ -33023,10 +33496,16 @@ export const env = createEnv({
 {{#if (eq auth "clerk")}}
 		NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: z.string().min(1),
 {{/if}}
+{{#if (eq auth "descope")}}
+		NEXT_PUBLIC_DESCOPE_PROJECT_ID: z.string().min(1),
+{{/if}}
 	},
 	runtimeEnv: {
 {{#if (eq auth "clerk")}}
 		NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
+{{/if}}
+{{#if (eq auth "descope")}}
+		NEXT_PUBLIC_DESCOPE_PROJECT_ID: process.env.NEXT_PUBLIC_DESCOPE_PROJECT_ID,
 {{/if}}
 	},
 {{else if (includes frontend "nuxt")}}
@@ -33036,6 +33515,9 @@ export const env = createEnv({
 	client: {
 {{#if (eq auth "clerk")}}
 		VITE_CLERK_PUBLISHABLE_KEY: z.string().min(1),
+{{/if}}
+{{#if (eq auth "descope")}}
+		VITE_DESCOPE_PROJECT_ID: z.string().min(1),
 {{/if}}
 	},
 	runtimeEnv: (import.meta as any).env,
@@ -33047,11 +33529,17 @@ export const env = createEnv({
 {{#if (eq auth "clerk")}}
 		NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: z.string().min(1),
 {{/if}}
+{{#if (eq auth "descope")}}
+		NEXT_PUBLIC_DESCOPE_PROJECT_ID: z.string().min(1),
+{{/if}}
 	},
 	runtimeEnv: {
 		NEXT_PUBLIC_SERVER_URL: process.env.NEXT_PUBLIC_SERVER_URL,
 {{#if (eq auth "clerk")}}
 		NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
+{{/if}}
+{{#if (eq auth "descope")}}
+		NEXT_PUBLIC_DESCOPE_PROJECT_ID: process.env.NEXT_PUBLIC_DESCOPE_PROJECT_ID,
 {{/if}}
 	},
 {{else if (includes frontend "nuxt")}}
@@ -33070,6 +33558,9 @@ export const env = createEnv({
 		VITE_SERVER_URL: {{#if (and (eq webDeploy "vercel") (eq serverDeploy "vercel"))}}serverUrlSchema{{else}}z.url(){{/if}},
 {{#if (eq auth "clerk")}}
 		VITE_CLERK_PUBLISHABLE_KEY: z.string().min(1),
+{{/if}}
+{{#if (eq auth "descope")}}
+		VITE_DESCOPE_PROJECT_ID: z.string().min(1),
 {{/if}}
 	},
 	runtimeEnv: (import.meta as any).env,
@@ -35531,4 +36022,4 @@ function SuccessPage() {
 `]
 ]);
 
-export const TEMPLATE_COUNT = 506;
+export const TEMPLATE_COUNT = 513;

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -14095,6 +14095,270 @@ export const startInstance = createStart(() => {
 	}
 })
 `],
+  ["auth/descope/convex/backend/convex/auth.config.ts.hbs", `export default {
+	providers: [
+		{
+			// Descope issues AWS API Gateway compliant JWTs. Enable the
+			// "AWS API Gateway" JWT template in your Descope project (Project
+			// Settings -> JWT Templates) so the \`iss\` claim becomes the fully
+			// qualified URL https://api.descope.com/<Your Descope Project ID>.
+			// The \`aud\` claim already matches your Project ID.
+			// Set DESCOPE_PROJECT_ID on the Convex Dashboard. \`domain\` must match
+			// the token's \`iss\` claim.
+			// See https://docs.descope.com/sessions/validation/jwt-authorizers/aws-jwt-authorizer
+			domain: \`https://api.descope.com/\${process.env.DESCOPE_PROJECT_ID}\`,
+			applicationID: process.env.DESCOPE_PROJECT_ID,
+		},
+	],
+};
+`],
+  ["auth/descope/convex/backend/convex/privateData.ts.hbs", `import { query } from "./_generated/server";
+
+export const get = query({
+	args: {},
+	handler: async (ctx) => {
+		const identity = await ctx.auth.getUserIdentity();
+		if (identity === null) {
+			return {
+				message: "Not authenticated",
+			};
+		}
+		return {
+			message: "This is private",
+		};
+	},
+});
+`],
+  ["auth/descope/convex/web/react/next/src/app/dashboard/page.tsx.hbs", `"use client";
+
+import { api } from "@{{projectName}}/backend/convex/_generated/api";
+import { Descope } from "@descope/nextjs-sdk";
+import { useDescope, useUser } from "@descope/nextjs-sdk/client";
+import { Authenticated, AuthLoading, Unauthenticated, useQuery } from "convex/react";
+
+export default function Dashboard() {
+  const { user } = useUser();
+  const sdk = useDescope();
+  const privateData = useQuery(api.privateData.get);
+  const displayName = user?.name || user?.email || user?.loginIds?.[0] || "User";
+
+  return (
+    <>
+      <Authenticated>
+        <div className="space-y-4 p-6">
+          <h1 className="text-2xl font-semibold">Dashboard</h1>
+          <p>Welcome {displayName}</p>
+          <p>privateData: {privateData?.message}</p>
+          <button
+            type="button"
+            className="rounded-md border px-3 py-1"
+            onClick={() => sdk.logout()}
+          >
+            Sign out
+          </button>
+        </div>
+      </Authenticated>
+      <Unauthenticated>
+        <div className="mx-auto max-w-md p-6">
+          <Descope flowId="sign-up-or-in" />
+        </div>
+      </Unauthenticated>
+      <AuthLoading>
+        <div className="p-6">Loading...</div>
+      </AuthLoading>
+    </>
+  );
+}
+`],
+  ["auth/descope/convex/web/react/next/src/app/sign-in/page.tsx.hbs", `"use client";
+
+import { Descope } from "@descope/nextjs-sdk";
+import { useRouter } from "next/navigation";
+
+export default function SignInPage() {
+	const router = useRouter();
+
+	return (
+		<div className="mx-auto max-w-md p-6">
+			<Descope
+				flowId="sign-up-or-in"
+				onSuccess={() => {
+					router.push("/dashboard");
+				}}
+			/>
+		</div>
+	);
+}
+`],
+  ["auth/descope/convex/web/react/next/src/utils/convex-descope-auth.ts.hbs", `import { getSessionToken, useSession } from "@descope/nextjs-sdk/client";
+import { useCallback, useMemo } from "react";
+
+// Bridges Descope's session state into Convex's \`ConvexProviderWithAuth\`.
+// The Descope SDK automatically refreshes the token via \`getSessionToken()\`
+// while the refresh token is still active.
+export function useAuthFromDescope() {
+	const { isSessionLoading, isAuthenticated } = useSession();
+
+	const fetchAccessToken = useCallback(async () => {
+		return getSessionToken() ?? null;
+	}, []);
+
+	return useMemo(
+		() => ({
+			isLoading: isSessionLoading,
+			isAuthenticated: isAuthenticated ?? false,
+			fetchAccessToken,
+		}),
+		[isSessionLoading, isAuthenticated, fetchAccessToken],
+	);
+}
+`],
+  ["auth/descope/convex/web/react/react-router/src/routes/dashboard.tsx.hbs", `import { api } from "@{{projectName}}/backend/convex/_generated/api";
+import { Descope, useDescope, useUser } from "@descope/react-sdk";
+import {
+	Authenticated,
+	AuthLoading,
+	Unauthenticated,
+	useQuery,
+} from "convex/react";
+
+export default function Dashboard() {
+	const { user } = useUser();
+	const sdk = useDescope();
+	const privateData = useQuery(api.privateData.get);
+	const displayName = user?.name || user?.email || user?.loginIds?.[0] || "User";
+
+	return (
+		<>
+			<Authenticated>
+				<div className="space-y-4 p-6">
+					<h1 className="text-2xl font-semibold">Dashboard</h1>
+					<p>Welcome {displayName}</p>
+					<p>privateData: {privateData?.message}</p>
+					<button
+						type="button"
+						className="rounded-md border px-3 py-1"
+						onClick={() => sdk.logout()}
+					>
+						Sign out
+					</button>
+				</div>
+			</Authenticated>
+			<Unauthenticated>
+				<div className="mx-auto max-w-md p-6">
+					<Descope flowId="sign-up-or-in" />
+				</div>
+			</Unauthenticated>
+			<AuthLoading>
+				<div className="p-6">Loading...</div>
+			</AuthLoading>
+		</>
+	);
+}
+`],
+  ["auth/descope/convex/web/react/react-router/src/utils/convex-descope-auth.ts.hbs", `import { getSessionToken, useSession } from "@descope/react-sdk";
+import { useCallback, useMemo } from "react";
+
+// Bridges Descope's session state into Convex's \`ConvexProviderWithAuth\`.
+// The Descope SDK automatically refreshes the token via \`getSessionToken()\`
+// while the refresh token is still active.
+export function useAuthFromDescope() {
+	const { isSessionLoading, isAuthenticated } = useSession();
+
+	const fetchAccessToken = useCallback(async () => {
+		return getSessionToken() ?? null;
+	}, []);
+
+	return useMemo(
+		() => ({
+			isLoading: isSessionLoading,
+			isAuthenticated: isAuthenticated ?? false,
+			fetchAccessToken,
+		}),
+		[isSessionLoading, isAuthenticated, fetchAccessToken],
+	);
+}
+`],
+  ["auth/descope/convex/web/react/tanstack-router/src/routes/_auth/dashboard.tsx.hbs", `import { api } from "@{{projectName}}/backend/convex/_generated/api";
+import { useDescope, useUser } from "@descope/react-sdk";
+import { createFileRoute } from "@tanstack/react-router";
+import { useQuery } from "convex/react";
+
+export const Route = createFileRoute("/_auth/dashboard")({
+	component: RouteComponent,
+});
+
+function RouteComponent() {
+	const { user } = useUser();
+	const sdk = useDescope();
+	const privateData = useQuery(api.privateData.get);
+	const displayName = user?.name || user?.email || user?.loginIds?.[0] || "User";
+
+	return (
+		<div className="space-y-4 p-6">
+			<h1 className="text-2xl font-semibold">Dashboard</h1>
+			<p>Welcome {displayName}</p>
+			<p>privateData: {privateData?.message}</p>
+			<button
+				type="button"
+				className="rounded-md border px-3 py-1"
+				onClick={() => sdk.logout()}
+			>
+				Sign out
+			</button>
+		</div>
+	);
+}
+`],
+  ["auth/descope/convex/web/react/tanstack-router/src/routes/_auth/route.tsx.hbs", `import { Descope } from "@descope/react-sdk";
+import { Outlet, createFileRoute } from "@tanstack/react-router";
+import { Authenticated, AuthLoading, Unauthenticated } from "convex/react";
+
+export const Route = createFileRoute("/_auth")({
+	component: AuthLayout,
+});
+
+function AuthLayout() {
+	return (
+		<>
+			<Authenticated>
+				<Outlet />
+			</Authenticated>
+			<Unauthenticated>
+				<div className="mx-auto max-w-md p-6">
+					<Descope flowId="sign-up-or-in" />
+				</div>
+			</Unauthenticated>
+			<AuthLoading>
+				<div className="p-6">Loading...</div>
+			</AuthLoading>
+		</>
+	);
+}
+`],
+  ["auth/descope/convex/web/react/tanstack-router/src/utils/convex-descope-auth.ts.hbs", `import { getSessionToken, useSession } from "@descope/react-sdk";
+import { useCallback, useMemo } from "react";
+
+// Bridges Descope's session state into Convex's \`ConvexProviderWithAuth\`.
+// The Descope SDK automatically refreshes the token via \`getSessionToken()\`
+// while the refresh token is still active.
+export function useAuthFromDescope() {
+	const { isSessionLoading, isAuthenticated } = useSession();
+
+	const fetchAccessToken = useCallback(async () => {
+		return getSessionToken() ?? null;
+	}, []);
+
+	return useMemo(
+		() => ({
+			isLoading: isSessionLoading,
+			isAuthenticated: isAuthenticated ?? false,
+			fetchAccessToken,
+		}),
+		[isSessionLoading, isAuthenticated, fetchAccessToken],
+	);
+}
+`],
   ["auth/descope/web/react/base/src/utils/descope-auth.ts.hbs", `{{#if (includes frontend "next")}}
 import { getSessionToken } from "@descope/nextjs-sdk/client";
 {{else}}
@@ -30456,6 +30720,10 @@ import { useAuth } from "@clerk/nextjs";
 import { ConvexReactClient } from "convex/react";
 import { ConvexProviderWithClerk } from "convex/react-clerk";
 import { env } from "@{{projectName}}/env/web";
+{{else if (eq auth "descope")}}
+import { ConvexProviderWithAuth, ConvexReactClient } from "convex/react";
+import { useAuthFromDescope } from "@/utils/convex-descope-auth";
+import { env } from "@{{projectName}}/env/web";
 {{else if (eq auth "better-auth")}}
 import { ConvexReactClient } from "convex/react";
 import { ConvexBetterAuthProvider } from "@convex-dev/better-auth/react";
@@ -30523,6 +30791,10 @@ export default function Providers({
       <ConvexProviderWithClerk client={convex} useAuth={useAuth}>
         {children}
       </ConvexProviderWithClerk>
+      {{else if (eq auth "descope")}}
+      <ConvexProviderWithAuth client={convex} useAuth={useAuthFromDescope}>
+        {children}
+      </ConvexProviderWithAuth>
       {{else if (eq auth "better-auth")}}
       <ConvexBetterAuthProvider
         client={convex}
@@ -30740,6 +31012,9 @@ import { AuthProvider } from "@descope/react-sdk";
 import { ConvexReactClient } from "convex/react";
   {{#if (eq auth "clerk")}}
 import { ConvexProviderWithClerk } from "convex/react-clerk";
+  {{else if (eq auth "descope")}}
+import { ConvexProviderWithAuth } from "convex/react";
+import { useAuthFromDescope } from "@/utils/convex-descope-auth";
   {{else if (eq auth "better-auth")}}
 import { ConvexBetterAuthProvider } from "@convex-dev/better-auth/react";
 import { authClient } from "@/lib/auth-client";
@@ -30853,6 +31128,25 @@ export default function App() {
         <Toaster richColors />
       </ThemeProvider>
     </ConvexBetterAuthProvider>
+  );
+  {{else if (eq auth "descope")}}
+  return (
+    <AuthProvider projectId={env.VITE_DESCOPE_PROJECT_ID}>
+      <ConvexProviderWithAuth client={convex} useAuth={useAuthFromDescope}>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="dark"
+          disableTransitionOnChange
+          storageKey="vite-ui-theme"
+        >
+          <div className="grid grid-rows-[auto_1fr] h-svh">
+            <Header />
+            <Outlet />
+          </div>
+          <Toaster richColors />
+        </ThemeProvider>
+      </ConvexProviderWithAuth>
+    </AuthProvider>
   );
   {{else}}
   return (
@@ -31328,6 +31622,9 @@ import { routeTree } from "./routeTree.gen";
   import { ConvexReactClient } from "convex/react";
   {{#if (eq auth "clerk")}}
   import { ConvexProviderWithClerk } from "convex/react-clerk";
+  {{else if (eq auth "descope")}}
+  import { ConvexProviderWithAuth } from "convex/react";
+  import { useAuthFromDescope } from "@/utils/convex-descope-auth";
   {{else if (eq auth "better-auth")}}
   import { ConvexBetterAuthProvider } from "@convex-dev/better-auth/react";
   import { authClient } from "@/lib/auth-client";
@@ -31418,6 +31715,14 @@ const router = createRouter({
           {children}
         </ConvexProviderWithClerk>
       </ClerkProvider>
+    );
+    {{else if (eq auth "descope")}}
+    return (
+      <AuthProvider projectId={env.VITE_DESCOPE_PROJECT_ID}>
+        <ConvexProviderWithAuth client={convex} useAuth={useAuthFromDescope}>
+          {children}
+        </ConvexProviderWithAuth>
+      </AuthProvider>
     );
     {{else if (eq auth "better-auth")}}
     return <ConvexBetterAuthProvider client={convex} authClient={authClient}>{children}</ConvexBetterAuthProvider>;
@@ -33460,6 +33765,9 @@ export const env = createEnv({
 {{#if (eq auth "clerk")}}
 		NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: z.string().min(1),
 {{/if}}
+{{#if (eq auth "descope")}}
+		NEXT_PUBLIC_DESCOPE_PROJECT_ID: z.string().min(1),
+{{/if}}
 	},
 	runtimeEnv: {
 		NEXT_PUBLIC_CONVEX_URL: process.env.NEXT_PUBLIC_CONVEX_URL,
@@ -33468,6 +33776,9 @@ export const env = createEnv({
 {{/if}}
 {{#if (eq auth "clerk")}}
 		NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
+{{/if}}
+{{#if (eq auth "descope")}}
+		NEXT_PUBLIC_DESCOPE_PROJECT_ID: process.env.NEXT_PUBLIC_DESCOPE_PROJECT_ID,
 {{/if}}
 	},
 {{else if (includes frontend "nuxt")}}
@@ -33489,6 +33800,9 @@ export const env = createEnv({
 {{/if}}
 {{#if (eq auth "clerk")}}
 		VITE_CLERK_PUBLISHABLE_KEY: z.string().min(1),
+{{/if}}
+{{#if (eq auth "descope")}}
+		VITE_DESCOPE_PROJECT_ID: z.string().min(1),
 {{/if}}
 	},
 	runtimeEnv: (import.meta as any).env,
@@ -33569,7 +33883,10 @@ export const env = createEnv({
 	runtimeEnv: (import.meta as any).env,
 {{/if}}
 {{/if}}
-	skipValidation: !!process.env.SKIP_ENV_VALIDATION,
+	// \`process\` is undefined in the browser (e.g. Vite SPA builds such as the
+	// Descope \`ssr: false\` setup), so guard the access to avoid a runtime crash.
+	skipValidation:
+		typeof process !== "undefined" && !!process.env.SKIP_ENV_VALIDATION,
 	emptyStringAsUndefined: true,
 });
 `],
@@ -36025,4 +36342,4 @@ function SuccessPage() {
 `]
 ]);
 
-export const TEMPLATE_COUNT = 513;
+export const TEMPLATE_COUNT = 523;

--- a/packages/template-generator/src/utils/add-deps.ts
+++ b/packages/template-generator/src/utils/add-deps.ts
@@ -26,6 +26,10 @@ export const dependencyVersionMap = {
   "@clerk/tanstack-react-start": "^1.4.12",
   "@clerk/expo": "^3.6.5",
 
+  "@descope/nextjs-sdk": "^0.15.52",
+  "@descope/react-sdk": "^2.30.3",
+  "@descope/node-sdk": "^2.12.0",
+
   "drizzle-orm": "^0.45.2",
   "drizzle-kit": "^0.31.10",
   "@planetscale/database": "^1.20.1",

--- a/packages/template-generator/templates/api/orpc/server/src/context.ts.hbs
+++ b/packages/template-generator/templates/api/orpc/server/src/context.ts.hbs
@@ -33,6 +33,23 @@ async function authenticateClerkRequest(request: Request): Promise<ClerkContextA
 {{/if}}
 {{/if}}
 
+{{#if (eq auth "descope")}}
+import DescopeClient from "@descope/node-sdk";
+import { env } from "@{{projectName}}/env/server";
+
+const descopeClient = DescopeClient({ projectId: env.DESCOPE_PROJECT_ID });
+
+async function validateDescopeSession(authHeader: string | null | undefined) {
+	if (!authHeader) return null;
+	const token = authHeader.replace(/^Bearer\s+/i, "");
+	try {
+		return await descopeClient.validateSession(token);
+	} catch {
+		return null;
+	}
+}
+{{/if}}
+
 {{#if (and (eq backend 'self') (includes frontend "next"))}}
 import type { NextRequest } from "next/server";
 {{#if (eq auth "better-auth")}}
@@ -57,6 +74,12 @@ export async function createContext({{#if (eq auth "none")}}_req{{else}}req{{/if
 	return {
 		auth: clerkAuth,
 		session: null,
+	};
+{{else if (eq auth "descope")}}
+	const session = await validateDescopeSession(req.headers.get("authorization"));
+	return {
+		auth: null,
+		session,
 	};
 {{else}}
 	return {
@@ -223,6 +246,12 @@ export async function createContext({{#if (eq auth "none")}}_options{{else}}{ co
 		auth: clerkAuth,
 		session: null,
 	};
+{{else if (eq auth "descope")}}
+	const session = await validateDescopeSession(context.req.header("Authorization"));
+	return {
+		auth: null,
+		session,
+	};
 {{else}}
 	return {
 		auth: null,
@@ -255,6 +284,12 @@ export async function createContext({{#if (eq auth "none")}}_options{{else}}{ co
 	return {
 		auth: clerkAuth,
 		session: null,
+	};
+{{else if (eq auth "descope")}}
+	const session = await validateDescopeSession(context.request.headers.get("authorization"));
+	return {
+		auth: null,
+		session,
 	};
 {{else}}
 	return {
@@ -292,6 +327,12 @@ export async function createContext({{#if (eq auth "none")}}_opts{{else}}opts{{/
 		auth: clerkAuth,
 		session: null,
 	};
+{{else if (eq auth "descope")}}
+	const session = await validateDescopeSession(opts.req.headers.authorization);
+	return {
+		auth: null,
+		session,
+	};
 {{else}}
 	return {
 		auth: null,
@@ -325,6 +366,12 @@ export async function createContext(req: {{#if (eq auth "clerk")}}Parameters<typ
 	return {
 		auth: clerkAuth,
 		session: null,
+	};
+{{else if (eq auth "descope")}}
+	const session = await validateDescopeSession(req.authorization);
+	return {
+		auth: null,
+		session,
 	};
 {{else}}
 	void req;

--- a/packages/template-generator/templates/api/orpc/server/src/index.ts.hbs
+++ b/packages/template-generator/templates/api/orpc/server/src/index.ts.hbs
@@ -1,14 +1,23 @@
-import { {{#if (or (eq auth "better-auth") (eq auth "clerk"))}}ORPCError, {{/if}}os } from "@orpc/server";
+import { {{#if (or (eq auth "better-auth") (eq auth "clerk") (eq auth "descope"))}}ORPCError, {{/if}}os } from "@orpc/server";
 import type { Context } from "./context";
 
 export const o = os.$context<Context>();
 
 export const publicProcedure = o;
 
-{{#if (or (eq auth "better-auth") (eq auth "clerk"))}}
+{{#if (or (eq auth "better-auth") (eq auth "clerk") (eq auth "descope"))}}
 const requireAuth = o.middleware(async ({ context, next }) => {
   {{#if (eq auth "better-auth")}}
   if (!context.session?.user) {
+    throw new ORPCError("UNAUTHORIZED");
+  }
+  return next({
+    context: {
+      session: context.session,
+    },
+  });
+  {{else if (eq auth "descope")}}
+  if (!context.session) {
     throw new ORPCError("UNAUTHORIZED");
   }
   return next({

--- a/packages/template-generator/templates/api/orpc/web/react/base/src/utils/orpc.ts.hbs
+++ b/packages/template-generator/templates/api/orpc/web/react/base/src/utils/orpc.ts.hbs
@@ -25,6 +25,9 @@ import { env } from "@{{projectName}}/env/web";
 {{#if (eq auth "clerk")}}
 import { getClerkAuthToken } from "@/utils/clerk-auth";
 {{/if}}
+{{#if (eq auth "descope")}}
+import { getDescopeAuthToken } from "@/utils/descope-auth";
+{{/if}}
 {{/if}}
 
 export function createQueryClient() {
@@ -131,6 +134,15 @@ export const link = new RPCLink({
 		const token = await getClerkAuthToken();
 		return token ? { Authorization: `Bearer ${token}` } : {};
 		{{/if}}
+	},
+{{/if}}
+{{#if (eq auth "descope")}}
+	headers: () => {
+		{{#if (includes frontend "next")}}
+		if (typeof window === "undefined") return {};
+		{{/if}}
+		const token = getDescopeAuthToken();
+		return token ? { Authorization: `Bearer ${token}` } : {};
 	},
 {{/if}}
 {{#if (eq auth "better-auth")}}

--- a/packages/template-generator/templates/api/trpc/server/src/context.ts.hbs
+++ b/packages/template-generator/templates/api/trpc/server/src/context.ts.hbs
@@ -30,6 +30,23 @@ async function authenticateClerkRequest(request: Request): Promise<ClerkContextA
 }
 {{/if}}
 
+{{#if (eq auth "descope")}}
+import DescopeClient from "@descope/node-sdk";
+import { env } from "@{{projectName}}/env/server";
+
+const descopeClient = DescopeClient({ projectId: env.DESCOPE_PROJECT_ID });
+
+async function validateDescopeSession(authHeader: string | null | undefined) {
+	if (!authHeader) return null;
+	const token = authHeader.replace(/^Bearer\s+/i, "");
+	try {
+		return await descopeClient.validateSession(token);
+	} catch {
+		return null;
+	}
+}
+{{/if}}
+
 {{#if (and (eq backend 'self') (includes frontend "next"))}}
 import type { NextRequest } from "next/server";
 {{#if (eq auth "better-auth")}}
@@ -40,7 +57,7 @@ import { auth } from "@{{projectName}}/auth";
 {{/if}}
 {{/if}}
 
-export async function createContext({{#if (eq auth "none")}}_req{{else}}req{{/if}}: NextRequest){{#if (eq auth "clerk")}}: Promise<ClerkRequestContext>{{/if}} {
+export async function createContext({{#if (or (eq auth "none"))}}_req{{else}}req{{/if}}: NextRequest){{#if (eq auth "clerk")}}: Promise<ClerkRequestContext>{{/if}} {
 {{#if (eq auth "better-auth")}}
 	const session = await {{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}createAuth(){{else}}auth{{/if}}.api.getSession({
 		headers: req.headers,
@@ -54,6 +71,12 @@ export async function createContext({{#if (eq auth "none")}}_req{{else}}req{{/if
 	return {
 		auth: clerkAuth,
 		session: null,
+	};
+{{else if (eq auth "descope")}}
+	const session = await validateDescopeSession(req.headers.get("authorization"));
+	return {
+		auth: null,
+		session,
 	};
 {{else}}
 	return {
@@ -72,7 +95,7 @@ import { auth } from "@{{projectName}}/auth";
 {{/if}}
 {{/if}}
 
-export async function createContext({{#if (eq auth "none")}}_options{{else}}{ req }{{/if}}: { req: Request }){{#if (eq auth "clerk")}}: Promise<ClerkRequestContext>{{/if}} {
+export async function createContext({{#if (or (eq auth "none") (eq auth "descope"))}}_options{{else}}{ req }{{/if}}: { req: Request }){{#if (eq auth "clerk")}}: Promise<ClerkRequestContext>{{/if}} {
 {{#if (eq auth "better-auth")}}
 	const session = await {{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare") (and (eq backend "self") (eq webDeploy "cloudflare")))}}createAuth(){{else}}auth{{/if}}.api.getSession({
 		headers: req.headers,
@@ -124,6 +147,12 @@ export async function createContext({{#if (eq auth "none")}}_options{{else}}{ co
 		auth: clerkAuth,
 		session: null,
 	};
+{{else if (eq auth "descope")}}
+	const session = await validateDescopeSession(context.req.header("Authorization"));
+	return {
+		auth: null,
+		session,
+	};
 {{else}}
 	return {
 		auth: null,
@@ -157,6 +186,12 @@ export async function createContext({{#if (eq auth "none")}}_options{{else}}{ co
 		auth: clerkAuth,
 		session: null,
 	};
+{{else if (eq auth "descope")}}
+	const session = await validateDescopeSession(context.request.headers.get("authorization"));
+	return {
+		auth: null,
+		session,
+	};
 {{else}}
 	return {
 		auth: null,
@@ -189,6 +224,12 @@ export async function createContext({{#if (eq auth "none")}}_opts{{else}}opts{{/
 		auth: clerkAuth,
 		session: null,
 	};
+{{else if (eq auth "descope")}}
+	const session = await validateDescopeSession(opts.req.headers.authorization);
+	return {
+		auth: null,
+		session,
+	};
 {{else}}
 	return {
 		auth: null,
@@ -220,6 +261,12 @@ export async function createContext({ req }: CreateFastifyContextOptions){{#if (
 	return {
 		auth: clerkAuth,
 		session: null,
+	};
+{{else if (eq auth "descope")}}
+	const session = await validateDescopeSession(req.headers.authorization);
+	return {
+		auth: null,
+		session,
 	};
 {{else}}
 	void req;

--- a/packages/template-generator/templates/api/trpc/server/src/index.ts.hbs
+++ b/packages/template-generator/templates/api/trpc/server/src/index.ts.hbs
@@ -1,4 +1,4 @@
-import { initTRPC{{#if (or (eq auth "better-auth") (eq auth "clerk"))}}, TRPCError{{/if}} } from "@trpc/server";
+import { initTRPC{{#if (or (eq auth "better-auth") (eq auth "clerk") (eq auth "descope"))}}, TRPCError{{/if}} } from "@trpc/server";
 import type { Context } from "./context";
 
 export const t = initTRPC.context<Context>().create();
@@ -7,9 +7,9 @@ export const router = t.router;
 
 export const publicProcedure = t.procedure;
 
-{{#if (or (eq auth "better-auth") (eq auth "clerk"))}}
+{{#if (or (eq auth "better-auth") (eq auth "clerk") (eq auth "descope"))}}
 export const protectedProcedure = t.procedure.use(({ ctx, next }) => {
-  {{#if (eq auth "better-auth")}}
+  {{#if (or (eq auth "better-auth") (eq auth "descope"))}}
   if (!ctx.session) {
     throw new TRPCError({
       code: "UNAUTHORIZED",
@@ -29,7 +29,7 @@ export const protectedProcedure = t.procedure.use(({ ctx, next }) => {
   return next({
     ctx: {
       ...ctx,
-      {{#if (eq auth "better-auth")}}
+      {{#if (or (eq auth "better-auth") (eq auth "descope"))}}
       session: ctx.session,
       {{else}}
       auth: ctx.auth,

--- a/packages/template-generator/templates/api/trpc/server/src/routers/index.ts.hbs
+++ b/packages/template-generator/templates/api/trpc/server/src/routers/index.ts.hbs
@@ -1,5 +1,5 @@
 {{#if (eq api "orpc")}}
-import { {{#if (eq auth "better-auth")}}protectedProcedure, {{/if}}publicProcedure } from "../index";
+import { {{#if (or (eq auth "better-auth") (eq auth "descope"))}}protectedProcedure, {{/if}}publicProcedure } from "../index";
 import type { RouterClient } from "@orpc/server";
 {{#if (includes examples "todo")}}
 import { todoRouter } from "./todo";
@@ -16,6 +16,13 @@ export const appRouter = {
       user: context.session?.user,
     };
   }),
+  {{else if (eq auth "descope")}}
+  privateData: protectedProcedure.handler(({ context }) => {
+    return {
+      message: "This is private",
+      userId: context.session?.token?.sub,
+    };
+  }),
   {{/if}}
   {{#if (includes examples "todo")}}
   todo: todoRouter,
@@ -25,7 +32,7 @@ export type AppRouter = typeof appRouter;
 export type AppRouterClient = RouterClient<typeof appRouter>;
 {{else if (eq api "trpc")}}
 import {
-  {{#if (or (eq auth "better-auth") (eq auth "clerk"))}}protectedProcedure, {{/if}}publicProcedure,
+  {{#if (or (eq auth "better-auth") (eq auth "clerk") (eq auth "descope"))}}protectedProcedure, {{/if}}publicProcedure,
   router,
 } from "../index";
 {{#if (includes examples "todo")}}
@@ -36,12 +43,14 @@ export const appRouter = router({
   healthCheck: publicProcedure.query(() => {
     return "OK";
   }),
-  {{#if (or (eq auth "better-auth") (eq auth "clerk"))}}
+  {{#if (or (eq auth "better-auth") (eq auth "clerk") (eq auth "descope"))}}
   privateData: protectedProcedure.query(({ ctx }) => {
     return {
       message: "This is private",
       {{#if (eq auth "better-auth")}}
       user: ctx.session.user,
+      {{else if (eq auth "descope")}}
+      userId: ctx.session.token.sub,
       {{else}}
       userId: ctx.auth.userId,
       {{/if}}

--- a/packages/template-generator/templates/api/trpc/web/react/base/src/utils/trpc.ts.hbs
+++ b/packages/template-generator/templates/api/trpc/web/react/base/src/utils/trpc.ts.hbs
@@ -12,6 +12,9 @@ import { env } from "@{{projectName}}/env/web";
 {{#if (eq auth "clerk")}}
 import { getClerkAuthToken } from "@/utils/clerk-auth";
 {{/if}}
+{{#if (eq auth "descope")}}
+import { getDescopeAuthToken } from "@/utils/descope-auth";
+{{/if}}
 
 export const queryClient = new QueryClient({
 	queryCache: new QueryCache({
@@ -50,6 +53,13 @@ const trpcClient = createTRPCClient<AppRouter>({
 				return token ? { Authorization: `Bearer ${token}` } : {};
 			},
 {{/if}}
+{{#if (eq auth "descope")}}
+			headers: () => {
+				if (typeof window === "undefined") return {};
+				const token = getDescopeAuthToken();
+				return token ? { Authorization: `Bearer ${token}` } : {};
+			},
+{{/if}}
 {{#if (eq auth "better-auth")}}
 			fetch(url, options) {
 				return fetch(url, {
@@ -84,6 +94,9 @@ import { env } from "@{{projectName}}/env/web";
 {{#if (eq auth "clerk")}}
 import { getClerkAuthToken } from "@/utils/clerk-auth";
 {{/if}}
+{{#if (eq auth "descope")}}
+import { getDescopeAuthToken } from "@/utils/descope-auth";
+{{/if}}
 
 {{> getServerUrl}}
 
@@ -109,6 +122,12 @@ export const trpcClient = createTRPCClient<AppRouter>({
 {{#if (eq auth "clerk")}}
 			headers: async () => {
 				const token = await getClerkAuthToken();
+				return token ? { Authorization: `Bearer ${token}` } : {};
+			},
+{{/if}}
+{{#if (eq auth "descope")}}
+			headers: () => {
+				const token = getDescopeAuthToken();
 				return token ? { Authorization: `Bearer ${token}` } : {};
 			},
 {{/if}}

--- a/packages/template-generator/templates/auth/descope/convex/backend/convex/auth.config.ts.hbs
+++ b/packages/template-generator/templates/auth/descope/convex/backend/convex/auth.config.ts.hbs
@@ -1,0 +1,16 @@
+export default {
+	providers: [
+		{
+			// Descope issues AWS API Gateway compliant JWTs. Enable the
+			// "AWS API Gateway" JWT template in your Descope project (Project
+			// Settings -> JWT Templates) so the `iss` claim becomes the fully
+			// qualified URL https://api.descope.com/<Your Descope Project ID>.
+			// The `aud` claim already matches your Project ID.
+			// Set DESCOPE_PROJECT_ID on the Convex Dashboard. `domain` must match
+			// the token's `iss` claim.
+			// See https://docs.descope.com/sessions/validation/jwt-authorizers/aws-jwt-authorizer
+			domain: `https://api.descope.com/${process.env.DESCOPE_PROJECT_ID}`,
+			applicationID: process.env.DESCOPE_PROJECT_ID,
+		},
+	],
+};

--- a/packages/template-generator/templates/auth/descope/convex/backend/convex/privateData.ts.hbs
+++ b/packages/template-generator/templates/auth/descope/convex/backend/convex/privateData.ts.hbs
@@ -1,0 +1,16 @@
+import { query } from "./_generated/server";
+
+export const get = query({
+	args: {},
+	handler: async (ctx) => {
+		const identity = await ctx.auth.getUserIdentity();
+		if (identity === null) {
+			return {
+				message: "Not authenticated",
+			};
+		}
+		return {
+			message: "This is private",
+		};
+	},
+});

--- a/packages/template-generator/templates/auth/descope/convex/web/react/next/src/app/dashboard/page.tsx.hbs
+++ b/packages/template-generator/templates/auth/descope/convex/web/react/next/src/app/dashboard/page.tsx.hbs
@@ -1,0 +1,40 @@
+"use client";
+
+import { api } from "@{{projectName}}/backend/convex/_generated/api";
+import { Descope } from "@descope/nextjs-sdk";
+import { useDescope, useUser } from "@descope/nextjs-sdk/client";
+import { Authenticated, AuthLoading, Unauthenticated, useQuery } from "convex/react";
+
+export default function Dashboard() {
+  const { user } = useUser();
+  const sdk = useDescope();
+  const privateData = useQuery(api.privateData.get);
+  const displayName = user?.name || user?.email || user?.loginIds?.[0] || "User";
+
+  return (
+    <>
+      <Authenticated>
+        <div className="space-y-4 p-6">
+          <h1 className="text-2xl font-semibold">Dashboard</h1>
+          <p>Welcome {displayName}</p>
+          <p>privateData: {privateData?.message}</p>
+          <button
+            type="button"
+            className="rounded-md border px-3 py-1"
+            onClick={() => sdk.logout()}
+          >
+            Sign out
+          </button>
+        </div>
+      </Authenticated>
+      <Unauthenticated>
+        <div className="mx-auto max-w-md p-6">
+          <Descope flowId="sign-up-or-in" />
+        </div>
+      </Unauthenticated>
+      <AuthLoading>
+        <div className="p-6">Loading...</div>
+      </AuthLoading>
+    </>
+  );
+}

--- a/packages/template-generator/templates/auth/descope/convex/web/react/next/src/app/sign-in/page.tsx.hbs
+++ b/packages/template-generator/templates/auth/descope/convex/web/react/next/src/app/sign-in/page.tsx.hbs
@@ -1,0 +1,19 @@
+"use client";
+
+import { Descope } from "@descope/nextjs-sdk";
+import { useRouter } from "next/navigation";
+
+export default function SignInPage() {
+	const router = useRouter();
+
+	return (
+		<div className="mx-auto max-w-md p-6">
+			<Descope
+				flowId="sign-up-or-in"
+				onSuccess={() => {
+					router.push("/dashboard");
+				}}
+			/>
+		</div>
+	);
+}

--- a/packages/template-generator/templates/auth/descope/convex/web/react/next/src/utils/convex-descope-auth.ts.hbs
+++ b/packages/template-generator/templates/auth/descope/convex/web/react/next/src/utils/convex-descope-auth.ts.hbs
@@ -1,0 +1,22 @@
+import { getSessionToken, useSession } from "@descope/nextjs-sdk/client";
+import { useCallback, useMemo } from "react";
+
+// Bridges Descope's session state into Convex's `ConvexProviderWithAuth`.
+// The Descope SDK automatically refreshes the token via `getSessionToken()`
+// while the refresh token is still active.
+export function useAuthFromDescope() {
+	const { isSessionLoading, isAuthenticated } = useSession();
+
+	const fetchAccessToken = useCallback(async () => {
+		return getSessionToken() ?? null;
+	}, []);
+
+	return useMemo(
+		() => ({
+			isLoading: isSessionLoading,
+			isAuthenticated: isAuthenticated ?? false,
+			fetchAccessToken,
+		}),
+		[isSessionLoading, isAuthenticated, fetchAccessToken],
+	);
+}

--- a/packages/template-generator/templates/auth/descope/convex/web/react/react-router/src/routes/dashboard.tsx.hbs
+++ b/packages/template-generator/templates/auth/descope/convex/web/react/react-router/src/routes/dashboard.tsx.hbs
@@ -1,0 +1,42 @@
+import { api } from "@{{projectName}}/backend/convex/_generated/api";
+import { Descope, useDescope, useUser } from "@descope/react-sdk";
+import {
+	Authenticated,
+	AuthLoading,
+	Unauthenticated,
+	useQuery,
+} from "convex/react";
+
+export default function Dashboard() {
+	const { user } = useUser();
+	const sdk = useDescope();
+	const privateData = useQuery(api.privateData.get);
+	const displayName = user?.name || user?.email || user?.loginIds?.[0] || "User";
+
+	return (
+		<>
+			<Authenticated>
+				<div className="space-y-4 p-6">
+					<h1 className="text-2xl font-semibold">Dashboard</h1>
+					<p>Welcome {displayName}</p>
+					<p>privateData: {privateData?.message}</p>
+					<button
+						type="button"
+						className="rounded-md border px-3 py-1"
+						onClick={() => sdk.logout()}
+					>
+						Sign out
+					</button>
+				</div>
+			</Authenticated>
+			<Unauthenticated>
+				<div className="mx-auto max-w-md p-6">
+					<Descope flowId="sign-up-or-in" />
+				</div>
+			</Unauthenticated>
+			<AuthLoading>
+				<div className="p-6">Loading...</div>
+			</AuthLoading>
+		</>
+	);
+}

--- a/packages/template-generator/templates/auth/descope/convex/web/react/react-router/src/utils/convex-descope-auth.ts.hbs
+++ b/packages/template-generator/templates/auth/descope/convex/web/react/react-router/src/utils/convex-descope-auth.ts.hbs
@@ -1,0 +1,22 @@
+import { getSessionToken, useSession } from "@descope/react-sdk";
+import { useCallback, useMemo } from "react";
+
+// Bridges Descope's session state into Convex's `ConvexProviderWithAuth`.
+// The Descope SDK automatically refreshes the token via `getSessionToken()`
+// while the refresh token is still active.
+export function useAuthFromDescope() {
+	const { isSessionLoading, isAuthenticated } = useSession();
+
+	const fetchAccessToken = useCallback(async () => {
+		return getSessionToken() ?? null;
+	}, []);
+
+	return useMemo(
+		() => ({
+			isLoading: isSessionLoading,
+			isAuthenticated: isAuthenticated ?? false,
+			fetchAccessToken,
+		}),
+		[isSessionLoading, isAuthenticated, fetchAccessToken],
+	);
+}

--- a/packages/template-generator/templates/auth/descope/convex/web/react/tanstack-router/src/routes/_auth/dashboard.tsx.hbs
+++ b/packages/template-generator/templates/auth/descope/convex/web/react/tanstack-router/src/routes/_auth/dashboard.tsx.hbs
@@ -1,0 +1,30 @@
+import { api } from "@{{projectName}}/backend/convex/_generated/api";
+import { useDescope, useUser } from "@descope/react-sdk";
+import { createFileRoute } from "@tanstack/react-router";
+import { useQuery } from "convex/react";
+
+export const Route = createFileRoute("/_auth/dashboard")({
+	component: RouteComponent,
+});
+
+function RouteComponent() {
+	const { user } = useUser();
+	const sdk = useDescope();
+	const privateData = useQuery(api.privateData.get);
+	const displayName = user?.name || user?.email || user?.loginIds?.[0] || "User";
+
+	return (
+		<div className="space-y-4 p-6">
+			<h1 className="text-2xl font-semibold">Dashboard</h1>
+			<p>Welcome {displayName}</p>
+			<p>privateData: {privateData?.message}</p>
+			<button
+				type="button"
+				className="rounded-md border px-3 py-1"
+				onClick={() => sdk.logout()}
+			>
+				Sign out
+			</button>
+		</div>
+	);
+}

--- a/packages/template-generator/templates/auth/descope/convex/web/react/tanstack-router/src/routes/_auth/route.tsx.hbs
+++ b/packages/template-generator/templates/auth/descope/convex/web/react/tanstack-router/src/routes/_auth/route.tsx.hbs
@@ -1,0 +1,25 @@
+import { Descope } from "@descope/react-sdk";
+import { Outlet, createFileRoute } from "@tanstack/react-router";
+import { Authenticated, AuthLoading, Unauthenticated } from "convex/react";
+
+export const Route = createFileRoute("/_auth")({
+	component: AuthLayout,
+});
+
+function AuthLayout() {
+	return (
+		<>
+			<Authenticated>
+				<Outlet />
+			</Authenticated>
+			<Unauthenticated>
+				<div className="mx-auto max-w-md p-6">
+					<Descope flowId="sign-up-or-in" />
+				</div>
+			</Unauthenticated>
+			<AuthLoading>
+				<div className="p-6">Loading...</div>
+			</AuthLoading>
+		</>
+	);
+}

--- a/packages/template-generator/templates/auth/descope/convex/web/react/tanstack-router/src/utils/convex-descope-auth.ts.hbs
+++ b/packages/template-generator/templates/auth/descope/convex/web/react/tanstack-router/src/utils/convex-descope-auth.ts.hbs
@@ -1,0 +1,22 @@
+import { getSessionToken, useSession } from "@descope/react-sdk";
+import { useCallback, useMemo } from "react";
+
+// Bridges Descope's session state into Convex's `ConvexProviderWithAuth`.
+// The Descope SDK automatically refreshes the token via `getSessionToken()`
+// while the refresh token is still active.
+export function useAuthFromDescope() {
+	const { isSessionLoading, isAuthenticated } = useSession();
+
+	const fetchAccessToken = useCallback(async () => {
+		return getSessionToken() ?? null;
+	}, []);
+
+	return useMemo(
+		() => ({
+			isLoading: isSessionLoading,
+			isAuthenticated: isAuthenticated ?? false,
+			fetchAccessToken,
+		}),
+		[isSessionLoading, isAuthenticated, fetchAccessToken],
+	);
+}

--- a/packages/template-generator/templates/auth/descope/web/react/base/src/utils/descope-auth.ts.hbs
+++ b/packages/template-generator/templates/auth/descope/web/react/base/src/utils/descope-auth.ts.hbs
@@ -1,0 +1,9 @@
+{{#if (includes frontend "next")}}
+import { getSessionToken } from "@descope/nextjs-sdk/client";
+{{else}}
+import { getSessionToken } from "@descope/react-sdk";
+{{/if}}
+
+export function getDescopeAuthToken(): string | null {
+	return getSessionToken() || null;
+}

--- a/packages/template-generator/templates/auth/descope/web/react/next/src/app/dashboard/page.tsx.hbs
+++ b/packages/template-generator/templates/auth/descope/web/react/next/src/app/dashboard/page.tsx.hbs
@@ -1,0 +1,60 @@
+"use client";
+
+{{#if (eq api "orpc")}}
+import { useQuery } from "@tanstack/react-query";
+import { orpc } from "@/utils/orpc";
+{{/if}}
+{{#if (eq api "trpc")}}
+import { useQuery } from "@tanstack/react-query";
+import { trpc } from "@/utils/trpc";
+{{/if}}
+import { Descope } from "@descope/nextjs-sdk";
+import { useDescope, useSession, useUser } from "@descope/nextjs-sdk/client";
+
+export default function Dashboard() {
+  const { isAuthenticated, isSessionLoading } = useSession();
+  const { user } = useUser();
+  const sdk = useDescope();
+  const displayName = user?.name || user?.email || user?.loginIds?.[0] || "User";
+  {{#if (eq api "orpc")}}
+  const privateData = useQuery({
+    ...orpc.privateData.queryOptions(),
+    enabled: isAuthenticated,
+  });
+  {{/if}}
+  {{#if (eq api "trpc")}}
+  const privateData = useQuery({
+    ...trpc.privateData.queryOptions(),
+    enabled: isAuthenticated,
+  });
+  {{/if}}
+
+  if (isSessionLoading) {
+    return <div className="p-6">Loading...</div>;
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <div className="mx-auto max-w-md p-6">
+        <Descope flowId="sign-up-or-in" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4 p-6">
+      <h1 className="text-2xl font-semibold">Dashboard</h1>
+      <p>Welcome {displayName}</p>
+      {{#if (or (eq api "orpc") (eq api "trpc"))}}
+      <p>API: {privateData.data?.message}</p>
+      {{/if}}
+      <button
+        type="button"
+        className="rounded-md border px-3 py-1"
+        onClick={() => sdk.logout()}
+      >
+        Sign out
+      </button>
+    </div>
+  );
+}

--- a/packages/template-generator/templates/auth/descope/web/react/next/src/app/sign-in/page.tsx.hbs
+++ b/packages/template-generator/templates/auth/descope/web/react/next/src/app/sign-in/page.tsx.hbs
@@ -1,0 +1,19 @@
+"use client";
+
+import { Descope } from "@descope/nextjs-sdk";
+import { useRouter } from "next/navigation";
+
+export default function SignInPage() {
+	const router = useRouter();
+
+	return (
+		<div className="mx-auto max-w-md p-6">
+			<Descope
+				flowId="sign-up-or-in"
+				onSuccess={() => {
+					router.push("/dashboard");
+				}}
+			/>
+		</div>
+	);
+}

--- a/packages/template-generator/templates/auth/descope/web/react/next/src/proxy.ts.hbs
+++ b/packages/template-generator/templates/auth/descope/web/react/next/src/proxy.ts.hbs
@@ -1,0 +1,18 @@
+import { authMiddleware } from "@descope/nextjs-sdk/server";
+
+export default authMiddleware({
+	projectId: process.env.NEXT_PUBLIC_DESCOPE_PROJECT_ID,
+	// Route unauthenticated users to the sign-in flow
+	redirectUrl: "/sign-in",
+	// Routes that do not require authentication
+	publicRoutes: ["/", "/sign-in"],
+});
+
+export const config = {
+	matcher: [
+		// Skip Next.js internals and all static files, unless found in search params
+		"/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
+		// Always run for API routes
+		"/(api|trpc)(.*)",
+	],
+};

--- a/packages/template-generator/templates/auth/descope/web/react/react-router/src/routes/dashboard.tsx.hbs
+++ b/packages/template-generator/templates/auth/descope/web/react/react-router/src/routes/dashboard.tsx.hbs
@@ -1,0 +1,57 @@
+{{#if (eq api "orpc")}}
+import { useQuery } from "@tanstack/react-query";
+import { orpc } from "@/utils/orpc";
+{{/if}}
+{{#if (eq api "trpc")}}
+import { useQuery } from "@tanstack/react-query";
+import { trpc } from "@/utils/trpc";
+{{/if}}
+import { Descope, useDescope, useSession, useUser } from "@descope/react-sdk";
+
+export default function Dashboard() {
+  const { isAuthenticated, isSessionLoading } = useSession();
+  const { user } = useUser();
+  const sdk = useDescope();
+  const displayName = user?.name || user?.email || user?.loginIds?.[0] || "User";
+  {{#if (eq api "orpc")}}
+  const privateData = useQuery({
+    ...orpc.privateData.queryOptions(),
+    enabled: isAuthenticated,
+  });
+  {{/if}}
+  {{#if (eq api "trpc")}}
+  const privateData = useQuery({
+    ...trpc.privateData.queryOptions(),
+    enabled: isAuthenticated,
+  });
+  {{/if}}
+
+  if (isSessionLoading) {
+    return <div className="p-6">Loading...</div>;
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <div className="mx-auto max-w-md p-6">
+        <Descope flowId="sign-up-or-in" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4 p-6">
+      <h1 className="text-2xl font-semibold">Dashboard</h1>
+      <p>Welcome {displayName}</p>
+      {{#if (or (eq api "orpc") (eq api "trpc"))}}
+      <p>API: {privateData.data?.message}</p>
+      {{/if}}
+      <button
+        type="button"
+        className="rounded-md border px-3 py-1"
+        onClick={() => sdk.logout()}
+      >
+        Sign out
+      </button>
+    </div>
+  );
+}

--- a/packages/template-generator/templates/auth/descope/web/react/tanstack-router/src/routes/_auth/dashboard.tsx.hbs
+++ b/packages/template-generator/templates/auth/descope/web/react/tanstack-router/src/routes/_auth/dashboard.tsx.hbs
@@ -1,0 +1,43 @@
+{{#if (eq api "orpc")}}
+import { useQuery } from "@tanstack/react-query";
+import { orpc } from "@/utils/orpc";
+{{/if}}
+{{#if (eq api "trpc")}}
+import { useQuery } from "@tanstack/react-query";
+import { trpc } from "@/utils/trpc";
+{{/if}}
+import { useDescope, useUser } from "@descope/react-sdk";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/_auth/dashboard")({
+	component: RouteComponent,
+});
+
+function RouteComponent() {
+	const { user } = useUser();
+	const sdk = useDescope();
+	const displayName = user?.name || user?.email || user?.loginIds?.[0] || "User";
+	{{#if (eq api "orpc")}}
+	const privateData = useQuery(orpc.privateData.queryOptions());
+	{{/if}}
+	{{#if (eq api "trpc")}}
+	const privateData = useQuery(trpc.privateData.queryOptions());
+	{{/if}}
+
+	return (
+		<div className="space-y-4 p-6">
+			<h1 className="text-2xl font-semibold">Dashboard</h1>
+			<p>Welcome {displayName}</p>
+			{{#if (or (eq api "orpc") (eq api "trpc"))}}
+			<p>API: {privateData.data?.message}</p>
+			{{/if}}
+			<button
+				type="button"
+				className="rounded-md border px-3 py-1"
+				onClick={() => sdk.logout()}
+			>
+				Sign out
+			</button>
+		</div>
+	);
+}

--- a/packages/template-generator/templates/auth/descope/web/react/tanstack-router/src/routes/_auth/route.tsx.hbs
+++ b/packages/template-generator/templates/auth/descope/web/react/tanstack-router/src/routes/_auth/route.tsx.hbs
@@ -1,0 +1,24 @@
+import { Descope, useSession } from "@descope/react-sdk";
+import { Outlet, createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/_auth")({
+	component: AuthLayout,
+});
+
+function AuthLayout() {
+	const { isAuthenticated, isSessionLoading } = useSession();
+
+	if (isSessionLoading) {
+		return <div className="p-6">Loading...</div>;
+	}
+
+	if (!isAuthenticated) {
+		return (
+			<div className="mx-auto max-w-md p-6">
+				<Descope flowId="sign-up-or-in" />
+			</div>
+		);
+	}
+
+	return <Outlet />;
+}

--- a/packages/template-generator/templates/frontend/react/next/src/app/layout.tsx.hbs
+++ b/packages/template-generator/templates/frontend/react/next/src/app/layout.tsx.hbs
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "../index.css";
 {{#if (eq auth "clerk")}}import { ClerkProvider } from "@clerk/nextjs";
+{{/if}}{{#if (eq auth "descope")}}import { AuthProvider } from "@descope/nextjs-sdk";
+import { env } from "@{{projectName}}/env/web";
 {{/if}}{{#if (and (eq backend "convex") (eq auth "better-auth"))}}
 import { getToken } from "@/lib/auth-server";
 {{/if}}
@@ -63,7 +65,14 @@ export default function RootLayout({
 							{children}
 						</div>
 					</Providers>
-				</ClerkProvider>{{else}}<Providers>
+				</ClerkProvider>{{else if (eq auth "descope")}}<AuthProvider projectId={env.NEXT_PUBLIC_DESCOPE_PROJECT_ID}>
+					<Providers>
+						<div className="grid grid-rows-[auto_1fr] h-svh">
+							<Header />
+							{children}
+						</div>
+					</Providers>
+				</AuthProvider>{{else}}<Providers>
 					<div className="grid grid-rows-[auto_1fr] h-svh">
 						<Header />
 						{children}

--- a/packages/template-generator/templates/frontend/react/next/src/components/providers.tsx.hbs
+++ b/packages/template-generator/templates/frontend/react/next/src/components/providers.tsx.hbs
@@ -12,6 +12,10 @@ import { useAuth } from "@clerk/nextjs";
 import { ConvexReactClient } from "convex/react";
 import { ConvexProviderWithClerk } from "convex/react-clerk";
 import { env } from "@{{projectName}}/env/web";
+{{else if (eq auth "descope")}}
+import { ConvexProviderWithAuth, ConvexReactClient } from "convex/react";
+import { useAuthFromDescope } from "@/utils/convex-descope-auth";
+import { env } from "@{{projectName}}/env/web";
 {{else if (eq auth "better-auth")}}
 import { ConvexReactClient } from "convex/react";
 import { ConvexBetterAuthProvider } from "@convex-dev/better-auth/react";
@@ -79,6 +83,10 @@ export default function Providers({
       <ConvexProviderWithClerk client={convex} useAuth={useAuth}>
         {children}
       </ConvexProviderWithClerk>
+      {{else if (eq auth "descope")}}
+      <ConvexProviderWithAuth client={convex} useAuth={useAuthFromDescope}>
+        {children}
+      </ConvexProviderWithAuth>
       {{else if (eq auth "better-auth")}}
       <ConvexBetterAuthProvider
         client={convex}

--- a/packages/template-generator/templates/frontend/react/react-router/react-router.config.ts.hbs
+++ b/packages/template-generator/templates/frontend/react/react-router/react-router.config.ts.hbs
@@ -7,6 +7,9 @@ export default {
 {{#if (or (includes addons "tauri") (includes addons "electrobun"))}}
   // Desktop addons package static web assets; SSR output cannot be bundled
   ssr: false,
+{{else if (eq auth "descope")}}
+  // Descope's SDK is client-only; render as a SPA so its AuthProvider/hooks work
+  ssr: false,
 {{/if}}
   appDirectory: "src",
 } satisfies Config;

--- a/packages/template-generator/templates/frontend/react/react-router/src/root.tsx.hbs
+++ b/packages/template-generator/templates/frontend/react/react-router/src/root.tsx.hbs
@@ -30,6 +30,9 @@ import { AuthProvider } from "@descope/react-sdk";
 import { ConvexReactClient } from "convex/react";
   {{#if (eq auth "clerk")}}
 import { ConvexProviderWithClerk } from "convex/react-clerk";
+  {{else if (eq auth "descope")}}
+import { ConvexProviderWithAuth } from "convex/react";
+import { useAuthFromDescope } from "@/utils/convex-descope-auth";
   {{else if (eq auth "better-auth")}}
 import { ConvexBetterAuthProvider } from "@convex-dev/better-auth/react";
 import { authClient } from "@/lib/auth-client";
@@ -143,6 +146,25 @@ export default function App() {
         <Toaster richColors />
       </ThemeProvider>
     </ConvexBetterAuthProvider>
+  );
+  {{else if (eq auth "descope")}}
+  return (
+    <AuthProvider projectId={env.VITE_DESCOPE_PROJECT_ID}>
+      <ConvexProviderWithAuth client={convex} useAuth={useAuthFromDescope}>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="dark"
+          disableTransitionOnChange
+          storageKey="vite-ui-theme"
+        >
+          <div className="grid grid-rows-[auto_1fr] h-svh">
+            <Header />
+            <Outlet />
+          </div>
+          <Toaster richColors />
+        </ThemeProvider>
+      </ConvexProviderWithAuth>
+    </AuthProvider>
   );
   {{else}}
   return (

--- a/packages/template-generator/templates/frontend/react/react-router/src/root.tsx.hbs
+++ b/packages/template-generator/templates/frontend/react/react-router/src/root.tsx.hbs
@@ -19,10 +19,15 @@ import { clerkMiddleware, rootAuthLoader } from "@clerk/react-router/server";
 import { useEffect } from "react";
 import { setClerkAuthTokenGetter } from "@/utils/clerk-auth";
 {{/if}}
+{{#if (or (eq backend "convex") (eq auth "descope"))}}
+import { env } from "@{{projectName}}/env/web";
+{{/if}}
+{{#if (eq auth "descope")}}
+import { AuthProvider } from "@descope/react-sdk";
+{{/if}}
 
 {{#if (eq backend "convex")}}
 import { ConvexReactClient } from "convex/react";
-import { env } from "@{{projectName}}/env/web";
   {{#if (eq auth "clerk")}}
 import { ConvexProviderWithClerk } from "convex/react-clerk";
   {{else if (eq auth "better-auth")}}
@@ -212,6 +217,59 @@ export default function App({ loaderData }: Route.ComponentProps) {
       </ThemeProvider>
       {{/if}}
     </ClerkProvider>
+  );
+}
+{{else if (eq auth "descope")}}
+export default function App() {
+  return (
+    <AuthProvider projectId={env.VITE_DESCOPE_PROJECT_ID}>
+      {{#if (eq api "orpc")}}
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="dark"
+          disableTransitionOnChange
+          storageKey="vite-ui-theme"
+        >
+          <div className="grid grid-rows-[auto_1fr] h-svh">
+            <Header />
+            <Outlet />
+          </div>
+          <Toaster richColors />
+        </ThemeProvider>
+        <ReactQueryDevtools position="bottom" buttonPosition="bottom-right" />
+      </QueryClientProvider>
+      {{else if (eq api "trpc")}}
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="dark"
+          disableTransitionOnChange
+          storageKey="vite-ui-theme"
+        >
+          <div className="grid grid-rows-[auto_1fr] h-svh">
+            <Header />
+            <Outlet />
+          </div>
+          <Toaster richColors />
+        </ThemeProvider>
+        <ReactQueryDevtools position="bottom" buttonPosition="bottom-right" />
+      </QueryClientProvider>
+      {{else}}
+      <ThemeProvider
+        attribute="class"
+        defaultTheme="dark"
+        disableTransitionOnChange
+        storageKey="vite-ui-theme"
+      >
+        <div className="grid grid-rows-[auto_1fr] h-svh">
+          <Header />
+          <Outlet />
+        </div>
+        <Toaster richColors />
+      </ThemeProvider>
+      {{/if}}
+    </AuthProvider>
   );
 }
 {{else if (eq api "orpc")}}

--- a/packages/template-generator/templates/frontend/react/tanstack-router/src/main.tsx.hbs
+++ b/packages/template-generator/templates/frontend/react/tanstack-router/src/main.tsx.hbs
@@ -28,6 +28,9 @@ import { routeTree } from "./routeTree.gen";
   import { ConvexReactClient } from "convex/react";
   {{#if (eq auth "clerk")}}
   import { ConvexProviderWithClerk } from "convex/react-clerk";
+  {{else if (eq auth "descope")}}
+  import { ConvexProviderWithAuth } from "convex/react";
+  import { useAuthFromDescope } from "@/utils/convex-descope-auth";
   {{else if (eq auth "better-auth")}}
   import { ConvexBetterAuthProvider } from "@convex-dev/better-auth/react";
   import { authClient } from "@/lib/auth-client";
@@ -118,6 +121,14 @@ const router = createRouter({
           {children}
         </ConvexProviderWithClerk>
       </ClerkProvider>
+    );
+    {{else if (eq auth "descope")}}
+    return (
+      <AuthProvider projectId={env.VITE_DESCOPE_PROJECT_ID}>
+        <ConvexProviderWithAuth client={convex} useAuth={useAuthFromDescope}>
+          {children}
+        </ConvexProviderWithAuth>
+      </AuthProvider>
     );
     {{else if (eq auth "better-auth")}}
     return <ConvexBetterAuthProvider client={convex} authClient={authClient}>{children}</ConvexBetterAuthProvider>;

--- a/packages/template-generator/templates/frontend/react/tanstack-router/src/main.tsx.hbs
+++ b/packages/template-generator/templates/frontend/react/tanstack-router/src/main.tsx.hbs
@@ -15,11 +15,14 @@ import { routeTree } from "./routeTree.gen";
   import { QueryClientProvider } from "@tanstack/react-query";
   import { queryClient, trpc } from "./utils/trpc";
 {{/if}}
-{{#if (or (eq backend "convex") (eq auth "clerk"))}}
+{{#if (or (eq backend "convex") (eq auth "clerk") (eq auth "descope"))}}
   import { env } from "@{{projectName}}/env/web";
 {{/if}}
 {{#if (eq auth "clerk")}}
   import { ClerkProvider{{#if (or (eq backend "convex") (ne api "none"))}}, useAuth{{/if}} } from "@clerk/react";
+{{/if}}
+{{#if (eq auth "descope")}}
+  import { AuthProvider } from "@descope/react-sdk";
 {{/if}}
 {{#if (eq backend "convex")}}
   import { ConvexReactClient } from "convex/react";
@@ -66,6 +69,12 @@ const router = createRouter({
           {children}
         </QueryClientProvider>
       </ClerkProvider>
+      {{else if (eq auth "descope")}}
+      <AuthProvider projectId={env.VITE_DESCOPE_PROJECT_ID}>
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      </AuthProvider>
       {{else}}
       <QueryClientProvider client={queryClient}>
         {children}
@@ -84,6 +93,12 @@ const router = createRouter({
           {children}
         </QueryClientProvider>
       </ClerkProvider>
+      {{else if (eq auth "descope")}}
+      <AuthProvider projectId={env.VITE_DESCOPE_PROJECT_ID}>
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      </AuthProvider>
       {{else}}
       <QueryClientProvider client={queryClient}>
         {children}
@@ -114,6 +129,11 @@ const router = createRouter({
   context: {},
   Wrap: function WrapComponent({ children }: { children: React.ReactNode }) {
     return <ClerkProvider publishableKey={env.VITE_CLERK_PUBLISHABLE_KEY}>{children}</ClerkProvider>;
+  },
+  {{else if (eq auth "descope")}}
+  context: {},
+  Wrap: function WrapComponent({ children }: { children: React.ReactNode }) {
+    return <AuthProvider projectId={env.VITE_DESCOPE_PROJECT_ID}>{children}</AuthProvider>;
   },
   {{else}}
   context: {},

--- a/packages/template-generator/templates/frontend/react/web-base/src/components/header.tsx.hbs
+++ b/packages/template-generator/templates/frontend/react/web-base/src/components/header.tsx.hbs
@@ -16,7 +16,7 @@ import UserMenu from "./user-menu";
 export default function Header() {
   const links = [
     { to: "/", label: "Home" },
-    {{#if (or (eq auth "better-auth") (eq auth "clerk"))}}
+    {{#if (or (eq auth "better-auth") (eq auth "clerk") (eq auth "descope"))}}
       { to: "/dashboard", label: "Dashboard" },
     {{/if}}
     {{#if (includes examples "todo")}}

--- a/packages/template-generator/templates/packages/env/src/server.ts.hbs
+++ b/packages/template-generator/templates/packages/env/src/server.ts.hbs
@@ -146,6 +146,9 @@ export const env = createEnv({
 		CLERK_PUBLISHABLE_KEY: z.string().min(1),
 {{/if}}
 {{/if}}
+{{#if (eq auth "descope")}}
+		DESCOPE_PROJECT_ID: z.string().min(1),
+{{/if}}
 {{#if (eq payments "polar")}}
 		POLAR_ACCESS_TOKEN: z.string().min(1),
 		POLAR_SUCCESS_URL: z.url(),

--- a/packages/template-generator/templates/packages/env/src/web.ts.hbs
+++ b/packages/template-generator/templates/packages/env/src/web.ts.hbs
@@ -42,6 +42,9 @@ export const env = createEnv({
 {{#if (eq auth "clerk")}}
 		NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: z.string().min(1),
 {{/if}}
+{{#if (eq auth "descope")}}
+		NEXT_PUBLIC_DESCOPE_PROJECT_ID: z.string().min(1),
+{{/if}}
 	},
 	runtimeEnv: {
 		NEXT_PUBLIC_CONVEX_URL: process.env.NEXT_PUBLIC_CONVEX_URL,
@@ -50,6 +53,9 @@ export const env = createEnv({
 {{/if}}
 {{#if (eq auth "clerk")}}
 		NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
+{{/if}}
+{{#if (eq auth "descope")}}
+		NEXT_PUBLIC_DESCOPE_PROJECT_ID: process.env.NEXT_PUBLIC_DESCOPE_PROJECT_ID,
 {{/if}}
 	},
 {{else if (includes frontend "nuxt")}}
@@ -71,6 +77,9 @@ export const env = createEnv({
 {{/if}}
 {{#if (eq auth "clerk")}}
 		VITE_CLERK_PUBLISHABLE_KEY: z.string().min(1),
+{{/if}}
+{{#if (eq auth "descope")}}
+		VITE_DESCOPE_PROJECT_ID: z.string().min(1),
 {{/if}}
 	},
 	runtimeEnv: (import.meta as any).env,
@@ -151,6 +160,9 @@ export const env = createEnv({
 	runtimeEnv: (import.meta as any).env,
 {{/if}}
 {{/if}}
-	skipValidation: !!process.env.SKIP_ENV_VALIDATION,
+	// `process` is undefined in the browser (e.g. Vite SPA builds such as the
+	// Descope `ssr: false` setup), so guard the access to avoid a runtime crash.
+	skipValidation:
+		typeof process !== "undefined" && !!process.env.SKIP_ENV_VALIDATION,
 	emptyStringAsUndefined: true,
 });

--- a/packages/template-generator/templates/packages/env/src/web.ts.hbs
+++ b/packages/template-generator/templates/packages/env/src/web.ts.hbs
@@ -81,10 +81,16 @@ export const env = createEnv({
 {{#if (eq auth "clerk")}}
 		NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: z.string().min(1),
 {{/if}}
+{{#if (eq auth "descope")}}
+		NEXT_PUBLIC_DESCOPE_PROJECT_ID: z.string().min(1),
+{{/if}}
 	},
 	runtimeEnv: {
 {{#if (eq auth "clerk")}}
 		NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
+{{/if}}
+{{#if (eq auth "descope")}}
+		NEXT_PUBLIC_DESCOPE_PROJECT_ID: process.env.NEXT_PUBLIC_DESCOPE_PROJECT_ID,
 {{/if}}
 	},
 {{else if (includes frontend "nuxt")}}
@@ -94,6 +100,9 @@ export const env = createEnv({
 	client: {
 {{#if (eq auth "clerk")}}
 		VITE_CLERK_PUBLISHABLE_KEY: z.string().min(1),
+{{/if}}
+{{#if (eq auth "descope")}}
+		VITE_DESCOPE_PROJECT_ID: z.string().min(1),
 {{/if}}
 	},
 	runtimeEnv: (import.meta as any).env,
@@ -105,11 +114,17 @@ export const env = createEnv({
 {{#if (eq auth "clerk")}}
 		NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: z.string().min(1),
 {{/if}}
+{{#if (eq auth "descope")}}
+		NEXT_PUBLIC_DESCOPE_PROJECT_ID: z.string().min(1),
+{{/if}}
 	},
 	runtimeEnv: {
 		NEXT_PUBLIC_SERVER_URL: process.env.NEXT_PUBLIC_SERVER_URL,
 {{#if (eq auth "clerk")}}
 		NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
+{{/if}}
+{{#if (eq auth "descope")}}
+		NEXT_PUBLIC_DESCOPE_PROJECT_ID: process.env.NEXT_PUBLIC_DESCOPE_PROJECT_ID,
 {{/if}}
 	},
 {{else if (includes frontend "nuxt")}}
@@ -128,6 +143,9 @@ export const env = createEnv({
 		VITE_SERVER_URL: {{#if (and (eq webDeploy "vercel") (eq serverDeploy "vercel"))}}serverUrlSchema{{else}}z.url(){{/if}},
 {{#if (eq auth "clerk")}}
 		VITE_CLERK_PUBLISHABLE_KEY: z.string().min(1),
+{{/if}}
+{{#if (eq auth "descope")}}
+		VITE_DESCOPE_PROJECT_ID: z.string().min(1),
 {{/if}}
 	},
 	runtimeEnv: (import.meta as any).env,

--- a/packages/types/src/schemas.ts
+++ b/packages/types/src/schemas.ts
@@ -88,7 +88,7 @@ export const DatabaseSetupSchema = z
 export const APISchema = z.enum(["trpc", "orpc", "none"]).describe("API type");
 
 export const AuthSchema = z
-  .enum(["better-auth", "clerk", "none"])
+  .enum(["better-auth", "clerk", "descope", "none"])
   .describe("Authentication provider");
 
 export const PaymentsSchema = z.enum(["polar", "none"]).describe("Payments provider");


### PR DESCRIPTION
## Summary

Adds **Descope** as a selectable authentication provider, end-to-end: CLI schema/prompts/validation, template generator, generated auth templates (Next.js, React Router, TanStack Router), and docs-site coverage.

## Changes

- **CLI & types:** `descope` added to the Auth enum, prompts, `compatibility-rules.ts`, and `config-validation.ts` (supported frontends: Next.js / React Router / TanStack Router; not compatible with the Convex backend).
- **Templates:** Descope auth templates for Next.js, React Router, and TanStack Router, plus dependency injection and post-install instructions. React Router wraps the app in `<AuthProvider>` and sets `ssr: false` (the SDK is client-only), which fixes a crash where `useSession()` ran outside the provider during SSR.
- **Docs site:** Descope now appears in the stack builder (auth card, icon, and compatibility gating) and is documented in the CLI options/compatibility pages.

## ⚠️ Note for maintainer — Descope logo hosting

The Descope icon is currently **bundled locally** at `apps/web/public/descope.svg` (referenced as `/descope.svg`), because I don't have write access to the `r2.better-t-stack.dev` bucket that hosts every other icon.

**If you'd prefer it served from R2 for consistency with the other icons**, please upload it and switch the reference:

```bash
npx wrangler r2 object put "bucket/icons/descope.svg" \
  --file=apps/web/public/descope.svg --remote
```

Then in `apps/web/src/lib/constant.ts` change `icon: "/descope.svg"` → `` icon: `${ICON_BASE_URL}/descope.svg` `` and delete the local file.

## Testing

- `descope-matrix.test.ts` (10/10) and web app tests (25/25) pass.
- Full CLI test suite, `oxlint`, `oxfmt --check`, and `bun build:cli` all pass.
- Verified a scaffolded React Router + Descope app builds and boots as a SPA.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **Descope** as a new CLI `--auth` option with generated sign-in/out pages, session handling, and protected auth flows for supported frontends (Next.js, React Router, TanStack Router), including ORPC/tRPC authorization wiring.
  * CLI “Next steps” now includes Descope-specific setup guidance and environment variable scaffolding.
* **Bug Fixes**
  * Improved tech icon rendering for root-relative (`/...`) icon paths.
* **Documentation**
  * Updated CLI docs and compatibility requirements to include Descope and its supported frontend/backend combinations.
* **Tests**
  * Added a Descope compatibility and generation matrix test suite with negative cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->