### PR TITLE
fix(web): stop the ascii banner clipping on real phones

### DIFF
--- a/apps/web/src/app/(home)/_components/rail/ascii-banner.tsx
+++ b/apps/web/src/app/(home)/_components/rail/ascii-banner.tsx
@@ -1,3 +1,9 @@
+"use client";
+
+import { useRef } from "react";
+
+import { useFitText } from "./use-fit-text";
+
 // ANSI Shadow, same face as the CLI banner in apps/cli/src/utils/render-title.ts.
 // Two cuts: 72 columns for the rail, and a stacked 41-column one for phones,
 // where 72 columns would render the glyphs too small to read. Divisors in
@@ -45,13 +51,18 @@ const NARROW = `██████╗  ██████╗ ██╗     █�
 ╚══════╝   ╚═╝   ╚═╝  ╚═╝ ╚═════╝╚═╝  ╚═╝`;
 
 export default function AsciiBanner() {
+  const wideRef = useRef<HTMLPreElement>(null);
+  const narrowRef = useRef<HTMLPreElement>(null);
+  useFitText(wideRef);
+  useFitText(narrowRef);
+
   return (
     <div className="bts-banner-fit">
       <h1 className="sr-only">Better T Stack: roll your own stack</h1>
-      <pre aria-hidden="true" className="bts-banner max-md:hidden">
+      <pre ref={wideRef} aria-hidden="true" className="bts-banner max-md:hidden">
         {WIDE}
       </pre>
-      <pre aria-hidden="true" className="bts-banner-narrow md:hidden">
+      <pre ref={narrowRef} aria-hidden="true" className="bts-banner-narrow md:hidden">
         {NARROW}
       </pre>
     </div>

--- a/apps/web/src/app/(home)/_components/rail/use-fit-text.ts
+++ b/apps/web/src/app/(home)/_components/rail/use-fit-text.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { type RefObject, useEffect, useLayoutEffect } from "react";
+
+// Correct before paint on the client so a clipped frame is never shown,
+// without tripping the SSR warning.
+const useIsomorphicLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect;
+
+/**
+ * Shrinks a <pre> until it actually fits its parent.
+ *
+ * The CSS sizes the banner from an assumed monospace advance, which holds only
+ * while every glyph comes from one font. Geist Mono has no box-drawing range,
+ * so those glyphs fall back to a system face whose advance can differ, and the
+ * line then renders wider than any precomputed divisor allows. Measuring is the
+ * only device-independent answer.
+ */
+export function useFitText(ref: RefObject<HTMLPreElement | null>) {
+  useIsomorphicLayoutEffect(() => {
+    const el = ref.current;
+    const parent = el?.parentElement;
+    if (!el || !parent) return;
+
+    const fit = () => {
+      el.style.fontSize = "";
+      const available = parent.clientWidth;
+      const natural = el.scrollWidth;
+      if (!available || !natural || natural <= available) return;
+      const current = Number.parseFloat(getComputedStyle(el).fontSize);
+      // 0.99 keeps a hair of margin instead of sitting flush against the clip.
+      el.style.fontSize = `${(current * available * 0.99) / natural}px`;
+    };
+
+    fit();
+
+    const observer = new ResizeObserver(fit);
+    observer.observe(parent);
+    // Fallback glyph metrics can change once fonts settle.
+    document.fonts?.ready.then(fit).catch(() => {});
+
+    return () => observer.disconnect();
+  }, [ref]);
+}

--- a/apps/web/src/app/global.css
+++ b/apps/web/src/app/global.css
@@ -451,6 +451,8 @@
   white-space: pre;
   width: max-content;
   margin: 0;
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
   background-image: var(--bts-banner-gradient);
   background-repeat: no-repeat;
   -webkit-background-clip: text;


### PR DESCRIPTION
Follow-up to #1135. That PR added a narrow 41-column cut so the banner is legible on phones, but it still sized the text from a **precomputed divisor**, and on real devices the last letter of `STACK` is sheared off:

<img width="320" alt="K clipped on Android" src="https://better-t-stack.dev" />

*(reported on Android Chrome at 630px CSS width, against production)*

## Why a bigger divisor would not have fixed it

The sizing math assumes every glyph shares one advance width. Geist Mono has no box-drawing range, so `█ ╗ ╝ ═ ║` come from a system fallback face. When that fallback's advance differs from the spaces around it, the rendered line is wider than `columns × advance × font-size` predicts — and `.bts-banner-fit` has `overflow: hidden`, so the rightmost glyph on the widest line gets clipped. `STACK`'s `K` is exactly that glyph.

Measured in headless Chrome the advance is a clean **0.6017** and it fits at 320/360/375/390/412/430 with ~5% margin. So the bug is not reproducible in the environment I can measure, and any divisor I picked would have been a guess against a device I cannot see.

## What this does instead

`useFitText` measures the actual rendered width and shrinks the `<pre>` only when it genuinely overflows its container:

- runs **before paint** (`useLayoutEffect`), so a clipped frame is never shown
- re-runs on `document.fonts.ready`, since fallback metrics can change once fonts settle
- re-runs via `ResizeObserver` for rotation and viewport changes
- targets 99% of the available width so it lands with a hair of margin rather than flush against the clip

Also pins `text-size-adjust: 100%` so mobile browsers cannot inflate the glyphs independently of the container-query sizing.

## Verification

- 320 / 390 / 630 / 1440px: no clipping, and the inline font-size stays **unset** in Chrome, so nothing regresses where the CSS was already correct
- The hook is inert unless the text actually overflows
- `bun run check` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ASCII banner sizing so wide and narrow layouts fit their containers more reliably.
  * Banners now automatically adapt when the display area changes size or fonts finish loading.
  * Prevented mobile browsers from unexpectedly adjusting banner text size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->