### PR TITLE
fix(web): make the hero ascii legible on phones

### DIFF
--- a/apps/web/src/app/(home)/_components/rail/ascii-banner.tsx
+++ b/apps/web/src/app/(home)/_components/rail/ascii-banner.tsx
@@ -1,6 +1,8 @@
 // ANSI Shadow, same face as the CLI banner in apps/cli/src/utils/render-title.ts.
-// 13 lines, 72 columns: the divisor in .bts-banner depends on that column count.
-const TITLE_TEXT = `██████╗  ██████╗ ██╗     ██╗       ██╗   ██╗ ██████╗ ██╗   ██╗██████╗
+// Two cuts: 72 columns for the rail, and a stacked 41-column one for phones,
+// where 72 columns would render the glyphs too small to read. Divisors in
+// .bts-banner / .bts-banner-narrow depend on those column counts.
+const WIDE = `██████╗  ██████╗ ██╗     ██╗       ██╗   ██╗ ██████╗ ██╗   ██╗██████╗
 ██╔══██╗██╔═══██╗██║     ██║       ╚██╗ ██╔╝██╔═══██╗██║   ██║██╔══██╗
 ██████╔╝██║   ██║██║     ██║        ╚████╔╝ ██║   ██║██║   ██║██████╔╝
 ██╔══██╗██║   ██║██║     ██║         ╚██╔╝  ██║   ██║██║   ██║██╔══██╗
@@ -14,12 +16,43 @@ const TITLE_TEXT = `██████╗  ██████╗ ██╗     �
 ╚██████╔╝╚███╔███╔╝██║ ╚████║  ███████║   ██║   ██║  ██║╚██████╗██║  ██╗
  ╚═════╝  ╚══╝╚══╝ ╚═╝  ╚═══╝  ╚══════╝   ╚═╝   ╚═╝  ╚═╝ ╚═════╝╚═╝  ╚═╝`;
 
+const NARROW = `██████╗  ██████╗ ██╗     ██╗
+██╔══██╗██╔═══██╗██║     ██║
+██████╔╝██║   ██║██║     ██║
+██╔══██╗██║   ██║██║     ██║
+██║  ██║╚██████╔╝███████╗███████╗
+╚═╝  ╚═╝ ╚═════╝ ╚══════╝╚══════╝
+
+██╗   ██╗ ██████╗ ██╗   ██╗██████╗
+╚██╗ ██╔╝██╔═══██╗██║   ██║██╔══██╗
+ ╚████╔╝ ██║   ██║██║   ██║██████╔╝
+  ╚██╔╝  ██║   ██║██║   ██║██╔══██╗
+   ██║   ╚██████╔╝╚██████╔╝██║  ██║
+   ╚═╝    ╚═════╝  ╚═════╝ ╚═╝  ╚═╝
+
+ ██████╗ ██╗    ██╗███╗   ██╗
+██╔═══██╗██║    ██║████╗  ██║
+██║   ██║██║ █╗ ██║██╔██╗ ██║
+██║   ██║██║███╗██║██║╚██╗██║
+╚██████╔╝╚███╔███╔╝██║ ╚████║
+ ╚═════╝  ╚══╝╚══╝ ╚═╝  ╚═══╝
+
+███████╗████████╗ █████╗  ██████╗██╗  ██╗
+██╔════╝╚══██╔══╝██╔══██╗██╔════╝██║ ██╔╝
+███████╗   ██║   ███████║██║     █████╔╝
+╚════██║   ██║   ██╔══██║██║     ██╔═██╗
+███████║   ██║   ██║  ██║╚██████╗██║  ██╗
+╚══════╝   ╚═╝   ╚═╝  ╚═╝ ╚═════╝╚═╝  ╚═╝`;
+
 export default function AsciiBanner() {
   return (
     <div className="bts-banner-fit">
       <h1 className="sr-only">Better T Stack: roll your own stack</h1>
-      <pre aria-hidden="true" className="bts-banner">
-        {TITLE_TEXT}
+      <pre aria-hidden="true" className="bts-banner max-md:hidden">
+        {WIDE}
+      </pre>
+      <pre aria-hidden="true" className="bts-banner-narrow md:hidden">
+        {NARROW}
       </pre>
     </div>
   );

--- a/apps/web/src/app/global.css
+++ b/apps/web/src/app/global.css
@@ -443,20 +443,30 @@
   overflow: hidden;
 }
 
-.bts-banner {
+.bts-banner,
+.bts-banner-narrow {
   font-family: var(--font-ascii);
   line-height: 1;
   letter-spacing: 0;
   white-space: pre;
   width: max-content;
   margin: 0;
-  font-size: clamp(6px, calc(100cqw / 45), 22px);
   background-image: var(--bts-banner-gradient);
   background-repeat: no-repeat;
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;
   -webkit-text-fill-color: transparent;
+}
+
+/* 72 columns. */
+.bts-banner {
+  font-size: clamp(6px, calc(100cqw / 45), 22px);
+}
+
+/* 41 columns, stacked one word per line: phones only. */
+.bts-banner-narrow {
+  font-size: clamp(8px, calc(100cqw / 26), 20px);
 }
 
 /* On the desktop rail the banner also has to fit the viewport height, so the
@@ -468,7 +478,8 @@
 }
 
 @media (prefers-contrast: more), (forced-colors: active) {
-  .bts-banner {
+  .bts-banner,
+  .bts-banner-narrow {
     forced-color-adjust: none;
     background-image: none;
     color: var(--primary);


### PR DESCRIPTION
The 72-column hero banner scales down to about **7.8px** at a 390px viewport, which mushes the block glyphs together into noise. It wasn't clipping, just unreadable.

This adds a second 41-column cut of the same ANSI Shadow face that stacks one word per line, shown below `md`. At 390px it renders at about **13.5px**, so the letterforms actually read.

| viewport | cut | font-size |
|---|---|---|
| 1440px | 72-col, two lines | 14.0px |
| 390px | 41-col, four lines | 13.5px |

Both cuts share the gradient, `background-clip` and container-query rules; only the font-size divisor differs, since it is derived from the column count (72 → 45, 41 → 26).

The narrow cut is generated from the same four word blocks the banner has always used, rather than transcribed by hand — an earlier hand-typed attempt rendered `BOLL` instead of `ROLL` because the R glyph's last two rows were wrong.

## Verification

- 390px: narrow cut visible, wide hidden, 332px inside a 350px box, no document overflow
- 1440px: wide cut visible, narrow hidden, pane 01 still has zero inner scroll
- `bun run check` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the banner layout for responsive display across screen sizes.
  * Added a stacked banner design for phone layouts.
  * Preserved high-contrast and forced-color accessibility styling across banner variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->