### PR TITLE
feat(template-generator): update Nuxt scaffold to 4.5

### DIFF
--- a/apps/cli/test/frontend.test.ts
+++ b/apps/cli/test/frontend.test.ts
@@ -114,6 +114,37 @@ describe("Frontend Configurations", () => {
   });
 
   describe("Frontend Compatibility with API", () => {
+    it("should generate the current Nuxt dependency baseline", async () => {
+      const result = await runTRPCTest({
+        projectName: "nuxt-dependency-baseline",
+        frontend: ["nuxt"],
+        api: "orpc",
+        backend: "hono",
+        runtime: "bun",
+        database: "sqlite",
+        orm: "drizzle",
+        auth: "none",
+        addons: ["none"],
+        examples: ["none"],
+        dbSetup: "none",
+        webDeploy: "none",
+        serverDeploy: "none",
+        install: false,
+      });
+
+      expectSuccess(result);
+
+      const packageJson = await fs.readJson(path.join(result.projectDir!, "apps/web/package.json"));
+      expect(packageJson.dependencies).toMatchObject({
+        "@nuxt/ui": "^4.10.0",
+        nuxt: "^4.5.0",
+        vue: "^3.5.39",
+        "vue-router": "^5.2.0",
+      });
+      expect(packageJson.devDependencies["vue-tsc"]).toBe("^3.3.7");
+      expect(packageJson.scripts["check-types"]).toBe("nuxt typecheck");
+    });
+
     it("should work with React frontends + tRPC", async () => {
       const result = await runTRPCTest({
         projectName: "react-trpc",

--- a/apps/web/content/docs/faq.mdx
+++ b/apps/web/content/docs/faq.mdx
@@ -24,7 +24,7 @@ import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 </Accordion>
 
 <Accordion id="faq-4" title="What Node.js version is required?">
-  Node.js 20+ (LTS recommended).
+  Node.js 22.19+ is required. Node.js 24 LTS is recommended.
 </Accordion>
 
 <Accordion id="faq-5" title="Can I use this with an existing project?">

--- a/apps/web/content/docs/faq.mdx
+++ b/apps/web/content/docs/faq.mdx
@@ -24,7 +24,7 @@ import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 </Accordion>
 
 <Accordion id="faq-4" title="What Node.js version is required?">
-  Node.js 22.19+ is required. Node.js 24 LTS is recommended.
+  Node.js LTS.
 </Accordion>
 
 <Accordion id="faq-5" title="Can I use this with an existing project?">

--- a/apps/web/content/docs/index.mdx
+++ b/apps/web/content/docs/index.mdx
@@ -14,7 +14,7 @@ description: Create your first Better-T-Stack project in minutes
 
 ### Prerequisites
 
-- **Node.js LTS** - [Download from nodejs.org](https://nodejs.org/)
+- **Node.js 22.19+** (Node.js 24 LTS recommended) - [Download from nodejs.org](https://nodejs.org/)
 - **Git** (optional) - [Download from git-scm.com](https://git-scm.com/) - if you want to initialize a git repository
 - **Bun** (optional) - [Download from bun.com](https://bun.com/) - if you want to use Bun as your package manager
 

--- a/apps/web/content/docs/index.mdx
+++ b/apps/web/content/docs/index.mdx
@@ -14,7 +14,7 @@ description: Create your first Better-T-Stack project in minutes
 
 ### Prerequisites
 
-- **Node.js 22.19+** (Node.js 24 LTS recommended) - [Download from nodejs.org](https://nodejs.org/)
+- **Node.js LTS** - [Download from nodejs.org](https://nodejs.org/)
 - **Git** (optional) - [Download from git-scm.com](https://git-scm.com/) - if you want to initialize a git repository
 - **Bun** (optional) - [Download from bun.com](https://bun.com/) - if you want to use Bun as your package manager
 

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -29742,19 +29742,22 @@ export default defineNuxtConfig({
   "type": "module",
   "scripts": {
     "build": "nuxt build",
+    "check-types": "nuxt typecheck",
     "dev": "nuxt dev",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare"
   },
   "dependencies": {
-    "@nuxt/ui": "^4.9.0",
-    "nuxt": "^4.4.8",
-    "vue": "^3.5.39"
+    "@nuxt/ui": "^4.10.0",
+    "nuxt": "^4.5.0",
+    "vue": "^3.5.39",
+    "vue-router": "^5.2.0"
   },
   "devDependencies": {
     "tailwindcss": "^4.3.2",
-    "@iconify-json/lucide": "^1.2.115"
+    "@iconify-json/lucide": "^1.2.115",
+    "vue-tsc": "^3.3.7"
   }
 }
 `],

--- a/packages/template-generator/templates/frontend/nuxt/package.json.hbs
+++ b/packages/template-generator/templates/frontend/nuxt/package.json.hbs
@@ -4,18 +4,21 @@
   "type": "module",
   "scripts": {
     "build": "nuxt build",
+    "check-types": "nuxt typecheck",
     "dev": "nuxt dev",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare"
   },
   "dependencies": {
-    "@nuxt/ui": "^4.9.0",
-    "nuxt": "^4.4.8",
-    "vue": "^3.5.39"
+    "@nuxt/ui": "^4.10.0",
+    "nuxt": "^4.5.0",
+    "vue": "^3.5.39",
+    "vue-router": "^5.2.0"
   },
   "devDependencies": {
     "tailwindcss": "^4.3.2",
-    "@iconify-json/lucide": "^1.2.115"
+    "@iconify-json/lucide": "^1.2.115",
+    "vue-tsc": "^3.3.7"
   }
 }


### PR DESCRIPTION
## Summary

- update generated Nuxt projects to Nuxt 4.5.0, Nuxt UI 4.10.0, and Vue Router 5.2.0
- add `vue-tsc` and a `nuxt typecheck` workspace script so the root type-check command includes the Nuxt app
- regenerate the embedded template bundle and add regression coverage for the Nuxt dependency and script baseline
- document Node.js LTS as the project requirement

## Why

Nuxt 4.5 moved the stable framework baseline forward, including Vite 8. A literal scaffold verification also found that generated Nuxt workspaces had no `check-types` script, so the root command silently checked only the backend.

## Impact

Fresh Nuxt projects now install the current stable stack and participate in repository-wide type-checking without an interactive Nuxt prompt.

## Validation

- `bun run check`
- `bun test test/frontend.test.ts` — 43 passed
- `BTS_BUILD_SAMPLES=1 BTS_BUILD_SAMPLE_FILTER=nuxt-orpc bun test test/generated-builds.test.ts` — fresh install, production build, and Nuxt/backend type-check passed
- manually scaffolded a clean Nuxt + Hono + oRPC project through the CLI with dependency installation enabled
- verified Nuxt 4.5.0, Vite 8.1.5, Vue 3.5.40, and Vue Router 5.2.0 in the generated project
- verified frontend and backend HTTP 200 responses and SSR `Connected (OK)`
- verified hydration and dark-mode interaction in Playwright with zero browser console errors or warnings

## Notes

Nuxt 4.5 emitted a non-blocking internal `NUXT_B2005` development warning for its own `check-if-page-unused.js` after dependency optimization. The installed file has a default export, and the warning did not affect type-checking, production builds, SSR, API connectivity, or browser behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the Nuxt starter template with refreshed Nuxt, Vue, and UI package versions.
  - Added Vue type-checking support and a `check-types` script to validate Nuxt projects.
  - Added the required Vue Router dependency to generated Nuxt applications.

- **Documentation**
  - Clarified the FAQ guidance: Node.js LTS is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->