### PR TITLE
feat(web): match the og images to the site design language

### DIFF
--- a/apps/web/src/app/og/docs/[...slug]/route.tsx
+++ b/apps/web/src/app/og/docs/[...slug]/route.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import { ImageResponse } from "next/og";
 
-import { OG_SIZE, OgShell, ogColors } from "@/lib/og";
+import { OG_SIZE, OgShell, ogColors, ogFonts } from "@/lib/og";
 import { getPageImage, source } from "@/lib/source";
 
 export const revalidate = false;
@@ -25,11 +25,11 @@ export async function GET(_req: Request, { params }: RouteContext<"/og/docs/[...
       >
         <div
           style={{
-            fontSize: "56px",
-            fontWeight: 700,
+            fontSize: "54px",
+            fontWeight: 500,
             color: ogColors.text,
             lineHeight: 1.15,
-            letterSpacing: "-0.025em",
+            letterSpacing: "-0.02em",
             display: "flex",
             flexWrap: "wrap",
           }}
@@ -52,7 +52,7 @@ export async function GET(_req: Request, { params }: RouteContext<"/og/docs/[...
         )}
       </div>
     </OgShell>,
-    OG_SIZE,
+    { ...OG_SIZE, fonts: await ogFonts() },
   );
 }
 

--- a/apps/web/src/app/og/site/[page]/route.tsx
+++ b/apps/web/src/app/og/site/[page]/route.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import { ImageResponse } from "next/og";
 
-import { OG_SIZE, OgShell, ogColors } from "@/lib/og";
+import { OG_SIZE, OgShell, ogColors, ogFonts } from "@/lib/og";
 
 export const revalidate = false;
 
@@ -70,7 +70,7 @@ export async function GET(_req: Request, { params }: RouteContext<"/og/site/[pag
               fontSize: "20px",
             }}
           >
-            <span style={{ color: ogColors.green, display: "flex" }}>$</span>
+            <span style={{ color: ogColors.accent, display: "flex" }}>$</span>
             <span style={{ color: ogColors.subtext, display: "flex" }}>{page.command}</span>
             <div
               style={{
@@ -89,7 +89,7 @@ export async function GET(_req: Request, { params }: RouteContext<"/og/site/[pag
             fontWeight: 700,
             color: ogColors.text,
             lineHeight: 1.1,
-            letterSpacing: "-0.025em",
+            letterSpacing: "-0.02em",
             display: "flex",
             flexWrap: "wrap",
           }}
@@ -111,7 +111,7 @@ export async function GET(_req: Request, { params }: RouteContext<"/og/site/[pag
         </div>
       </div>
     </OgShell>,
-    OG_SIZE,
+    { ...OG_SIZE, fonts: await ogFonts() },
   );
 }
 

--- a/apps/web/src/app/og/stack/route.tsx
+++ b/apps/web/src/app/og/stack/route.tsx
@@ -2,7 +2,7 @@ import { ImageResponse } from "next/og";
 import type { NextRequest } from "next/server";
 
 import type { StackState } from "@/lib/constant";
-import { OG_SIZE, OgShell, ogColors } from "@/lib/og";
+import { OG_SIZE, OgShell, ogColors, ogFonts } from "@/lib/og";
 import { loadStackParams } from "@/lib/stack-url-state";
 import { getSelectedTechs } from "@/lib/stack-utils";
 
@@ -60,11 +60,10 @@ export async function GET(req: NextRequest) {
             display: "flex",
             alignItems: "center",
             gap: "12px",
-            fontFamily: "monospace",
-            fontSize: "20px",
+            fontSize: "22px",
           }}
         >
-          <span style={{ color: ogColors.green, display: "flex" }}>$</span>
+          <span style={{ color: ogColors.accent, display: "flex" }}>$</span>
           <span style={{ color: ogColors.subtext, display: "flex" }}>
             {commandBase(stack.packageManager)} {projectName}
           </span>
@@ -72,8 +71,8 @@ export async function GET(req: NextRequest) {
 
         <div
           style={{
-            fontSize: "54px",
-            fontWeight: 700,
+            fontSize: "52px",
+            fontWeight: 500,
             color: ogColors.text,
             lineHeight: 1.1,
             letterSpacing: "-0.025em",
@@ -93,7 +92,7 @@ export async function GET(req: NextRequest) {
                   display: "flex",
                   alignItems: "center",
                   padding: "6px 16px",
-                  borderRadius: "9999px",
+                  borderRadius: "4px",
                   border: `1px solid ${color}4d`,
                   background: `${color}1a`,
                   color,
@@ -111,7 +110,7 @@ export async function GET(req: NextRequest) {
                 display: "flex",
                 alignItems: "center",
                 padding: "6px 16px",
-                borderRadius: "9999px",
+                borderRadius: "4px",
                 border: `1px solid ${ogColors.border}`,
                 color: ogColors.overlay,
                 fontSize: "20px",
@@ -123,6 +122,6 @@ export async function GET(req: NextRequest) {
         </div>
       </div>
     </OgShell>,
-    OG_SIZE,
+    { ...OG_SIZE, fonts: await ogFonts() },
   );
 }

--- a/apps/web/src/lib/og.tsx
+++ b/apps/web/src/lib/og.tsx
@@ -2,20 +2,61 @@ import type { ReactNode } from "react";
 
 export const OG_SIZE = { width: 1200, height: 630 };
 
+/** Dark-theme site tokens, resolved to literals because Satori has no CSS vars. */
 export const ogColors = {
-  base: "#0a0a0a",
-  surface: "#11111b",
-  mantle: "#181825",
-  border: "#313244",
-  text: "#cdd6f4",
-  subtext: "#6c7086",
-  overlay: "#585b70",
-  faint: "#45475a",
+  base: "#0d0d0d",
+  surface: "#0d0d0d",
+  mantle: "#0d0d0d",
+  border: "#303030",
+  text: "#ebebeb",
+  subtext: "#a3a3a3",
+  overlay: "#8a8a8a",
+  faint: "#5c5c5c",
   accent: "#cba6f7",
   green: "#a6e3a1",
   red: "#f38ba8",
   yellow: "#f9e2af",
 };
+
+type FontSpec = { name: string; data: ArrayBuffer; weight: 400 | 500; style: "normal" };
+
+async function fetchGoogleFont(family: string, weight: number): Promise<ArrayBuffer | null> {
+  try {
+    const css = await fetch(
+      `https://fonts.googleapis.com/css2?family=${family.replace(/ /g, "+")}:wght@${weight}`,
+      // An old UA makes Google serve TTF, which Satori can parse; woff2 it cannot.
+      { headers: { "User-Agent": "Mozilla/5.0 (Windows NT 6.1; WOW64)" } },
+    ).then((res) => (res.ok ? res.text() : ""));
+    const url = css.match(/src: url\((.+?)\) format\('(?:opentype|truetype)'\)/)?.[1];
+    if (!url) return null;
+    const res = await fetch(url);
+    return res.ok ? await res.arrayBuffer() : null;
+  } catch {
+    return null;
+  }
+}
+
+let fontsPromise: Promise<FontSpec[]> | undefined;
+
+/**
+ * Geist Mono for the OG images so they read as the same system as the site.
+ * Resolves to [] if the fetch fails, letting Satori fall back rather than
+ * failing the build.
+ */
+export function ogFonts(): Promise<FontSpec[]> {
+  fontsPromise ??= Promise.all([
+    fetchGoogleFont("Geist Mono", 400),
+    fetchGoogleFont("Geist Mono", 500),
+  ]).then(([regular, medium]) => {
+    const fonts: FontSpec[] = [];
+    if (regular) fonts.push({ name: "Geist Mono", data: regular, weight: 400, style: "normal" });
+    if (medium) fonts.push({ name: "Geist Mono", data: medium, weight: 500, style: "normal" });
+    return fonts;
+  });
+  return fontsPromise;
+}
+
+export const OG_FONT_FAMILY = "Geist Mono, ui-monospace, monospace";
 
 export function OgShell({
   path,
@@ -36,8 +77,7 @@ export function OgShell({
         display: "flex",
         flexDirection: "column",
         background: ogColors.base,
-        fontFamily: "system-ui, sans-serif",
-        position: "relative",
+        fontFamily: OG_FONT_FAMILY,
       }}
     >
       <div
@@ -47,103 +87,58 @@ export function OgShell({
           margin: "40px",
           flex: 1,
           border: `1px solid ${ogColors.border}`,
-          borderRadius: "8px",
-          overflow: "hidden",
-          background: ogColors.surface,
+          borderRadius: "4px",
         }}
       >
+        {/* Pane header: the same marker + lowercase title + index the rail uses. */}
         <div
           style={{
             display: "flex",
             alignItems: "center",
-            padding: "14px 20px",
-            background: ogColors.mantle,
+            height: "48px",
+            padding: "0 28px",
             borderBottom: `1px solid ${ogColors.border}`,
-            gap: "8px",
+            gap: "12px",
           }}
         >
-          <div style={{ display: "flex", gap: "8px" }}>
-            <div
-              style={{
-                width: "12px",
-                height: "12px",
-                borderRadius: "50%",
-                background: ogColors.red,
-                display: "flex",
-              }}
-            />
-            <div
-              style={{
-                width: "12px",
-                height: "12px",
-                borderRadius: "50%",
-                background: ogColors.yellow,
-                display: "flex",
-              }}
-            />
-            <div
-              style={{
-                width: "12px",
-                height: "12px",
-                borderRadius: "50%",
-                background: ogColors.green,
-                display: "flex",
-              }}
-            />
-          </div>
-          <div
+          <span style={{ color: ogColors.accent, fontSize: "15px", display: "flex" }}>•</span>
+          <span
             style={{
-              flex: 1,
-              textAlign: "center",
-              color: ogColors.overlay,
-              fontSize: "14px",
-              fontFamily: "monospace",
+              color: ogColors.subtext,
+              fontSize: "16px",
+              letterSpacing: "0.08em",
+              textTransform: "uppercase",
               display: "flex",
-              justifyContent: "center",
             }}
           >
             {path}
-          </div>
+          </span>
         </div>
 
         {children}
 
+        {/* Status bar. */}
         <div
           style={{
             display: "flex",
-            justifyContent: "space-between",
             alignItems: "center",
-            padding: "16px 56px",
+            height: "46px",
+            padding: "0 28px",
             borderTop: `1px solid ${ogColors.border}`,
-            background: ogColors.mantle,
+            gap: "14px",
+            fontSize: "15px",
+            letterSpacing: "0.1em",
+            textTransform: "uppercase",
           }}
         >
-          <div style={{ display: "flex", alignItems: "center", gap: "10px" }}>
-            <span
-              style={{
-                color: ogColors.accent,
-                fontSize: "18px",
-                fontWeight: 600,
-                display: "flex",
-              }}
-            >
-              Better-T Stack
-            </span>
-            <span style={{ color: ogColors.border, fontSize: "18px", display: "flex" }}>/</span>
-            <span style={{ color: ogColors.overlay, fontSize: "16px", display: "flex" }}>
-              {section}
-            </span>
-          </div>
-          <div
-            style={{
-              color: ogColors.faint,
-              fontSize: "14px",
-              fontFamily: "monospace",
-              display: "flex",
-            }}
-          >
-            {footerRight}
-          </div>
+          <span style={{ color: ogColors.accent, display: "flex" }}>•</span>
+          <span style={{ color: ogColors.text, fontWeight: 500, display: "flex" }}>
+            better-t-stack
+          </span>
+          <span style={{ color: ogColors.border, display: "flex" }}>|</span>
+          <span style={{ color: ogColors.subtext, display: "flex" }}>{section}</span>
+          <span style={{ flex: 1, display: "flex" }} />
+          <span style={{ color: ogColors.faint, display: "flex" }}>{footerRight}</span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
The OG cards still rendered the pre-redesign look: a rounded window chrome with macOS traffic-light dots, filled surfaces, and bold sans type. None of that exists on the site any more, so links previewed as a different product.

## Rebuilt on the rail's language

- Flat hairline frame at `rounded-[4px]`, no filled surfaces, no decorative dots
- The rail's pane header (`• ~/docs/analytics`) at the top and its status bar (`• BETTER-T-STACK | DOCS … better-t-stack.dev`) at the bottom
- One accent throughout, including the `$` prompt, which was green
- Titles drop from weight 700 to 500, matching the site's "no bold" rule
- Stack badges squared from `9999px` to `4px`; their brand colours stay, on the same reasoning as the chart palette and the package-manager icons

## The images were never monospace

Every route asked for `fontFamily: "monospace"`, but no font was ever registered with Satori, so it silently fell back to its default sans. That's a large part of why the cards didn't read as the same system as the site.

`ogFonts()` now fetches Geist Mono 400/500 and registers it, memoised across routes so a build renders it once. A failed fetch resolves to an empty font list, so a network hiccup degrades the typeface rather than failing the build.

## Verification

Generated and inspected all three routes:

- `/og/site/home.png` — 1200×630, genuine mono, hairline frame
- `/og/docs/analytics/image.png` — 200
- `/og/stack?frontend=next&backend=hono&database=postgres` — 200, badges squared

`bun run check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refreshed social preview images with a darker color palette, updated typography, and improved font rendering.
  * Updated preview layouts with flatter headers and status bars for a cleaner appearance.
  * Refined title sizing, spacing, command prompts, and technology labels across previews.
  * Improved font loading resilience so previews remain available if external fonts cannot be fetched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->