### PR TITLE
fix(web): use native scrolling, and only show the live feed when it fits

### DIFF
--- a/apps/web/src/app/(home)/_components/rail/panes/live-feed.tsx
+++ b/apps/web/src/app/(home)/_components/rail/panes/live-feed.tsx
@@ -9,6 +9,7 @@ import { GroupHeader } from "../chrome";
 // 50 is the server-side cap in getRecentEvents. At ~227 projects/day
 // (~9.5/hour) that still covers a busy hour for the last-hour count.
 const FEED_LIMIT = 50;
+const VISIBLE_ROWS = 6;
 const ONE_HOUR_MS = 60 * 60 * 1000;
 
 /** Relative, so the row never depends on the reader's timezone. */
@@ -91,9 +92,7 @@ export default function LiveFeed() {
     inLastHour !== null && inLastHour === events?.length && inLastHour === FEED_LIMIT;
 
   return (
-    /* Below ~820px tall the group header alone costs more room than the pane
-       has spare, so the feed drops out entirely rather than forcing a scrollbar. */
-    <div className="flex min-h-0 flex-1 flex-col max-md:hidden [@media(max-height:820px)]:hidden">
+    <div className="flex flex-col max-md:hidden [@media(max-height:1080px)]:hidden">
       <GroupHeader
         label="live"
         count={
@@ -109,12 +108,8 @@ export default function LiveFeed() {
         }
       />
 
-      <ol
-        aria-label="Recent project starts"
-        data-pane-scroll
-        className="fd-scroll-container min-h-0 flex-1 overflow-y-auto overscroll-y-contain font-mono text-[11px] leading-[1.7]"
-      >
-        {events?.map((event) => (
+      <ol aria-label="Recent project starts" className="font-mono text-[11px] leading-[1.7]">
+        {events?.slice(0, VISIBLE_ROWS).map((event) => (
           <li key={event._id} className="flex items-baseline gap-3 py-px">
             <span className="w-[7ch] shrink-0 text-right text-fd-muted-foreground/60 tabular-nums">
               {now === null ? "" : ago(event._creationTime, now)}

--- a/apps/web/src/app/(home)/_components/rail/use-rail-nav.ts
+++ b/apps/web/src/app/(home)/_components/rail/use-rail-nav.ts
@@ -9,34 +9,6 @@ const DESKTOP_QUERY = "(min-width: 768px)";
 // pane's top edge has to cross before that pane counts as the active one.
 const MOBILE_PROBE_PX = 56 + 32;
 
-/**
- * True when the wheel event originated inside a pane body that can still scroll
- * in the requested direction, meaning the rail must not hijack it.
- * Pure and exported so the seven edge cases can be unit tested directly.
- */
-/** The pane body the event started in, or null if it started outside one. */
-export function findPaneScroller(path: EventTarget[], rail: HTMLElement): HTMLElement | null {
-  for (const target of path) {
-    if (target === rail) return null;
-    const el = target as HTMLElement;
-    if (typeof el.hasAttribute !== "function") continue;
-    if (el.hasAttribute("data-pane-scroll")) return el;
-  }
-  return null;
-}
-
-export function canScrollVertically(path: EventTarget[], dy: number, rail: HTMLElement): boolean {
-  const el = findPaneScroller(path, rail);
-  if (!el) return false;
-  return dy < 0 ? el.scrollTop > 0 : el.scrollTop < el.scrollHeight - el.clientHeight - 1;
-}
-
-function normalize(delta: number, mode: number, pageSize: number): number {
-  if (mode === 1) return delta * 16;
-  if (mode === 2) return delta * pageSize;
-  return delta;
-}
-
 export function useRailNav(railRef: RefObject<HTMLDivElement | null>) {
   const [activeIndex, setActiveIndex] = useState(0);
   const [atStart, setAtStart] = useState(true);
@@ -182,44 +154,6 @@ export function useRailNav(railRef: RefObject<HTMLDivElement | null>) {
       if (frame) cancelAnimationFrame(frame);
     };
   }, []);
-
-  useEffect(() => {
-    const rail = railRef.current;
-    if (!rail) return;
-
-    const options: AddEventListenerOptions = { passive: false };
-    // Axis lock. Without it a trackpad gesture, which is never purely on one
-    // axis, scrolls a pane vertically and drifts the rail horizontally at once.
-    const onWheel = (event: WheelEvent) => {
-      if (!window.matchMedia(DESKTOP_QUERY).matches) return;
-
-      const path = event.composedPath();
-      const vertical = Math.abs(event.deltaY) >= Math.abs(event.deltaX);
-      const dy = normalize(event.deltaY, event.deltaMode, rail.clientHeight);
-      const dx = normalize(event.deltaX, event.deltaMode, rail.clientWidth);
-
-      if (!vertical) {
-        event.preventDefault();
-        rail.scrollLeft += dx;
-        return;
-      }
-
-      const pane = findPaneScroller(path, rail);
-      const paneCanTake =
-        pane &&
-        (dy < 0 ? pane.scrollTop > 0 : pane.scrollTop < pane.scrollHeight - pane.clientHeight - 1);
-
-      event.preventDefault();
-      if (paneCanTake) {
-        pane.scrollTop += dy;
-      } else {
-        rail.scrollLeft += dy;
-      }
-    };
-
-    rail.addEventListener("wheel", onWheel, options);
-    return () => rail.removeEventListener("wheel", onWheel, options);
-  }, [railRef]);
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {


### PR DESCRIPTION
## Native scrolling

The rail intercepted every vertical wheel event on desktop and translated it into horizontal movement. That's gone. Vertical wheel and trackpad gestures now do whatever the browser does.

Deleted `canScrollVertically`, `findPaneScroller`, the `deltaMode` normalisation, and the `{ passive: false }` wheel listener — `use-rail-nav.ts` drops 66 lines and is now just measuring, the scroll spy, keyboard nav, and hash reading.

The rail moves on horizontal intent only: native trackpad swipe, shift+wheel, the status bar window list, or `h`/`l` and `1`–`4`.

**Tradeoff worth knowing:** a plain mouse wheel only emits `deltaY`, so mouse users can no longer move the rail by scrolling and need shift+wheel or the status bar. That's the behaviour the hijack existed to avoid. If it strands people, the narrower fix is to bridge the wheel *only* when the pointer is over a pane that cannot scroll vertically.

## Live feed

A feed showing one and a half rows behind a scrollbar read as broken rather than live. It now renders a fixed **6 rows with no inner scroller**, and hides entirely below 1080px tall — the height at which 6 rows would push the init pane into a scrollbar.

| viewport height | feed | init pane overflow |
|---|---|---|
| 830 / 970 / 1050 | hidden | 0 |
| 1081 / 1200 / 1440 | 6 rows | 0 |

Still fetches 50 events, since the "N in the last hour" count needs the full window; it just renders 6.

This supersedes the inner-scroll fix from #1139 — with no scroller, `overflow-y-auto` and `data-pane-scroll` come off the list. `data-pane-scroll` stays on pane bodies, where `media.tsx` uses it as the `IntersectionObserver` root.

## Verification

- Vertical wheel: `defaultPrevented: false`, rail does not move
- Native horizontal scrolling and keyboard nav still work
- Feed thresholds measured at the six heights above
- `bun run check` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Limited the live feed to six events for a more focused view.
  * Hidden the live feed pane on shorter desktop screens to improve layout usability.
  * Simplified event list scrolling and removed custom rail scroll behavior for a more consistent browsing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->