### PR TITLE
feat(cli): refresh interactive experience

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -71,8 +71,8 @@
   "dependencies": {
     "@better-t-stack/template-generator": "workspace:*",
     "@better-t-stack/types": "workspace:*",
-    "@clack/core": "^1.4.1",
-    "@clack/prompts": "^1.5.1",
+    "@clack/core": "^1.4.3",
+    "@clack/prompts": "^1.7.0",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@trpc/server": "^11.17.0",
     "better-result": "^2.9.2",

--- a/apps/cli/src/commands/history.ts
+++ b/apps/cli/src/commands/history.ts
@@ -1,6 +1,7 @@
-import { intro, log } from "@clack/prompts";
+import { intro, log, outro } from "@clack/prompts";
 import pc from "picocolors";
 
+import { formatConfigValue } from "../utils/display-config";
 import { clearHistory, getHistory, type ProjectHistoryEntry } from "../utils/project-history";
 import { renderTitle } from "../utils/render-title";
 
@@ -14,19 +15,19 @@ function formatStackSummary(entry: ProjectHistoryEntry): string {
   const parts: string[] = [];
 
   if (entry.stack.frontend.length > 0 && !entry.stack.frontend.includes("none")) {
-    parts.push(entry.stack.frontend.join(", "));
+    parts.push(formatConfigValue(entry.stack.frontend));
   }
 
   if (entry.stack.backend && entry.stack.backend !== "none") {
-    parts.push(entry.stack.backend);
+    parts.push(formatConfigValue(entry.stack.backend));
   }
 
   if (entry.stack.database && entry.stack.database !== "none") {
-    parts.push(entry.stack.database);
+    parts.push(formatConfigValue(entry.stack.database));
   }
 
   if (entry.stack.orm && entry.stack.orm !== "none") {
-    parts.push(entry.stack.orm);
+    parts.push(formatConfigValue(entry.stack.orm));
   }
 
   return parts.length > 0 ? parts.join(" + ") : "minimal";
@@ -41,6 +42,22 @@ function formatDate(isoString: string): string {
     hour: "2-digit",
     minute: "2-digit",
   });
+}
+
+export function formatHistoryEntry(entry: ProjectHistoryEntry, index: number): string {
+  const rows = [
+    { label: "Created", value: formatDate(entry.createdAt) },
+    { label: "Location", value: entry.projectDir },
+    { label: "Stack", value: formatStackSummary(entry) },
+  ];
+  const labelWidth = Math.max(...rows.map(({ label }) => label.length));
+  const details = rows
+    .map(({ label, value }) => `${pc.dim(label.padEnd(labelWidth))}  ${value}`)
+    .join("\n");
+
+  return `${pc.cyan(pc.bold(`${index + 1}. ${entry.projectName}`))}\n${details}\n${pc.dim(
+    "Recreate",
+  )}\n${pc.cyan(entry.reproducibleCommand)}`;
 }
 
 export async function historyHandler(input: HistoryCommandInput): Promise<void> {
@@ -61,30 +78,23 @@ export async function historyHandler(input: HistoryCommandInput): Promise<void> 
   }
   const entries = historyResult.value;
 
-  if (entries.length === 0) {
-    log.info(pc.dim("No projects in history yet."));
-    log.info(pc.dim("Create a project with: create-better-t-stack my-app"));
-    return;
-  }
-
   if (input.json) {
     console.log(JSON.stringify(entries, null, 2));
     return;
   }
 
   renderTitle();
-  intro(pc.magenta(`Project History (${entries.length} entries)`));
+  intro(pc.magenta(`Project history · ${entries.length}`));
 
-  for (const [index, entry] of entries.entries()) {
-    const num = pc.dim(`${index + 1}.`);
-    const name = pc.cyan(pc.bold(entry.projectName));
-    const stack = pc.dim(formatStackSummary(entry));
-
-    log.message(`${num} ${name}`);
-    log.message(`   ${pc.dim("Created:")} ${formatDate(entry.createdAt)}`);
-    log.message(`   ${pc.dim("Path:")} ${entry.projectDir}`);
-    log.message(`   ${pc.dim("Stack:")} ${stack}`);
-    log.message(`   ${pc.dim("Command:")} ${pc.dim(entry.reproducibleCommand)}`);
-    log.message("");
+  if (entries.length === 0) {
+    outro(
+      `${pc.dim("No saved projects yet · create one with")} ${pc.cyan(
+        "create-better-t-stack my-app",
+      )}`,
+    );
+    return;
   }
+
+  log.message(entries.map(formatHistoryEntry).join("\n\n"));
+  outro(pc.dim("Run a command above to recreate that project"));
 }

--- a/apps/cli/src/commands/meta.ts
+++ b/apps/cli/src/commands/meta.ts
@@ -25,7 +25,7 @@ async function openExternalUrl(url: string, successMessage: string) {
 
 export async function showSponsorsCommand() {
   renderTitle();
-  intro(pc.magenta("Better-T-Stack Sponsors"));
+  intro(pc.magenta("Sponsors"));
 
   const sponsorsResult = await fetchSponsors();
   if (sponsorsResult.isErr()) {

--- a/apps/cli/src/helpers/core/add-handler.ts
+++ b/apps/cli/src/helpers/core/add-handler.ts
@@ -22,6 +22,7 @@ import type { AddInput, Addons, AddonOptions, ProjectConfig } from "../../types"
 import { updateBtsConfig } from "../../utils/bts-config";
 import { validateAddonsAgainstConfig } from "../../utils/compatibility-rules";
 import { isSilent, runWithContextAsync } from "../../utils/context";
+import { formatConfigValue } from "../../utils/display-config";
 import { CLIError, UserCancelledError, displayError } from "../../utils/errors";
 import { validateAgentSafePathInput } from "../../utils/input-hardening";
 import { renderTitle } from "../../utils/render-title";
@@ -209,7 +210,7 @@ async function addHandlerInternal(
 
   if (!isSilent()) {
     renderTitle();
-    intro(pc.magenta("Add addons to your Better-T-Stack project"));
+    intro(pc.magenta("Add to your project"));
   }
 
   // Detect existing project configuration
@@ -238,7 +239,8 @@ async function addHandlerInternal(
 
     if (addonsToAdd.length === 0) {
       if (!isSilent()) {
-        log.warn(pc.yellow("All specified addons are already installed or invalid."));
+        log.warn(pc.yellow("Nothing to add — those addons are already installed"));
+        outro(pc.dim("Project unchanged"));
       }
       return Result.ok({
         success: true,
@@ -273,8 +275,7 @@ async function addHandlerInternal(
 
     if (selectedAddons.length === 0) {
       if (!isSilent()) {
-        log.info(pc.dim("No addons selected."));
-        outro(pc.magenta("Nothing to add."));
+        outro(pc.dim("Nothing selected · project unchanged"));
       }
       return Result.ok({
         success: true,
@@ -294,7 +295,7 @@ async function addHandlerInternal(
   }
 
   if (!isSilent()) {
-    log.info(pc.cyan(`Adding addons: ${addonsToAdd.join(", ")}`));
+    log.info(`${pc.dim("Adding")} ${pc.cyan(formatConfigValue(addonsToAdd))}`);
   }
 
   const mergedAddonOptions = mergeAddonOptions(existingConfig.addonOptions, input.addonOptions);
@@ -327,7 +328,7 @@ async function addHandlerInternal(
 
   // Create VFS and process addon templates using template-generator's logic
   if (!isSilent()) {
-    log.info(pc.dim("Installing addon files..."));
+    log.info(pc.dim("Preparing addon files…"));
   }
 
   const vfs = new VirtualFileSystem();
@@ -392,9 +393,9 @@ async function addHandlerInternal(
 
   if (input.dryRun) {
     if (!isSilent()) {
-      log.success(pc.green("Dry run validation passed. No addon files were written."));
-      log.info(pc.dim(`Planned addon files: ${vfs.getFileCount()}`));
-      outro(pc.magenta("Dry run complete."));
+      log.success(pc.green("Dry run passed · no files written"));
+      log.message(pc.dim(`${vfs.getFileCount()} addon files planned`));
+      outro(pc.dim("Project unchanged"));
     }
 
     return Result.ok({
@@ -449,24 +450,19 @@ async function addHandlerInternal(
 
   // Install dependencies if requested
   if (input.install) {
-    if (!isSilent()) {
-      log.info(pc.dim("Installing dependencies..."));
-    }
     await installDependencies({ projectDir, packageManager: config.packageManager });
   }
 
   if (!isSilent()) {
-    log.success(pc.green(`Successfully added: ${addonsToAdd.join(", ")}`));
+    log.success(pc.green(`Added ${formatConfigValue(addonsToAdd)}`));
 
     if (!input.install) {
-      log.info(
-        pc.yellow(
-          `Run '${config.packageManager === "npm" ? "npm install" : `${config.packageManager} install`}' to install new dependencies.`,
-        ),
-      );
+      const installCommand =
+        config.packageManager === "npm" ? "npm install" : `${config.packageManager} install`;
+      log.message(`${pc.dim("Next step")}\n${pc.cyan(installCommand)}`);
     }
 
-    outro(pc.magenta("Addons added successfully!"));
+    outro(pc.magenta("Project updated"));
   }
 
   return Result.ok({

--- a/apps/cli/src/helpers/core/command-handlers.ts
+++ b/apps/cli/src/helpers/core/command-handlers.ts
@@ -3,7 +3,6 @@ import path from "node:path";
 import { generateReproducibleCommand } from "@better-t-stack/template-generator";
 import { intro, log, outro } from "@clack/prompts";
 import { Result, UnhandledException } from "better-result";
-import fs from "fs-extra";
 import pc from "picocolors";
 
 import { getDefaultConfig } from "../../constants";
@@ -24,7 +23,13 @@ import {
   displayError,
 } from "../../utils/errors";
 import { validateAgentSafePathInput } from "../../utils/input-hardening";
-import { handleDirectoryConflict, setupProjectDirectory } from "../../utils/project-directory";
+import {
+  findAvailableIncrementedPath,
+  handleDirectoryConflict,
+  inspectProjectPath,
+  setupProjectDirectory,
+  validateSafeProjectDirectoryPath,
+} from "../../utils/project-directory";
 import { addToHistory } from "../../utils/project-history";
 import { validateProjectName } from "../../utils/project-name-validation";
 import { renderTitle } from "../../utils/render-title";
@@ -169,13 +174,11 @@ async function createProjectHandlerInternal(
     } else if (input.yes) {
       const defaultConfig = getDefaultConfig();
       let defaultName: string = defaultConfig.relativePath;
-      let counter = 1;
-      while (
-        (await fs.pathExists(path.resolve(process.cwd(), defaultName))) &&
-        (await fs.readdir(path.resolve(process.cwd(), defaultName))).length > 0
-      ) {
-        defaultName = `${defaultConfig.projectName}-${counter}`;
-        counter++;
+      const defaultPathState = yield* Result.await(
+        inspectProjectPath(path.resolve(process.cwd(), defaultName)),
+      );
+      if (defaultPathState !== "missing" && defaultPathState !== "empty-directory") {
+        defaultName = yield* Result.await(findAvailableIncrementedPath(defaultConfig.projectName));
       }
       currentPathInput = defaultName;
     } else {
@@ -207,6 +210,7 @@ async function createProjectHandlerInternal(
     finalPathInput = conflictResult.finalPathInput;
     shouldClearDirectory = conflictResult.shouldClearDirectory;
     yield* validateResolvedProjectPathInput(finalPathInput);
+    yield* Result.await(validateSafeProjectDirectoryPath(finalPathInput));
 
     let finalResolvedPath: string;
     let finalBaseName: string;
@@ -519,18 +523,35 @@ async function handleDirectoryConflictResult(
 async function handleDirectoryConflictProgrammatically(
   currentPathInput: string,
   strategy: DirectoryConflict,
-): Promise<Result<DirectoryConflictResult, DirectoryConflictError>> {
+): Promise<Result<DirectoryConflictResult, CLIError | DirectoryConflictError>> {
   const currentPath = path.resolve(process.cwd(), currentPathInput);
+  const pathStateResult = await inspectProjectPath(currentPath);
+  if (pathStateResult.isErr()) return Result.err(pathStateResult.error);
+  const pathState = pathStateResult.value;
 
-  if (!(await fs.pathExists(currentPath))) {
+  if (pathState === "missing" || pathState === "empty-directory") {
     return Result.ok({ finalPathInput: currentPathInput, shouldClearDirectory: false });
   }
 
-  const dirContents = await fs.readdir(currentPath);
-  const isNotEmpty = dirContents.length > 0;
+  if (strategy === "increment") {
+    const incrementResult = await findAvailableIncrementedPath(currentPathInput);
+    if (incrementResult.isErr()) return Result.err(incrementResult.error);
+    return Result.ok({ finalPathInput: incrementResult.value, shouldClearDirectory: false });
+  }
 
-  if (!isNotEmpty) {
-    return Result.ok({ finalPathInput: currentPathInput, shouldClearDirectory: false });
+  if (pathState === "symbolic-link") {
+    return Result.err(
+      new CLIError({
+        message: `Project path "${currentPathInput}" is a symbolic link. Choose a real directory or use directoryConflict: "increment".`,
+      }),
+    );
+  }
+  if (pathState === "non-directory") {
+    return Result.err(
+      new CLIError({
+        message: `Project path "${currentPathInput}" exists and is not a directory. Choose a different path or use directoryConflict: "increment".`,
+      }),
+    );
   }
 
   switch (strategy) {
@@ -539,22 +560,6 @@ async function handleDirectoryConflictProgrammatically(
 
     case "merge":
       return Result.ok({ finalPathInput: currentPathInput, shouldClearDirectory: false });
-
-    case "increment": {
-      let counter = 1;
-      const baseName = currentPathInput;
-      let finalPathInput = `${baseName}-${counter}`;
-
-      while (
-        (await fs.pathExists(path.resolve(process.cwd(), finalPathInput))) &&
-        (await fs.readdir(path.resolve(process.cwd(), finalPathInput))).length > 0
-      ) {
-        counter++;
-        finalPathInput = `${baseName}-${counter}`;
-      }
-
-      return Result.ok({ finalPathInput, shouldClearDirectory: false });
-    }
 
     case "error":
       return Result.err(new DirectoryConflictError({ directory: currentPathInput }));

--- a/apps/cli/src/helpers/core/command-handlers.ts
+++ b/apps/cli/src/helpers/core/command-handlers.ts
@@ -29,7 +29,6 @@ import { addToHistory } from "../../utils/project-history";
 import { validateProjectName } from "../../utils/project-name-validation";
 import { renderTitle } from "../../utils/render-title";
 import { getTemplateConfig, getTemplateDescription } from "../../utils/templates";
-import { cliConsola } from "../../utils/terminal-output";
 import {
   getProvidedFlags,
   processAndValidateFlags,
@@ -157,7 +156,7 @@ async function createProjectHandlerInternal(
     if (!isSilent()) intro(pc.magenta("Configure your new project"));
 
     if (!isSilent() && input.yolo) {
-      cliConsola.fatal("YOLO mode enabled - skipping checks. Things may break!");
+      log.warn(pc.yellow("YOLO mode enabled — compatibility checks are disabled."));
     }
 
     // Get project name
@@ -250,8 +249,9 @@ async function createProjectHandlerInternal(
         const templateName = input.template.toUpperCase();
         const templateDescription = getTemplateDescription(input.template);
         if (!isSilent()) {
-          log.message(pc.bold(pc.cyan(`Using template: ${pc.white(templateName)}`)));
-          log.message(pc.dim(`   ${templateDescription}`));
+          log.info(
+            `${pc.dim("Template")} ${pc.bold(pc.cyan(templateName))}\n${pc.dim(templateDescription)}`,
+          );
         }
         const userOverrides: Record<string, unknown> = {};
         for (const [key, value] of Object.entries(originalInput)) {
@@ -309,16 +309,18 @@ async function createProjectHandlerInternal(
       const flagConfig = flagConfigResult.value;
       const { projectName: _projectNameFromFlags, ...otherFlags } = flagConfig;
 
-      if (!isSilent() && Object.keys(otherFlags).length > 0) {
-        log.info(pc.dim("Preselected from command-line flags:"));
-        log.message(displayConfig(otherFlags));
+      const isTemplateSetup = input.template && input.template !== "none";
+      if (!isSilent() && !isTemplateSetup && Object.keys(otherFlags).length > 0) {
+        log.info(pc.dim("Command-line options applied."));
       }
 
       // gatherConfig may throw UserCancelledError
       const gatherResult = yield* Result.await(
         Result.tryPromise({
           try: async () =>
-            gatherConfig(flagConfig, finalBaseName, finalResolvedPath, finalPathInput),
+            gatherConfig(flagConfig, finalBaseName, finalResolvedPath, finalPathInput, {
+              skipCompatibilityChecks: cliInput.yolo,
+            }),
           catch: (e: unknown) => {
             if (e instanceof UserCancelledError) return e;
             return new CLIError({
@@ -378,7 +380,7 @@ async function createProjectHandlerInternal(
             ),
           );
         }
-        log.success(pc.green("Dry run validation passed. No files were written."));
+        log.success(pc.green("Configuration ready. No files were written."));
         log.message(pc.dim(`Target directory: ${finalResolvedPath}`));
         log.message(pc.dim(`Run without --dry-run to create the project.`));
         outro(pc.magenta("Dry run complete."));

--- a/apps/cli/src/helpers/core/command-handlers.ts
+++ b/apps/cli/src/helpers/core/command-handlers.ts
@@ -11,6 +11,7 @@ import { gatherConfig } from "../../prompts/config-prompts";
 import { getProjectName } from "../../prompts/project-name";
 import type { CreateInput, DirectoryConflict, ProjectConfig } from "../../types";
 import { trackProjectCreation } from "../../utils/analytics";
+import { getCliSubcommandCommand } from "../../utils/cli-invocation";
 import { validateAddonsAgainstFrontends } from "../../utils/compatibility-rules";
 import { isSilent, runWithContextAsync } from "../../utils/context";
 import { displayConfig } from "../../utils/display-config";
@@ -153,7 +154,7 @@ async function createProjectHandlerInternal(
     if (!isSilent() && input.renderTitle !== false) {
       renderTitle();
     }
-    if (!isSilent()) intro(pc.magenta("Creating a new Better-T-Stack project"));
+    if (!isSilent()) intro(pc.magenta("Configure your new project"));
 
     if (!isSilent() && input.yolo) {
       cliConsola.fatal("YOLO mode enabled - skipping checks. Things may break!");
@@ -295,8 +296,7 @@ async function createProjectHandlerInternal(
       }
 
       if (!isSilent()) {
-        log.info(pc.yellow("Using default/flag options (config prompts skipped):"));
-        log.message(displayConfig(config));
+        log.info(pc.dim("Quick setup selected — using defaults and provided flags."));
       }
     } else {
       // Process and validate flags
@@ -310,9 +310,8 @@ async function createProjectHandlerInternal(
       const { projectName: _projectNameFromFlags, ...otherFlags } = flagConfig;
 
       if (!isSilent() && Object.keys(otherFlags).length > 0) {
-        log.info(pc.yellow("Using these pre-selected options:"));
+        log.info(pc.dim("Preselected from command-line flags:"));
         log.message(displayConfig(otherFlags));
-        log.message("");
       }
 
       // gatherConfig may throw UserCancelledError
@@ -361,6 +360,11 @@ async function createProjectHandlerInternal(
       }
     }
 
+    if (!isSilent()) {
+      log.info(pc.magenta(pc.bold("Stack ready")));
+      log.message(displayConfig(config));
+    }
+
     const reproducibleCommand = generateReproducibleCommand(config);
 
     if (input.dryRun) {
@@ -399,26 +403,22 @@ async function createProjectHandlerInternal(
       }),
     );
 
-    if (!isSilent()) {
-      log.success(
-        pc.blue(`You can reproduce this setup with the following command:\n${reproducibleCommand}`),
-      );
-    }
-
     await trackProjectCreation(config, input.disableAnalytics);
 
     // Track locally in history.json (non-fatal)
     const historyResult = await addToHistory(config, reproducibleCommand);
     if (historyResult.isErr() && !isSilent()) {
       log.warn(pc.yellow(historyResult.error.message));
+      log.message(`${pc.dim("Recreate this stack")}\n${pc.cyan(reproducibleCommand)}`);
+    } else if (!isSilent()) {
+      const historyCommand = getCliSubcommandCommand("history", config.packageManager);
+      log.message(`${pc.dim("Setup saved to history")}\n${pc.cyan(historyCommand)}`);
     }
 
     const elapsedTimeMs = Date.now() - startTime;
     if (!isSilent()) {
-      const elapsedTimeInSeconds = (elapsedTimeMs / 1000).toFixed(2);
-      outro(
-        pc.magenta(`Project created successfully in ${pc.bold(elapsedTimeInSeconds)} seconds!`),
-      );
+      const elapsedTimeInSeconds = (elapsedTimeMs / 1000).toFixed(1);
+      outro(pc.magenta(`Project ready in ${pc.bold(`${elapsedTimeInSeconds}s`)}`));
     }
 
     return Result.ok({

--- a/apps/cli/src/helpers/core/create-project.ts
+++ b/apps/cli/src/helpers/core/create-project.ts
@@ -117,7 +117,7 @@ export async function createProject(
     // Format project
     yield* Result.await(formatProject(projectDir));
 
-    if (!isSilent()) log.success("Project template successfully scaffolded!");
+    if (!isSilent()) log.success("Project scaffolded");
 
     // Install dependencies if requested
     if (options.install) {

--- a/apps/cli/src/helpers/core/install-dependencies.ts
+++ b/apps/cli/src/helpers/core/install-dependencies.ts
@@ -39,7 +39,7 @@ export async function installDependencies({
   });
 
   if (result.isOk()) {
-    s.stop("Dependencies installed successfully");
+    s.stop("Dependencies installed");
   } else {
     s.stop(pc.red("Failed to install dependencies"));
   }

--- a/apps/cli/src/helpers/core/post-installation.ts
+++ b/apps/cli/src/helpers/core/post-installation.ts
@@ -1,3 +1,4 @@
+import { box, log } from "@clack/prompts";
 import pc from "picocolors";
 
 import type {
@@ -17,7 +18,7 @@ import {
   fetchSponsorsQuietly,
   formatPostInstallSpecialSponsorsSection,
 } from "../../utils/sponsors";
-import { cliConsola } from "../../utils/terminal-output";
+import { cliLog } from "../../utils/terminal-output";
 
 function getDesktopStaticBuildNote(frontend: Frontend[]): string {
   const staticBuildFrontends = new Map<Frontend, string>([
@@ -145,7 +146,7 @@ export async function displayPostInstallInstructions(
     packageManager === "bun" && hasNative && hasWeb ? getBunWebNativeWarning() : "";
   const noOrmWarning = !isConvex && database !== "none" && orm === "none" ? getNoOrmWarning() : "";
 
-  let output = `${pc.bold("Next steps")}\n${pc.cyan("1.")} ${cdCmd}\n`;
+  let output = `${pc.cyan("1.")} ${cdCmd}\n`;
   let stepCounter = 2;
 
   if (!depsInstalled) {
@@ -189,36 +190,53 @@ export async function displayPostInstallInstructions(
     hasWeb || hasStandaloneBackend || addons?.includes("starlight") || addons?.includes("fumadocs");
 
   if (hasAnyService) {
-    output += `${pc.bold("Your project will be available at:")}\n`;
+    const localServices: Array<{ label: string; url: string }> = [];
+    let localDevelopmentNote = "";
 
     if (hasWeb) {
-      output += `${pc.cyan("•")} Frontend: http://localhost:${webPort}\n`;
+      localServices.push({ label: "Frontend", url: `http://localhost:${webPort}` });
     } else if (!hasNative && !addons?.includes("starlight")) {
-      output += `${pc.yellow(
-        "NOTE:",
-      )} You are creating a backend-only app\n   (no frontend selected)\n`;
+      localDevelopmentNote = "Backend-only app — no frontend selected";
     }
 
     if (!isConvex && !isBackendSelf && hasStandaloneBackend) {
-      output += `${pc.cyan("•")} Backend API: http://localhost:3000\n`;
+      localServices.push({ label: "API", url: "http://localhost:3000" });
 
       if (api === "orpc") {
-        output += `${pc.cyan("•")} OpenAPI (Scalar UI): http://localhost:3000/api-reference\n`;
+        localServices.push({
+          label: "API reference",
+          url: "http://localhost:3000/api-reference",
+        });
       }
     }
 
     if (isBackendSelf && api === "orpc") {
       const rpcPath =
         frontend?.includes("next") || frontend?.includes("tanstack-start") ? "/api/rpc" : "/rpc";
-      output += `${pc.cyan("•")} OpenAPI (Scalar UI): http://localhost:${webPort}${rpcPath}/api-reference\n`;
+      localServices.push({
+        label: "API reference",
+        url: `http://localhost:${webPort}${rpcPath}/api-reference`,
+      });
     }
 
     if (addons?.includes("starlight")) {
-      output += `${pc.cyan("•")} Docs: http://localhost:4321\n`;
+      localServices.push({ label: "Docs", url: "http://localhost:4321" });
     }
 
     if (addons?.includes("fumadocs")) {
-      output += `${pc.cyan("•")} Fumadocs: http://localhost:4000\n`;
+      localServices.push({ label: "Fumadocs", url: "http://localhost:4000" });
+    }
+
+    output += `\n${pc.bold("Local development")}\n`;
+    if (localDevelopmentNote) {
+      output += `${pc.dim(localDevelopmentNote)}\n`;
+    }
+
+    if (localServices.length > 0) {
+      const labelWidth = Math.max(...localServices.map(({ label }) => label.length));
+      for (const { label, url } of localServices) {
+        output += `${pc.dim(label.padEnd(labelWidth))}  ${pc.cyan(url)}\n`;
+      }
     }
   }
 
@@ -246,16 +264,23 @@ export async function displayPostInstallInstructions(
     ? formatPostInstallSpecialSponsorsSection(sponsorsResult.value)
     : "";
 
+  log.message([], { spacing: 1 });
+  box(output.trimEnd(), pc.bold("Next steps"), {
+    contentPadding: 2,
+    formatBorder: pc.dim,
+    rounded: true,
+    width: "auto",
+  });
+
   if (specialSponsorsSection) {
-    output += `\n${specialSponsorsSection.trim()}\n`;
+    cliLog.message(specialSponsorsSection);
   }
 
-  output += `\n${pc.bold(
-    "Like Better-T-Stack?",
-  )} Please consider giving us a star\n   on GitHub:\n`;
-  output += pc.cyan("https://github.com/AmanVarshney01/create-better-t-stack");
-
-  cliConsola.box(output);
+  cliLog.message(
+    `${pc.bold("Like Better T Stack?")} ${pc.dim("Star the project on GitHub")}\n${pc.cyan(
+      "https://github.com/AmanVarshney01/create-better-t-stack",
+    )}`,
+  );
 }
 
 function getNativeInstructions(
@@ -336,7 +361,8 @@ async function getDatabaseInstructions(
   serverDeploy: ServerDeploy,
   backend: Backend,
 ) {
-  const instructions: string[] = [];
+  const notes: string[] = [];
+  const commands: Array<{ label: string; command: string }> = [];
   const isD1Alchemy =
     dbSetup === "d1" &&
     (serverDeploy === "cloudflare" || (backend === "self" && webDeploy === "cloudflare"));
@@ -345,28 +371,27 @@ async function getDatabaseInstructions(
     const dockerStatus = await getDockerStatus(database);
 
     if (dockerStatus.message) {
-      instructions.push(dockerStatus.message);
-      instructions.push("");
+      notes.push(dockerStatus.message);
     }
   }
 
   if (isD1Alchemy) {
     if (orm === "drizzle") {
-      instructions.push(`${pc.cyan("•")} Generate migrations: ${`${runCmd} db:generate`}`);
+      commands.push({ label: "Generate migrations", command: `${runCmd} db:generate` });
     } else if (orm === "prisma") {
-      instructions.push(`${pc.cyan("•")} Generate Prisma client: ${`${runCmd} db:generate`}`);
-      instructions.push(`${pc.cyan("•")} Apply migrations: ${`${runCmd} db:migrate`}`);
+      commands.push({ label: "Generate client", command: `${runCmd} db:generate` });
+      commands.push({ label: "Apply migrations", command: `${runCmd} db:migrate` });
     }
   }
 
   if (dbSetup === "planetscale") {
     if (database === "mysql" && orm === "drizzle") {
-      instructions.push(
+      notes.push(
         `${pc.yellow("NOTE:")} Enable foreign key constraints in PlanetScale database settings`,
       );
     }
     if (database === "mysql" && orm === "prisma") {
-      instructions.push(
+      notes.push(
         `${pc.yellow(
           "NOTE:",
         )} How to handle Prisma migrations with PlanetScale:\n   https://github.com/prisma/prisma/issues/7292`,
@@ -375,7 +400,7 @@ async function getDatabaseInstructions(
   }
 
   if (dbSetup === "turso" && orm === "prisma") {
-    instructions.push(
+    notes.push(
       `${pc.yellow(
         "NOTE:",
       )} Follow Turso's Prisma guide for migrations via the Turso CLI:\n   https://docs.turso.tech/sdk/ts/orm/prisma`,
@@ -384,39 +409,55 @@ async function getDatabaseInstructions(
 
   if (orm === "prisma") {
     if (database === "mongodb" && dbSetup === "docker") {
-      instructions.push(
+      notes.push(
         `${pc.yellow("WARNING:")} Prisma + MongoDB + Docker combination\n   may not work.`,
       );
     }
     if (dbSetup === "docker") {
-      instructions.push(`${pc.cyan("•")} Start docker container: ${`${runCmd} db:start`}`);
+      commands.push({ label: "Start database", command: `${runCmd} db:start` });
     }
     if (!isD1Alchemy) {
-      instructions.push(`${pc.cyan("•")} Generate Prisma Client: ${`${runCmd} db:generate`}`);
-      instructions.push(`${pc.cyan("•")} Apply schema: ${`${runCmd} db:push`}`);
+      commands.push({ label: "Generate client", command: `${runCmd} db:generate` });
+      commands.push({ label: "Apply schema", command: `${runCmd} db:push` });
     }
     if (!isD1Alchemy) {
-      instructions.push(`${pc.cyan("•")} Database UI: ${`${runCmd} db:studio`}`);
+      commands.push({ label: "Open studio", command: `${runCmd} db:studio` });
     }
   } else if (orm === "drizzle") {
     if (dbSetup === "docker") {
-      instructions.push(`${pc.cyan("•")} Start docker container: ${`${runCmd} db:start`}`);
+      commands.push({ label: "Start database", command: `${runCmd} db:start` });
     }
     if (!isD1Alchemy) {
-      instructions.push(`${pc.cyan("•")} Apply schema: ${`${runCmd} db:push`}`);
+      commands.push({ label: "Apply schema", command: `${runCmd} db:push` });
     }
     if (!isD1Alchemy) {
-      instructions.push(`${pc.cyan("•")} Database UI: ${`${runCmd} db:studio`}`);
+      commands.push({ label: "Open studio", command: `${runCmd} db:studio` });
     }
   } else if (orm === "mongoose") {
     if (dbSetup === "docker") {
-      instructions.push(`${pc.cyan("•")} Start docker container: ${`${runCmd} db:start`}`);
+      commands.push({ label: "Start database", command: `${runCmd} db:start` });
     }
   } else if (orm === "none") {
-    instructions.push(`${pc.yellow("NOTE:")} Manual database schema setup\n   required.`);
+    notes.push(`${pc.yellow("NOTE:")} Manual database schema setup required.`);
   }
 
-  return instructions.length ? `${pc.bold("Database commands:")}\n${instructions.join("\n")}` : "";
+  if (notes.length === 0 && commands.length === 0) {
+    return "";
+  }
+
+  const sections = [pc.bold("Database")];
+  if (notes.length > 0) {
+    sections.push(notes.join("\n"));
+  }
+  if (commands.length > 0) {
+    const labelWidth = Math.max(...commands.map(({ label }) => label.length));
+    const commandRows = commands.map(
+      ({ label, command }) => `${pc.dim(label.padEnd(labelWidth))}  ${pc.cyan(command)}`,
+    );
+    sections.push(commandRows.join("\n"));
+  }
+
+  return sections.join("\n");
 }
 
 function getTauriInstructions(runCmd: string, frontend: Frontend[]) {

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -180,7 +180,7 @@ export const router = t.router({
       };
       const result = await createProjectHandler(combinedInput);
 
-      if (options.verbose || options.dryRun) {
+      if (options.verbose) {
         return result;
       }
     }),

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -231,6 +231,11 @@ export const router = t.router({
           .describe("Install dependencies after adding"),
         packageManager: PackageManagerSchema.optional().describe("Package manager to use"),
         projectDir: z.string().optional().describe("Project directory (defaults to current)"),
+        dryRun: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Preview addon changes without writing files"),
       }),
     )
     .mutation(async ({ input }) => {

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -9,6 +9,7 @@ import { openBuilderCommand, openDocsCommand, showSponsorsCommand } from "./comm
 import { addHandler, type AddResult } from "./helpers/core/add-handler";
 import { createProjectHandler } from "./helpers/core/command-handlers";
 import {
+  type AddInput,
   type Addons,
   AddonsSchema,
   type AddonOptions,
@@ -43,6 +44,7 @@ import {
   type Payments,
   PaymentsSchema,
   type ProjectConfig,
+  ProjectConfigSchema,
   ProjectNameSchema,
   type Runtime,
   RuntimeSchema,
@@ -87,6 +89,13 @@ export const SchemaNameSchema = z
     "initResult",
   ])
   .default("all");
+
+const CreateVirtualInputSchema = ProjectConfigSchema.omit({
+  projectDir: true,
+  relativePath: true,
+})
+  .partial()
+  .strict();
 
 export type SchemaName = z.infer<typeof SchemaNameSchema>;
 
@@ -289,6 +298,17 @@ export { Result } from "better-result";
  */
 export type CreateError = UserCancelledError | CLIError | ProjectCreationError;
 
+function formatInputValidationError(label: string, error: z.ZodError): string {
+  const details = error.issues
+    .map((issue) => {
+      const field = issue.path.join(".");
+      return field ? `${field}: ${issue.message}` : issue.message;
+    })
+    .join("; ");
+
+  return `Invalid ${label} input: ${details}`;
+}
+
 /**
  * Programmatic API to create a new Better-T-Stack project.
  * Returns a Result type - no console output, no interactive prompts.
@@ -318,13 +338,27 @@ export async function create(
   projectName?: string,
   options?: Partial<CreateInput>,
 ): Promise<Result<InitResult, CreateError>> {
+  const rawInput =
+    options === undefined || (typeof options === "object" && options !== null)
+      ? { ...options, projectName }
+      : options;
+  const parsedInput = CreateInputSchema.safeParse(rawInput);
+
+  if (!parsedInput.success) {
+    return Result.err(
+      new CLIError({
+        message: formatInputValidationError("create", parsedInput.error),
+        cause: parsedInput.error,
+      }),
+    );
+  }
+
   const input = {
-    ...options,
-    projectName,
+    ...parsedInput.data,
     renderTitle: false,
     verbose: true,
-    disableAnalytics: options?.disableAnalytics ?? true,
-    directoryConflict: options?.directoryConflict ?? "error",
+    disableAnalytics: parsedInput.data.disableAnalytics ?? true,
+    directoryConflict: parsedInput.data.directoryConflict ?? "error",
   } as CreateInput & { projectName?: string };
 
   return Result.tryPromise({
@@ -413,28 +447,40 @@ import {
 export async function createVirtual(
   options: Partial<Omit<ProjectConfig, "projectDir" | "relativePath">>,
 ): Promise<Result<VirtualFileTree, GeneratorError>> {
+  const parsedInput = CreateVirtualInputSchema.safeParse(options);
+  if (!parsedInput.success) {
+    return Result.err(
+      new GeneratorError({
+        message: formatInputValidationError("virtual create", parsedInput.error),
+        phase: "validation",
+        cause: parsedInput.error,
+      }),
+    );
+  }
+
+  const virtualOptions = parsedInput.data;
   const config: ProjectConfig = {
-    projectName: options.projectName || "my-project",
+    projectName: virtualOptions.projectName || "my-project",
     projectDir: "/virtual",
     relativePath: "./virtual",
-    addonOptions: options.addonOptions,
-    dbSetupOptions: options.dbSetupOptions,
-    database: options.database || "none",
-    orm: options.orm || "none",
-    backend: options.backend || "hono",
-    runtime: options.runtime || "bun",
-    frontend: options.frontend || ["tanstack-router"],
-    addons: options.addons || [],
-    examples: options.examples || [],
-    auth: options.auth || "none",
-    payments: options.payments || "none",
-    git: options.git ?? false,
-    packageManager: options.packageManager || "bun",
+    addonOptions: virtualOptions.addonOptions,
+    dbSetupOptions: virtualOptions.dbSetupOptions,
+    database: virtualOptions.database || "none",
+    orm: virtualOptions.orm || "none",
+    backend: virtualOptions.backend || "hono",
+    runtime: virtualOptions.runtime || "bun",
+    frontend: virtualOptions.frontend || ["tanstack-router"],
+    addons: virtualOptions.addons || [],
+    examples: virtualOptions.examples || [],
+    auth: virtualOptions.auth || "none",
+    payments: virtualOptions.payments || "none",
+    git: virtualOptions.git ?? false,
+    packageManager: virtualOptions.packageManager || "bun",
     install: false,
-    dbSetup: options.dbSetup || "none",
-    api: options.api || "trpc",
-    webDeploy: options.webDeploy || "none",
-    serverDeploy: options.serverDeploy || "none",
+    dbSetup: virtualOptions.dbSetup || "none",
+    api: virtualOptions.api || "trpc",
+    webDeploy: virtualOptions.webDeploy || "none",
+    serverDeploy: virtualOptions.serverDeploy || "none",
   };
 
   const providedFlags = new Set([
@@ -476,6 +522,7 @@ export async function createVirtual(
 export type {
   CreateInput,
   InitResult,
+  ProjectConfig,
   BetterTStackConfig,
   Database,
   ORM,
@@ -499,6 +546,11 @@ export type {
 
 export type { AddResult };
 
+export type AddOptions = Pick<
+  AddInput,
+  "addons" | "addonOptions" | "install" | "packageManager" | "projectDir" | "dryRun"
+>;
+
 /**
  * Programmatic API to add addons to an existing Better-T-Stack project.
  *
@@ -511,22 +563,31 @@ export type { AddResult };
  *   install: true,
  * });
  *
- * if (result?.success) {
+ * if (result.success) {
  *   console.log(`Added: ${result.addedAddons.join(", ")}`);
  * }
  * ```
  */
-export async function add(
-  options: {
-    addons?: Addons[];
-    addonOptions?: AddonOptions;
-    install?: boolean;
-    packageManager?: PackageManager;
-    projectDir?: string;
-    dryRun?: boolean;
-  } = {},
-): Promise<AddResult | undefined> {
-  return addHandler(options, { silent: true });
+export async function add(options: AddOptions = {}): Promise<AddResult> {
+  const parsedInput = AddInputSchema.safeParse(options);
+  if (!parsedInput.success) {
+    return {
+      success: false,
+      addedAddons: [],
+      projectDir: "",
+      error: formatInputValidationError("add", parsedInput.error),
+    };
+  }
+
+  const result = await addHandler(parsedInput.data, { silent: true });
+  return (
+    result ?? {
+      success: false,
+      addedAddons: [],
+      projectDir: parsedInput.data.projectDir ?? "",
+      error: "Operation cancelled",
+    }
+  );
 }
 
 // Re-export error types for consumers

--- a/apps/cli/src/prompts/addons.ts
+++ b/apps/cli/src/prompts/addons.ts
@@ -193,7 +193,7 @@ export async function getAddonsChoice(
   );
 
   const response = await navigableGroupMultiselect<Addons>({
-    message: "Select addons",
+    message: "Pick addons",
     options: groupedOptions,
     initialValues: initialValues,
     required: false,

--- a/apps/cli/src/prompts/api.ts
+++ b/apps/cli/src/prompts/api.ts
@@ -44,7 +44,7 @@ export async function getApiChoice(
   );
 
   const apiType = await navigableSelect<API>({
-    message: "Select API type",
+    message: "Choose an API layer",
     options: apiOptions,
     initialValue: preferValidInitial(apiOptions, previousValue, apiOptions[0].value),
   });

--- a/apps/cli/src/prompts/auth.ts
+++ b/apps/cli/src/prompts/auth.ts
@@ -78,7 +78,7 @@ export async function getAuthChoice(
   });
 
   const response = await navigableSelect({
-    message: "Select authentication provider",
+    message: "Choose authentication",
     options,
     initialValue: preferValidInitial(
       options,

--- a/apps/cli/src/prompts/backend.ts
+++ b/apps/cli/src/prompts/backend.ts
@@ -74,7 +74,7 @@ export async function getBackendFrameworkChoice(
   });
 
   const response = await navigableSelect<Backend>({
-    message: "Select backend",
+    message: "Choose a backend",
     options: backendOptions,
     initialValue: preferValidInitial(
       backendOptions,

--- a/apps/cli/src/prompts/config-prompts.ts
+++ b/apps/cli/src/prompts/config-prompts.ts
@@ -60,6 +60,7 @@ export async function gatherConfig(
   projectName: string,
   projectDir: string,
   relativePath: string,
+  options: { skipCompatibilityChecks?: boolean } = {},
 ) {
   if (isSilent()) {
     return {
@@ -168,6 +169,7 @@ export async function gatherConfig(
       install: ({ previousAnswer }) => getinstallChoice(flags.install, previousAnswer),
     },
     {
+      preselected: options.skipCompatibilityChecks ? flags : undefined,
       sections: [
         { label: "App", prompts: ["frontend", "backend", "runtime", "api"] },
         { label: "Data", prompts: ["database", "orm", "dbSetup"] },

--- a/apps/cli/src/prompts/config-prompts.ts
+++ b/apps/cli/src/prompts/config-prompts.ts
@@ -95,6 +95,8 @@ export async function gatherConfig(
         getBackendFrameworkChoice(flags.backend, results.frontend, previousAnswer),
       runtime: ({ results, previousAnswer }) =>
         getRuntimeChoice(flags.runtime, results.backend, previousAnswer),
+      api: ({ results, previousAnswer }) =>
+        getApiChoice(flags.api, results.frontend, results.backend, previousAnswer) as Promise<API>,
       database: ({ results, previousAnswer }) =>
         getDatabaseChoice(flags.database, results.backend, results.runtime, previousAnswer),
       orm: ({ results, previousAnswer }) =>
@@ -106,8 +108,15 @@ export async function gatherConfig(
           results.runtime,
           previousAnswer,
         ),
-      api: ({ results, previousAnswer }) =>
-        getApiChoice(flags.api, results.frontend, results.backend, previousAnswer) as Promise<API>,
+      dbSetup: ({ results, previousAnswer }) =>
+        getDBSetupChoice(
+          results.database ?? "none",
+          flags.dbSetup,
+          results.orm,
+          results.backend,
+          results.runtime,
+          previousAnswer,
+        ),
       auth: ({ results, previousAnswer }) =>
         getAuthChoice(flags.auth, results.backend, results.frontend, previousAnswer),
       payments: ({ results, previousAnswer }) =>
@@ -136,15 +145,6 @@ export async function gatherConfig(
           results.api,
           previousAnswer,
         ) as Promise<Examples[]>,
-      dbSetup: ({ results, previousAnswer }) =>
-        getDBSetupChoice(
-          results.database ?? "none",
-          flags.dbSetup,
-          results.orm,
-          results.backend,
-          results.runtime,
-          previousAnswer,
-        ),
       webDeploy: ({ results, previousAnswer }) =>
         getDeploymentChoice(
           flags.webDeploy,
@@ -168,6 +168,15 @@ export async function gatherConfig(
       install: ({ previousAnswer }) => getinstallChoice(flags.install, previousAnswer),
     },
     {
+      sections: [
+        { label: "App", prompts: ["frontend", "backend", "runtime", "api"] },
+        { label: "Data", prompts: ["database", "orm", "dbSetup"] },
+        { label: "Product", prompts: ["auth", "payments", "addons", "examples"] },
+        {
+          label: "Ship",
+          prompts: ["webDeploy", "serverDeploy", "git", "packageManager", "install"],
+        },
+      ],
       onCancel: () => {
         throw new UserCancelledError({ message: "Operation cancelled" });
       },

--- a/apps/cli/src/prompts/database-setup.ts
+++ b/apps/cli/src/prompts/database-setup.ts
@@ -102,7 +102,7 @@ export async function getDBSetupChoice(
   }
 
   const response = await navigableSelect<DatabaseSetup>({
-    message: `Select ${databaseType} setup option`,
+    message: `Choose a ${databaseType} setup`,
     options,
     initialValue: preferValidInitial(options, previousValue, "none"),
   });

--- a/apps/cli/src/prompts/database.ts
+++ b/apps/cli/src/prompts/database.ts
@@ -51,7 +51,7 @@ export async function getDatabaseChoice(
   }
 
   const response = await navigableSelect<Database>({
-    message: "Select database",
+    message: "Choose a database",
     options: databaseOptions,
     initialValue: preferValidInitial(databaseOptions, previousValue, DEFAULT_CONFIG.database),
   });

--- a/apps/cli/src/prompts/examples.ts
+++ b/apps/cli/src/prompts/examples.ts
@@ -40,7 +40,7 @@ export async function getExamplesChoice(
   if (options.length === 0) return [];
 
   response = await navigableMultiselect<Examples>({
-    message: "Include examples",
+    message: "Include starter examples?",
     options: options,
     required: false,
     initialValues: (previousValue ?? DEFAULT_CONFIG.examples)?.filter((ex) =>

--- a/apps/cli/src/prompts/frontend.ts
+++ b/apps/cli/src/prompts/frontend.ts
@@ -39,7 +39,7 @@ export async function getFrontendChoice(
     const wasFirstPrompt = isFirstPrompt();
 
     const frontendTypes = await navigableMultiselect({
-      message: "Select project type",
+      message: "What are you building?",
       options: [
         {
           value: "web",
@@ -115,7 +115,7 @@ export async function getFrontendChoice(
       );
 
       const webFramework = await navigableSelect<Frontend>({
-        message: "Choose web",
+        message: "Choose a web framework",
         options: webOptions,
         initialValue: preferValidInitial(webOptions, previousWeb, DEFAULT_CONFIG.frontend[0]),
       });
@@ -136,7 +136,7 @@ export async function getFrontendChoice(
 
     if (frontendTypes.includes("native")) {
       const nativeFramework = await navigableSelect<Frontend>({
-        message: "Choose native",
+        message: "Choose a native setup",
         options: [
           {
             value: "native-bare" as const,

--- a/apps/cli/src/prompts/git.ts
+++ b/apps/cli/src/prompts/git.ts
@@ -6,7 +6,7 @@ export async function getGitChoice(git?: boolean, previousValue?: boolean) {
   if (git !== undefined) return git;
 
   const response = await navigableConfirm({
-    message: "Initialize git repository?",
+    message: "Initialize a Git repository?",
     initialValue: previousValue ?? DEFAULT_CONFIG.git,
   });
 

--- a/apps/cli/src/prompts/navigable-group.ts
+++ b/apps/cli/src/prompts/navigable-group.ts
@@ -2,7 +2,12 @@
  * Navigable group - a group of prompts that allows going back
  */
 
-import { didLastPromptShowUI, setIsFirstPrompt, setLastPromptShownUI } from "../utils/context";
+import {
+  didLastPromptShowUI,
+  setIsFirstPrompt,
+  setLastPromptShownUI,
+  setPromptProgress,
+} from "../utils/context";
 import { isGoBack } from "../utils/navigation";
 import { isCancel } from "./navigable";
 
@@ -20,6 +25,11 @@ export interface NavigablePromptGroupOptions<T> {
    * if one of the prompts is canceled.
    */
   onCancel?: (opts: { results: Prettify<Partial<PromptGroupAwaitedReturn<T>>> }) => void;
+  /** Group related questions into named stages shown in the prompt chrome. */
+  sections?: ReadonlyArray<{
+    label: string;
+    prompts: ReadonlyArray<keyof T>;
+  }>;
 }
 
 export type NavigablePromptGroup<T> = {
@@ -53,51 +63,65 @@ export async function navigableGroup<T>(
     currentIndex--;
   };
 
-  while (currentIndex < promptNames.length) {
-    const name = promptNames[currentIndex];
-    const prompt = prompts[name];
+  try {
+    while (currentIndex < promptNames.length) {
+      const name = promptNames[currentIndex];
+      const prompt = prompts[name];
+      const section = opts?.sections?.find(({ prompts: sectionPrompts }) =>
+        sectionPrompts.includes(name),
+      );
+      const sectionPromptIndex = section?.prompts.indexOf(name) ?? -1;
 
-    setIsFirstPrompt(currentIndex === 0);
+      setPromptProgress({
+        current: currentIndex + 1,
+        total: promptNames.length,
+        section: section?.label ?? "Setup",
+        sectionCurrent: sectionPromptIndex + 1,
+        sectionTotal: section?.prompts.length ?? promptNames.length,
+      });
 
-    setLastPromptShownUI(false);
+      setIsFirstPrompt(currentIndex === 0);
+      setLastPromptShownUI(false);
 
-    const result = await prompt({ results, previousAnswer: previousAnswers[name] })?.catch((e) => {
-      throw e;
-    });
+      const pendingResult = prompt({
+        results,
+        previousAnswer: previousAnswers[name],
+      });
+      const result = pendingResult ? await pendingResult : undefined;
 
-    if (isGoBack(result)) {
-      goingBack = true;
-      if (currentIndex > 0) {
-        stepBack();
+      if (isGoBack(result)) {
+        goingBack = true;
+        if (currentIndex > 0) {
+          stepBack();
+          continue;
+        }
+        goingBack = false;
         continue;
       }
+
+      if (isCancel(result)) {
+        if (typeof opts?.onCancel === "function") {
+          results[name] = "canceled";
+          opts.onCancel({ results });
+        }
+        return results;
+      }
+
+      if (goingBack && !didLastPromptShowUI()) {
+        if (currentIndex > 0) {
+          stepBack();
+          continue;
+        }
+      }
+
       goingBack = false;
-      continue;
+      results[name] = result;
+      currentIndex++;
     }
-
-    if (isCancel(result)) {
-      if (typeof opts?.onCancel === "function") {
-        results[name] = "canceled";
-        opts.onCancel({ results });
-      }
-      setIsFirstPrompt(false);
-      return results;
-    }
-
-    if (goingBack && !didLastPromptShowUI()) {
-      if (currentIndex > 0) {
-        stepBack();
-        continue;
-      }
-    }
-
-    goingBack = false;
-
-    results[name] = result;
-    currentIndex++;
+  } finally {
+    setIsFirstPrompt(false);
+    setPromptProgress(undefined);
   }
-
-  setIsFirstPrompt(false);
 
   return results;
 }

--- a/apps/cli/src/prompts/navigable-group.ts
+++ b/apps/cli/src/prompts/navigable-group.ts
@@ -30,6 +30,8 @@ export interface NavigablePromptGroupOptions<T> {
     label: string;
     prompts: ReadonlyArray<keyof T>;
   }>;
+  /** Values to accept without invoking their prompt resolvers. */
+  preselected?: Partial<PromptGroupAwaitedReturn<T>>;
 }
 
 export type NavigablePromptGroup<T> = {
@@ -83,11 +85,14 @@ export async function navigableGroup<T>(
       setIsFirstPrompt(currentIndex === 0);
       setLastPromptShownUI(false);
 
-      const pendingResult = prompt({
-        results,
-        previousAnswer: previousAnswers[name],
-      });
-      const result = pendingResult ? await pendingResult : undefined;
+      const presetResult = opts?.preselected?.[name];
+      const result =
+        presetResult !== undefined
+          ? presetResult
+          : await prompt({
+              results,
+              previousAnswer: previousAnswers[name],
+            });
 
       if (isGoBack(result)) {
         goingBack = true;

--- a/apps/cli/src/prompts/navigable.ts
+++ b/apps/cli/src/prompts/navigable.ts
@@ -3,18 +3,23 @@
  * These prompts return GO_BACK_SYMBOL when 'b' is pressed (instead of canceling)
  */
 
+import type { Readable, Writable } from "node:stream";
+
 import {
   ConfirmPrompt,
+  type Prompt,
   type State,
   GroupMultiSelectPrompt,
   MultiSelectPrompt,
   SelectPrompt,
   isCancel,
 } from "@clack/core";
+import { limitOptions } from "@clack/prompts";
 import pc from "picocolors";
 
 import {
   didLastPromptShowUI as ctxDidLastPromptShowUI,
+  getPromptProgress,
   isFirstPrompt as ctxIsFirstPrompt,
   setIsFirstPrompt as ctxSetIsFirstPrompt,
   setLastPromptShownUI as ctxSetLastPromptShownUI,
@@ -26,6 +31,7 @@ const S_STEP_ACTIVE = unicode ? "◆" : "*";
 const S_STEP_CANCEL = unicode ? "■" : "x";
 const S_STEP_ERROR = unicode ? "▲" : "x";
 const S_STEP_SUBMIT = unicode ? "◇" : "o";
+const S_STEP_BACK = unicode ? "↶" : "<";
 const S_BAR = unicode ? "│" : "|";
 const S_BAR_END = unicode ? "└" : "—";
 const S_RADIO_ACTIVE = unicode ? "●" : ">";
@@ -33,6 +39,11 @@ const S_RADIO_INACTIVE = unicode ? "○" : " ";
 const S_CHECKBOX_ACTIVE = unicode ? "◻" : "[•]";
 const S_CHECKBOX_SELECTED = unicode ? "◼" : "[+]";
 const S_CHECKBOX_INACTIVE = unicode ? "◻" : "[ ]";
+const promptsNavigatingBack = new WeakSet<object>();
+
+function keycap(label: string): string {
+  return pc.inverse(` ${label} `);
+}
 
 function symbol(state: State) {
   switch (state) {
@@ -49,19 +60,19 @@ function symbol(state: State) {
 }
 
 const KEYBOARD_HINT = pc.dim(
-  `${pc.gray("↑/↓")} navigate • ${pc.gray("enter")} confirm • ${pc.gray("b")} back • ${pc.gray("ctrl+c")} cancel`,
+  `${keycap("↑↓")} move  ${keycap("enter")} choose  ${keycap("b")} back  ${keycap("^c")} cancel`,
 );
 
 const KEYBOARD_HINT_FIRST = pc.dim(
-  `${pc.gray("↑/↓")} navigate • ${pc.gray("enter")} confirm • ${pc.gray("ctrl+c")} cancel`,
+  `${keycap("↑↓")} move  ${keycap("enter")} choose  ${keycap("^c")} cancel`,
 );
 
 const KEYBOARD_HINT_MULTI = pc.dim(
-  `${pc.gray("↑/↓")} navigate • ${pc.gray("space")} select • ${pc.gray("enter")} confirm • ${pc.gray("b")} back • ${pc.gray("ctrl+c")} cancel`,
+  `${keycap("↑↓")} move  ${keycap("space")} toggle  ${keycap("enter")} choose  ${keycap("b")} back  ${keycap("^c")} cancel`,
 );
 
 const KEYBOARD_HINT_MULTI_FIRST = pc.dim(
-  `${pc.gray("↑/↓")} navigate • ${pc.gray("space")} select • ${pc.gray("enter")} confirm • ${pc.gray("ctrl+c")} cancel`,
+  `${keycap("↑↓")} move  ${keycap("space")} toggle  ${keycap("enter")} choose  ${keycap("^c")} cancel`,
 );
 
 export const setIsFirstPrompt = ctxSetIsFirstPrompt;
@@ -76,26 +87,61 @@ function getMultiHint(): string {
   return ctxIsFirstPrompt() ? KEYBOARD_HINT_MULTI_FIRST : KEYBOARD_HINT_MULTI;
 }
 
+function activePromptTitle(message: string, state: "active" | "error" = "active"): string {
+  const progress = getPromptProgress();
+  const eyebrow = progress
+    ? `${pc.magenta(pc.bold(progress.section.toUpperCase()))} ${pc.dim(`· ${progress.current}/${progress.total}`)}`
+    : pc.dim("SETUP");
+
+  return `${pc.gray(S_BAR)}  ${eyebrow}\n${symbol(state)}  ${pc.bold(message)}\n`;
+}
+
+function resolvedPrompt(message: string, value: string, state: "submit" | "cancel"): string {
+  const promptMessage = state === "cancel" ? pc.strikethrough(pc.dim(message)) : pc.dim(message);
+  return `${symbol(state)}  ${promptMessage} ${pc.dim("›")} ${value}`;
+}
+
+function canceledPrompt(prompt: object, message: string, value: string): string {
+  if (promptsNavigatingBack.has(prompt)) {
+    return `${pc.cyan(S_STEP_BACK)}  ${pc.dim(message)}`;
+  }
+  return resolvedPrompt(message, value, "cancel");
+}
+
 function normalizeValidationMessage(
   validationMessage: string | Error | undefined,
 ): string | undefined {
   return validationMessage instanceof Error ? validationMessage.message : validationMessage;
 }
 
-async function runWithNavigation<T>(prompt: any): Promise<T | symbol> {
+async function runWithNavigation<T>(prompt: Prompt<T>): Promise<T | symbol> {
   let goBack = false;
 
   prompt.on("key", (char: string | undefined) => {
     if ((char === "b" || char === "B") && !ctxIsFirstPrompt()) {
       goBack = true;
+      promptsNavigatingBack.add(prompt);
+      // Use Clack's public state field so the normal keypress finalize path
+      // restores raw mode, listeners, and the terminal cursor.
       prompt.state = "cancel";
     }
   });
 
   ctxSetLastPromptShownUI(true);
-  const result = await prompt.prompt();
+  try {
+    const result = await prompt.prompt();
+    return goBack ? GO_BACK_SYMBOL : (result as T | symbol);
+  } finally {
+    promptsNavigatingBack.delete(prompt);
+  }
+}
 
-  return goBack ? GO_BACK_SYMBOL : result;
+interface NavigableCommonOptions {
+  /** Abort this prompt through Clack's normal cancellation path. */
+  signal?: AbortSignal;
+  /** Override streams for embedding or deterministic prompt tests. */
+  input?: Readable;
+  output?: Writable;
 }
 
 interface SelectOption<T> {
@@ -105,17 +151,19 @@ interface SelectOption<T> {
   disabled?: boolean;
 }
 
-export interface NavigableSelectOptions<T> {
+export interface NavigableSelectOptions<T> extends NavigableCommonOptions {
   message: string;
   options: SelectOption<T>[];
   initialValue?: T;
+  maxItems?: number;
 }
 
 export async function navigableSelect<T>(opts: NavigableSelectOptions<T>): Promise<T | symbol> {
   const opt = (
-    option: SelectOption<T>,
+    option: SelectOption<T> | undefined,
     state: "inactive" | "active" | "selected" | "cancelled" | "disabled",
   ) => {
+    if (!option) return pc.dim("none");
     const label = option.label ?? String(option.value);
     switch (state) {
       case "disabled":
@@ -123,7 +171,7 @@ export async function navigableSelect<T>(opts: NavigableSelectOptions<T>): Promi
       case "selected":
         return `${pc.dim(label)}`;
       case "active":
-        return `${pc.green(S_RADIO_ACTIVE)} ${label}${option.hint ? ` ${pc.dim(`(${option.hint})`)}` : ""}`;
+        return `${pc.cyan(S_RADIO_ACTIVE)} ${label}${option.hint ? ` ${pc.dim(`(${option.hint})`)}` : ""}`;
       case "cancelled":
         return `${pc.strikethrough(pc.dim(label))}`;
       default:
@@ -134,24 +182,30 @@ export async function navigableSelect<T>(opts: NavigableSelectOptions<T>): Promi
   const prompt = new SelectPrompt({
     options: opts.options,
     initialValue: opts.initialValue,
+    signal: opts.signal,
+    input: opts.input,
+    output: opts.output,
     render() {
-      const title = `${pc.gray(S_BAR)}\n${symbol(this.state)}  ${opts.message}\n`;
-
       switch (this.state) {
         case "submit": {
-          return `${title}${pc.gray(S_BAR)}  ${opt(this.options[this.cursor], "selected")}`;
+          return resolvedPrompt(opts.message, opt(this.options[this.cursor], "selected"), "submit");
         }
         case "cancel": {
-          return `${title}${pc.gray(S_BAR)}  ${opt(this.options[this.cursor], "cancelled")}\n${pc.gray(S_BAR)}`;
+          return canceledPrompt(this, opts.message, opt(this.options[this.cursor], "cancelled"));
         }
         default: {
-          const optionsText = this.options
-            .map((option, i) =>
-              opt(option, option.disabled ? "disabled" : i === this.cursor ? "active" : "inactive"),
-            )
-            .join(`\n${pc.cyan(S_BAR)}  `);
-          const hint = `\n${pc.gray(S_BAR)}  ${getHint()}`;
-          return `${title}${pc.cyan(S_BAR)}  ${optionsText}\n${pc.cyan(S_BAR_END)}${hint}\n`;
+          const optionsText = limitOptions({
+            output: opts.output,
+            options: this.options,
+            cursor: this.cursor,
+            maxItems: opts.maxItems,
+            columnPadding: 3,
+            rowPadding: 5,
+            style: (option, active) =>
+              opt(option, option.disabled ? "disabled" : active ? "active" : "inactive"),
+          }).join(`\n${pc.cyan(S_BAR)}  `);
+          const hint = `${pc.gray(S_BAR_END)}  ${getHint()}`;
+          return `${activePromptTitle(opts.message)}${pc.cyan(S_BAR)}  ${optionsText}\n${hint}\n`;
         }
       }
     },
@@ -160,10 +214,12 @@ export async function navigableSelect<T>(opts: NavigableSelectOptions<T>): Promi
   return runWithNavigation(prompt) as Promise<T | symbol>;
 }
 
-export interface NavigableMultiselectOptions<T> {
+export interface NavigableMultiselectOptions<T> extends NavigableCommonOptions {
   message: string;
   options: SelectOption<T>[];
   initialValues?: T[];
+  cursorAt?: T;
+  maxItems?: number;
   required?: boolean;
   validate?: (selected: T[] | undefined) => string | Error | undefined;
 }
@@ -209,7 +265,11 @@ export async function navigableMultiselect<T>(
   const prompt = new MultiSelectPrompt({
     options: opts.options,
     initialValues: opts.initialValues,
+    cursorAt: opts.cursorAt,
     required,
+    signal: opts.signal,
+    input: opts.input,
+    output: opts.output,
     validate(selected: T[] | undefined) {
       if (required && (selected === undefined || selected.length === 0)) {
         return `Please select at least one option.\n${pc.reset(pc.dim(`Press ${pc.gray(pc.bgWhite(pc.inverse(" space ")))} to select, ${pc.gray(pc.bgWhite(pc.inverse(" enter ")))} to submit`))}`;
@@ -217,7 +277,6 @@ export async function navigableMultiselect<T>(
       return normalizeValidationMessage(opts.validate?.(selected));
     },
     render() {
-      const title = `${pc.gray(S_BAR)}\n${symbol(this.state)}  ${opts.message}\n`;
       const value = this.value ?? [];
 
       const styleOption = (option: SelectOption<T>, active: boolean) => {
@@ -241,31 +300,44 @@ export async function navigableMultiselect<T>(
               .filter(({ value: optionValue }) => value.includes(optionValue))
               .map((option) => opt(option, "submitted"))
               .join(pc.dim(", ")) || pc.dim("none");
-          return `${title}${pc.gray(S_BAR)}  ${submitText}`;
+          return resolvedPrompt(opts.message, submitText, "submit");
         }
         case "cancel": {
-          const label = this.options
-            .filter(({ value: optionValue }) => value.includes(optionValue))
-            .map((option) => opt(option, "cancelled"))
-            .join(pc.dim(", "));
-          return `${title}${pc.gray(S_BAR)}  ${label}\n${pc.gray(S_BAR)}`;
+          const label =
+            this.options
+              .filter(({ value: optionValue }) => value.includes(optionValue))
+              .map((option) => opt(option, "cancelled"))
+              .join(pc.dim(", ")) || pc.dim("none");
+          return canceledPrompt(this, opts.message, label);
         }
         case "error": {
           const footer = this.error
             .split("\n")
             .map((ln, i) => (i === 0 ? `${pc.yellow(S_BAR_END)}  ${pc.yellow(ln)}` : `   ${ln}`))
             .join("\n");
-          const optionsText = this.options
-            .map((option, i) => styleOption(option, i === this.cursor))
-            .join(`\n${pc.yellow(S_BAR)}  `);
-          return `${title}${pc.yellow(S_BAR)}  ${optionsText}\n${footer}\n`;
+          const optionsText = limitOptions({
+            output: opts.output,
+            options: this.options,
+            cursor: this.cursor,
+            maxItems: opts.maxItems,
+            columnPadding: 3,
+            rowPadding: footer.split("\n").length + 4,
+            style: styleOption,
+          }).join(`\n${pc.yellow(S_BAR)}  `);
+          return `${activePromptTitle(opts.message, "error")}${pc.yellow(S_BAR)}  ${optionsText}\n${footer}\n`;
         }
         default: {
-          const optionsText = this.options
-            .map((option, i) => styleOption(option, i === this.cursor))
-            .join(`\n${pc.cyan(S_BAR)}  `);
-          const hint = `\n${pc.gray(S_BAR)}  ${getMultiHint()}`;
-          return `${title}${pc.cyan(S_BAR)}  ${optionsText}\n${pc.cyan(S_BAR_END)}${hint}\n`;
+          const optionsText = limitOptions({
+            output: opts.output,
+            options: this.options,
+            cursor: this.cursor,
+            maxItems: opts.maxItems,
+            columnPadding: 3,
+            rowPadding: 5,
+            style: styleOption,
+          }).join(`\n${pc.cyan(S_BAR)}  `);
+          const hint = `${pc.gray(S_BAR_END)}  ${getMultiHint()}`;
+          return `${activePromptTitle(opts.message)}${pc.cyan(S_BAR)}  ${optionsText}\n${hint}\n`;
         }
       }
     },
@@ -274,7 +346,7 @@ export async function navigableMultiselect<T>(
   return runWithNavigation(prompt) as Promise<T[] | symbol>;
 }
 
-export interface NavigableConfirmOptions {
+export interface NavigableConfirmOptions extends NavigableCommonOptions {
   message: string;
   active?: string;
   inactive?: string;
@@ -289,26 +361,28 @@ export async function navigableConfirm(opts: NavigableConfirmOptions): Promise<b
     active,
     inactive,
     initialValue: opts.initialValue ?? true,
+    signal: opts.signal,
+    input: opts.input,
+    output: opts.output,
     render() {
-      const title = `${pc.gray(S_BAR)}\n${symbol(this.state)}  ${opts.message}\n`;
       const value = this.value ? active : inactive;
 
       switch (this.state) {
         case "submit":
-          return `${title}${pc.gray(S_BAR)}  ${pc.dim(value)}`;
+          return resolvedPrompt(opts.message, pc.dim(value), "submit");
         case "cancel":
-          return `${title}${pc.gray(S_BAR)}  ${pc.strikethrough(pc.dim(value))}\n${pc.gray(S_BAR)}`;
+          return canceledPrompt(this, opts.message, pc.strikethrough(pc.dim(value)));
         default: {
-          const hint = `\n${pc.gray(S_BAR)}  ${getHint()}`;
-          return `${title}${pc.cyan(S_BAR)}  ${
+          const hint = `${pc.gray(S_BAR_END)}  ${getHint()}`;
+          return `${activePromptTitle(opts.message)}${pc.cyan(S_BAR)}  ${
             this.value
-              ? `${pc.green(S_RADIO_ACTIVE)} ${active}`
+              ? `${pc.cyan(S_RADIO_ACTIVE)} ${active}`
               : `${pc.dim(S_RADIO_INACTIVE)} ${pc.dim(active)}`
           } ${pc.dim("/")} ${
             !this.value
-              ? `${pc.green(S_RADIO_ACTIVE)} ${inactive}`
+              ? `${pc.cyan(S_RADIO_ACTIVE)} ${inactive}`
               : `${pc.dim(S_RADIO_INACTIVE)} ${pc.dim(inactive)}`
-          }\n${pc.cyan(S_BAR_END)}${hint}\n`;
+          }\n${hint}\n`;
         }
       }
     },
@@ -324,10 +398,12 @@ export interface GroupMultiSelectOption<T> {
   disabled?: boolean;
 }
 
-export interface NavigableGroupMultiselectOptions<T> {
+export interface NavigableGroupMultiselectOptions<T> extends NavigableCommonOptions {
   message: string;
   options: Record<string, GroupMultiSelectOption<T>[]>;
   initialValues?: T[];
+  cursorAt?: T;
+  maxItems?: number;
   required?: boolean;
   validate?: (selected: T[] | undefined) => string | Error | undefined;
 }
@@ -385,8 +461,12 @@ export async function navigableGroupMultiselect<T>(
   const prompt = new GroupMultiSelectPrompt<GroupMultiSelectOption<T>>({
     options: opts.options,
     initialValues: opts.initialValues,
+    cursorAt: opts.cursorAt,
     required,
     selectableGroups: true,
+    signal: opts.signal,
+    input: opts.input,
+    output: opts.output,
     validate(selected: T[] | undefined) {
       if (required && (selected === undefined || selected.length === 0)) {
         return `Please select at least one option.\n${pc.reset(pc.dim(`Press ${pc.gray(pc.bgWhite(pc.inverse(" space ")))} to select, ${pc.gray(pc.bgWhite(pc.inverse(" enter ")))} to submit`))}`;
@@ -394,86 +474,74 @@ export async function navigableGroupMultiselect<T>(
       return normalizeValidationMessage(opts.validate?.(selected));
     },
     render() {
-      const title = `${pc.gray(S_BAR)}\n${symbol(this.state)}  ${opts.message}\n`;
       const value = this.value ?? [];
+      const styleOption = (
+        option: GroupMultiSelectOption<T> & { group: string | boolean },
+        active: boolean,
+      ) => {
+        const selected =
+          value.includes(option.value) ||
+          (option.group === true && this.isGroupSelected(`${option.value}`));
+        const groupActive =
+          !active &&
+          typeof option.group === "string" &&
+          this.options[this.cursor]?.value === option.group;
+        if (groupActive) {
+          return opt(option, selected ? "group-active-selected" : "group-active", this.options);
+        }
+        if (active && selected) {
+          return opt(option, "active-selected", this.options);
+        }
+        if (selected) {
+          return opt(option, "selected", this.options);
+        }
+        return opt(option, active ? "active" : "inactive", this.options);
+      };
 
       switch (this.state) {
         case "submit": {
           const selectedOptions = this.options
             .filter(({ value: optionValue }) => value.includes(optionValue))
             .map((option) => opt(option, "submitted"));
-          const optionsText =
-            selectedOptions.length === 0 ? "" : `  ${selectedOptions.join(pc.dim(", "))}`;
-          return `${title}${pc.gray(S_BAR)}${optionsText}`;
+          const optionsText = selectedOptions.join(pc.dim(", ")) || pc.dim("none");
+          return resolvedPrompt(opts.message, optionsText, "submit");
         }
         case "cancel": {
-          const label = this.options
-            .filter(({ value: optionValue }) => value.includes(optionValue))
-            .map((option) => opt(option, "cancelled"))
-            .join(pc.dim(", "));
-          return `${title}${pc.gray(S_BAR)}  ${label.trim() ? `${label}\n${pc.gray(S_BAR)}` : ""}`;
+          const label =
+            this.options
+              .filter(({ value: optionValue }) => value.includes(optionValue))
+              .map((option) => opt(option, "cancelled"))
+              .join(pc.dim(", ")) || pc.dim("none");
+          return canceledPrompt(this, opts.message, label);
         }
         case "error": {
           const footer = this.error
             .split("\n")
             .map((ln, i) => (i === 0 ? `${pc.yellow(S_BAR_END)}  ${pc.yellow(ln)}` : `   ${ln}`))
             .join("\n");
-          const optionsText = this.options
-            .map((option, i, options) => {
-              const selected =
-                value.includes(option.value) ||
-                (option.group === true && this.isGroupSelected(`${option.value}`));
-              const active = i === this.cursor;
-              const groupActive =
-                !active &&
-                typeof option.group === "string" &&
-                this.options[this.cursor].value === option.group;
-              if (groupActive) {
-                return opt(option, selected ? "group-active-selected" : "group-active", options);
-              }
-              if (active && selected) {
-                return opt(option, "active-selected", options);
-              }
-              if (selected) {
-                return opt(option, "selected", options);
-              }
-              return opt(option, active ? "active" : "inactive", options);
-            })
-            .join(`\n${pc.yellow(S_BAR)}  `);
-          return `${title}${pc.yellow(S_BAR)}  ${optionsText}\n${footer}\n`;
+          const optionsText = limitOptions({
+            output: opts.output,
+            options: this.options,
+            cursor: this.cursor,
+            maxItems: opts.maxItems,
+            columnPadding: 3,
+            rowPadding: footer.split("\n").length + 4,
+            style: styleOption,
+          }).join(`\n${pc.yellow(S_BAR)}  `);
+          return `${activePromptTitle(opts.message, "error")}${pc.yellow(S_BAR)}  ${optionsText}\n${footer}\n`;
         }
         default: {
-          const optionsText = this.options
-            .map((option, i, options) => {
-              const selected =
-                value.includes(option.value) ||
-                (option.group === true && this.isGroupSelected(`${option.value}`));
-              const active = i === this.cursor;
-              const groupActive =
-                !active &&
-                typeof option.group === "string" &&
-                this.options[this.cursor].value === option.group;
-              let optionText = "";
-              if (groupActive) {
-                optionText = opt(
-                  option,
-                  selected ? "group-active-selected" : "group-active",
-                  options,
-                );
-              } else if (active && selected) {
-                optionText = opt(option, "active-selected", options);
-              } else if (selected) {
-                optionText = opt(option, "selected", options);
-              } else {
-                optionText = opt(option, active ? "active" : "inactive", options);
-              }
-              const optPrefix = i !== 0 && !optionText.startsWith("\n") ? "  " : "";
-              return `${optPrefix}${optionText}`;
-            })
-            .join(`\n${pc.cyan(S_BAR)}`);
-          const optionsPrefix = optionsText.startsWith("\n") ? "" : "  ";
-          const hint = `\n${pc.gray(S_BAR)}  ${getMultiHint()}`;
-          return `${title}${pc.cyan(S_BAR)}${optionsPrefix}${optionsText}\n${pc.cyan(S_BAR_END)}${hint}\n`;
+          const optionsText = limitOptions({
+            output: opts.output,
+            options: this.options,
+            cursor: this.cursor,
+            maxItems: opts.maxItems,
+            columnPadding: 3,
+            rowPadding: 5,
+            style: styleOption,
+          }).join(`\n${pc.cyan(S_BAR)}  `);
+          const hint = `${pc.gray(S_BAR_END)}  ${getMultiHint()}`;
+          return `${activePromptTitle(opts.message)}${pc.cyan(S_BAR)}  ${optionsText}\n${hint}\n`;
         }
       }
     },

--- a/apps/cli/src/prompts/orm.ts
+++ b/apps/cli/src/prompts/orm.ts
@@ -47,7 +47,7 @@ export async function getORMChoice(
       : [ormOptions.drizzle, ormOptions.prisma];
 
   const response = await navigableSelect<ORM>({
-    message: "Select ORM",
+    message: "Choose an ORM",
     options,
     initialValue: preferValidInitial(
       options,

--- a/apps/cli/src/prompts/payments.ts
+++ b/apps/cli/src/prompts/payments.ts
@@ -36,7 +36,7 @@ export async function getPaymentsChoice(
   ];
 
   const response = await navigableSelect<Payments>({
-    message: "Select payments provider",
+    message: "Add payments?",
     options,
     initialValue: preferValidInitial(options, previousValue, DEFAULT_CONFIG.payments),
   });

--- a/apps/cli/src/prompts/project-name.ts
+++ b/apps/cli/src/prompts/project-name.ts
@@ -46,10 +46,24 @@ export async function getProjectName(initialName?: string): Promise<string> {
   let defaultName: string = DEFAULT_CONFIG.projectName;
   let counter = 1;
 
-  while (
-    (await fs.pathExists(path.resolve(process.cwd(), defaultName))) &&
-    (await fs.readdir(path.resolve(process.cwd(), defaultName))).length > 0
-  ) {
+  while (true) {
+    const defaultPath = path.resolve(process.cwd(), defaultName);
+    let stats;
+    try {
+      stats = await fs.lstat(defaultPath);
+    } catch (error) {
+      if (
+        typeof error === "object" &&
+        error !== null &&
+        "code" in error &&
+        error.code === "ENOENT"
+      ) {
+        break;
+      }
+      throw error;
+    }
+
+    if (stats.isDirectory() && (await fs.readdir(defaultPath)).length === 0) break;
     defaultName = `${DEFAULT_CONFIG.projectName}-${counter}`;
     counter++;
   }

--- a/apps/cli/src/prompts/project-name.ts
+++ b/apps/cli/src/prompts/project-name.ts
@@ -56,7 +56,7 @@ export async function getProjectName(initialName?: string): Promise<string> {
 
   while (!isValid) {
     const response = await text({
-      message: "Enter your project name or path (relative to current directory)",
+      message: "Where should we create your project?",
       placeholder: defaultName,
       initialValue: initialName,
       defaultValue: defaultName,

--- a/apps/cli/src/prompts/runtime.ts
+++ b/apps/cli/src/prompts/runtime.ts
@@ -40,7 +40,7 @@ export async function getRuntimeChoice(
   }
 
   const response = await navigableSelect<Runtime>({
-    message: "Select runtime",
+    message: "Choose a runtime",
     options: runtimeOptions,
     initialValue: preferValidInitial(runtimeOptions, previousValue, DEFAULT_CONFIG.runtime),
   });

--- a/apps/cli/src/prompts/server-deploy.ts
+++ b/apps/cli/src/prompts/server-deploy.ts
@@ -121,7 +121,7 @@ export async function getServerDeploymentToAdd(
   }
 
   const response = await navigableSelect<ServerDeploy>({
-    message: "Select server deployment",
+    message: "Choose server deployment",
     options,
     initialValue: DEFAULT_CONFIG.serverDeploy,
   });

--- a/apps/cli/src/prompts/server-deploy.ts
+++ b/apps/cli/src/prompts/server-deploy.ts
@@ -70,7 +70,7 @@ export async function getServerDeploymentChoice(
   });
 
   const response = await navigableSelect<ServerDeploy>({
-    message: "Select server deployment",
+    message: "Choose server deployment",
     options,
     initialValue: preferValidInitial(options, previousValue, DEFAULT_CONFIG.serverDeploy),
   });

--- a/apps/cli/src/prompts/web-deploy.ts
+++ b/apps/cli/src/prompts/web-deploy.ts
@@ -71,7 +71,7 @@ export async function getDeploymentChoice(
   });
 
   const response = await navigableSelect<WebDeploy>({
-    message: "Select web deployment",
+    message: "Choose web deployment",
     options,
     initialValue: preferValidInitial(options, previousValue, DEFAULT_CONFIG.webDeploy),
   });

--- a/apps/cli/src/utils/cli-invocation.ts
+++ b/apps/cli/src/utils/cli-invocation.ts
@@ -1,0 +1,19 @@
+import type { PackageManager } from "../types";
+import { getPackageExecutionCommand } from "./package-runner";
+
+export function getCliSubcommandCommand(
+  subcommand: string,
+  fallbackPackageManager: PackageManager,
+  userAgent = process.env.npm_config_user_agent,
+): string {
+  const normalizedUserAgent = userAgent?.toLowerCase();
+  const packageManager = normalizedUserAgent?.startsWith("bun")
+    ? "bun"
+    : normalizedUserAgent?.startsWith("pnpm")
+      ? "pnpm"
+      : normalizedUserAgent?.startsWith("npm")
+        ? "npm"
+        : fallbackPackageManager;
+
+  return getPackageExecutionCommand(packageManager, `create-better-t-stack@latest ${subcommand}`);
+}

--- a/apps/cli/src/utils/compatibility-rules.ts
+++ b/apps/cli/src/utils/compatibility-rules.ts
@@ -20,11 +20,8 @@ import { ValidationError } from "./errors";
 type ValidationResult = Result<void, ValidationError>;
 type AddonCompatibilityConfig = Pick<ProjectConfig, "frontend" | "auth" | "backend" | "runtime">;
 const TASK_RUNNER_ADDONS = ["turborepo", "nx", "vite-plus"] as const satisfies readonly Addons[];
-const STATIC_DESKTOP_ADDONS = ["tauri", "electrobun"] as const satisfies readonly Addons[];
-const TAURI_STATIC_EXPORT_FRONTENDS = [
-  "next",
-  "tanstack-start",
-] as const satisfies readonly Frontend[];
+const STATIC_DESKTOP_ADDONS: readonly Addons[] = ["tauri", "electrobun"];
+const TAURI_STATIC_EXPORT_FRONTENDS: readonly Frontend[] = ["next", "tanstack-start"];
 
 export const CONVEX_BETTER_AUTH_INCOMPATIBLE_FRONTENDS = [
   "nuxt",
@@ -356,12 +353,12 @@ export function validateVercelServerDeploy(
 }
 
 // Frontends whose docker image needs server output, which desktop addons replace with a static export
-const DOCKER_SERVER_OUTPUT_FRONTENDS = [
+const DOCKER_SERVER_OUTPUT_FRONTENDS: readonly Frontend[] = [
   "next",
   "svelte",
   "astro",
   "react-router",
-] as const satisfies readonly Frontend[];
+];
 
 export function validateDockerWebDeployDesktopAddons(
   webDeploy: WebDeploy | undefined,

--- a/apps/cli/src/utils/context.ts
+++ b/apps/cli/src/utils/context.ts
@@ -5,6 +5,15 @@ import type { PackageManager } from "../types";
 export type NavigationState = {
   isFirstPrompt: boolean;
   lastPromptShownUI: boolean;
+  promptProgress?: PromptProgress;
+};
+
+export type PromptProgress = {
+  current: number;
+  total: number;
+  section: string;
+  sectionCurrent: number;
+  sectionTotal: number;
 };
 
 export type CLIContext = {
@@ -61,6 +70,10 @@ export function didLastPromptShowUI(): boolean {
   return getContext().navigation.lastPromptShownUI;
 }
 
+export function getPromptProgress(): PromptProgress | undefined {
+  return getContext().navigation.promptProgress;
+}
+
 export function getProjectDir(): string | undefined {
   return getContext().projectDir;
 }
@@ -80,6 +93,13 @@ export function setLastPromptShownUI(value: boolean): void {
   const ctx = tryGetContext();
   if (ctx) {
     ctx.navigation.lastPromptShownUI = value;
+  }
+}
+
+export function setPromptProgress(value: PromptProgress | undefined): void {
+  const ctx = tryGetContext();
+  if (ctx) {
+    ctx.navigation.promptProgress = value;
   }
 }
 

--- a/apps/cli/src/utils/display-config.ts
+++ b/apps/cli/src/utils/display-config.ts
@@ -2,96 +2,160 @@ import pc from "picocolors";
 
 import type { ProjectConfig } from "../types";
 
-export function displayConfig(config: Partial<ProjectConfig>) {
-  const configDisplay: string[] = [];
+export type ConfigDisplayRow = {
+  label: string;
+  value: string;
+};
 
-  if (config.projectName) {
-    configDisplay.push(`${pc.blue("Project Name:")} ${config.projectName}`);
+export type ConfigDisplaySection = {
+  title: string;
+  rows: ConfigDisplayRow[];
+};
+
+const VALUE_LABELS: Record<string, string> = {
+  none: "None",
+  "tanstack-router": "TanStack Router",
+  "react-router": "React Router",
+  "tanstack-start": "TanStack Start",
+  next: "Next.js",
+  nuxt: "Nuxt",
+  svelte: "SvelteKit",
+  solid: "SolidStart",
+  astro: "Astro",
+  "native-bare": "Expo (bare)",
+  "native-uniwind": "Expo + Uniwind",
+  "native-unistyles": "Expo + Unistyles",
+  hono: "Hono",
+  express: "Express",
+  fastify: "Fastify",
+  elysia: "Elysia",
+  convex: "Convex",
+  self: "Fullstack framework",
+  bun: "Bun",
+  node: "Node.js",
+  workers: "Cloudflare Workers",
+  trpc: "tRPC",
+  orpc: "oRPC",
+  sqlite: "SQLite",
+  postgres: "PostgreSQL",
+  mysql: "MySQL",
+  mongodb: "MongoDB",
+  drizzle: "Drizzle",
+  prisma: "Prisma",
+  mongoose: "Mongoose",
+  "better-auth": "Better Auth",
+  clerk: "Clerk",
+  polar: "Polar",
+  pwa: "PWA",
+  tauri: "Tauri",
+  electrobun: "Electrobun",
+  biome: "Biome",
+  oxlint: "Oxlint + Oxfmt",
+  ultracite: "Ultracite",
+  lefthook: "Lefthook",
+  husky: "Husky",
+  turborepo: "Turborepo",
+  nx: "Nx",
+  "vite-plus": "Vite+",
+  starlight: "Starlight",
+  fumadocs: "Fumadocs",
+  opentui: "OpenTUI",
+  wxt: "WXT",
+  skills: "Agent skills",
+  mcp: "MCP servers",
+  evlog: "evlog",
+  todo: "Todo app",
+  ai: "AI chat",
+  turso: "Turso",
+  neon: "Neon",
+  planetscale: "PlanetScale",
+  supabase: "Supabase",
+  "prisma-postgres": "Prisma Postgres",
+  "mongodb-atlas": "MongoDB Atlas",
+  d1: "Cloudflare D1",
+  docker: "Docker",
+  cloudflare: "Cloudflare",
+  vercel: "Vercel",
+  npm: "npm",
+  pnpm: "pnpm",
+};
+
+export function formatConfigValue(value: unknown): string {
+  if (typeof value === "boolean") return value ? "Yes" : "No";
+  if (Array.isArray(value)) {
+    return value.length > 0 ? value.map(formatConfigValue).join(", ") : "None";
   }
 
-  if (config.frontend !== undefined) {
-    const frontend = Array.isArray(config.frontend) ? config.frontend : [config.frontend];
-    const frontendText =
-      frontend.length > 0 && frontend[0] !== undefined ? frontend.join(", ") : "none";
-    configDisplay.push(`${pc.blue("Frontend:")} ${frontendText}`);
-  }
+  const text = String(value);
+  return (
+    VALUE_LABELS[text] ??
+    text
+      .split("-")
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(" ")
+  );
+}
 
-  if (config.backend !== undefined) {
-    configDisplay.push(`${pc.blue("Backend:")} ${String(config.backend)}`);
-  }
+function section(
+  title: string,
+  entries: Array<[label: string, value: unknown, format?: "raw"]>,
+): ConfigDisplaySection | undefined {
+  const rows = entries
+    .filter(([, value]) => value !== undefined)
+    .map(([label, value, format]) => ({
+      label,
+      value: format === "raw" ? String(value) : formatConfigValue(value),
+    }));
 
-  if (config.runtime !== undefined) {
-    configDisplay.push(`${pc.blue("Runtime:")} ${String(config.runtime)}`);
-  }
+  return rows.length > 0 ? { title, rows } : undefined;
+}
 
-  if (config.api !== undefined) {
-    configDisplay.push(`${pc.blue("API:")} ${String(config.api)}`);
-  }
+export function getConfigSections(config: Partial<ProjectConfig>): ConfigDisplaySection[] {
+  return [
+    section("Project", [
+      ["Name", config.projectName, "raw"],
+      ["Directory", config.relativePath, "raw"],
+    ]),
+    section("Application", [
+      ["Frontend", config.frontend],
+      ["Backend", config.backend],
+      ["Runtime", config.runtime],
+      ["API", config.api],
+    ]),
+    section("Data", [
+      ["Database", config.database],
+      ["ORM", config.orm],
+      ["Setup", config.dbSetup],
+    ]),
+    section("Product", [
+      ["Auth", config.auth],
+      ["Payments", config.payments],
+      ["Addons", config.addons],
+      ["Examples", config.examples],
+    ]),
+    section("Delivery", [
+      ["Web deploy", config.webDeploy],
+      ["Server deploy", config.serverDeploy],
+      ["Package manager", config.packageManager],
+      ["Git", config.git],
+      ["Install deps", config.install],
+    ]),
+  ].filter((value): value is ConfigDisplaySection => value !== undefined);
+}
 
-  if (config.database !== undefined) {
-    configDisplay.push(`${pc.blue("Database:")} ${String(config.database)}`);
-  }
-
-  if (config.orm !== undefined) {
-    configDisplay.push(`${pc.blue("ORM:")} ${String(config.orm)}`);
-  }
-
-  if (config.auth !== undefined) {
-    configDisplay.push(`${pc.blue("Auth:")} ${String(config.auth)}`);
-  }
-
-  if (config.payments !== undefined) {
-    configDisplay.push(`${pc.blue("Payments:")} ${String(config.payments)}`);
-  }
-
-  if (config.addons !== undefined) {
-    const addons = Array.isArray(config.addons) ? config.addons : [config.addons];
-    const addonsText = addons.length > 0 && addons[0] !== undefined ? addons.join(", ") : "none";
-    configDisplay.push(`${pc.blue("Addons:")} ${addonsText}`);
-  }
-
-  if (config.examples !== undefined) {
-    const examples = Array.isArray(config.examples) ? config.examples : [config.examples];
-    const examplesText =
-      examples.length > 0 && examples[0] !== undefined ? examples.join(", ") : "none";
-    configDisplay.push(`${pc.blue("Examples:")} ${examplesText}`);
-  }
-
-  if (config.git !== undefined) {
-    const gitText =
-      typeof config.git === "boolean" ? (config.git ? "Yes" : "No") : String(config.git);
-    configDisplay.push(`${pc.blue("Git Init:")} ${gitText}`);
-  }
-
-  if (config.packageManager !== undefined) {
-    configDisplay.push(`${pc.blue("Package Manager:")} ${String(config.packageManager)}`);
-  }
-
-  if (config.install !== undefined) {
-    const installText =
-      typeof config.install === "boolean"
-        ? config.install
-          ? "Yes"
-          : "No"
-        : String(config.install);
-    configDisplay.push(`${pc.blue("Install Dependencies:")} ${installText}`);
-  }
-
-  if (config.dbSetup !== undefined) {
-    configDisplay.push(`${pc.blue("Database Setup:")} ${String(config.dbSetup)}`);
-  }
-
-  if (config.webDeploy !== undefined) {
-    configDisplay.push(`${pc.blue("Web Deployment:")} ${String(config.webDeploy)}`);
-  }
-
-  if (config.serverDeploy !== undefined) {
-    configDisplay.push(`${pc.blue("Server Deployment:")} ${String(config.serverDeploy)}`);
-  }
-
-  if (configDisplay.length === 0) {
+export function displayConfig(config: Partial<ProjectConfig>): string {
+  const sections = getConfigSections(config);
+  if (sections.length === 0) {
     return pc.yellow("No configuration selected.");
   }
 
-  return configDisplay.join("\n");
+  return sections
+    .map(({ title, rows }) => {
+      const labelWidth = Math.max(...rows.map(({ label }) => label.length));
+      const renderedRows = rows
+        .map(({ label, value }) => `  ${pc.dim(label.padEnd(labelWidth))}  ${value}`)
+        .join("\n");
+      return `${pc.magenta(pc.bold(title))}\n${renderedRows}`;
+    })
+    .join("\n\n");
 }

--- a/apps/cli/src/utils/project-directory.ts
+++ b/apps/cli/src/utils/project-directory.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 
-import { isCancel, log, select, spinner } from "@clack/prompts";
+import { confirm, isCancel, log, select, spinner } from "@clack/prompts";
 import { Result } from "better-result";
 import fs from "fs-extra";
 import pc from "picocolors";
@@ -9,48 +9,90 @@ import { getProjectName } from "../prompts/project-name";
 import { isSilent } from "./context";
 import { CLIError, UserCancelledError } from "./errors";
 
+export type ProjectPathState =
+  | "missing"
+  | "empty-directory"
+  | "non-empty-directory"
+  | "symbolic-link"
+  | "non-directory";
+
+type DirectoryConflictAction = "increment" | "overwrite" | "merge" | "rename" | "cancel";
+
 export async function handleDirectoryConflict(currentPathInput: string): Promise<{
   finalPathInput: string;
   shouldClearDirectory: boolean;
 }> {
   while (true) {
     const resolvedPath = path.resolve(process.cwd(), currentPathInput);
-    const dirExists = await fs.pathExists(resolvedPath);
-    const dirIsNotEmpty = dirExists && (await fs.readdir(resolvedPath)).length > 0;
+    const pathStateResult = await inspectProjectPath(resolvedPath);
+    if (pathStateResult.isErr()) throw pathStateResult.error;
+    const pathState = pathStateResult.value;
 
-    if (!dirIsNotEmpty) {
+    if (pathState === "missing" || pathState === "empty-directory") {
       return { finalPathInput: currentPathInput, shouldClearDirectory: false };
     }
 
     if (isSilent()) {
       throw new CLIError({
-        message: `Directory "${currentPathInput}" already exists and is not empty. In silent mode, please provide a different project name or clear the directory manually.`,
+        message: `Project path "${currentPathInput}" is unavailable. In silent mode, provide a different project path or an explicit directoryConflict strategy.`,
       });
     }
 
-    log.warn(`Directory "${pc.yellow(currentPathInput)}" already exists and is not empty.`);
+    if (pathState === "symbolic-link") {
+      log.warn(`Project path "${pc.yellow(currentPathInput)}" is a symbolic link.`);
+    } else if (pathState === "non-directory") {
+      log.warn(`Project path "${pc.yellow(currentPathInput)}" exists and is not a directory.`);
+    } else {
+      log.warn(`Directory "${pc.yellow(currentPathInput)}" already exists and is not empty.`);
+    }
 
-    const action = await select<"overwrite" | "merge" | "rename" | "cancel">({
-      message: "What would you like to do?",
-      options: [
-        {
-          value: "overwrite",
-          label: "Overwrite",
-          hint: "Empty the directory and create the project",
-        },
+    let incrementedPath: string | undefined;
+    if (currentPathInput !== ".") {
+      const incrementResult = await findAvailableIncrementedPath(currentPathInput);
+      if (incrementResult.isErr()) throw incrementResult.error;
+      incrementedPath = incrementResult.value;
+    }
+    const options: Array<{
+      value: DirectoryConflictAction;
+      label: string;
+      hint: string;
+    }> = [];
+
+    if (incrementedPath) {
+      options.push({
+        value: "increment",
+        label: `Create as "${incrementedPath}"`,
+        hint: "Keep the existing path untouched",
+      });
+    }
+
+    options.push({
+      value: "rename",
+      label: "Choose another path",
+      hint: "Enter a different project directory",
+    });
+
+    if (pathState === "non-empty-directory") {
+      options.push(
         {
           value: "merge",
-          label: "Merge",
-          hint: "Create project files inside, potentially overwriting conflicts",
+          label: "Merge into this directory",
+          hint: "Keep unrelated files; replace conflicts",
         },
         {
-          value: "rename",
-          label: "Choose a different name/path",
-          hint: "Keep the existing directory and create a new one",
+          value: "overwrite",
+          label: "Delete and overwrite",
+          hint: "Permanently remove existing contents",
         },
-        { value: "cancel", label: "Cancel", hint: "Abort the process" },
-      ],
-      initialValue: "rename",
+      );
+    }
+
+    options.push({ value: "cancel", label: "Cancel", hint: "Leave everything unchanged" });
+
+    const action = await select<DirectoryConflictAction>({
+      message: "How should we continue?",
+      options,
+      initialValue: incrementedPath ? "increment" : "rename",
     });
 
     if (isCancel(action)) {
@@ -58,8 +100,22 @@ export async function handleDirectoryConflict(currentPathInput: string): Promise
     }
 
     switch (action) {
-      case "overwrite":
+      case "increment":
+        return { finalPathInput: incrementedPath!, shouldClearDirectory: false };
+      case "overwrite": {
+        const confirmed = await confirm({
+          message: `Permanently delete every file in "${currentPathInput}"?`,
+          initialValue: false,
+        });
+        if (isCancel(confirmed)) {
+          throw new UserCancelledError({ message: "Operation cancelled." });
+        }
+        if (!confirmed) {
+          log.info("Nothing was deleted. Choose another option.");
+          continue;
+        }
         return { finalPathInput: currentPathInput, shouldClearDirectory: true };
+      }
       case "merge":
         log.info(
           `Proceeding into existing directory "${pc.yellow(
@@ -71,9 +127,8 @@ export async function handleDirectoryConflict(currentPathInput: string): Promise
           shouldClearDirectory: false,
         };
       case "rename": {
-        log.info("Please choose a different project name or path.");
-        const newPathInput = await getProjectName(undefined);
-        return await handleDirectoryConflict(newPathInput);
+        currentPathInput = await getProjectName(undefined);
+        continue;
       }
       case "cancel":
         throw new UserCancelledError({ message: "Operation cancelled." });
@@ -96,9 +151,12 @@ export async function setupProjectDirectory(
     finalBaseName = path.basename(finalResolvedPath);
   }
 
+  const pathSafetyResult = await validateSafeProjectDirectoryPath(finalPathInput);
+  if (pathSafetyResult.isErr()) throw pathSafetyResult.error;
+
   if (shouldClearDirectory) {
-    const s = spinner();
-    s.start(`Clearing directory "${finalResolvedPath}"...`);
+    const s = isSilent() ? undefined : spinner();
+    s?.start(`Clearing directory "${finalResolvedPath}"...`);
 
     const clearResult = await Result.tryPromise({
       try: () => fs.emptyDir(finalResolvedPath),
@@ -110,14 +168,143 @@ export async function setupProjectDirectory(
     });
 
     if (clearResult.isErr()) {
-      s.stop(pc.red(`Failed to clear directory "${finalResolvedPath}".`));
+      s?.stop(pc.red(`Failed to clear directory "${finalResolvedPath}".`));
       throw clearResult.error;
     }
 
-    s.stop(`Directory "${finalResolvedPath}" cleared.`);
+    s?.stop(`Directory "${finalResolvedPath}" cleared.`);
   } else {
     await fs.ensureDir(finalResolvedPath);
   }
 
   return { finalResolvedPath, finalBaseName };
+}
+
+export async function validateSafeProjectDirectoryPath(
+  finalPathInput: string,
+): Promise<Result<void, CLIError>> {
+  return Result.tryPromise({
+    try: async () => {
+      const cwd = path.resolve(process.cwd());
+      const targetPath = finalPathInput === "." ? cwd : path.resolve(cwd, finalPathInput);
+      const relativeTarget = path.relative(cwd, targetPath);
+      if (
+        relativeTarget === ".." ||
+        relativeTarget.startsWith(`..${path.sep}`) ||
+        path.isAbsolute(relativeTarget)
+      ) {
+        throw new CLIError({
+          message: `Project path "${finalPathInput}" resolves outside the current working directory.`,
+        });
+      }
+      const pathSegments = relativeTarget.split(path.sep).filter(Boolean);
+      let nearestExistingPath = cwd;
+
+      for (const segment of pathSegments) {
+        const candidatePath = path.join(nearestExistingPath, segment);
+        let stats;
+        try {
+          stats = await fs.lstat(candidatePath);
+        } catch (error) {
+          if (
+            typeof error === "object" &&
+            error !== null &&
+            "code" in error &&
+            error.code === "ENOENT"
+          ) {
+            break;
+          }
+          throw error;
+        }
+
+        if (stats.isSymbolicLink()) {
+          throw new CLIError({
+            message: `Project path "${finalPathInput}" passes through symbolic link "${path.relative(cwd, candidatePath)}". Choose a real directory within the current working directory.`,
+          });
+        }
+        if (!stats.isDirectory()) {
+          throw new CLIError({
+            message: `Project path "${finalPathInput}" passes through "${path.relative(cwd, candidatePath)}", which is not a directory.`,
+          });
+        }
+
+        nearestExistingPath = candidatePath;
+      }
+
+      const [realCwd, realExistingPath] = await Promise.all([
+        fs.realpath(cwd),
+        fs.realpath(nearestExistingPath),
+      ]);
+      const relativeRealPath = path.relative(realCwd, realExistingPath);
+      if (
+        relativeRealPath === ".." ||
+        relativeRealPath.startsWith(`..${path.sep}`) ||
+        path.isAbsolute(relativeRealPath)
+      ) {
+        throw new CLIError({
+          message: `Project path "${finalPathInput}" resolves outside the current working directory.`,
+        });
+      }
+    },
+    catch: (error) =>
+      CLIError.is(error)
+        ? error
+        : new CLIError({
+            message: `Unable to validate project path "${finalPathInput}".`,
+            cause: error,
+          }),
+  });
+}
+
+export async function inspectProjectPath(
+  targetPath: string,
+): Promise<Result<ProjectPathState, CLIError>> {
+  return Result.tryPromise({
+    try: async () => {
+      let stats;
+      try {
+        stats = await fs.lstat(targetPath);
+      } catch (error) {
+        if (
+          typeof error === "object" &&
+          error !== null &&
+          "code" in error &&
+          error.code === "ENOENT"
+        ) {
+          return "missing" as const;
+        }
+        throw error;
+      }
+
+      if (stats.isSymbolicLink()) return "symbolic-link" as const;
+      if (!stats.isDirectory()) return "non-directory" as const;
+
+      const entries = await fs.readdir(targetPath);
+      return entries.length === 0 ? ("empty-directory" as const) : ("non-empty-directory" as const);
+    },
+    catch: (error) =>
+      new CLIError({
+        message: `Unable to inspect project path "${targetPath}".`,
+        cause: error,
+      }),
+  });
+}
+
+export async function findAvailableIncrementedPath(
+  currentPathInput: string,
+): Promise<Result<string, CLIError>> {
+  let counter = 1;
+
+  while (true) {
+    const candidate = `${currentPathInput}-${counter}`;
+    const candidateStateResult = await inspectProjectPath(path.resolve(process.cwd(), candidate));
+    if (candidateStateResult.isErr()) return Result.err(candidateStateResult.error);
+    if (
+      candidateStateResult.value === "missing" ||
+      candidateStateResult.value === "empty-directory"
+    ) {
+      return Result.ok(candidate);
+    }
+    counter++;
+  }
 }

--- a/apps/cli/src/utils/sponsors.ts
+++ b/apps/cli/src/utils/sponsors.ts
@@ -1,10 +1,9 @@
-import { log, outro, spinner } from "@clack/prompts";
+import { box, log, outro, spinner } from "@clack/prompts";
 import { Result } from "better-result";
 import pc from "picocolors";
 import z from "zod";
 
 import { CLIError } from "./errors";
-import { cliConsola } from "./terminal-output";
 
 export const SPONSORS_JSON_URL = "https://sponsors.better-t-stack.dev/sponsors.json";
 export const GITHUB_SPONSOR_URL = "https://github.com/sponsors/AmanVarshney01";
@@ -113,19 +112,17 @@ export async function fetchSponsorsQuietly({
 export function displaySponsors(sponsors: SponsorEntry) {
   const { total_sponsors } = sponsors.summary;
   if (total_sponsors === 0) {
-    log.info("No sponsors found. You can be the first one! ✨");
-    outro(pc.cyan(`Visit ${GITHUB_SPONSOR_URL} to become a sponsor.`));
+    log.info("No sponsors found yet");
+    outro(`${pc.dim("Become the first sponsor ·")} ${pc.cyan(GITHUB_SPONSOR_URL)}`);
     return;
   }
 
   displaySponsorsBox(sponsors);
 
   if (total_sponsors - sponsors.specialSponsors.length > 0) {
-    log.message(
-      pc.blue(`+${total_sponsors - sponsors.specialSponsors.length} more amazing sponsors.\n`),
-    );
+    log.message(pc.dim(`+${total_sponsors - sponsors.specialSponsors.length} more sponsors`));
   }
-  outro(pc.magenta(`Visit ${GITHUB_SPONSOR_URL} to become a sponsor.`));
+  outro(`${pc.dim("Become a sponsor ·")} ${pc.cyan(GITHUB_SPONSOR_URL)}`);
 }
 
 function displaySponsorsBox(sponsors: SponsorEntry) {
@@ -133,26 +130,29 @@ function displaySponsorsBox(sponsors: SponsorEntry) {
     return;
   }
 
-  let output = `${pc.bold(pc.cyan("-> Special Sponsors"))}\n\n`;
+  box(formatSpecialSponsorsDetails(sponsors), pc.bold("Special sponsors"), {
+    contentPadding: 2,
+    formatBorder: pc.dim,
+    rounded: true,
+    width: "auto",
+  });
+}
 
-  sponsors.specialSponsors.forEach((sponsor: Sponsor, idx: number) => {
+export function formatSpecialSponsorsDetails(sponsors: SponsorEntry): string {
+  const blocks = sponsors.specialSponsors.map((sponsor) => {
     const displayName = sponsor.name ?? sponsor.githubId;
-    const tier = sponsor.tierName ? ` ${pc.yellow(`(${sponsor.tierName})`)}` : "";
+    const tier = sponsor.tierName ? pc.dim(` · ${sponsor.tierName}`) : "";
+    const links: string[] = [];
 
-    output += `${pc.green(`• ${displayName}`)}${tier}\n`;
-    output += `  ${pc.dim("GitHub:")} https://github.com/${sponsor.githubId}\n`;
-
-    const website = sponsor.websiteUrl ?? sponsor.githubUrl;
-    if (website) {
-      output += `  ${pc.dim("Website:")} ${website}\n`;
+    if (sponsor.websiteUrl) {
+      links.push(`${pc.dim("Website")}  ${pc.cyan(sponsor.websiteUrl)}`);
     }
+    links.push(`${pc.dim("GitHub ")}  ${pc.cyan(sponsor.githubUrl)}`);
 
-    if (idx < sponsors.specialSponsors.length - 1) {
-      output += "\n";
-    }
+    return `${pc.bold(displayName)}${tier}\n${links.join("\n")}`;
   });
 
-  cliConsola.box(output);
+  return blocks.join("\n\n");
 }
 
 export function formatPostInstallSpecialSponsorsSection(sponsors: SponsorEntry): string {
@@ -253,7 +253,7 @@ async function fetchSponsorsData({
     }
 
     if (s) {
-      s.stop("Sponsors fetched successfully!");
+      s.stop("Sponsors loaded");
     }
 
     return Result.ok(parseResult.data);

--- a/apps/cli/test/addons.test.ts
+++ b/apps/cli/test/addons.test.ts
@@ -474,7 +474,7 @@ describe("Addon Configurations", () => {
         expectError: true,
       });
 
-      expectError(result, "Cannot combine 'turborepo', 'nx', and 'vite-plus' addons");
+      expectError(result, "`nx`, `turborepo`, and `vite-plus` cannot be used together");
     });
 
     it("should hide task runner addons when one is already installed", () => {

--- a/apps/cli/test/basic-configurations.test.ts
+++ b/apps/cli/test/basic-configurations.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
 
 import { expectError, expectSuccess, PACKAGE_MANAGERS, runTRPCTest } from "./test-utils";
 
@@ -75,6 +77,18 @@ describe("Basic Configurations", () => {
 
         expectSuccess(result);
         expect(result.result?.projectConfig.packageManager).toBe(packageManager);
+
+        const config = await readFile(join(result.projectDir!, "bts.jsonc"), "utf8");
+        const expectedAddCommand =
+          packageManager === "npm"
+            ? "npx create-better-t-stack@latest add"
+            : packageManager === "pnpm"
+              ? "pnpm dlx create-better-t-stack@latest add"
+              : "bunx create-better-t-stack@latest add";
+
+        expect(config).toContain("Keep this file to use the `add` command.");
+        expect(config).toContain(`Add addons: ${expectedAddCommand}`);
+        expect(config).not.toContain("This file is safe to delete");
       });
     }
   });

--- a/apps/cli/test/cli-ux.test.ts
+++ b/apps/cli/test/cli-ux.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { PassThrough } from "node:stream";
+import { stripVTControlCharacters } from "node:util";
 
 import { formatHistoryEntry } from "../src/commands/history";
 import { gatherConfig } from "../src/prompts/config-prompts";
@@ -32,10 +33,11 @@ describe("CLI flow presentation", () => {
     input.write("b");
 
     expect(isGoBack(await resultPromise)).toBe(true);
-    expect(rendered).toContain("Pick a framework");
-    expect(rendered).toContain("back");
-    expect(rendered).toContain("↶  Pick a framework");
-    expect(rendered).not.toContain("■");
+    const plainRendered = stripVTControlCharacters(rendered);
+    expect(plainRendered).toContain("Pick a framework");
+    expect(plainRendered).toContain("back");
+    expect(plainRendered).toContain("↶  Pick a framework");
+    expect(plainRendered).not.toContain("■");
   });
 
   it("limits long lists and honors AbortSignal cancellation", async () => {

--- a/apps/cli/test/cli-ux.test.ts
+++ b/apps/cli/test/cli-ux.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "bun:test";
+import { PassThrough } from "node:stream";
+
+import { formatHistoryEntry } from "../src/commands/history";
+import { isCancel, isGoBack, navigableSelect } from "../src/prompts/navigable";
+import { navigableGroup } from "../src/prompts/navigable-group";
+import type { ProjectConfig } from "../src/types";
+import { getCliSubcommandCommand } from "../src/utils/cli-invocation";
+import { getPromptProgress, runWithContextAsync, type PromptProgress } from "../src/utils/context";
+import { getConfigSections } from "../src/utils/display-config";
+
+describe("CLI flow presentation", () => {
+  it("supports back navigation through custom streams", async () => {
+    const input = new PassThrough();
+    const output = Object.assign(new PassThrough(), { columns: 80, rows: 20 });
+    let rendered = "";
+    output.on("data", (chunk) => (rendered += chunk));
+
+    const resultPromise = runWithContextAsync({}, () =>
+      navigableSelect({
+        message: "Pick a framework",
+        options: [
+          { value: "next", label: "Next.js" },
+          { value: "nuxt", label: "Nuxt" },
+        ],
+        input,
+        output,
+      }),
+    );
+
+    input.write("b");
+
+    expect(isGoBack(await resultPromise)).toBe(true);
+    expect(rendered).toContain("Pick a framework");
+    expect(rendered).toContain("back");
+    expect(rendered).toContain("↶  Pick a framework");
+    expect(rendered).not.toContain("■");
+  });
+
+  it("limits long lists and honors AbortSignal cancellation", async () => {
+    const input = new PassThrough();
+    const output = Object.assign(new PassThrough(), { columns: 60, rows: 10 });
+    const controller = new AbortController();
+    let rendered = "";
+    output.on("data", (chunk) => (rendered += chunk));
+
+    const resultPromise = runWithContextAsync({}, () =>
+      navigableSelect({
+        message: "Pick an option",
+        options: Array.from({ length: 20 }, (_, index) => ({
+          value: index,
+          label: `Option ${index + 1}`,
+        })),
+        input,
+        output,
+        signal: controller.signal,
+      }),
+    );
+
+    controller.abort();
+
+    expect(isCancel(await resultPromise)).toBe(true);
+    expect(rendered).toContain("...");
+    expect(rendered).not.toContain("Option 20");
+  });
+
+  it("tracks staged progress while a navigable group runs", async () => {
+    const seen: PromptProgress[] = [];
+
+    await runWithContextAsync({}, async () => {
+      const result = await navigableGroup<{ frontend: string; database: string }>(
+        {
+          frontend: async () => {
+            seen.push(getPromptProgress()!);
+            return "next";
+          },
+          database: async () => {
+            seen.push(getPromptProgress()!);
+            return "postgres";
+          },
+        },
+        {
+          sections: [
+            { label: "App", prompts: ["frontend"] },
+            { label: "Data", prompts: ["database"] },
+          ],
+        },
+      );
+
+      expect(result).toEqual({ frontend: "next", database: "postgres" });
+      expect(getPromptProgress()).toBeUndefined();
+    });
+
+    expect(seen).toEqual([
+      {
+        current: 1,
+        total: 2,
+        section: "App",
+        sectionCurrent: 1,
+        sectionTotal: 1,
+      },
+      {
+        current: 2,
+        total: 2,
+        section: "Data",
+        sectionCurrent: 1,
+        sectionTotal: 1,
+      },
+    ]);
+  });
+
+  it("groups the selected stack and uses product-facing labels", () => {
+    const config = {
+      projectName: "acme-app",
+      relativePath: "apps/acme-app",
+      frontend: ["tanstack-router"],
+      backend: "hono",
+      runtime: "bun",
+      api: "trpc",
+      database: "postgres",
+      orm: "drizzle",
+      dbSetup: "neon",
+      auth: "better-auth",
+      payments: "none",
+      addons: ["turborepo", "mcp"],
+      examples: [],
+      packageManager: "pnpm",
+      git: true,
+      install: false,
+    } satisfies Partial<ProjectConfig>;
+
+    expect(getConfigSections(config)).toEqual([
+      {
+        title: "Project",
+        rows: [
+          { label: "Name", value: "acme-app" },
+          { label: "Directory", value: "apps/acme-app" },
+        ],
+      },
+      {
+        title: "Application",
+        rows: [
+          { label: "Frontend", value: "TanStack Router" },
+          { label: "Backend", value: "Hono" },
+          { label: "Runtime", value: "Bun" },
+          { label: "API", value: "tRPC" },
+        ],
+      },
+      {
+        title: "Data",
+        rows: [
+          { label: "Database", value: "PostgreSQL" },
+          { label: "ORM", value: "Drizzle" },
+          { label: "Setup", value: "Neon" },
+        ],
+      },
+      {
+        title: "Product",
+        rows: [
+          { label: "Auth", value: "Better Auth" },
+          { label: "Payments", value: "None" },
+          { label: "Addons", value: "Turborepo, MCP servers" },
+          { label: "Examples", value: "None" },
+        ],
+      },
+      {
+        title: "Delivery",
+        rows: [
+          { label: "Package manager", value: "pnpm" },
+          { label: "Git", value: "Yes" },
+          { label: "Install deps", value: "No" },
+        ],
+      },
+    ]);
+  });
+
+  it("formats history as a compact, human-readable recreation entry", () => {
+    const output = formatHistoryEntry(
+      {
+        id: "history-1",
+        projectName: "acme-app",
+        projectDir: "/work/acme-app",
+        createdAt: "2026-07-23T04:30:00.000Z",
+        stack: {
+          frontend: ["tanstack-router"],
+          backend: "hono",
+          database: "sqlite",
+          orm: "drizzle",
+          runtime: "bun",
+          auth: "better-auth",
+          payments: "none",
+          api: "trpc",
+          addons: ["turborepo"],
+          examples: ["none"],
+          dbSetup: "none",
+          packageManager: "bun",
+        },
+        cliVersion: "1.0.0",
+        reproducibleCommand: "bun create better-t-stack@latest acme-app --yes",
+      },
+      0,
+    );
+
+    expect(output).toContain("1. acme-app");
+    expect(output).toContain("Location");
+    expect(output).toContain("TanStack Router + Hono + SQLite + Drizzle");
+    expect(output).toContain("Recreate");
+    expect(output).toContain("bun create better-t-stack@latest acme-app --yes");
+    expect(output).not.toContain("tanstack-router");
+  });
+
+  it("uses the active package runner for follow-up commands", () => {
+    expect(getCliSubcommandCommand("history", "npm", "bun/1.3.0")).toBe(
+      "bunx create-better-t-stack@latest history",
+    );
+    expect(getCliSubcommandCommand("history", "bun", "npm/11.0.0")).toBe(
+      "npx create-better-t-stack@latest history",
+    );
+    expect(getCliSubcommandCommand("history", "npm", "pnpm/10.0.0")).toBe(
+      "pnpm dlx create-better-t-stack@latest history",
+    );
+    expect(getCliSubcommandCommand("history", "bun", "")).toBe(
+      "bunx create-better-t-stack@latest history",
+    );
+  });
+});

--- a/apps/cli/test/cli-ux.test.ts
+++ b/apps/cli/test/cli-ux.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { PassThrough } from "node:stream";
 
 import { formatHistoryEntry } from "../src/commands/history";
+import { gatherConfig } from "../src/prompts/config-prompts";
 import { isCancel, isGoBack, navigableSelect } from "../src/prompts/navigable";
 import { navigableGroup } from "../src/prompts/navigable-group";
 import type { ProjectConfig } from "../src/types";
@@ -107,6 +108,40 @@ describe("CLI flow presentation", () => {
         sectionTotal: 1,
       },
     ]);
+  });
+
+  it("keeps incompatible preselected values when YOLO validation is disabled", async () => {
+    const result = await runWithContextAsync({}, () =>
+      gatherConfig(
+        {
+          frontend: ["nuxt"],
+          backend: "hono",
+          runtime: "bun",
+          api: "trpc",
+          database: "mongodb",
+          orm: "drizzle",
+          dbSetup: "none",
+          auth: "none",
+          payments: "none",
+          addons: ["none"],
+          examples: ["none"],
+          webDeploy: "none",
+          serverDeploy: "none",
+          git: false,
+          packageManager: "bun",
+          install: false,
+        },
+        "yolo-app",
+        "/tmp/yolo-app",
+        "yolo-app",
+        { skipCompatibilityChecks: true },
+      ),
+    );
+
+    expect(result.frontend).toEqual(["nuxt"]);
+    expect(result.api).toBe("trpc");
+    expect(result.database).toBe("mongodb");
+    expect(result.orm).toBe("drizzle");
   });
 
   it("groups the selected stack and uses product-facing labels", () => {

--- a/apps/cli/test/db-setup-options.test.ts
+++ b/apps/cli/test/db-setup-options.test.ts
@@ -105,7 +105,7 @@ describe("Database setup options", () => {
       dbSetupOptions: {
         mode: "auto",
         neon: {
-          method: "get-db",
+          method: "neondb",
         },
       },
       disableAnalytics: true,

--- a/apps/cli/test/directory-conflicts.test.ts
+++ b/apps/cli/test/directory-conflicts.test.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import path from "node:path";
+
+import fs from "fs-extra";
+
+import { create } from "../src/index";
+import { SMOKE_DIR } from "./setup";
+
+const TEST_ROOT = path.join(SMOKE_DIR, "directory-conflicts");
+
+describe("Directory conflicts", () => {
+  beforeEach(async () => {
+    await fs.remove(TEST_ROOT);
+    await fs.ensureDir(TEST_ROOT);
+  });
+
+  it("returns an actionable error when the project path is an existing file", async () => {
+    const projectPath = path.join(TEST_ROOT, "existing-file");
+    await fs.writeFile(projectPath, "keep-me", "utf8");
+
+    const result = await create(projectPath, {
+      yes: true,
+      dryRun: true,
+      directoryConflict: "error",
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(result.error?.message).toContain("exists and is not a directory");
+    expect(result.error?.message).not.toContain("ENOTDIR");
+    expect(await fs.readFile(projectPath, "utf8")).toBe("keep-me");
+  });
+
+  it("rejects overwrite when the project path is a directory symlink", async () => {
+    const targetPath = path.join(TEST_ROOT, "symlink-target");
+    const projectPath = path.join(TEST_ROOT, "symlink-project");
+    const sentinelPath = path.join(targetPath, "keep-me.txt");
+    await fs.ensureDir(targetPath);
+    await fs.writeFile(sentinelPath, "keep-me", "utf8");
+    await fs.symlink(targetPath, projectPath, "dir");
+
+    const result = await create(projectPath, {
+      yes: true,
+      install: false,
+      git: false,
+      directoryConflict: "overwrite",
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(result.error?.message).toContain("symbolic link");
+    expect(await fs.readFile(sentinelPath, "utf8")).toBe("keep-me");
+    expect(await fs.pathExists(path.join(targetPath, "package.json"))).toBe(false);
+  });
+
+  it("increments past existing files without modifying them", async () => {
+    const projectPath = path.join(TEST_ROOT, "increment-file");
+    const firstIncrementPath = `${projectPath}-1`;
+    const expectedProjectPath = `${projectPath}-2`;
+    await fs.writeFile(projectPath, "original", "utf8");
+    await fs.writeFile(firstIncrementPath, "first-increment", "utf8");
+
+    const result = await create(projectPath, {
+      yes: true,
+      install: false,
+      git: false,
+      directoryConflict: "increment",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(result.value?.projectDirectory).toBe(expectedProjectPath);
+    expect(await fs.readFile(projectPath, "utf8")).toBe("original");
+    expect(await fs.readFile(firstIncrementPath, "utf8")).toBe("first-increment");
+    expect(await fs.pathExists(path.join(expectedProjectPath, "package.json"))).toBe(true);
+  });
+
+  it("rejects a project path with a symbolic-link parent", async () => {
+    const targetParent = path.join(TEST_ROOT, "parent-target");
+    const linkedParent = path.join(TEST_ROOT, "linked-parent");
+    const projectPath = path.join(linkedParent, "project");
+    await fs.ensureDir(targetParent);
+    await fs.symlink(targetParent, linkedParent, "dir");
+
+    const result = await create(projectPath, {
+      yes: true,
+      install: false,
+      git: false,
+      directoryConflict: "overwrite",
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(result.error?.message).toContain("symbolic link");
+    expect(await fs.pathExists(path.join(targetParent, "project"))).toBe(false);
+  });
+
+  it("rejects merge when a generated path would pass through a nested symbolic link", async () => {
+    const projectPath = path.join(TEST_ROOT, "nested-symlink-project");
+    const outsidePath = path.join(TEST_ROOT, "nested-symlink-target");
+    await fs.ensureDir(projectPath);
+    await fs.ensureDir(outsidePath);
+    await fs.symlink(outsidePath, path.join(projectPath, "apps"), "dir");
+
+    const result = await create(projectPath, {
+      yes: true,
+      install: false,
+      git: false,
+      directoryConflict: "merge",
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(result.error?.message).toContain("symbolic link");
+    expect(await fs.pathExists(path.join(outsidePath, "web"))).toBe(false);
+    expect(await fs.pathExists(path.join(outsidePath, "server"))).toBe(false);
+  });
+
+  it("overwrites a non-empty directory only when explicitly requested", async () => {
+    const projectPath = path.join(TEST_ROOT, "overwrite-project");
+    const sentinelPath = path.join(projectPath, "remove-me.txt");
+    await fs.ensureDir(projectPath);
+    await fs.writeFile(sentinelPath, "remove-me", "utf8");
+
+    const result = await create(projectPath, {
+      yes: true,
+      install: false,
+      git: false,
+      directoryConflict: "overwrite",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(await fs.pathExists(sentinelPath)).toBe(false);
+    expect(await fs.pathExists(path.join(projectPath, "package.json"))).toBe(true);
+  });
+
+  it("merges into a non-empty directory while preserving unrelated files", async () => {
+    const projectPath = path.join(TEST_ROOT, "merge-project");
+    const sentinelPath = path.join(projectPath, "keep-me.txt");
+    await fs.ensureDir(projectPath);
+    await fs.writeFile(sentinelPath, "keep-me", "utf8");
+
+    const result = await create(projectPath, {
+      yes: true,
+      install: false,
+      git: false,
+      directoryConflict: "merge",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(await fs.readFile(sentinelPath, "utf8")).toBe("keep-me");
+    expect(await fs.pathExists(path.join(projectPath, "package.json"))).toBe(true);
+  });
+
+  it("increments past occupied directories", async () => {
+    const projectPath = path.join(TEST_ROOT, "increment-project");
+    const firstIncrementPath = `${projectPath}-1`;
+    const expectedProjectPath = `${projectPath}-2`;
+    await fs.ensureDir(projectPath);
+    await fs.ensureDir(firstIncrementPath);
+    await fs.writeFile(path.join(projectPath, "keep-me.txt"), "original", "utf8");
+    await fs.writeFile(path.join(firstIncrementPath, "keep-me.txt"), "first", "utf8");
+
+    const result = await create(projectPath, {
+      yes: true,
+      install: false,
+      git: false,
+      directoryConflict: "increment",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(result.value?.projectDirectory).toBe(expectedProjectPath);
+    expect(await fs.readFile(path.join(projectPath, "keep-me.txt"), "utf8")).toBe("original");
+    expect(await fs.readFile(path.join(firstIncrementPath, "keep-me.txt"), "utf8")).toBe("first");
+  });
+
+  it("returns a conflict error without modifying a non-empty directory", async () => {
+    const projectPath = path.join(TEST_ROOT, "error-project");
+    const sentinelPath = path.join(projectPath, "keep-me.txt");
+    await fs.ensureDir(projectPath);
+    await fs.writeFile(sentinelPath, "keep-me", "utf8");
+
+    const result = await create(projectPath, {
+      yes: true,
+      install: false,
+      git: false,
+      directoryConflict: "error",
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(result.error?.message).toContain("already exists and is not empty");
+    expect(await fs.readFile(sentinelPath, "utf8")).toBe("keep-me");
+    expect(await fs.pathExists(path.join(projectPath, "package.json"))).toBe(false);
+  });
+});

--- a/apps/cli/test/programmatic-api.test.ts
+++ b/apps/cli/test/programmatic-api.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+import { join } from "node:path";
+
+import { add, CLIError, create, createVirtual } from "../src/index";
+import { SMOKE_DIR } from "./setup";
+
+describe("programmatic API input validation", () => {
+  it("returns a typed error when create receives an invalid input shape", async () => {
+    const result = await create("invalid-runtime", {
+      runtime: "deno",
+      dryRun: true,
+    } as never);
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      throw new Error("Expected create() to reject an invalid runtime");
+    }
+
+    expect(CLIError.is(result.error)).toBe(true);
+    expect(result.error.message).toContain("Invalid create input");
+    expect(result.error.message).toContain("runtime");
+  });
+
+  it("returns a generator validation error for an invalid virtual input shape", async () => {
+    const result = await createVirtual({
+      runtime: "deno",
+    } as never);
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      throw new Error("Expected createVirtual() to reject an invalid runtime");
+    }
+
+    expect(result.error.phase).toBe("validation");
+    expect(result.error.message).toContain("Invalid virtual create input");
+    expect(result.error.message).toContain("runtime");
+  });
+
+  it("returns a structured failure instead of throwing for an invalid add input shape", async () => {
+    const projectDir = join(SMOKE_DIR, "programmatic-add-invalid-input");
+    const createResult = await create(projectDir, {
+      yes: true,
+      git: false,
+      install: false,
+      directoryConflict: "overwrite",
+      disableAnalytics: true,
+    });
+    if (createResult.isErr()) {
+      throw createResult.error;
+    }
+
+    const result = await add({
+      projectDir,
+      addons: "oxlint",
+    } as never);
+
+    expect(result.success).toBe(false);
+    expect(result.addedAddons).toEqual([]);
+    expect(result.error).toContain("Invalid add input");
+    expect(result.error).toContain("addons");
+  });
+});

--- a/apps/cli/test/silent-create-output.test.ts
+++ b/apps/cli/test/silent-create-output.test.ts
@@ -12,11 +12,16 @@ type SilentCreateCase = {
   name: string;
   projectName: string;
   options: Record<string, unknown>;
+  existingFile?: string;
 };
 
 async function runSilentCreate(testCase: SilentCreateCase) {
   const projectPath = path.join(SMOKE_DIR, testCase.projectName);
   await fs.remove(projectPath);
+  if (testCase.existingFile) {
+    await fs.ensureDir(projectPath);
+    await fs.writeFile(path.join(projectPath, testCase.existingFile), "keep-me", "utf8");
+  }
 
   const script = `
     import { create } from ${JSON.stringify(CLI_INDEX_PATH)};
@@ -48,6 +53,17 @@ async function runSilentCreate(testCase: SilentCreateCase) {
 
 describe("silent create output", () => {
   const cases: SilentCreateCase[] = [
+    {
+      name: "stays quiet while overwriting an existing directory",
+      projectName: "silent-directory-overwrite",
+      existingFile: "remove-me.txt",
+      options: {
+        yes: true,
+        git: false,
+        install: false,
+        directoryConflict: "overwrite",
+      },
+    },
     {
       name: "stays quiet for oxlint addon setup",
       projectName: "silent-addon-oxlint",

--- a/apps/cli/test/sponsors.test.ts
+++ b/apps/cli/test/sponsors.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "bun:test";
 
 import type { SponsorEntry } from "../src/utils/sponsors";
-import { formatPostInstallSpecialSponsorsSection } from "../src/utils/sponsors";
+import {
+  formatPostInstallSpecialSponsorsSection,
+  formatSpecialSponsorsDetails,
+} from "../src/utils/sponsors";
 
 function createSponsorsFixture(): SponsorEntry {
   return {
@@ -74,5 +77,14 @@ describe("formatPostInstallSpecialSponsorsSection", () => {
     expect(output).not.toContain("Pro");
     expect(output).not.toContain("Starter");
     expect(output).not.toContain("Become a sponsor");
+  });
+
+  it("formats the dedicated sponsors view without the legacy arrow heading", () => {
+    const output = formatSpecialSponsorsDetails(createSponsorsFixture());
+
+    expect(output).toContain("Ada");
+    expect(output).toContain("· Pro");
+    expect(output).toContain("https://github.com/ada");
+    expect(output).not.toContain("-> Special Sponsors");
   });
 });

--- a/apps/web/content/docs/bts-config.mdx
+++ b/apps/web/content/docs/bts-config.mdx
@@ -18,20 +18,25 @@ If `bts.jsonc` is missing, the `add` command cannot run because the project cann
 
 ## Safe to delete (with a caveat)
 
-It’s safe to delete for normal development; the generated code in `apps/*` and `packages/*` remains the source of truth. However, if you plan to use the `add` command later, you must keep `bts.jsonc` (or recreate it) so the CLI can detect your project.
+It’s safe to delete for normal development; the generated code in `apps/*` and `packages/*` remains the source of truth. However, if you plan to use the `add` command later, you must keep `bts.jsonc` so the CLI can detect your project.
 
 ## Format
 
 The file is JSONC with comments enabled and includes a `$schema` URL for tooling.
 
 ```jsonc
-// Better-T-Stack configuration file
-// safe to delete
+// Better-T-Stack project metadata
+//
+// Keep this file to use the `add` command.
+// Add addons: bunx create-better-t-stack@latest add
+//
+// Docs: https://better-t-stack.dev/docs
+// Stack Builder: https://better-t-stack.dev/new
 {
   "$schema": "https://r2.better-t-stack.dev/schema.json",
   "version": "x.y.z",
   "createdAt": "2025-01-01T00:00:00.000Z",
-  "reproducibleCommand": "bun create better-t-stack@latest create-json --input '{...}'",
+  "reproducibleCommand": "bun create better-t-stack@latest my-app --frontend tanstack-router ...",
   "frontend": ["tanstack-router"],
   "backend": "hono",
   "runtime": "bun",
@@ -39,6 +44,7 @@ The file is JSONC with comments enabled and includes a `$schema` URL for tooling
   "orm": "drizzle",
   "api": "trpc",
   "auth": "better-auth",
+  "payments": "none",
   "addons": ["turborepo"],
   "addonOptions": {
     "wxt": {
@@ -59,8 +65,8 @@ The file is JSONC with comments enabled and includes a `$schema` URL for tooling
 Notes:
 
 - Values mirror what you selected during project creation
-- `reproducibleCommand` contains the exact command to recreate this project
-- When structured options are present, the reproducible command uses `create-json`
+- `reproducibleCommand` contains the normal CLI command generated when the project was created
+- Deeply nested structured options remain in `addonOptions` or `dbSetupOptions` and may not be fully represented in the one-line command
 - `addonOptions` stores nested configuration for prompt-driven addons
 - `dbSetupOptions` stores structured database setup behavior for automation
 - The file may be updated when you run `add` (addons and addon-specific config)

--- a/apps/web/content/docs/cli/options.mdx
+++ b/apps/web/content/docs/cli/options.mdx
@@ -96,10 +96,14 @@ create-better-t-stack --no-render-title
 
 How to handle existing, non-empty target directories:
 
-- `merge`: Keep existing files and merge new ones
-- `overwrite`: Clear the directory before scaffolding
+- `merge`: Keep unrelated files and replace conflicting generated files
+- `overwrite`: Permanently clear the directory before scaffolding
 - `increment`: Create a suffixed directory (e.g., `my-app-1`)
 - `error`: Fail instead of prompting
+
+The interactive prompt recommends the first available suffixed directory and requires an extra
+confirmation before overwriting. Project targets and generated paths that pass through symbolic
+links are rejected instead of being followed.
 
 ```bash
 # Overwrite an existing directory without prompting

--- a/apps/web/content/docs/cli/programmatic-api.mdx
+++ b/apps/web/content/docs/cli/programmatic-api.mdx
@@ -30,7 +30,6 @@ const result = await create("my-app", {
   auth: "better-auth",
   packageManager: "bun",
   install: false,
-  dryRun: true,
 });
 
 result.match({
@@ -62,6 +61,7 @@ Notes:
 - Uses the same option model as the CLI `create` command (`frontend`, `backend`, `database`, `orm`, `api`, `auth`, `addons`, etc.).
 - Supports structured `addonOptions` and `dbSetupOptions`.
 - Supports `dryRun` for validation-only automation.
+- Validates JavaScript inputs at runtime using the same schemas as the CLI.
 - Runs in silent mode (no interactive prompts / no CLI UI output).
 - Returns a `Result` (`ok`/`err`) instead of exiting the process.
 
@@ -77,7 +77,7 @@ function add(options?: {
   packageManager?: PackageManager;
   projectDir?: string;
   dryRun?: boolean;
-}): Promise<AddResult | undefined>;
+}): Promise<AddResult>;
 ```
 
 Example:
@@ -98,12 +98,15 @@ const result = await add({
   install: true,
 });
 
-if (result?.success) {
+if (result.success) {
   console.log(`Added: ${result.addedAddons.join(", ")}`);
 } else {
-  console.error(result?.error ?? "Failed to add addons");
+  console.error(result.error ?? "Failed to add addons");
 }
 ```
+
+`add()` validates its input at runtime and always returns an `AddResult`. Invalid input and
+addon failures return `{ success: false, error }` instead of throwing or exiting the process.
 
 ### `createVirtual(options)`
 
@@ -123,9 +126,14 @@ const result = await createVirtual({
     },
   },
 });
+
+if (result.isErr()) {
+  console.error(result.error.message);
+}
 ```
 
-This is useful for previews, tests, and web-based builders.
+This is useful for previews, tests, and web-based builders. Invalid input or incompatible project
+configurations are returned as a `GeneratorError` with the `validation` phase.
 
 ### `sponsors()`
 
@@ -176,6 +184,9 @@ type AddResult = {
 - `UserCancelledError`
 - `CLIError`
 - `ProjectCreationError`
+
+The `CreateInput`, `AddOptions`, `ProjectConfig`, `InitResult`, and `AddResult` types are exported
+from `create-better-t-stack`.
 
 ## Error Handling Pattern
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "better-t-stack",
       "dependencies": {
-        "@clack/prompts": "^1.5.1",
+        "@clack/prompts": "^1.7.0",
       },
       "devDependencies": {
         "@types/bun": "^1.3.14",
@@ -14,7 +14,7 @@
         "lint-staged": "^17.0.4",
         "oxfmt": "catalog:",
         "oxlint": "^1.64.0",
-        "turbo": "^2.10.2",
+        "turbo": "^2.10.6",
         "typescript": "catalog:",
       },
     },
@@ -27,8 +27,8 @@
       "dependencies": {
         "@better-t-stack/template-generator": "workspace:*",
         "@better-t-stack/types": "workspace:*",
-        "@clack/core": "^1.4.1",
-        "@clack/prompts": "^1.5.1",
+        "@clack/core": "^1.4.3",
+        "@clack/prompts": "^1.7.0",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@trpc/server": "^11.17.0",
         "better-result": "^2.9.2",
@@ -247,9 +247,9 @@
 
     "@better-t-stack/types": ["@better-t-stack/types@workspace:packages/types"],
 
-    "@clack/core": ["@clack/core@1.4.1", "", { "dependencies": { "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-FILJa1gGKEFTGZAJE9RpVhrjKz3c3h4ar60dSv6cGuDqufQ84YEIS3GAGvZiN+H6yaLbbvTFNejjCC4tXpZEuw=="],
+    "@clack/core": ["@clack/core@1.4.3", "", { "dependencies": { "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ=="],
 
-    "@clack/prompts": ["@clack/prompts@1.5.1", "", { "dependencies": { "@clack/core": "1.4.1", "fast-string-width": "^3.0.2", "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-zccHj2z2oCCO4yrDiRSlFOxWerGqRiysP7a5jPK6uoI9URKAquwY42Dd/iUP8JWHxEzdRe4TlbvZCo8z1/mhrw=="],
+    "@clack/prompts": ["@clack/prompts@1.7.0", "", { "dependencies": { "@clack/core": "1.4.3", "fast-string-width": "^3.0.2", "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A=="],
 
     "@convex-dev/crons": ["@convex-dev/crons@0.2.0", "", { "dependencies": { "cron-parser": "^4.9.0" }, "peerDependencies": { "convex": "^1.24.8" } }, "sha512-JowF/DDPl8FuhXml2/0jmEa6uIKr/UK1UwP+FdbPt2BRVxACRX4CNlzDQEtHbO2p2FVKiJh4zEg8p5/YM27PEA=="],
 
@@ -829,17 +829,17 @@
 
     "@ts-morph/common": ["@ts-morph/common@0.29.0", "", { "dependencies": { "minimatch": "^10.0.1", "path-browserify": "^1.0.1", "tinyglobby": "^0.2.14" } }, "sha512-35oUmphHbJvQ/+UTwFNme/t2p3FoKiGJ5auTjjpNTop2dyREspirjMy82PLSC1pnDJ8ah1GU98hwpVt64YXQsg=="],
 
-    "@turbo/darwin-64": ["@turbo/darwin-64@2.10.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-wBM3ObqOWnKUDmg7QfUFDkDHPFUAJmrYlYqmEM8jMPAPA/I6wRJIbWimeQUqhOiQ8xPKhzyWM+xaiUP0wz8FEQ=="],
+    "@turbo/darwin-64": ["@turbo/darwin-64@2.10.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-S+yIyZkmjYBQbIM7sTqMAwnLeMjSK60Q9grUDPbTWvkRjbsn5k1Rt5sPvTX80M4PnlYQBwLiYsjlu6tHsuIqQQ=="],
 
-    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.10.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-/Cq0joWnuMjDPfhjbFP4sv+C/7gkQ415zlaO4XUzD5EZxbtrKgXKvuuydMvogG8GeUnN1aDltW71RlmEfpjbyw=="],
+    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.10.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gnS8G78EjvJzDc1+tFES5BYXdlF+292n+h57G9G+5LJYelRh195f4Ed22RCo4EFIbI4Du9S5xfE9YjrqhoZaxQ=="],
 
-    "@turbo/linux-64": ["@turbo/linux-64@2.10.2", "", { "os": "linux", "cpu": "x64" }, "sha512-mMsf5IIhiKuceEXNstd25IbadjBXZ0amxzFOqliEzJX6HyeeHdBQPVSY583PWqYDyqM/FB8d5ZjkthfBSeuH3Q=="],
+    "@turbo/linux-64": ["@turbo/linux-64@2.10.6", "", { "os": "linux", "cpu": "x64" }, "sha512-lPv5AVkzvhs4z6Isr2ZE2UYt9Ndym5aWSMEIRh9OROnAdyEG1CFugJwAn/aFuDMmiCoHasyvD5tTDmVVTTrYxw=="],
 
-    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.10.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Wcng1i2kaKmXutmwxT9MUoYZvdaIekXAdlGr4+0TpgbhGLw7nDuEcRBFrxb5BbRoX1d1q8SpdRxLc45TvDZIdQ=="],
+    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.10.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-yeQ24es8pz+FhZxt25HIXj4ml7HpWMrmOL1BtCP4XUz7mBJZdAfC7z7HGF+wPSUZoKmoSZbL4r4QWbRddhPZIQ=="],
 
-    "@turbo/windows-64": ["@turbo/windows-64@2.10.2", "", { "os": "win32", "cpu": "x64" }, "sha512-SsNhM7Ho7EpAdwtrJKBOic9Hso23vu6Dp0gAfLOvUFjPzurr/sGQlXZEvr6z89ne4RDOypTwz5CBDrixpMKtXw=="],
+    "@turbo/windows-64": ["@turbo/windows-64@2.10.6", "", { "os": "win32", "cpu": "x64" }, "sha512-JiFscBN83F43VG3oM+QU2LvgHcf11tgirLJ3c1QDJBtulTCbDwupzIjqB9yBlfiMWAe6g3ssD6gqLP6a4g7FzA=="],
 
-    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.10.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gf+S7ICAdimT/n02bOuVWKvhHnct/HYjZg3oBNIz5hZ9ZyWHbQim9J3P5Qip8WpX0ksxF7eaBVziJCuLnjhqDg=="],
+    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.10.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-emWVdriXsaSVS5VXJxy4DppQ0UnGD+PUKu40DGjC3E5JXeoszL09B/1xU6B+Y8lJQg38cFoaB1NqGC4ayY5SQQ=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
@@ -2393,7 +2393,7 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "turbo": ["turbo@2.10.2", "", { "optionalDependencies": { "@turbo/darwin-64": "2.10.2", "@turbo/darwin-arm64": "2.10.2", "@turbo/linux-64": "2.10.2", "@turbo/linux-arm64": "2.10.2", "@turbo/windows-64": "2.10.2", "@turbo/windows-arm64": "2.10.2" }, "bin": { "turbo": "bin/turbo" } }, "sha512-wTExrNrRjB8qzIcg+ZLm0A3GFNLDsWNwdS/RBXB0FPrBDyzk3i96Yx+TxWZC7a0k1SIreFB8ciUbxjmEqTH8IQ=="],
+    "turbo": ["turbo@2.10.6", "", { "optionalDependencies": { "@turbo/darwin-64": "2.10.6", "@turbo/darwin-arm64": "2.10.6", "@turbo/linux-64": "2.10.6", "@turbo/linux-arm64": "2.10.6", "@turbo/windows-64": "2.10.6", "@turbo/windows-arm64": "2.10.6" }, "bin": { "turbo": "bin/turbo" } }, "sha512-3VfH7fK7WQ/ZHYjvfWyVnPRpcNaX3ZqXfGDMdc82eGdM0ESATyxFK4R4PM3wNsVFsdkUFZ4pZpkNeG37dxOv+g=="],
 
     "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "smoke:vercel": "bash scripts/vercel-smoke.sh"
   },
   "dependencies": {
-    "@clack/prompts": "^1.5.1"
+    "@clack/prompts": "^1.7.0"
   },
   "devDependencies": {
     "@types/bun": "^1.3.14",
@@ -58,7 +58,7 @@
     "lint-staged": "^17.0.4",
     "oxfmt": "catalog:",
     "oxlint": "^1.64.0",
-    "turbo": "^2.10.2",
+    "turbo": "^2.10.6",
     "typescript": "catalog:"
   },
   "lint-staged": {

--- a/packages/template-generator/src/bts-config.ts
+++ b/packages/template-generator/src/bts-config.ts
@@ -45,21 +45,18 @@ export function writeBtsConfigToVfs(
 
   const addCommand =
     projectConfig.packageManager === "npm"
-      ? "npx create-better-t-stack add"
+      ? "npx create-better-t-stack@latest add"
       : projectConfig.packageManager === "pnpm"
-        ? "pnpm dlx create-better-t-stack add"
-        : "bun create better-t-stack add";
+        ? "pnpm dlx create-better-t-stack@latest add"
+        : "bunx create-better-t-stack@latest add";
 
-  const finalContent = `// Better-T-Stack
+  const finalContent = `// Better-T-Stack project metadata
 //
-// Website: https://www.better-t-stack.dev/
-// Stack Builder: https://www.better-t-stack.dev/new
-// Analytics: https://www.better-t-stack.dev/analytics
-// Showcase: https://www.better-t-stack.dev/showcase
-// Sponsor: https://github.com/sponsors/AmanVarshney01
+// Keep this file to use the \`add\` command.
+// Add addons: ${addCommand}
 //
-// Add new addons with: ${addCommand}
-// This file is safe to delete
+// Docs: https://better-t-stack.dev/docs
+// Stack Builder: https://better-t-stack.dev/new
 
 ${jsonContent}`;
 

--- a/packages/template-generator/src/fs-writer.ts
+++ b/packages/template-generator/src/fs-writer.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs/promises";
+import path from "node:path";
 
 import { Result, TaggedError } from "better-result";
 import { join, dirname } from "pathe";
@@ -51,6 +52,7 @@ async function writeNodeInternal(
 
   if (node.type === "file") {
     const fileNode = node as VirtualFile;
+    await assertSafeWritePath(baseDir, fullPath);
     await fs.mkdir(dirname(fullPath), { recursive: true });
 
     if (fileNode.content === BINARY_FILE_MARKER && fileNode.sourcePath) {
@@ -59,6 +61,7 @@ async function writeNodeInternal(
       await fs.writeFile(fullPath, fileNode.content, "utf-8");
     }
   } else {
+    await assertSafeWritePath(baseDir, fullPath);
     await fs.mkdir(fullPath, { recursive: true });
     for (const child of (node as VirtualDirectory).children) {
       await writeNodeInternal(child, baseDir, nodePath);
@@ -103,6 +106,7 @@ async function writeSelectedNodeInternal(
   if (node.type === "file") {
     if (filter(nodePath)) {
       const fileNode = node as VirtualFile;
+      await assertSafeWritePath(baseDir, join(baseDir, nodePath));
       await fs.mkdir(dirname(join(baseDir, nodePath)), { recursive: true });
 
       if (fileNode.content === BINARY_FILE_MARKER && fileNode.sourcePath) {
@@ -124,4 +128,49 @@ async function copyBinaryFile(templatePath: string, destPath: string): Promise<v
   const sourcePath = join(templatesRoot, templatePath);
   // Let errors propagate - they'll be caught by the Result wrapper
   await fs.copyFile(sourcePath, destPath);
+}
+
+async function assertSafeWritePath(baseDir: string, destinationPath: string): Promise<void> {
+  const resolvedBase = path.resolve(baseDir);
+  const resolvedDestination = path.resolve(destinationPath);
+  const relativeDestination = path.relative(resolvedBase, resolvedDestination);
+
+  if (
+    relativeDestination === ".." ||
+    relativeDestination.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relativeDestination)
+  ) {
+    throw new FileWriteError({
+      message: `Refusing to write outside project directory: ${resolvedDestination}`,
+      path: resolvedDestination,
+    });
+  }
+
+  let currentPath = resolvedBase;
+  const pathSegments = relativeDestination.split(path.sep).filter(Boolean);
+  for (const segment of ["", ...pathSegments]) {
+    if (segment) currentPath = path.join(currentPath, segment);
+
+    let stats;
+    try {
+      stats = await fs.lstat(currentPath);
+    } catch (error) {
+      if (
+        typeof error === "object" &&
+        error !== null &&
+        "code" in error &&
+        error.code === "ENOENT"
+      ) {
+        return;
+      }
+      throw error;
+    }
+
+    if (stats.isSymbolicLink()) {
+      throw new FileWriteError({
+        message: `Refusing to write through symbolic link: ${currentPath}`,
+        path: currentPath,
+      });
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- refresh the interactive create flow with staged progress, back navigation, terminal-aware option limits, and clearer prompt copy
- polish create, add, history, sponsors, stack summaries, and post-install next steps with consistent Clack-native presentation
- preserve the full ASCII banner while improving compact and non-interactive command flows
- redesign directory-conflict handling with increment-first recovery, explicit overwrite confirmation, and clear merge semantics
- reject project targets, parent paths, and generated write paths that traverse symbolic links
- return actionable errors for file conflicts and keep programmatic overwrite output silent
- validate runtime input across the public `create()`, `createVirtual()`, and `add()` APIs
- make YOLO truly bypass compatibility checks, keep JSON output exclusive to verbose mode, and remove template/flag summary duplication
- make follow-up commands runner-aware across Bun, npm, and pnpm and clarify saved recreation history
- update generated `bts.jsonc` guidance and CLI documentation
- upgrade Clack to 1.7.0 and Turborepo to 2.10.6

## Why

The CLI mixed custom prompts, legacy Consola boxes, and inconsistent command output. Long post-install sections dominated the terminal, history rendered excessive guide spacing, and follow-up commands assumed a globally installed binary. Directory conflicts also had unsafe edge cases: overwrite followed directory symlinks, merge could write through nested symlinks, and existing files caused an `ENOTDIR` panic.

The public JavaScript API also trusted compile-time TypeScript types at runtime. `create()` and `createVirtual()` accepted unsupported values such as `runtime: "deno"`, while malformed `add()` input could escape as a raw `TypeError`.

This change gives each workflow a consistent hierarchy while keeping commands copyable, ephemeral-runner friendly, safe around existing filesystem state, and predictable for automation consumers.

## Impact

- interactive users get clearer progress, keyboard guidance, and reversible navigation
- directory conflicts recommend the first safe suffixed path and default overwrite confirmation to No
- overwrite, merge, increment, error, file conflicts, dry-run, and cancellation have regression coverage
- project and template writes refuse symbolic-link traversal instead of escaping the intended directory
- quick setup users get a compact configuration receipt and focused next steps
- `add --dry-run` can preview addon changes without writing files
- YOLO, verbose, dry-run, and template flows have distinct and predictable output
- history and sponsor output follow the same Clack guide and box language
- generated project metadata points to the correct package-manager-specific add command
- `create()` returns a typed `CLIError` for malformed input instead of accepting it
- `createVirtual()` returns a validation-phase `GeneratorError` for malformed input
- `add()` always returns an `AddResult`; malformed input becomes `{ success: false, error }` instead of throwing
- the root package now exports the public `AddOptions` and `ProjectConfig` types

## Validation

- `bun run check`
- `cd apps/cli && bun run check-types`
- `cd apps/cli && BTS_SKIP_EXTERNAL_COMMANDS=1 BTS_TEST_MODE=1 bun test --dots --only-failures` — full CLI suite passed
- `cd apps/cli && BTS_SKIP_EXTERNAL_COMMANDS=1 BTS_TEST_MODE=1 bun test test/programmatic-api.test.ts` — 3 passed, 0 failed
- `bun run build:cli` — production package build and `publint` passed
- `cd apps/web && bun run build` — production docs build passed
- built-package smoke test for valid virtual generation and malformed `create()`, `createVirtual()`, and `add()` inputs
- real PTY previews for create, directory increment/merge/overwrite confirmation/file conflicts/cancellation, YOLO, verbose, dry-run, templates, add dry-run, history, sponsors, and back navigation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved CLI UX with sectioned configuration summaries, richer prompt navigation/progress, and more consistent value labeling.
  * Enhanced post-install guidance with consistently formatted next steps and local service URLs.
  * Improved history output with cleaner stack rendering and “Recreate” command hints.
* **Bug Fixes**
  * Safer project directory conflict handling (symlinks, non-empty dirs, overwrite confirmation).
  * Safer template file writes to prevent unsafe paths and symlink traversal.
  * Programmatic API updates with stricter runtime validation and consistent structured results.
* **Documentation**
  * Updated `bts.jsonc`, `--directory-conflict`, and programmatic API docs to match new behavior/contracts.
* **Chores**
  * Dependency/runtime updates for improved CLI prompt behavior.
* **Style**
  * Refreshed user-facing prompt and output wording across the CLI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
