### PR TITLE
fix(web): wrap sponsor row so no sponsor is hidden

### DIFF
--- a/apps/web/src/app/(home)/new/_components/special-sponsors-panel.tsx
+++ b/apps/web/src/app/(home)/new/_components/special-sponsors-panel.tsx
@@ -33,7 +33,7 @@ export function SpecialSponsorsPanel({ sponsors, compact = false }: SpecialSpons
         </span>
       </div>
 
-      <div className="no-scrollbar flex items-center gap-2 overflow-x-auto pb-1">
+      <div className="flex flex-wrap items-center gap-2">
         {sponsors.map((entry) => {
           const sponsorUrl = getSponsorUrl(entry);
 


### PR DESCRIPTION
The special sponsors row used `overflow-x-auto` together with `.no-scrollbar`, which sets `scrollbar-width: none` and hides the webkit scrollbar. In the builder sidebar the row measures 271px wide with 328px of tiles, so roughly a sponsor and a half sat off-screen with **no visual affordance that more existed**. Sponsors are paying for visibility, so silently hiding them is the wrong tradeoff.

Switching to `flex-wrap` keeps every sponsor visible at every width.

Verified in browser:

| viewport | rows | result |
|---|---|---|
| 1440px | 1 | all 7 tiles fit (328px of tiles in a 351px sidebar) |
| 640px | 2 | 5 + 2, all visible, no hidden overflow |
| 375px (compact) | 1 | 7 x 36px tiles in 343px |

No horizontal page overflow at any width. Complements #1124.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the special sponsors panel to wrap sponsor cards onto multiple lines.
  * Removed horizontal scrolling when displaying many sponsors, improving readability and layout flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->