### PR TITLE
fix(web): og images in the site design language, and a reachable live feed

### DIFF
--- a/apps/web/src/app/(home)/_components/rail/panes/live-feed.tsx
+++ b/apps/web/src/app/(home)/_components/rail/panes/live-feed.tsx
@@ -111,7 +111,8 @@ export default function LiveFeed() {
 
       <ol
         aria-label="Recent project starts"
-        className="fd-scroll-container min-h-0 flex-1 overflow-hidden font-mono text-[11px] leading-[1.7]"
+        data-pane-scroll
+        className="fd-scroll-container min-h-0 flex-1 overflow-y-auto overscroll-y-contain font-mono text-[11px] leading-[1.7]"
       >
         {events?.map((event) => (
           <li key={event._id} className="flex items-baseline gap-3 py-px">

--- a/apps/web/src/app/og/docs/[...slug]/route.tsx
+++ b/apps/web/src/app/og/docs/[...slug]/route.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import { ImageResponse } from "next/og";
 
-import { OG_SIZE, OgShell, ogColors } from "@/lib/og";
+import { OG_SIZE, OgShell, ogColors, ogFonts } from "@/lib/og";
 import { getPageImage, source } from "@/lib/source";
 
 export const revalidate = false;
@@ -25,11 +25,11 @@ export async function GET(_req: Request, { params }: RouteContext<"/og/docs/[...
       >
         <div
           style={{
-            fontSize: "56px",
-            fontWeight: 700,
+            fontSize: "54px",
+            fontWeight: 500,
             color: ogColors.text,
             lineHeight: 1.15,
-            letterSpacing: "-0.025em",
+            letterSpacing: "-0.02em",
             display: "flex",
             flexWrap: "wrap",
           }}
@@ -52,7 +52,7 @@ export async function GET(_req: Request, { params }: RouteContext<"/og/docs/[...
         )}
       </div>
     </OgShell>,
-    OG_SIZE,
+    { ...OG_SIZE, fonts: await ogFonts() },
   );
 }
 

--- a/apps/web/src/app/og/site/[page]/route.tsx
+++ b/apps/web/src/app/og/site/[page]/route.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import { ImageResponse } from "next/og";
 
-import { OG_SIZE, OgShell, ogColors } from "@/lib/og";
+import { OG_SIZE, OgShell, ogColors, ogFonts } from "@/lib/og";
 
 export const revalidate = false;
 
@@ -70,7 +70,7 @@ export async function GET(_req: Request, { params }: RouteContext<"/og/site/[pag
               fontSize: "20px",
             }}
           >
-            <span style={{ color: ogColors.green, display: "flex" }}>$</span>
+            <span style={{ color: ogColors.accent, display: "flex" }}>$</span>
             <span style={{ color: ogColors.subtext, display: "flex" }}>{page.command}</span>
             <div
               style={{
@@ -89,7 +89,7 @@ export async function GET(_req: Request, { params }: RouteContext<"/og/site/[pag
             fontWeight: 700,
             color: ogColors.text,
             lineHeight: 1.1,
-            letterSpacing: "-0.025em",
+            letterSpacing: "-0.02em",
             display: "flex",
             flexWrap: "wrap",
           }}
@@ -111,7 +111,7 @@ export async function GET(_req: Request, { params }: RouteContext<"/og/site/[pag
         </div>
       </div>
     </OgShell>,
-    OG_SIZE,
+    { ...OG_SIZE, fonts: await ogFonts() },
   );
 }
 

--- a/apps/web/src/app/og/stack/route.tsx
+++ b/apps/web/src/app/og/stack/route.tsx
@@ -2,7 +2,7 @@ import { ImageResponse } from "next/og";
 import type { NextRequest } from "next/server";
 
 import type { StackState } from "@/lib/constant";
-import { OG_SIZE, OgShell, ogColors } from "@/lib/og";
+import { OG_SIZE, OgShell, ogColors, ogFonts } from "@/lib/og";
 import { loadStackParams } from "@/lib/stack-url-state";
 import { getSelectedTechs } from "@/lib/stack-utils";
 
@@ -60,11 +60,10 @@ export async function GET(req: NextRequest) {
             display: "flex",
             alignItems: "center",
             gap: "12px",
-            fontFamily: "monospace",
-            fontSize: "20px",
+            fontSize: "22px",
           }}
         >
-          <span style={{ color: ogColors.green, display: "flex" }}>$</span>
+          <span style={{ color: ogColors.accent, display: "flex" }}>$</span>
           <span style={{ color: ogColors.subtext, display: "flex" }}>
             {commandBase(stack.packageManager)} {projectName}
           </span>
@@ -72,8 +71,8 @@ export async function GET(req: NextRequest) {
 
         <div
           style={{
-            fontSize: "54px",
-            fontWeight: 700,
+            fontSize: "52px",
+            fontWeight: 500,
             color: ogColors.text,
             lineHeight: 1.1,
             letterSpacing: "-0.025em",
@@ -93,7 +92,7 @@ export async function GET(req: NextRequest) {
                   display: "flex",
                   alignItems: "center",
                   padding: "6px 16px",
-                  borderRadius: "9999px",
+                  borderRadius: "4px",
                   border: `1px solid ${color}4d`,
                   background: `${color}1a`,
                   color,
@@ -111,7 +110,7 @@ export async function GET(req: NextRequest) {
                 display: "flex",
                 alignItems: "center",
                 padding: "6px 16px",
-                borderRadius: "9999px",
+                borderRadius: "4px",
                 border: `1px solid ${ogColors.border}`,
                 color: ogColors.overlay,
                 fontSize: "20px",
@@ -123,6 +122,6 @@ export async function GET(req: NextRequest) {
         </div>
       </div>
     </OgShell>,
-    OG_SIZE,
+    { ...OG_SIZE, fonts: await ogFonts() },
   );
 }

--- a/apps/web/src/lib/og.tsx
+++ b/apps/web/src/lib/og.tsx
@@ -2,20 +2,61 @@ import type { ReactNode } from "react";
 
 export const OG_SIZE = { width: 1200, height: 630 };
 
+/** Dark-theme site tokens, resolved to literals because Satori has no CSS vars. */
 export const ogColors = {
-  base: "#0a0a0a",
-  surface: "#11111b",
-  mantle: "#181825",
-  border: "#313244",
-  text: "#cdd6f4",
-  subtext: "#6c7086",
-  overlay: "#585b70",
-  faint: "#45475a",
+  base: "#0d0d0d",
+  surface: "#0d0d0d",
+  mantle: "#0d0d0d",
+  border: "#303030",
+  text: "#ebebeb",
+  subtext: "#a3a3a3",
+  overlay: "#8a8a8a",
+  faint: "#5c5c5c",
   accent: "#cba6f7",
   green: "#a6e3a1",
   red: "#f38ba8",
   yellow: "#f9e2af",
 };
+
+type FontSpec = { name: string; data: ArrayBuffer; weight: 400 | 500; style: "normal" };
+
+async function fetchGoogleFont(family: string, weight: number): Promise<ArrayBuffer | null> {
+  try {
+    const css = await fetch(
+      `https://fonts.googleapis.com/css2?family=${family.replace(/ /g, "+")}:wght@${weight}`,
+      // An old UA makes Google serve TTF, which Satori can parse; woff2 it cannot.
+      { headers: { "User-Agent": "Mozilla/5.0 (Windows NT 6.1; WOW64)" } },
+    ).then((res) => (res.ok ? res.text() : ""));
+    const url = css.match(/src: url\((.+?)\) format\('(?:opentype|truetype)'\)/)?.[1];
+    if (!url) return null;
+    const res = await fetch(url);
+    return res.ok ? await res.arrayBuffer() : null;
+  } catch {
+    return null;
+  }
+}
+
+let fontsPromise: Promise<FontSpec[]> | undefined;
+
+/**
+ * Geist Mono for the OG images so they read as the same system as the site.
+ * Resolves to [] if the fetch fails, letting Satori fall back rather than
+ * failing the build.
+ */
+export function ogFonts(): Promise<FontSpec[]> {
+  fontsPromise ??= Promise.all([
+    fetchGoogleFont("Geist Mono", 400),
+    fetchGoogleFont("Geist Mono", 500),
+  ]).then(([regular, medium]) => {
+    const fonts: FontSpec[] = [];
+    if (regular) fonts.push({ name: "Geist Mono", data: regular, weight: 400, style: "normal" });
+    if (medium) fonts.push({ name: "Geist Mono", data: medium, weight: 500, style: "normal" });
+    return fonts;
+  });
+  return fontsPromise;
+}
+
+export const OG_FONT_FAMILY = "Geist Mono, ui-monospace, monospace";
 
 export function OgShell({
   path,
@@ -36,8 +77,7 @@ export function OgShell({
         display: "flex",
         flexDirection: "column",
         background: ogColors.base,
-        fontFamily: "system-ui, sans-serif",
-        position: "relative",
+        fontFamily: OG_FONT_FAMILY,
       }}
     >
       <div
@@ -47,103 +87,58 @@ export function OgShell({
           margin: "40px",
           flex: 1,
           border: `1px solid ${ogColors.border}`,
-          borderRadius: "8px",
-          overflow: "hidden",
-          background: ogColors.surface,
+          borderRadius: "4px",
         }}
       >
+        {/* Pane header: the same marker + lowercase title + index the rail uses. */}
         <div
           style={{
             display: "flex",
             alignItems: "center",
-            padding: "14px 20px",
-            background: ogColors.mantle,
+            height: "48px",
+            padding: "0 28px",
             borderBottom: `1px solid ${ogColors.border}`,
-            gap: "8px",
+            gap: "12px",
           }}
         >
-          <div style={{ display: "flex", gap: "8px" }}>
-            <div
-              style={{
-                width: "12px",
-                height: "12px",
-                borderRadius: "50%",
-                background: ogColors.red,
-                display: "flex",
-              }}
-            />
-            <div
-              style={{
-                width: "12px",
-                height: "12px",
-                borderRadius: "50%",
-                background: ogColors.yellow,
-                display: "flex",
-              }}
-            />
-            <div
-              style={{
-                width: "12px",
-                height: "12px",
-                borderRadius: "50%",
-                background: ogColors.green,
-                display: "flex",
-              }}
-            />
-          </div>
-          <div
+          <span style={{ color: ogColors.accent, fontSize: "15px", display: "flex" }}>•</span>
+          <span
             style={{
-              flex: 1,
-              textAlign: "center",
-              color: ogColors.overlay,
-              fontSize: "14px",
-              fontFamily: "monospace",
+              color: ogColors.subtext,
+              fontSize: "16px",
+              letterSpacing: "0.08em",
+              textTransform: "uppercase",
               display: "flex",
-              justifyContent: "center",
             }}
           >
             {path}
-          </div>
+          </span>
         </div>
 
         {children}
 
+        {/* Status bar. */}
         <div
           style={{
             display: "flex",
-            justifyContent: "space-between",
             alignItems: "center",
-            padding: "16px 56px",
+            height: "46px",
+            padding: "0 28px",
             borderTop: `1px solid ${ogColors.border}`,
-            background: ogColors.mantle,
+            gap: "14px",
+            fontSize: "15px",
+            letterSpacing: "0.1em",
+            textTransform: "uppercase",
           }}
         >
-          <div style={{ display: "flex", alignItems: "center", gap: "10px" }}>
-            <span
-              style={{
-                color: ogColors.accent,
-                fontSize: "18px",
-                fontWeight: 600,
-                display: "flex",
-              }}
-            >
-              Better-T Stack
-            </span>
-            <span style={{ color: ogColors.border, fontSize: "18px", display: "flex" }}>/</span>
-            <span style={{ color: ogColors.overlay, fontSize: "16px", display: "flex" }}>
-              {section}
-            </span>
-          </div>
-          <div
-            style={{
-              color: ogColors.faint,
-              fontSize: "14px",
-              fontFamily: "monospace",
-              display: "flex",
-            }}
-          >
-            {footerRight}
-          </div>
+          <span style={{ color: ogColors.accent, display: "flex" }}>•</span>
+          <span style={{ color: ogColors.text, fontWeight: 500, display: "flex" }}>
+            better-t-stack
+          </span>
+          <span style={{ color: ogColors.border, display: "flex" }}>|</span>
+          <span style={{ color: ogColors.subtext, display: "flex" }}>{section}</span>
+          <span style={{ flex: 1, display: "flex" }} />
+          <span style={{ color: ogColors.faint, display: "flex" }}>{footerRight}</span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Combines #1137 and #1138.

## OG images

They still rendered the pre-redesign look: rounded window chrome with macOS traffic-light dots, filled surfaces, bold sans type. Links previewed as a different product.

- Flat hairline frame at `rounded-[4px]`, no fills, no decorative dots
- The rail's pane header on top and status bar underneath
- One accent, including the `$` prompt which was green
- Titles from weight 700 to 500
- Stack badges squared from `9999px` to `4px`; brand colours kept, same reasoning as the chart palette

**The images were never actually monospace.** Every route asked for `fontFamily: "monospace"` but no font was registered with Satori, so it silently fell back to its default sans. `ogFonts()` now fetches and registers Geist Mono 400/500, memoised across routes. A failed fetch resolves to an empty font list, so a network hiccup degrades the typeface rather than failing the build.

## Live feed

Reported as "can't scroll the init section on MacBooks". The pane itself has zero overflow at every MacBook size; the problem was one level down.

The `<ol>` had `overflow-hidden` with `flex-1`, so it absorbed the leftover space and hid the rest — measured at 1512×970, **1053px of entries inside a 76px box**, about 14 project starts unreachable. Because the clipping happened inside the `<ol>`, the pane's own `scrollHeight` never grew, so the pane didn't scroll either.

It also lacked `data-pane-scroll`, which the rail's wheel handler uses to decide a vertical gesture belongs to a scroller. Without it the walk continued to the pane body, found it couldn't scroll, and moved the rail sideways — so `overflow-y-auto` alone would not have fixed it.

Visibility is unchanged: still hidden below `md` and below 820px tall.

| gesture | before | after |
|---|---|---|
| wheel over feed, mid-list | rail slid, feed frozen | feed scrolls, rail frozen |
| wheel down, feed at bottom | — | rail advances (handoff intact) |
| wheel up, feed at top | — | hands back to the rail |

## Verification

- All three OG routes generated and inspected at 1200×630
- Feed visibility confirmed at 390×844 (hidden), 1440×780 (hidden), 1512×970 (shown)
- `bun run check` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Live feed panels now support vertical scrolling with improved overscroll behavior.
  - Generated social preview images now use custom typography with graceful fallback support.

- **Style**
  - Refined social preview layouts, spacing, title weights, letter spacing, colors, and metadata presentation.
  - Updated stack previews with sharper-corner technology tags and refreshed header styling.
  - Improved documentation and site preview typography for a more consistent visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->