### PR TITLE
fix(analytics): count empty selections as none

### DIFF
--- a/apps/cli/test/analytics.test.ts
+++ b/apps/cli/test/analytics.test.ts
@@ -54,4 +54,17 @@ describe("buildAnalyticsEvent", () => {
       node_version: process.version,
     });
   });
+
+  test("sends none for empty multi-select choices", () => {
+    const event = buildAnalyticsEvent({
+      ...projectConfig,
+      frontend: [],
+      addons: [],
+      examples: [],
+    });
+
+    expect(event.frontend).toEqual(["none"]);
+    expect(event.addons).toEqual(["none"]);
+    expect(event.examples).toEqual(["none"]);
+  });
 });

--- a/apps/web/src/app/(home)/analytics/_components/dev-environment-charts.tsx
+++ b/apps/web/src/app/(home)/analytics/_components/dev-environment-charts.tsx
@@ -185,7 +185,7 @@ export function DevToolsSection({ data }: { data: AggregatedAnalyticsData }) {
         {data.examplesDistribution.length > 0 ? (
           <PreferenceChartCard
             title="Examples"
-            description="How often each example was included."
+            description="Selected examples and projects created without an example."
             data={data.examplesDistribution}
             colorKey="chart4"
             layout="vertical"
@@ -196,7 +196,7 @@ export function DevToolsSection({ data }: { data: AggregatedAnalyticsData }) {
       {data.addonsDistribution.length > 0 ? (
         <PreferenceChartCard
           title="Addons"
-          description="How often each addon was selected."
+          description="Selected addons and projects created without addons."
           data={data.addonsDistribution}
           colorKey="chart1"
           columnCount={2}

--- a/apps/web/src/app/(home)/analytics/_components/stack-configuration-charts.tsx
+++ b/apps/web/src/app/(home)/analytics/_components/stack-configuration-charts.tsx
@@ -39,7 +39,7 @@ export function StackSection({ data }: { data: AggregatedAnalyticsData }) {
       <div className="grid gap-4 xl:grid-cols-2">
         <PreferenceChartCard
           title="Frontend"
-          description="How often each frontend was selected."
+          description="Selected frontends and projects created without a frontend."
           data={data.frontendDistribution}
           colorKey="chart1"
         />

--- a/packages/backend/convex/analytics.ts
+++ b/packages/backend/convex/analytics.ts
@@ -1,9 +1,9 @@
-import { AnalyticsEventSchema } from "@better-t-stack/types";
+import { AnalyticsEventSchema, normalizeAnalyticsSelection } from "@better-t-stack/types";
 import { paginationOptsValidator } from "convex/server";
 import { v } from "convex/values";
 
 import { internal } from "./_generated/api";
-import { internalAction, internalMutation, query } from "./_generated/server";
+import { internalAction, internalMutation, internalQuery, query } from "./_generated/server";
 import { buildDailyWindow } from "./analytics_date_utils";
 import {
   adjustAnalyticsStats,
@@ -13,6 +13,12 @@ import {
 
 const MAX_DAILY_STATS_WINDOW = 366;
 const ANALYTICS_REPAIR_BATCH_SIZE = 512;
+
+function incrementDistribution(distribution: Record<string, number>, keys: string[]): void {
+  for (const key of keys) {
+    distribution[key] = (distribution[key] || 0) + 1;
+  }
+}
 
 function normalizeStats(stats: {
   totalProjects: number;
@@ -291,6 +297,133 @@ export const getRecentEvents = query({
       .withIndex("by_quarantined", (q) => q.eq("quarantinedAt", undefined))
       .order("desc")
       .take(limit);
+  },
+});
+
+export const getSelectionDistributionsBatch = internalQuery({
+  args: {
+    paginationOpts: paginationOptsValidator,
+  },
+  returns: v.object({
+    continueCursor: v.string(),
+    isDone: v.boolean(),
+    scanned: v.number(),
+    frontend: distributionValidator,
+    addons: distributionValidator,
+    examples: distributionValidator,
+  }),
+  handler: async (ctx, args) => {
+    const page = await ctx.db
+      .query("analyticsEvents")
+      .withIndex("by_quarantined", (q) => q.eq("quarantinedAt", undefined))
+      .order("asc")
+      .paginate(args.paginationOpts);
+    const frontend: Record<string, number> = {};
+    const addons: Record<string, number> = {};
+    const examples: Record<string, number> = {};
+
+    for (const event of page.page) {
+      incrementDistribution(frontend, normalizeAnalyticsSelection(event.frontend));
+      incrementDistribution(addons, normalizeAnalyticsSelection(event.addons));
+      incrementDistribution(examples, normalizeAnalyticsSelection(event.examples));
+    }
+
+    return {
+      continueCursor: page.continueCursor,
+      isDone: page.isDone,
+      scanned: page.page.length,
+      frontend,
+      addons,
+      examples,
+    };
+  },
+});
+
+export const replaceSelectionDistributions = internalMutation({
+  args: {
+    expectedTotal: v.number(),
+    frontend: distributionValidator,
+    addons: distributionValidator,
+    examples: distributionValidator,
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const stats = await ctx.db.query("analyticsStats").first();
+    if (!stats) {
+      throw new Error("Cannot rebuild missing analytics stats");
+    }
+    if (stats.totalProjects !== args.expectedTotal) {
+      throw new Error(
+        `Expected ${args.expectedTotal} active events, stats contain ${stats.totalProjects}`,
+      );
+    }
+
+    await ctx.db.patch(stats._id, {
+      frontend: args.frontend,
+      addons: args.addons,
+      examples: args.examples,
+    });
+    return null;
+  },
+});
+
+export const rebuildSelectionDistributions = internalAction({
+  args: {
+    dryRun: v.boolean(),
+  },
+  returns: v.object({
+    scanned: v.number(),
+    frontend: distributionValidator,
+    addons: distributionValidator,
+    examples: distributionValidator,
+  }),
+  handler: async (ctx, args) => {
+    let cursor: string | null = null;
+    let scanned = 0;
+    const frontend: Record<string, number> = {};
+    const addons: Record<string, number> = {};
+    const examples: Record<string, number> = {};
+
+    while (true) {
+      const result: {
+        continueCursor: string;
+        isDone: boolean;
+        scanned: number;
+        frontend: Record<string, number>;
+        addons: Record<string, number>;
+        examples: Record<string, number>;
+      } = await ctx.runQuery(internal.analytics.getSelectionDistributionsBatch, {
+        paginationOpts: {
+          numItems: ANALYTICS_REPAIR_BATCH_SIZE,
+          cursor,
+        },
+      });
+
+      scanned += result.scanned;
+      for (const [key, count] of Object.entries(result.frontend)) {
+        frontend[key] = (frontend[key] || 0) + count;
+      }
+      for (const [key, count] of Object.entries(result.addons)) {
+        addons[key] = (addons[key] || 0) + count;
+      }
+      for (const [key, count] of Object.entries(result.examples)) {
+        examples[key] = (examples[key] || 0) + count;
+      }
+
+      if (result.isDone) break;
+      cursor = result.continueCursor;
+    }
+
+    if (!args.dryRun) {
+      await ctx.runMutation(internal.analytics.replaceSelectionDistributions, {
+        expectedTotal: scanned,
+        frontend,
+        addons,
+        examples,
+      });
+    }
+
+    return { scanned, frontend, addons, examples };
   },
 });
 

--- a/packages/backend/convex/analytics_helpers.ts
+++ b/packages/backend/convex/analytics_helpers.ts
@@ -1,4 +1,8 @@
-import { normalizeAnalyticsCLIVersion, normalizeAnalyticsNodeVersion } from "@better-t-stack/types";
+import {
+  normalizeAnalyticsCLIVersion,
+  normalizeAnalyticsNodeVersion,
+  normalizeAnalyticsSelection,
+} from "@better-t-stack/types";
 
 export type AnalyticsStatsFields = {
   totalProjects: number;
@@ -165,7 +169,10 @@ export function adjustAnalyticsStats(
 
   for (const { event, creationTime } of events) {
     const hourKey = String(new Date(creationTime).getUTCHours()).padStart(2, "0");
-    const frontend = event.frontend?.[0] || "none";
+    const frontendSelections = normalizeAnalyticsSelection(event.frontend);
+    const addonSelections = normalizeAnalyticsSelection(event.addons);
+    const exampleSelections = normalizeAnalyticsSelection(event.examples);
+    const frontend = frontendSelections[0] || "none";
     const backend = event.backend || "none";
     const database = event.database || "none";
     const orm = event.orm || "none";
@@ -176,7 +183,7 @@ export function adjustAnalyticsStats(
     }
 
     adjustKey(next, "backend", event.backend, delta);
-    adjustKeys(next, "frontend", event.frontend, delta);
+    adjustKeys(next, "frontend", frontendSelections, delta);
     adjustKey(next, "database", event.database, delta);
     adjustKey(next, "orm", event.orm, delta);
     adjustKey(next, "api", event.api, delta);
@@ -184,8 +191,8 @@ export function adjustAnalyticsStats(
     adjustKey(next, "runtime", event.runtime, delta);
     adjustKey(next, "packageManager", event.packageManager, delta);
     adjustKey(next, "platform", event.platform, delta);
-    adjustKeys(next, "addons", event.addons, delta);
-    adjustKeys(next, "examples", event.examples, delta);
+    adjustKeys(next, "addons", addonSelections, delta);
+    adjustKeys(next, "examples", exampleSelections, delta);
     adjustKey(next, "dbSetup", event.dbSetup, delta);
     adjustKey(next, "webDeploy", event.webDeploy, delta);
     adjustKey(next, "serverDeploy", event.serverDeploy, delta);

--- a/packages/backend/test/analytics-helpers.test.ts
+++ b/packages/backend/test/analytics-helpers.test.ts
@@ -38,6 +38,29 @@ const poisonedEvent: AnalyticsEventFields = {
 };
 
 describe("adjustAnalyticsStats", () => {
+  test("counts empty and missing selections as none", () => {
+    const stats = adjustAnalyticsStats(
+      createEmptyAnalyticsStats(),
+      [
+        {
+          event: {
+            ...legitimateEvent,
+            frontend: [],
+            addons: [],
+            examples: undefined,
+          },
+          creationTime: Date.UTC(2026, 7, 10, 4),
+        },
+      ],
+      1,
+    );
+
+    expect(stats.frontend).toEqual({ none: 1 });
+    expect(stats.addons).toEqual({ none: 1 });
+    expect(stats.examples).toEqual({ none: 1 });
+    expect(stats.stackCombinations).toEqual({ "hono + none": 1 });
+  });
+
   test("normalizes version keys during ingestion", () => {
     const stats = adjustAnalyticsStats(
       createEmptyAnalyticsStats(),

--- a/packages/types/src/analytics.ts
+++ b/packages/types/src/analytics.ts
@@ -69,23 +69,30 @@ function hasNoMixedNone(values: string[]): boolean {
   return values.length <= 1 || !values.includes("none");
 }
 
+export function normalizeAnalyticsSelection<T extends string>(values: T[] | undefined): T[] {
+  return values && values.length > 0 ? values : (["none"] as T[]);
+}
+
 const AnalyticsFrontendListSchema = z
   .array(FrontendSchema)
   .max(FRONTEND_VALUES.length)
   .refine(hasUniqueValues)
-  .refine(hasNoMixedNone);
+  .refine(hasNoMixedNone)
+  .transform(normalizeAnalyticsSelection);
 
 const AnalyticsAddonListSchema = z
   .array(AnalyticsAddonSchema)
   .max(ANALYTICS_ADDON_VALUES.length)
   .refine(hasUniqueValues)
-  .refine(hasNoMixedNone);
+  .refine(hasNoMixedNone)
+  .transform(normalizeAnalyticsSelection);
 
 const AnalyticsExampleListSchema = z
   .array(ExamplesSchema)
   .max(EXAMPLES_VALUES.length)
   .refine(hasUniqueValues)
-  .refine(hasNoMixedNone);
+  .refine(hasNoMixedNone)
+  .transform(normalizeAnalyticsSelection);
 
 export function normalizeAnalyticsCLIVersion(version: string): string {
   const match = /^(\d+)\.(\d+)\.(\d+)/.exec(version);

--- a/packages/types/test/analytics.test.ts
+++ b/packages/types/test/analytics.test.ts
@@ -113,4 +113,17 @@ describe("AnalyticsEventSchema", () => {
     expect(normalizeAnalyticsCLIVersion("3.38.2-canary.1")).toBe("3.38.2");
     expect(normalizeAnalyticsNodeVersion("v24.5.0")).toBe("v24");
   });
+
+  test("normalizes empty multi-select choices to none", () => {
+    const parsed = AnalyticsEventSchema.parse({
+      ...validEvent,
+      frontend: [],
+      addons: [],
+      examples: [],
+    });
+
+    expect(parsed.frontend).toEqual(["none"]);
+    expect(parsed.addons).toEqual(["none"]);
+    expect(parsed.examples).toEqual(["none"]);
+  });
 });


### PR DESCRIPTION
## Summary

- normalize empty frontend, addon, and example selections to the canonical `none` option at the shared schema and aggregate boundaries
- add a guarded, paginated internal Convex repair action for the three affected distributions
- clarify chart descriptions so `none` is visibly defined as “created without” that option

## Root cause and data audit

The CLI historically sent `[]` when no multi-select option was chosen, while the aggregate logic counted only array members. That made “none” nearly disappear from the charts even though raw events were valid.

I audited all 56,004 active production events against every aggregate. Only the three multi-select distributions were inconsistent:

- frontend `none`: 2,174
- addons `none`: 2,938
- examples `none`: 42,165

All other option distributions and control totals matched the raw events.

## Production repair

- exported a fresh production backup before mutation
- ran the repair in dry-run mode first
- rebuilt only `frontend`, `addons`, and `examples` aggregate maps
- did not modify or delete raw analytics events
- reconciled every aggregate control total to 56,004 afterward

The replacement mutation is guarded by the scanned active-event total so it cannot install a stale partial result if ingestion changes during the paginated scan.

## Verification

- `bun run check`
- `bun run build:web`
- Convex codegen and TypeScript validation
- analytics type, backend-helper, and CLI unit tests
- full CLI suite: 574 passed, 13 skipped, 0 failed
- live production chart/data verification after the aggregate rebuild

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Analytics**
  * Improved reporting for projects created without a selected frontend, addon, or example.
  * Analytics charts now clearly include projects with no corresponding selection.
  * Empty or missing selections are consistently grouped as “none.”

* **Bug Fixes**
  * Corrected analytics aggregation and distribution rebuilding for unselected configuration options.

* **Tests**
  * Added coverage for empty and missing selections across analytics tracking and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->