### PR TITLE
Update the description for Ultracite to be more accurate

### DIFF
--- a/apps/web/src/lib/constant.ts
+++ b/apps/web/src/lib/constant.ts
@@ -624,7 +624,7 @@ export const TECH_OPTIONS: Record<
     {
       id: "ultracite",
       name: "Ultracite",
-      description: "Biome preset with AI integration",
+      description: "A zero-config preset for ESLint, Biome, and Oxlint that helps AI write better code",
       icon: `${ICON_BASE_URL}/ultracite.svg`,
       color: "from-blue-500 to-blue-700",
       className: "invert-0 dark:invert",


### PR DESCRIPTION
The current description makes it seem like Ultracite is for Biome only:

<img width="1088" height="284" alt="2026-08-10_Dia_18-48-39@2x" src="https://github.com/user-attachments/assets/57d763ab-c141-458a-97ab-d5d233b02527" />

<img width="1274" height="798" alt="2026-08-10_Dia_18-53-14@2x" src="https://github.com/user-attachments/assets/b2fbb6ae-a791-4963-8c58-623a30b55977" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Ultracite addon description to highlight its ESLint, Biome, and Oxlint presets, along with AI-assisted coding capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->