### PR TITLE
fix(web): keep builder sponsor avatars square

### DIFF
--- a/apps/web/src/app/(home)/new/_components/special-sponsors-panel.tsx
+++ b/apps/web/src/app/(home)/new/_components/special-sponsors-panel.tsx
@@ -46,7 +46,7 @@ export function SpecialSponsorsPanel({ sponsors, compact = false }: SpecialSpons
                     target="_blank"
                     rel="noopener noreferrer"
                     aria-label={entry.name}
-                    className="inline-flex rounded-md"
+                    className="inline-flex shrink-0 rounded-md"
                   />
                 }
               >
@@ -128,7 +128,7 @@ export function SpecialSponsorsPanel({ sponsors, compact = false }: SpecialSpons
                 rel="noopener noreferrer"
                 aria-label="Become a sponsor"
                 className={cn(
-                  "builder-focus-ring inline-flex items-center justify-center rounded-md border border-dashed border-primary/40 bg-primary/10 text-primary transition-colors hover:border-primary/60 hover:bg-primary/16",
+                  "builder-focus-ring inline-flex shrink-0 items-center justify-center rounded-md border border-dashed border-primary/40 bg-primary/10 text-primary transition-colors hover:border-primary/60 hover:bg-primary/16",
                   compact ? "h-9 w-9" : "h-10 w-10",
                 )}
               />

--- a/apps/web/src/app/(home)/new/_components/special-sponsors-panel.tsx
+++ b/apps/web/src/app/(home)/new/_components/special-sponsors-panel.tsx
@@ -56,7 +56,7 @@ export function SpecialSponsorsPanel({ sponsors, compact = false }: SpecialSpons
                   width={64}
                   height={64}
                   className={cn(
-                    "rounded-md border border-border/70 transition-colors hover:border-primary/40",
+                    "shrink-0 rounded-md border border-border/70 transition-colors hover:border-primary/40",
                     compact ? "h-9 w-9" : "h-10 w-10",
                   )}
                   unoptimized


### PR DESCRIPTION
prior to this, the sponsor avatar was skewed at the `sm` breakpoint.
smaller than `sm` is fine, anything `md` and above is also fine.

evidence screenshot:
<img width="1024" height="1192" alt="image" src="https://github.com/user-attachments/assets/afd4161a-6b9e-4ed6-b0f3-5be8baccaf0d" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sponsor avatar layout stability by preventing sponsor images from shrinking in constrained spaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->