### PR TITLE
feat(web): surface the mcp server on the homepage

### DIFF
--- a/apps/web/src/app/(home)/_components/rail/panes/install-pane.tsx
+++ b/apps/web/src/app/(home)/_components/rail/panes/install-pane.tsx
@@ -92,7 +92,7 @@ export default function InstallPane() {
             href="/docs/cli/agent-workflows#mcp"
             className="builder-focus-ring font-mono text-[13px] text-fd-muted-foreground transition-colors duration-150 hover:text-primary"
           >
-            or run it as an mcp server -&gt;
+            or run it as an MCP server -&gt;
           </Link>
         </div>
       </div>

--- a/apps/web/src/app/(home)/_components/rail/panes/install-pane.tsx
+++ b/apps/web/src/app/(home)/_components/rail/panes/install-pane.tsx
@@ -81,12 +81,20 @@ export default function InstallPane() {
         <p className="mb-3 font-mono text-[13px] text-fd-muted-foreground leading-[1.55]">
           Configure every option in the browser, then copy the generated command.
         </p>
-        <Link
-          href="/new"
-          className="builder-focus-ring font-mono text-[13px] text-primary transition-colors duration-150 hover:text-primary/70"
-        >
-          open builder -&gt;
-        </Link>
+        <div className="flex flex-wrap items-baseline gap-x-6 gap-y-1">
+          <Link
+            href="/new"
+            className="builder-focus-ring font-mono text-[13px] text-primary transition-colors duration-150 hover:text-primary/70"
+          >
+            open builder -&gt;
+          </Link>
+          <Link
+            href="/docs/cli/agent-workflows"
+            className="builder-focus-ring font-mono text-[13px] text-fd-muted-foreground transition-colors duration-150 hover:text-primary"
+          >
+            or run it as an mcp server -&gt;
+          </Link>
+        </div>
       </div>
     </>
   );

--- a/apps/web/src/app/(home)/_components/rail/panes/install-pane.tsx
+++ b/apps/web/src/app/(home)/_components/rail/panes/install-pane.tsx
@@ -89,7 +89,7 @@ export default function InstallPane() {
             open builder -&gt;
           </Link>
           <Link
-            href="/docs/cli/agent-workflows"
+            href="/docs/cli/agent-workflows#mcp"
             className="builder-focus-ring font-mono text-[13px] text-fd-muted-foreground transition-colors duration-150 hover:text-primary"
           >
             or run it as an mcp server -&gt;


### PR DESCRIPTION
Running the CLI as a local MCP server (`npx create-better-t-stack@latest mcp`, exposing six `bts_*` tools) is a third entry point alongside the install command and the stack builder, but it only existed in `docs/cli/agent-workflows`. For anyone driving Claude Code or Cursor it's the *preferred* way in, and most scaffolding CLIs don't have one.

Added as a second link on the existing stack-builder row:

```
open builder ->    or run it as an mcp server ->
```

## Why a link on that row rather than its own group or pane

Pane 01 has **zero spare height at every viewport** — measured `clientHeight - scrollHeight = 0` at 900, 1080 and 1200px. It fits because the ASCII banner is height-aware and silently shrinks to absorb whatever is added. So anything new in that pane comes directly out of the banner, and raises the viewport threshold the live feed needs.

Putting it on a row that already exists costs nothing: banner stays 183px and pane overflow stays 0 at 900 / 1080 / 1200.

Left the `mcp` **addon** (adding MCP servers to a generated project) out of this deliberately — different feature, confusingly similar name, and mixing them muddles the pitch.

## Verification

- Same row at 632px pane width, wraps via `flex-wrap` if it ever doesn't fit
- Banner unchanged, pane overflow 0 at 900 / 1080 / 1200
- `bun run check` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a link to CLI agent workflows documentation for running the tool as an MCP server.
  * Improved the layout of links in the installation pane.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->