### PR TITLE
fix(web): make the live feed reachable in the init pane

### DIFF
--- a/apps/web/src/app/(home)/_components/rail/panes/live-feed.tsx
+++ b/apps/web/src/app/(home)/_components/rail/panes/live-feed.tsx
@@ -111,7 +111,8 @@ export default function LiveFeed() {
 
       <ol
         aria-label="Recent project starts"
-        className="fd-scroll-container min-h-0 flex-1 overflow-hidden font-mono text-[11px] leading-[1.7]"
+        data-pane-scroll
+        className="fd-scroll-container min-h-0 flex-1 overflow-y-auto overscroll-y-contain font-mono text-[11px] leading-[1.7]"
       >
         {events?.map((event) => (
           <li key={event._id} className="flex items-baseline gap-3 py-px">


### PR DESCRIPTION
Reported as "can't scroll the init section on MacBooks".

The init pane itself has zero vertical overflow at every MacBook size (`scrollHeight === clientHeight` at 1440×789, 1512×830, 1728×969), so the pane looked fine. The problem was one level down, in the live feed.

## Two compounding causes

**The list clipped instead of scrolling.** `<ol>` had `overflow-hidden` with `flex-1 min-h-0`, so it took whatever vertical space was left and hid the rest. Measured at 1512×970: **1053px of entries inside a 76px box** — roughly 14 project starts with no way to reach them. Because the clipping happened inside the `<ol>`, the pane's own `scrollHeight` never grew, so the pane didn't scroll either.

**The wheel handler didn't know it was a scroller.** `findPaneScroller` walks `composedPath()` looking for `data-pane-scroll`. The `<ol>` didn't have it, so the walk continued up to the pane body, found it couldn't scroll, and moved the rail sideways. Adding `overflow-y-auto` alone would not have fixed this — a trackpad gesture would still have slid the rail instead of scrolling the list.

## Fix

`overflow-y-auto overscroll-y-contain` plus `data-pane-scroll` on the list.

## Verification

| gesture | before | after |
|---|---|---|
| wheel over feed, mid-list | rail slid 120px, feed frozen | feed scrolls 120px, rail frozen |
| wheel down, feed at bottom | — | rail advances 120px (handoff intact) |
| wheel up, feed at top | — | hands back to the rail |

`bun run check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the live feed panel’s scrolling behavior.
  * Added contained vertical scrolling to prevent overscroll from affecting the surrounding page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->