### PR TITLE
fix(cli): validate resolved project configurations

### DIFF
--- a/apps/cli/src/helpers/core/command-handlers.ts
+++ b/apps/cli/src/helpers/core/command-handlers.ts
@@ -8,10 +8,9 @@ import pc from "picocolors";
 import { getDefaultConfig } from "../../constants";
 import { gatherConfig } from "../../prompts/config-prompts";
 import { getProjectName } from "../../prompts/project-name";
-import type { CreateInput, DirectoryConflict, ProjectConfig } from "../../types";
+import type { CLIInput, CreateInput, DirectoryConflict, ProjectConfig } from "../../types";
 import { trackProjectCreation } from "../../utils/analytics";
 import { getCliSubcommandCommand } from "../../utils/cli-invocation";
-import { validateAddonsAgainstFrontends } from "../../utils/compatibility-rules";
 import { isSilent, runWithContextAsync } from "../../utils/context";
 import { displayConfig } from "../../utils/display-config";
 import {
@@ -42,6 +41,22 @@ import {
 } from "../../validation";
 import { createProject } from "./create-project";
 import { mergeResolvedDbSetupOptions } from "./db-setup-options";
+
+const RESOLVED_CONFIG_FLAGS = new Set([
+  "database",
+  "orm",
+  "backend",
+  "runtime",
+  "frontend",
+  "addons",
+  "examples",
+  "auth",
+  "dbSetup",
+  "payments",
+  "api",
+  "webDeploy",
+  "serverDeploy",
+]);
 
 export interface CreateHandlerOptions {
   silent?: boolean;
@@ -354,15 +369,18 @@ async function createProjectHandlerInternal(
     }
 
     if (!input.yolo) {
-      const addonsValidationResult = validateAddonsAgainstFrontends(
-        config.addons,
-        config.frontend,
-        config.auth,
-        config.backend,
-        config.runtime,
+      const resolvedConfigValidationResult = validateConfigCompatibility(
+        config,
+        RESOLVED_CONFIG_FLAGS,
+        config as unknown as CLIInput,
       );
-      if (addonsValidationResult.isErr()) {
-        return Result.err(new CLIError({ message: addonsValidationResult.error.message }));
+      if (resolvedConfigValidationResult.isErr()) {
+        return Result.err(
+          new CLIError({
+            message: resolvedConfigValidationResult.error.message,
+            cause: resolvedConfigValidationResult.error,
+          }),
+        );
       }
     }
 

--- a/apps/cli/src/helpers/core/command-handlers.ts
+++ b/apps/cli/src/helpers/core/command-handlers.ts
@@ -8,7 +8,7 @@ import pc from "picocolors";
 import { getDefaultConfig } from "../../constants";
 import { gatherConfig } from "../../prompts/config-prompts";
 import { getProjectName } from "../../prompts/project-name";
-import type { CLIInput, CreateInput, DirectoryConflict, ProjectConfig } from "../../types";
+import type { CreateInput, DirectoryConflict, ProjectConfig } from "../../types";
 import { trackProjectCreation } from "../../utils/analytics";
 import { getCliSubcommandCommand } from "../../utils/cli-invocation";
 import { isSilent, runWithContextAsync } from "../../utils/context";
@@ -26,6 +26,7 @@ import {
   findAvailableIncrementedPath,
   handleDirectoryConflict,
   inspectProjectPath,
+  resolveProjectDirectoryPath,
   setupProjectDirectory,
   validateSafeProjectDirectoryPath,
 } from "../../utils/project-directory";
@@ -38,25 +39,10 @@ import {
   processAndValidateFlags,
   processProvidedFlagsWithoutValidation,
   validateConfigCompatibility,
+  validateResolvedConfigCompatibility,
 } from "../../validation";
 import { createProject } from "./create-project";
 import { mergeResolvedDbSetupOptions } from "./db-setup-options";
-
-const RESOLVED_CONFIG_FLAGS = new Set([
-  "database",
-  "orm",
-  "backend",
-  "runtime",
-  "frontend",
-  "addons",
-  "examples",
-  "auth",
-  "dbSetup",
-  "payments",
-  "api",
-  "webDeploy",
-  "serverDeploy",
-]);
 
 export interface CreateHandlerOptions {
   silent?: boolean;
@@ -116,52 +102,75 @@ function createEmptyResult(
   };
 }
 
-type CreateHandlerError =
+export type CreateHandlerError =
   | UserCancelledError
   | CLIError
   | DirectoryConflictError
   | ProjectCreationError
   | UnhandledException;
 
-export async function createProjectHandler(
+interface CreateHandlerExecution {
+  result: Result<CreateProjectResult, CreateHandlerError>;
+  startTime: number;
+  timeScaffolded: string;
+}
+
+async function executeCreateProjectHandler(
   input: CreateInput & { projectName?: string },
-  options: CreateHandlerOptions = {},
-): Promise<CreateProjectResult | undefined> {
+  options: CreateHandlerOptions,
+): Promise<CreateHandlerExecution> {
   const { silent = false } = options;
 
   return runWithContextAsync({ silent }, async () => {
     const startTime = Date.now();
     const timeScaffolded = new Date().toISOString();
-
     const result = await createProjectHandlerInternal(input, startTime, timeScaffolded);
 
-    // Handle success case
-    if (result.isOk()) {
-      return result.value;
-    }
+    return { result, startTime, timeScaffolded };
+  });
+}
 
-    // Handle error cases
-    const error = result.error;
-    const elapsedTimeMs = Date.now() - startTime;
+export async function createProjectHandlerResult(
+  input: CreateInput & { projectName?: string },
+  options: CreateHandlerOptions = {},
+): Promise<Result<CreateProjectResult, CreateHandlerError>> {
+  const execution = await executeCreateProjectHandler(input, options);
+  return execution.result;
+}
 
-    // Handle user cancellation specially
-    if (UserCancelledError.is(error)) {
-      if (isSilent()) {
-        return createEmptyResult(timeScaffolded, elapsedTimeMs, error.message);
-      }
-      // In CLI mode, just return undefined (the cancel UI was already shown)
-      return undefined;
-    }
+export async function createProjectHandler(
+  input: CreateInput & { projectName?: string },
+  options: CreateHandlerOptions = {},
+): Promise<CreateProjectResult | undefined> {
+  const { silent = false } = options;
+  const { result, startTime, timeScaffolded } = await executeCreateProjectHandler(input, options);
 
-    // For silent mode, always return a failed result instead of throwing
-    if (isSilent()) {
+  // Handle success case
+  if (result.isOk()) {
+    return result.value;
+  }
+
+  // Handle error cases
+  const error = result.error;
+  const elapsedTimeMs = Date.now() - startTime;
+
+  // Handle user cancellation specially
+  if (UserCancelledError.is(error)) {
+    if (silent) {
       return createEmptyResult(timeScaffolded, elapsedTimeMs, error.message);
     }
+    // In CLI mode, just return undefined (the cancel UI was already shown)
+    return undefined;
+  }
 
-    // In CLI mode, display error and exit
-    displayError(error as AppError);
-    process.exit(1);
-  });
+  // For silent mode, always return a failed result instead of throwing
+  if (silent) {
+    return createEmptyResult(timeScaffolded, elapsedTimeMs, error.message);
+  }
+
+  // In CLI mode, display error and exit
+  displayError(error as AppError);
+  process.exit(1);
 }
 
 async function createProjectHandlerInternal(
@@ -227,30 +236,7 @@ async function createProjectHandlerInternal(
     yield* validateResolvedProjectPathInput(finalPathInput);
     yield* Result.await(validateSafeProjectDirectoryPath(finalPathInput));
 
-    let finalResolvedPath: string;
-    let finalBaseName: string;
-
-    if (input.dryRun) {
-      finalResolvedPath =
-        finalPathInput === "." ? process.cwd() : path.resolve(process.cwd(), finalPathInput);
-      finalBaseName = path.basename(finalResolvedPath);
-    } else {
-      // Setup project directory
-      const setupResult = yield* Result.await(
-        Result.tryPromise({
-          try: async () => setupProjectDirectory(finalPathInput, shouldClearDirectory),
-          catch: (e: unknown) => {
-            if (e instanceof UserCancelledError) return e;
-            return new CLIError({
-              message: e instanceof Error ? e.message : String(e),
-              cause: e,
-            });
-          },
-        }),
-      );
-      finalResolvedPath = setupResult.finalResolvedPath;
-      finalBaseName = setupResult.finalBaseName;
-    }
+    const { finalResolvedPath, finalBaseName } = resolveProjectDirectoryPath(finalPathInput);
 
     const originalInput = {
       ...input,
@@ -369,11 +355,7 @@ async function createProjectHandlerInternal(
     }
 
     if (!input.yolo) {
-      const resolvedConfigValidationResult = validateConfigCompatibility(
-        config,
-        RESOLVED_CONFIG_FLAGS,
-        config as unknown as CLIInput,
-      );
+      const resolvedConfigValidationResult = validateResolvedConfigCompatibility(config);
       if (resolvedConfigValidationResult.isErr()) {
         return Result.err(
           new CLIError({
@@ -382,6 +364,21 @@ async function createProjectHandlerInternal(
           }),
         );
       }
+    }
+
+    if (!input.dryRun) {
+      yield* Result.await(
+        Result.tryPromise({
+          try: async () => setupProjectDirectory(finalPathInput, shouldClearDirectory),
+          catch: (e: unknown) => {
+            if (e instanceof UserCancelledError) return e;
+            return new CLIError({
+              message: e instanceof Error ? e.message : String(e),
+              cause: e,
+            });
+          },
+        }),
+      );
     }
 
     if (!isSilent()) {

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -7,7 +7,7 @@ import z from "zod";
 import { historyHandler } from "./commands/history";
 import { openBuilderCommand, openDocsCommand, showSponsorsCommand } from "./commands/meta";
 import { addHandler, type AddResult } from "./helpers/core/add-handler";
-import { createProjectHandler } from "./helpers/core/command-handlers";
+import { createProjectHandler, createProjectHandlerResult } from "./helpers/core/command-handlers";
 import {
   type AddInput,
   type Addons,
@@ -363,22 +363,16 @@ export async function create(
 
   return Result.tryPromise({
     try: async () => {
-      const result = await createProjectHandler(input, { silent: true });
-      if (!result) {
-        // User cancelled (undefined return means cancellation in CLI mode)
-        throw new UserCancelledError({ message: "Operation cancelled" });
+      const result = await createProjectHandlerResult(input, { silent: true });
+      if (result.isErr()) {
+        throw result.error;
       }
-      if (!result.success) {
-        throw new CLIError({
-          message: result.error || "Unknown error occurred",
-        });
-      }
-      return result as InitResult;
+      return result.value as InitResult;
     },
     catch: (e: unknown) => {
-      if (e instanceof UserCancelledError) return e;
-      if (e instanceof CLIError) return e;
-      if (e instanceof ProjectCreationError) return e;
+      if (UserCancelledError.is(e)) return e;
+      if (CLIError.is(e)) return e;
+      if (ProjectCreationError.is(e)) return e;
       return new CLIError({
         message: e instanceof Error ? e.message : String(e),
         cause: e,

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -55,7 +55,12 @@ import {
   type WebDeploy,
   WebDeploySchema,
 } from "./types";
-import { CLIError, ProjectCreationError, UserCancelledError } from "./utils/errors";
+import {
+  CLIError,
+  DirectoryConflictError,
+  ProjectCreationError,
+  UserCancelledError,
+} from "./utils/errors";
 import { getLatestCLIVersion } from "./utils/get-latest-cli-version";
 import { validateConfigCompatibility } from "./validation";
 
@@ -296,7 +301,11 @@ export { Result } from "better-result";
 /**
  * Error types that can be returned from create/createVirtual
  */
-export type CreateError = UserCancelledError | CLIError | ProjectCreationError;
+export type CreateError =
+  | UserCancelledError
+  | CLIError
+  | DirectoryConflictError
+  | ProjectCreationError;
 
 function formatInputValidationError(label: string, error: z.ZodError): string {
   const details = error.issues
@@ -372,6 +381,7 @@ export async function create(
     catch: (e: unknown) => {
       if (UserCancelledError.is(e)) return e;
       if (CLIError.is(e)) return e;
+      if (DirectoryConflictError.is(e)) return e;
       if (ProjectCreationError.is(e)) return e;
       return new CLIError({
         message: e instanceof Error ? e.message : String(e),

--- a/apps/cli/src/utils/project-directory.ts
+++ b/apps/cli/src/utils/project-directory.ts
@@ -136,20 +136,24 @@ export async function handleDirectoryConflict(currentPathInput: string): Promise
   }
 }
 
+export function resolveProjectDirectoryPath(finalPathInput: string): {
+  finalResolvedPath: string;
+  finalBaseName: string;
+} {
+  const finalResolvedPath =
+    finalPathInput === "." ? process.cwd() : path.resolve(process.cwd(), finalPathInput);
+
+  return {
+    finalResolvedPath,
+    finalBaseName: path.basename(finalResolvedPath),
+  };
+}
+
 export async function setupProjectDirectory(
   finalPathInput: string,
   shouldClearDirectory: boolean,
 ): Promise<{ finalResolvedPath: string; finalBaseName: string }> {
-  let finalResolvedPath: string;
-  let finalBaseName: string;
-
-  if (finalPathInput === ".") {
-    finalResolvedPath = process.cwd();
-    finalBaseName = path.basename(finalResolvedPath);
-  } else {
-    finalResolvedPath = path.resolve(process.cwd(), finalPathInput);
-    finalBaseName = path.basename(finalResolvedPath);
-  }
+  const { finalResolvedPath, finalBaseName } = resolveProjectDirectoryPath(finalPathInput);
 
   const pathSafetyResult = await validateSafeProjectDirectoryPath(finalPathInput);
   if (pathSafetyResult.isErr()) throw pathSafetyResult.error;

--- a/apps/cli/src/validation.ts
+++ b/apps/cli/src/validation.ts
@@ -8,7 +8,7 @@ import { extractAndValidateProjectName } from "./utils/project-name-validation";
 
 type ValidationResult<T> = Result<T, ValidationError>;
 
-const CORE_STACK_FLAGS = new Set([
+const coreStackFlags = new Set([
   "database",
   "orm",
   "backend",
@@ -35,7 +35,7 @@ function validateYesFlagCombination(
   }
 
   const coreStackFlagsProvided = Array.from(providedFlags).filter((flag) =>
-    CORE_STACK_FLAGS.has(flag),
+    coreStackFlags.has(flag),
   );
 
   if (coreStackFlagsProvided.length > 0) {
@@ -138,6 +138,10 @@ export function validateConfigCompatibility(
   } else {
     return validateConfigForProgrammaticUse(config);
   }
+}
+
+export function validateResolvedConfigCompatibility(config: ProjectConfig): ValidationResult<void> {
+  return validateFullConfig(config, coreStackFlags, config);
 }
 
 export { getProvidedFlags };

--- a/apps/cli/test/programmatic-api.test.ts
+++ b/apps/cli/test/programmatic-api.test.ts
@@ -21,6 +21,43 @@ describe("programmatic API input validation", () => {
     expect(result.error.message).toContain("runtime");
   });
 
+  it("rejects an invalid configuration after resolving omitted defaults", async () => {
+    const result = await create("invalid-defaulted-orm", {
+      database: "mongodb",
+      dryRun: true,
+      git: false,
+      install: false,
+      disableAnalytics: true,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      throw new Error("Expected create() to reject MongoDB with the default Drizzle ORM");
+    }
+
+    expect(CLIError.is(result.error)).toBe(true);
+    expect(result.error.message).toContain("Drizzle ORM does not support MongoDB");
+  });
+
+  it("rejects incompatible overrides after applying a template", async () => {
+    const result = await create("invalid-template-orm", {
+      template: "mern",
+      orm: "drizzle",
+      dryRun: true,
+      git: false,
+      install: false,
+      disableAnalytics: true,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      throw new Error("Expected create() to reject a Drizzle override for the MERN template");
+    }
+
+    expect(CLIError.is(result.error)).toBe(true);
+    expect(result.error.message).toContain("Drizzle ORM does not support MongoDB");
+  });
+
   it("returns a generator validation error for an invalid virtual input shape", async () => {
     const result = await createVirtual({
       runtime: "deno",

--- a/apps/cli/test/programmatic-api.test.ts
+++ b/apps/cli/test/programmatic-api.test.ts
@@ -3,7 +3,14 @@ import { join } from "node:path";
 
 import fs from "fs-extra";
 
-import { add, CLIError, create, createVirtual, ValidationError } from "../src/index";
+import {
+  add,
+  CLIError,
+  create,
+  createVirtual,
+  DirectoryConflictError,
+  ValidationError,
+} from "../src/index";
 import { SMOKE_DIR } from "./setup";
 
 describe("programmatic API input validation", () => {
@@ -99,6 +106,27 @@ describe("programmatic API input validation", () => {
 
     expect(result.isErr()).toBe(true);
     expect(await fs.pathExists(projectDir)).toBe(false);
+  });
+
+  it("preserves typed directory conflict errors", async () => {
+    const projectDir = join(SMOKE_DIR, "programmatic-directory-conflict");
+    await fs.ensureDir(projectDir);
+    await fs.writeFile(join(projectDir, "keep-me.txt"), "keep-me", "utf8");
+
+    const result = await create(projectDir, {
+      yes: true,
+      git: false,
+      install: false,
+      disableAnalytics: true,
+      directoryConflict: "error",
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      throw new Error("Expected create() to return a directory conflict");
+    }
+
+    expect(DirectoryConflictError.is(result.error)).toBe(true);
   });
 
   it("returns a generator validation error for an invalid virtual input shape", async () => {

--- a/apps/cli/test/programmatic-api.test.ts
+++ b/apps/cli/test/programmatic-api.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import { join } from "node:path";
 
-import { add, CLIError, create, createVirtual } from "../src/index";
+import fs from "fs-extra";
+
+import { add, CLIError, create, createVirtual, ValidationError } from "../src/index";
 import { SMOKE_DIR } from "./setup";
 
 describe("programmatic API input validation", () => {
@@ -37,6 +39,7 @@ describe("programmatic API input validation", () => {
 
     expect(CLIError.is(result.error)).toBe(true);
     expect(result.error.message).toContain("Drizzle ORM does not support MongoDB");
+    expect(ValidationError.is(result.error.cause)).toBe(true);
   });
 
   it("rejects incompatible overrides after applying a template", async () => {
@@ -56,6 +59,46 @@ describe("programmatic API input validation", () => {
 
     expect(CLIError.is(result.error)).toBe(true);
     expect(result.error.message).toContain("Drizzle ORM does not support MongoDB");
+    expect(ValidationError.is(result.error.cause)).toBe(true);
+  });
+
+  it("does not modify an overwrite target when the resolved configuration is invalid", async () => {
+    const projectDir = join(SMOKE_DIR, "invalid-resolved-config-overwrite");
+    const sentinelPath = join(projectDir, "keep-me.txt");
+    await fs.ensureDir(projectDir);
+    await fs.writeFile(sentinelPath, "keep-me", "utf8");
+
+    const result = await create(projectDir, {
+      database: "mongodb",
+      git: false,
+      install: false,
+      disableAnalytics: true,
+      directoryConflict: "overwrite",
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      throw new Error("Expected create() to reject MongoDB with the default Drizzle ORM");
+    }
+
+    expect(result.error.message).toContain("Drizzle ORM does not support MongoDB");
+    expect(await fs.readFile(sentinelPath, "utf8")).toBe("keep-me");
+    expect(await fs.pathExists(join(projectDir, "package.json"))).toBe(false);
+  });
+
+  it("does not create a target directory when the resolved configuration is invalid", async () => {
+    const projectDir = join(SMOKE_DIR, "invalid-resolved-config-new-directory");
+    await fs.remove(projectDir);
+
+    const result = await create(projectDir, {
+      database: "mongodb",
+      git: false,
+      install: false,
+      disableAnalytics: true,
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(await fs.pathExists(projectDir)).toBe(false);
   });
 
   it("returns a generator validation error for an invalid virtual input shape", async () => {

--- a/apps/cli/test/programmatic-api.test.ts
+++ b/apps/cli/test/programmatic-api.test.ts
@@ -105,6 +105,13 @@ describe("programmatic API input validation", () => {
     });
 
     expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      throw new Error("Expected create() to reject MongoDB with the default Drizzle ORM");
+    }
+
+    expect(CLIError.is(result.error)).toBe(true);
+    expect(result.error.message).toContain("Drizzle ORM does not support MongoDB");
+    expect(ValidationError.is(result.error.cause)).toBe(true);
     expect(await fs.pathExists(projectDir)).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

- validate the fully resolved Project Configuration after defaults and templates are applied
- reject incompatible programmatic API input before any directory is created or cleared
- preserve typed validation and directory-conflict errors for programmatic callers
- cover defaulted, template-based, filesystem-safety, and public error-contract regressions

## Root cause

Compatibility validation previously ran before missing values were resolved. A partial programmatic request or a template override could therefore combine values that the CLI normally rejects. The first implementation of the final validation also ran after directory setup, so an invalid request could modify its target before failing.

## Checks

- `bun run check`
- focused validation/filesystem/API regressions — 48 passed
- `BTS_MATRIX_MODE=smoke bun test apps/cli/test/matrix/create-matrix.test.ts` — 282 passed (178 valid, 104 invalid)
- `cd apps/cli && bun run test:ci` — 572 passed, 13 skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for fully resolved project configurations.
  * Added clearer errors for incompatible ORM and template combinations.
  * Invalid configurations now return consistent CLI errors.
  * Dry runs no longer create project directories unnecessarily.
  * Existing overwrite targets are preserved during project creation.
  * Directory conflicts now produce clearer, consistent errors in the programmatic API.

* **Tests**
  * Added coverage for invalid configurations, template overrides, overwrite targets, directory creation behavior, and directory conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->