### PR TITLE
fix(cli): stabilize Cloudflare and EvLog scaffolds

### DIFF
--- a/apps/cli/src/helpers/addons/evlog-setup.ts
+++ b/apps/cli/src/helpers/addons/evlog-setup.ts
@@ -117,6 +117,38 @@ function getAuthExpression(config: ProjectConfig) {
   return usesCreateAuthFactory(config) ? "createAuth()" : "auth";
 }
 
+function addAiSdkEvlogTelemetry(content: string, loggerExpression: string) {
+  let nextContent = addNamedImport(content, "evlog/ai", [
+    "createAILogger",
+    "createEvlogIntegration",
+  ]);
+
+  if (!nextContent.includes("const ai = createAILogger(")) {
+    nextContent = nextContent.replace(
+      /^(\s*)const model = wrapLanguageModel\({/m,
+      (_match, indent: string) =>
+        `${indent}const ai = createAILogger(${loggerExpression});\n${indent}const model = wrapLanguageModel({`,
+    );
+  }
+
+  if (!nextContent.includes("model: ai.wrap(model)")) {
+    nextContent = nextContent.replace(
+      /(const result = streamText\({\n\s*)model,/,
+      "$1model: ai.wrap(model),",
+    );
+  }
+
+  if (!nextContent.includes("createEvlogIntegration(ai)")) {
+    nextContent = nextContent.replace(
+      /^(\s*)(messages:\s*await convertToModelMessages\([^)]+\),?)/m,
+      (_match, indent: string, messages: string) =>
+        `${indent}${messages.endsWith(",") ? messages : `${messages},`}\n${indent}telemetry: {\n${indent}\tisEnabled: true,\n${indent}\tintegrations: [createEvlogIntegration(ai)],\n${indent}},`,
+    );
+  }
+
+  return nextContent;
+}
+
 function addEvlogBetterAuthServerSetup(
   content: string,
   backend: EvlogBackend,
@@ -152,6 +184,7 @@ function addEvlogBetterAuthServerSetup(
   }
 
   if (backend === "express") {
+    nextContent = addNamedImport(nextContent, "evlog/express", ["useLogger"]);
     nextContent = insertBeforeOnce(
       nextContent,
       "const app = express();",
@@ -161,8 +194,8 @@ function addEvlogBetterAuthServerSetup(
     return insertAfterOnce(
       nextContent,
       "app.use(evlog());",
-      `\napp.use(async (req, _res, next) => {${identifyUserSetup}\n\tawait identifyUser(req.log, req.headers, req.path);\n\tnext();\n});`,
-      "identifyUser(req.log",
+      `\napp.use(async (req, _res, next) => {${identifyUserSetup}\n\tawait identifyUser(useLogger(), req.headers, req.path);\n\tnext();\n});`,
+      "identifyUser(useLogger()",
     );
   }
 
@@ -182,9 +215,12 @@ function addEvlogBetterAuthServerSetup(
     );
   }
 
+  const elysiaMarker = nextContent.includes("const app = new Elysia")
+    ? "const app = new Elysia"
+    : "new Elysia";
   nextContent = insertBeforeOnce(
     nextContent,
-    "new Elysia",
+    elysiaMarker,
     identifySnippet,
     "createAuthMiddleware(",
   );
@@ -267,7 +303,10 @@ export function addEvlogServerSetup(content: string, backend: EvlogBackend, serv
     'import { initLogger } from "evlog";',
     'import { evlog } from "evlog/elysia";',
   ]);
-  nextContent = insertBeforeOnce(nextContent, "new Elysia", initSnippet, "initLogger({");
+  const elysiaMarker = nextContent.includes("const app = new Elysia")
+    ? "const app = new Elysia"
+    : "new Elysia";
+  nextContent = insertBeforeOnce(nextContent, elysiaMarker, initSnippet, "initLogger({");
   for (const marker of ["new Elysia({ adapter: node() })", "new Elysia()"]) {
     nextContent = insertAfterOnce(nextContent, marker, "\n\t.use(evlog())", ".use(evlog())");
   }
@@ -474,7 +513,7 @@ function addNextRouteWrappers(content: string) {
 }
 
 function addNextAiEvlogSetup(content: string) {
-  let nextContent = addNamedImport(content, "@/lib/evlog", ["withEvlog"]);
+  let nextContent = addNamedImport(content, "@/lib/evlog", ["withEvlog", "useLogger"]);
 
   if (!nextContent.includes("withEvlog(async (req: Request)")) {
     nextContent = nextContent.replace(
@@ -486,7 +525,48 @@ function addNextAiEvlogSetup(content: string) {
     }
   }
 
-  return nextContent;
+  return addAiSdkEvlogTelemetry(nextContent, "useLogger()");
+}
+
+function addNuxtAiEvlogSetup(content: string) {
+  const nextContent = addNamedImport(content, "evlog/nitro", ["useLogger"]);
+  return addAiSdkEvlogTelemetry(nextContent, "useLogger(event)");
+}
+
+function addSvelteAiEvlogSetup(content: string) {
+  const nextContent = content.replace(
+    "export const POST: RequestHandler = async ({ request }) => {",
+    "export const POST: RequestHandler = async ({ request, locals }) => {",
+  );
+
+  return addAiSdkEvlogTelemetry(nextContent, "locals.log");
+}
+
+function addTanstackStartAiEvlogSetup(content: string) {
+  const nextContent = prependMissingImports(content, [
+    'import type { RequestLogger } from "evlog";',
+    'import { useRequest } from "nitro/context";',
+  ]);
+
+  return addAiSdkEvlogTelemetry(nextContent, "useRequest().context.log as RequestLogger");
+}
+
+function addBackendAiEvlogSetup(content: string, backend: EvlogBackend) {
+  if (backend === "hono") {
+    return addAiSdkEvlogTelemetry(content, 'c.get("log")');
+  }
+
+  if (backend === "express") {
+    const nextContent = addNamedImport(content, "evlog/express", ["useLogger"]);
+    return addAiSdkEvlogTelemetry(nextContent, "useLogger()");
+  }
+
+  if (backend === "fastify") {
+    const nextContent = addNamedImport(content, "evlog/fastify", ["useLogger"]);
+    return addAiSdkEvlogTelemetry(nextContent, "useLogger()");
+  }
+
+  return addAiSdkEvlogTelemetry(content, "context.log");
 }
 
 function addNextBetterAuthToRoute(content: string) {
@@ -854,6 +934,10 @@ async function setupNuxtEvlog(config: ProjectConfig, serviceName: string) {
       await writeFileIfChanged(authMiddlewarePath, getNuxtEvlogAuthMiddlewareFile(config));
     }
   }
+
+  if (config.examples.includes("ai")) {
+    await updateFileIfExists(path.join(webDir, "server/api/ai.post.ts"), addNuxtAiEvlogSetup);
+  }
 }
 
 async function setupSvelteEvlog(config: ProjectConfig, serviceName: string) {
@@ -882,6 +966,13 @@ export const { handle, handleError } = createEvlogHooks();
       addSvelteBetterAuthEvlogSetup(content, config),
     );
   }
+
+  if (config.examples.includes("ai")) {
+    await updateFileIfExists(
+      path.join(webDir, "src/routes/api/ai/+server.ts"),
+      addSvelteAiEvlogSetup,
+    );
+  }
 }
 
 async function setupTanstackStartEvlog(config: ProjectConfig, serviceName: string) {
@@ -900,6 +991,13 @@ async function setupTanstackStartEvlog(config: ProjectConfig, serviceName: strin
     if (!(await fs.pathExists(authPluginPath))) {
       await writeFileIfChanged(authPluginPath, getNitroEvlogAuthPluginFile(config));
     }
+  }
+
+  if (config.examples.includes("ai")) {
+    await updateFileIfExists(
+      path.join(webDir, "src/routes/api/ai/$.ts"),
+      addTanstackStartAiEvlogSetup,
+    );
   }
 }
 
@@ -966,6 +1064,10 @@ export async function setupEvlog(config: ProjectConfig): Promise<Result<void, Ad
               config.backend,
               getAuthExpression(config),
             );
+          }
+
+          if (config.examples.includes("ai")) {
+            nextContent = addBackendAiEvlogSetup(nextContent, config.backend);
           }
 
           if (nextContent !== content) {

--- a/apps/cli/test/addons.test.ts
+++ b/apps/cli/test/addons.test.ts
@@ -1082,7 +1082,7 @@ describe("Addon Configurations", () => {
         expect(serverIndex).toContain('import { initLogger } from "evlog";');
         expect(serverIndex).toContain(backendSnippets[backend]);
         expect(serverIndex).toContain(`env: { service: "evlog-${backend}-server" }`);
-        expect(serverPackageJson).toContain('"evlog": "^2.19.2"');
+        expect(serverPackageJson).toContain('"evlog": "^2.22.0"');
       });
     }
 
@@ -1159,7 +1159,7 @@ describe("Addon Configurations", () => {
         }
 
         const webPackageJson = await readFile(join(projectDir, "apps/web/package.json"), "utf-8");
-        expect(webPackageJson).toContain('"evlog": "^2.19.2"');
+        expect(webPackageJson).toContain('"evlog": "^2.22.0"');
         if (webCase.frontend === "tanstack-start") {
           expect(webPackageJson).toContain('"nitro": "^3.0.260610-beta"');
         }
@@ -1200,6 +1200,9 @@ describe("Addon Configurations", () => {
       expect(nuxtConfig).toContain("alchemy({ dev: { configPath: alchemyConfigPath } })");
       expect(nuxtConfig).toContain("isNuxtDev");
       expect(nuxtConfig).toContain("const cloudflareWorkersShimPath = fileURLToPath");
+      expect(nuxtConfig).toContain(
+        "const cloudflareWorkersAlias: Record<string, string> = shouldUseAlchemy",
+      );
       expect(nuxtConfig).toContain('"cloudflare:workers"');
       expect(nuxtConfig).toContain("cloudflareWorkersShimPath");
       expect(nuxtConfig).toContain("evlog:");
@@ -1433,7 +1436,7 @@ describe("Addon Configurations", () => {
       expectError(result, "Convex and backend none are not supported yet");
     });
 
-    it("should wire evlog Better Auth without AI SDK 7 incompatible helpers for server projects", async () => {
+    it("should wire evlog Better Auth and AI SDK helpers for server projects", async () => {
       const result = await runTRPCTest({
         projectName: "evlog-hono-auth-ai",
         addons: ["evlog"],
@@ -1466,15 +1469,17 @@ describe("Addon Configurations", () => {
         'await identifyUser(c.get("log"), c.req.raw.headers, c.req.path);',
       );
       expectDocsShapedEvlogAuth(serverIndex);
-      expect(serverIndex).not.toContain('from "evlog/ai"');
-      expect(serverIndex).not.toContain("createAILogger");
-      expect(serverIndex).not.toContain("model: ai.wrap(model)");
-      expect(serverIndex).not.toContain("telemetry:");
+      expect(serverIndex).toContain(
+        'import { createAILogger, createEvlogIntegration } from "evlog/ai";',
+      );
+      expect(serverIndex).toContain('const ai = createAILogger(c.get("log"));');
+      expect(serverIndex).toContain("model: ai.wrap(model)");
+      expect(serverIndex).toContain("telemetry:");
       expect(serverIndex).not.toContain("experimental_telemetry");
-      expect(serverIndex).not.toContain("createEvlogIntegration(ai)");
+      expect(serverIndex).toContain("integrations: [createEvlogIntegration(ai)]");
     });
 
-    it("should avoid evlog AI SDK 7 incompatible helpers for Express server projects", async () => {
+    it("should wire evlog AI SDK helpers for Express server projects", async () => {
       const result = await runTRPCTest({
         projectName: "evlog-express-ai",
         addons: ["evlog"],
@@ -1497,15 +1502,17 @@ describe("Addon Configurations", () => {
       if (!projectDir) throw new Error("Expected generated project directory");
 
       const serverIndex = await readFile(join(projectDir, "apps/server/src/index.ts"), "utf-8");
-      expect(serverIndex).not.toContain('from "evlog/ai"');
-      expect(serverIndex).not.toContain("createAILogger");
-      expect(serverIndex).not.toContain("model: ai.wrap(model)");
-      expect(serverIndex).not.toContain("telemetry:");
+      expect(serverIndex).toContain(
+        'import { createAILogger, createEvlogIntegration } from "evlog/ai";',
+      );
+      expect(serverIndex).toContain("const ai = createAILogger(useLogger());");
+      expect(serverIndex).toContain("model: ai.wrap(model)");
+      expect(serverIndex).toContain("telemetry:");
       expect(serverIndex).not.toContain("experimental_telemetry");
-      expect(serverIndex).not.toContain("createEvlogIntegration(ai)");
+      expect(serverIndex).toContain("integrations: [createEvlogIntegration(ai)]");
     });
 
-    it("should not leave orphaned evlog AI logger setup in AI routes", async () => {
+    it("should wire evlog AI SDK helpers to every supported AI route", async () => {
       const cases = [
         {
           projectName: "evlog-fastify-ai",
@@ -1514,7 +1521,25 @@ describe("Addon Configurations", () => {
           runtime: "node",
           api: "orpc",
           filePath: "apps/server/src/index.ts",
-          unexpected: ['import { useLogger } from "evlog/fastify";', "useLogger()"],
+          expectedLogger: "const ai = createAILogger(useLogger());",
+        },
+        {
+          projectName: "evlog-elysia-ai",
+          frontend: "tanstack-router",
+          backend: "elysia",
+          runtime: "bun",
+          api: "trpc",
+          filePath: "apps/server/src/index.ts",
+          expectedLogger: "const ai = createAILogger(context.log);",
+        },
+        {
+          projectName: "evlog-nuxt-self-ai",
+          frontend: "nuxt",
+          backend: "self",
+          runtime: "none",
+          api: "orpc",
+          filePath: "apps/web/server/api/ai.post.ts",
+          expectedLogger: "const ai = createAILogger(useLogger(event));",
         },
         {
           projectName: "evlog-svelte-self-ai",
@@ -1523,7 +1548,7 @@ describe("Addon Configurations", () => {
           runtime: "none",
           api: "orpc",
           filePath: "apps/web/src/routes/api/ai/+server.ts",
-          unexpected: ["locals })", "locals.log"],
+          expectedLogger: "const ai = createAILogger(locals.log);",
         },
         {
           projectName: "evlog-tanstack-start-self-ai",
@@ -1532,11 +1557,7 @@ describe("Addon Configurations", () => {
           runtime: "none",
           api: "orpc",
           filePath: "apps/web/src/routes/api/ai/$.ts",
-          unexpected: [
-            'import type { RequestLogger } from "evlog";',
-            'from "nitro/context"',
-            "useRequest()",
-          ],
+          expectedLogger: "const ai = createAILogger(useRequest().context.log as RequestLogger);",
         },
       ] as const;
 
@@ -1563,12 +1584,21 @@ describe("Addon Configurations", () => {
         if (!projectDir) throw new Error("Expected generated project directory");
 
         const aiFile = await readFile(join(projectDir, testCase.filePath), "utf-8");
-        expect(aiFile).not.toContain('from "evlog/ai"');
-        expect(aiFile).not.toContain("createAILogger");
-        expect(aiFile).not.toContain("model: ai.wrap(model)");
-        expect(aiFile).not.toContain("createEvlogIntegration(ai)");
-        for (const unexpected of testCase.unexpected) {
-          expect(aiFile).not.toContain(unexpected);
+        expect(aiFile).toContain(
+          'import { createAILogger, createEvlogIntegration } from "evlog/ai";',
+        );
+        if (testCase.frontend === "nuxt") {
+          expect(aiFile).toContain('import { useLogger } from "evlog/nitro";');
+        }
+        expect(aiFile).toContain(testCase.expectedLogger);
+        expect(aiFile).toContain("model: ai.wrap(model)");
+        expect(aiFile).toContain("telemetry:");
+        expect(aiFile).toContain("isEnabled: true");
+        expect(aiFile).toContain("integrations: [createEvlogIntegration(ai)]");
+        expect(aiFile).not.toContain("experimental_telemetry");
+        if (testCase.backend === "elysia") {
+          expect(aiFile).toContain("new Elysia()");
+          expect(aiFile).not.toContain("const app =");
         }
       }
     });
@@ -1611,9 +1641,9 @@ describe("Addon Configurations", () => {
       expect(trpcRoute).toContain("await identifyEvlogUser(req);");
       expect(aiRoute).toContain("withEvlog(async (req: Request)");
       expect(aiRoute).toContain("await identifyEvlogUser(req);");
-      expect(aiRoute).not.toContain("createAILogger");
-      expect(aiRoute).not.toContain("model: ai.wrap(model)");
-      expect(aiRoute).not.toContain("createEvlogIntegration(ai)");
+      expect(aiRoute).toContain("const ai = createAILogger(useLogger());");
+      expect(aiRoute).toContain("model: ai.wrap(model)");
+      expect(aiRoute).toContain("integrations: [createEvlogIntegration(ai)]");
     });
 
     const separateBackendWebAuthCases = [
@@ -1712,7 +1742,7 @@ describe("Addon Configurations", () => {
 
       expect(serverIndex).toContain('import { evlog, type EvlogVariables } from "evlog/hono";');
       expect(serverIndex).toContain("app.use(evlog());");
-      expect(serverPackageJson).toContain('"evlog": "^2.19.2"');
+      expect(serverPackageJson).toContain('"evlog": "^2.22.0"');
     });
 
     it("should reject evlog when added later to a Convex project", async () => {

--- a/apps/cli/test/deployment.test.ts
+++ b/apps/cli/test/deployment.test.ts
@@ -891,6 +891,9 @@ describe("Deployment Configurations", () => {
 
       const files = collectFiles(result.value.root, result.value.root.path);
       const infraFile = files.get("packages/infra/alchemy.run.ts");
+      const webPkg = JSON.parse(files.get("apps/web/package.json") ?? "{}") as {
+        devDependencies?: Record<string, string>;
+      };
 
       expect(infraFile).toContain('export const server = await Worker("server"');
       expect(infraFile).toContain("url: true");
@@ -898,6 +901,7 @@ describe("Deployment Configurations", () => {
       expect(infraFile!.indexOf('export const server = await Worker("server"')).toBeLessThan(
         infraFile!.indexOf('export const web = await TanStackStart("web"'),
       );
+      expect(webPkg.devDependencies?.["@cloudflare/vite-plugin"]).toBe("1.43.0");
     });
 
     it("should keep native Metro from watching Alchemy state", async () => {

--- a/apps/cli/test/examples.test.ts
+++ b/apps/cli/test/examples.test.ts
@@ -1,4 +1,6 @@
-import { describe, it } from "bun:test";
+import { expect, describe, it } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
 
 import { expectError, expectSuccess, runTRPCTest } from "./test-utils";
 
@@ -151,6 +153,10 @@ describe("Example Configurations", () => {
       });
 
       expectSuccess(result);
+      const projectDir = result.result?.projectDirectory;
+      if (!projectDir) throw new Error("Expected generated project directory");
+      const aiPage = await readFile(join(projectDir, "apps/web/app/pages/ai.vue"), "utf-8");
+      expect(aiPage).toContain('@reload="() => regenerate()"');
     });
 
     it("should work with AI example + Svelte", async () => {

--- a/packages/template-generator/src/processors/alchemy-plugins.ts
+++ b/packages/template-generator/src/processors/alchemy-plugins.ts
@@ -146,7 +146,7 @@ const hasAlchemyConfig = existsSync(alchemyConfigPath);`,
       .findIndex((statement) => Node.isExportAssignment(statement));
     sourceFile.insertStatements(
       firstExport === -1 ? sourceFile.getStatements().length : firstExport,
-      `const cloudflareWorkersAlias = shouldUseAlchemy
+      `const cloudflareWorkersAlias: Record<string, string> = shouldUseAlchemy
   ? {}
   : {
       "cloudflare:workers": cloudflareWorkersShimPath,

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -14355,7 +14355,7 @@ const apiHandler = new OpenAPIHandler(appRouter, {
 });
 {{/if}}
 
-const app = {{#if (eq runtime "node")}}new Elysia({ adapter: node() }){{else}}new Elysia(){{/if}}
+{{#if (eq serverDeploy "vercel")}}const app = {{/if}}{{#if (eq runtime "node")}}new Elysia({ adapter: node() }){{else}}new Elysia(){{/if}}
 	.use(
 		cors({
 			origin: env.CORS_ORIGIN,
@@ -19856,7 +19856,7 @@ async function handleSubmit(e: Event) {
             class="ms-auto"
             :status="status"
             @stop="stop"
-            @reload="regenerate"
+            @reload="() => regenerate()"
           />
         </UChatPrompt>
 

--- a/packages/template-generator/src/utils/add-deps.ts
+++ b/packages/template-generator/src/utils/add-deps.ts
@@ -147,8 +147,6 @@ export const dependencyVersionMap = {
   "@tanstack/solid-router-devtools": "^1.167.0",
 
   wrangler: "^4.107.0",
-  // Alchemy 0.93.12 shares persisted Miniflare state with this plugin.
-  // Newer plugin releases use an incompatible workerd alarm-table schema.
   "@cloudflare/vite-plugin": "1.43.0",
   "@opennextjs/cloudflare": "^1.20.1",
   "nitro-cloudflare-dev": "^0.2.2",

--- a/packages/template-generator/src/utils/add-deps.ts
+++ b/packages/template-generator/src/utils/add-deps.ts
@@ -174,7 +174,7 @@ export const dependencyVersionMap = {
   "@stripe/react-stripe-js": "^5.6.1",
   "@stripe/stripe-js": "^8.11.0",
 
-  evlog: "^2.19.2",
+  evlog: "^2.22.0",
 } as const;
 
 export type AvailableDependencies = keyof typeof dependencyVersionMap;

--- a/packages/template-generator/src/utils/add-deps.ts
+++ b/packages/template-generator/src/utils/add-deps.ts
@@ -147,7 +147,9 @@ export const dependencyVersionMap = {
   "@tanstack/solid-router-devtools": "^1.167.0",
 
   wrangler: "^4.107.0",
-  "@cloudflare/vite-plugin": "^1.43.0",
+  // Alchemy 0.93.12 shares persisted Miniflare state with this plugin.
+  // Newer plugin releases use an incompatible workerd alarm-table schema.
+  "@cloudflare/vite-plugin": "1.43.0",
   "@opennextjs/cloudflare": "^1.20.1",
   "nitro-cloudflare-dev": "^0.2.2",
   "@sveltejs/adapter-cloudflare": "^7.2.9",

--- a/packages/template-generator/templates/backend/server/elysia/src/index.ts.hbs
+++ b/packages/template-generator/templates/backend/server/elysia/src/index.ts.hbs
@@ -49,7 +49,7 @@ const apiHandler = new OpenAPIHandler(appRouter, {
 });
 {{/if}}
 
-const app = {{#if (eq runtime "node")}}new Elysia({ adapter: node() }){{else}}new Elysia(){{/if}}
+{{#if (eq serverDeploy "vercel")}}const app = {{/if}}{{#if (eq runtime "node")}}new Elysia({ adapter: node() }){{else}}new Elysia(){{/if}}
 	.use(
 		cors({
 			origin: env.CORS_ORIGIN,

--- a/packages/template-generator/templates/examples/ai/web/nuxt/app/pages/ai.vue.hbs
+++ b/packages/template-generator/templates/examples/ai/web/nuxt/app/pages/ai.vue.hbs
@@ -130,7 +130,7 @@ async function handleSubmit(e: Event) {
             class="ms-auto"
             :status="status"
             @stop="stop"
-            @reload="regenerate"
+            @reload="() => regenerate()"
           />
         </UChatPrompt>
 


### PR DESCRIPTION
## Summary

- pin `@cloudflare/vite-plugin` to `1.43.0` for generated Cloudflare TanStack Start projects
- update the EvLog addon to `2.22.0`
- restore EvLog AI SDK v7 telemetry for Hono, Express, Fastify, Elysia, Next.js, Nuxt, SvelteKit, and TanStack Start
- fix generated Express logger typing, Elysia local startup, Nuxt Cloudflare aliases, and Nuxt AI retry typing found by the scaffold matrix

## Root cause

The Cloudflare plugin range could resolve past the version compatible with Alchemy 0.93.12. A newer workerd alarm schema then conflicted with Alchemy's persisted Miniflare state on the second development launch.

EvLog was still pinned to 2.19.2 and its AI integration had been disabled when the templates moved to AI SDK v7. EvLog 2.22.0 supports AI SDK v7, but each generated request handler needs its framework-specific request logger.

## Impact

Cloudflare TanStack Start projects can restart against persisted local state, and EvLog projects now generate current AI telemetry wiring across every supported server and full-stack integration.

## Verification

- manually reproduced #1112, applied the exact plugin pin, and verified two consecutive launches with HTTP 200 responses
- generated, installed, typechecked, and built a 21-case EvLog matrix covering all supported integrations, Bun/Node/Workers runtimes, tRPC/oRPC routes, local/Cloudflare deployment, and AI/Better Auth wiring
- verified generated installs with Bun, pnpm, and npm
- started Hono, Express, Fastify, and Elysia projects and received HTTP 200 responses through their EvLog middleware
- `bun test apps/cli/test/addons.test.ts` — 93 passed
- `bun test apps/cli/test/deployment.test.ts` — 44 passed
- `bun test apps/cli/test/examples.test.ts` — 22 passed
- `bun run build:cli`
- `bun run check` — 0 warnings and 0 errors

Fixes #1112


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic AI telemetry to generated AI examples across supported frameworks.
  * AI requests now include Evlog integrations, wrapped models, and framework-specific logger setup.
  * Extended AI telemetry support to Nuxt, Svelte, and TanStack Start projects.

* **Bug Fixes**
  * Improved generated Elysia server setup for different deployment targets.
  * Fixed Nuxt AI prompt reload behavior.
  * Updated Cloudflare deployment configuration handling.

* **Chores**
  * Updated generated project dependency versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->