### PR TITLE
feat(payments): add Mollie as a payment provider option in builder

### DIFF
--- a/apps/cli/src/prompts/payments.ts
+++ b/apps/cli/src/prompts/payments.ts
@@ -3,6 +3,15 @@ import type { Auth, Backend, Frontend, Payments } from "../types";
 import { UserCancelledError } from "../utils/errors";
 import { isCancel, navigableSelect, preferValidInitial } from "./navigable";
 
+/**
+ * Prompt user for payments provider selection.
+ * @param payments Optional initial payments option
+ * @param auth Selected auth option
+ * @param backend Selected backend option
+ * @param _frontends Selected frontend frameworks
+ * @param previousValue Previously selected payments option
+ * @returns Selected payments choice
+ */
 export async function getPaymentsChoice(
   payments?: Payments,
   auth?: Auth,
@@ -27,6 +36,11 @@ export async function getPaymentsChoice(
       value: "polar" as Payments,
       label: "Polar",
       hint: "Turn your software into a business. 6 lines of code.",
+    },
+    {
+      value: "mollie" as Payments,
+      label: "Mollie",
+      hint: "Effortless payments for European businesses & beyond.",
     },
     {
       value: "none" as Payments,

--- a/apps/cli/src/utils/compatibility-rules.ts
+++ b/apps/cli/src/utils/compatibility-rules.ts
@@ -650,7 +650,7 @@ export function validateAddonsAgainstConfig(
 export function validatePaymentsCompatibility(
   payments: Payments | undefined,
   auth: Auth | undefined,
-  _backend: Backend | undefined,
+  backend: Backend | undefined,
   _frontends: Frontend[] = [],
 ): ValidationResult {
   if (!payments || payments === "none") return Result.ok(undefined);
@@ -659,6 +659,20 @@ export function validatePaymentsCompatibility(
     if (!auth || auth === "none" || auth !== "better-auth") {
       return validationErr(
         "Polar payments requires Better Auth. Please use '--auth better-auth' or choose a different payments provider.",
+      );
+    }
+  }
+
+  if (payments === "mollie") {
+    if (auth !== "better-auth") {
+      return validationErr(
+        "Mollie payments requires Better Auth. Please use '--auth better-auth' or choose a different payments provider.",
+      );
+    }
+
+    if (backend === "convex") {
+      return validationErr(
+        "Mollie payments is not supported with the Convex backend. Please choose a different backend or payments provider.",
       );
     }
   }

--- a/apps/cli/src/utils/display-config.ts
+++ b/apps/cli/src/utils/display-config.ts
@@ -54,6 +54,7 @@ const VALUE_LABELS = {
   "better-auth": "Better Auth",
   clerk: "Clerk",
   polar: "Polar",
+  mollie: "Mollie",
   pwa: "PWA",
   tauri: "Tauri",
   electrobun: "Electrobun",

--- a/apps/web/src/app/(home)/new/_components/tech-icon.tsx
+++ b/apps/web/src/app/(home)/new/_components/tech-icon.tsx
@@ -29,7 +29,7 @@ export function TechIcon({
       icon.includes("clerk") ||
       icon.includes("planetscale") ||
       icon.includes("nx") ||
-      icon.includes("polar") ||
+      icon.includes("polar") || icon.includes("mollie") ||
       icon.includes("astro") ||
       icon.includes("vercel"))
   ) {

--- a/apps/web/src/components/ui/tech-badge.tsx
+++ b/apps/web/src/components/ui/tech-badge.tsx
@@ -65,7 +65,7 @@ function TechIcon({ icon, name, className }: { icon: string; name: string; class
       icon.includes("clerk") ||
       icon.includes("planetscale") ||
       icon.includes("nx") ||
-      icon.includes("polar") ||
+      icon.includes("polar") || icon.includes("mollie") ||
       icon.includes("astro") ||
       icon.includes("vercel"))
   ) {

--- a/apps/web/src/lib/constant.ts
+++ b/apps/web/src/lib/constant.ts
@@ -503,6 +503,14 @@ export const TECH_OPTIONS = {
       default: false,
     },
     {
+      id: "mollie",
+      name: "Mollie",
+      description: "Effortless payments for European businesses & beyond.",
+      icon: `${ICON_BASE_URL}/mollie.svg`,
+      color: "from-blue-400 to-blue-600",
+      default: false,
+    },
+    {
       id: "none",
       name: "No Payments",
       description: "Skip payments integration",

--- a/packages/template-generator/src/processors/env-vars.ts
+++ b/packages/template-generator/src/processors/env-vars.ts
@@ -538,6 +538,11 @@ function buildServerVars(
       condition: payments === "polar",
     },
     {
+      key: "MOLLIE_API_KEY",
+      value: "",
+      condition: payments === "mollie",
+    },
+    {
       key: "CORS_ORIGIN",
       value: corsOrigin,
       condition: backend !== "self",

--- a/packages/template-generator/src/processors/payments-deps.ts
+++ b/packages/template-generator/src/processors/payments-deps.ts
@@ -11,6 +11,17 @@ export function processPaymentsDeps(vfs: VirtualFileSystem, config: ProjectConfi
   const authPath = "packages/auth/package.json";
   const webPath = "apps/web/package.json";
 
+  if (payments === "mollie") {
+    if (backend !== "convex" && vfs.exists(authPath)) {
+      addPackageDependency({
+        vfs,
+        packagePath: authPath,
+        dependencies: ["@mollie/api-client"],
+      });
+    }
+    return;
+  }
+
   if (payments === "polar") {
     if (backend === "convex") {
       if (vfs.exists(backendPath)) {

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -33510,6 +33510,9 @@ export const env = createEnv({
 		POLAR_ACCESS_TOKEN: z.string().min(1),
 		POLAR_SUCCESS_URL: z.url(),
 {{/if}}
+{{#if (eq payments "mollie")}}
+		MOLLIE_API_KEY: z.string().min(1),
+{{/if}}
 {{#if (ne backend "self")}}
 		CORS_ORIGIN: z.url(),
 {{/if}}
@@ -35464,6 +35467,36 @@ export function cn(...inputs: ClassValue[]) {
   "exclude": ["node_modules"]
 }
 `],
+  ["payments/mollie/server/base/src/lib/payments.ts.hbs", `/**
+ * Mollie payment client configuration.
+ */
+import { createMollieClient as createMollieSDKClient } from "@mollie/api-client";
+{{#if (and (eq backend "self") (eq webDeploy "cloudflare") (includes frontend "svelte"))}}
+import type {} from "@{{projectName}}/env/server";
+{{else}}
+import { env } from "@{{projectName}}/env/server";
+{{/if}}
+
+{{#if (and (eq backend "self") (eq webDeploy "cloudflare") (includes frontend "svelte"))}}
+/**
+ * Create a new Mollie client instance for Cloudflare/Svelte environment.
+ * @param env Environment variables object
+ * @returns Configured Mollie API client instance
+ */
+export function createMollieClient({{#if (and (eq backend "self") (eq webDeploy "cloudflare") (includes frontend "svelte"))}}env: Env{{/if}}) {
+	return createMollieSDKClient({
+		apiKey: env.MOLLIE_API_KEY,
+	});
+}
+{{else}}
+/**
+ * Configured Mollie API client singleton instance.
+ */
+export const mollieClient = createMollieSDKClient({
+	apiKey: env.MOLLIE_API_KEY,
+});
+{{/if}}
+`],
   ["payments/polar/convex/backend/convex/polar.ts.hbs", `import { Polar } from "@convex-dev/polar";
 
 import { api, components } from "./_generated/api";
@@ -35680,4 +35713,4 @@ export default function Success() {
 `]
 ]);
 
-export const TEMPLATE_COUNT = 522;
+export const TEMPLATE_COUNT = 523;

--- a/packages/template-generator/src/utils/add-deps.ts
+++ b/packages/template-generator/src/utils/add-deps.ts
@@ -178,6 +178,7 @@ export const dependencyVersionMap = {
   "@polar-sh/better-auth": "^1.8.4",
   "@polar-sh/checkout": "^0.4.0",
   "@polar-sh/sdk": "^0.47.0",
+  "@mollie/api-client": "^4.6.0",
   "@stripe/react-stripe-js": "^6.8.0",
   "@stripe/stripe-js": "^9.12.1",
 

--- a/packages/template-generator/templates/packages/env/src/server.ts.hbs
+++ b/packages/template-generator/templates/packages/env/src/server.ts.hbs
@@ -159,6 +159,9 @@ export const env = createEnv({
 		POLAR_ACCESS_TOKEN: z.string().min(1),
 		POLAR_SUCCESS_URL: z.url(),
 {{/if}}
+{{#if (eq payments "mollie")}}
+		MOLLIE_API_KEY: z.string().min(1),
+{{/if}}
 {{#if (ne backend "self")}}
 		CORS_ORIGIN: z.url(),
 {{/if}}

--- a/packages/template-generator/templates/payments/mollie/server/base/src/lib/payments.ts.hbs
+++ b/packages/template-generator/templates/payments/mollie/server/base/src/lib/payments.ts.hbs
@@ -1,0 +1,29 @@
+/**
+ * Mollie payment client configuration.
+ */
+import { createMollieClient as createMollieSDKClient } from "@mollie/api-client";
+{{#if (and (eq backend "self") (eq webDeploy "cloudflare") (includes frontend "svelte"))}}
+import type {} from "@{{projectName}}/env/server";
+{{else}}
+import { env } from "@{{projectName}}/env/server";
+{{/if}}
+
+{{#if (and (eq backend "self") (eq webDeploy "cloudflare") (includes frontend "svelte"))}}
+/**
+ * Create a new Mollie client instance for Cloudflare/Svelte environment.
+ * @param env Environment variables object
+ * @returns Configured Mollie API client instance
+ */
+export function createMollieClient({{#if (and (eq backend "self") (eq webDeploy "cloudflare") (includes frontend "svelte"))}}env: Env{{/if}}) {
+	return createMollieSDKClient({
+		apiKey: env.MOLLIE_API_KEY,
+	});
+}
+{{else}}
+/**
+ * Configured Mollie API client singleton instance.
+ */
+export const mollieClient = createMollieSDKClient({
+	apiKey: env.MOLLIE_API_KEY,
+});
+{{/if}}

--- a/packages/types/src/schemas.ts
+++ b/packages/types/src/schemas.ts
@@ -91,7 +91,7 @@ export const AuthSchema = z
   .enum(["better-auth", "clerk", "none"])
   .describe("Authentication provider");
 
-export const PaymentsSchema = z.enum(["polar", "none"]).describe("Payments provider");
+export const PaymentsSchema = z.enum(["polar", "mollie", "none"]).describe("Payments provider");
 
 export const WebDeploySchema = z
   .enum(["cloudflare", "prisma", "docker", "vercel", "none"])


### PR DESCRIPTION
Add Mollie as a payment provider option in the stack builder, CLI prompt, and template generator for European payment support.

Closes #1077

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Mollie as a selectable payments provider.
  * Added Mollie payment setup and API client configuration for generated projects.
  * Added Mollie branding, labels, icons, and light-theme support.
* **Updates**
  * Updated payment configuration validation and generated environment settings to support Mollie API keys.
  * Added Mollie-specific setup options for supported deployment configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->