### PR TITLE
chore(lint): add anti-slop rules

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "jsPlugins": [
+    {
+      "name": "anti-slop",
+      "specifier": "./tools/oxlint/anti-slop/index.ts"
+    }
+  ],
+  "rules": {
+    "anti-slop/no-chained-type-assertions": "error",
+    "anti-slop/no-conditional-empty-object-spread": "error",
+    "anti-slop/no-known-value-widening": "error",
+    "anti-slop/no-object-parameters": "error",
+    "anti-slop/no-runtime-typeof": "error",
+    "anti-slop/no-shape-in-symbol-names": "error",
+    "anti-slop/no-unknown-parameters": "error",
+    "anti-slop/no-unknown-type-aliases": "error",
+    "anti-slop/no-unsafe-dictionary-type": "error",
+    "anti-slop/no-widen-then-assert": "error"
+  }
+}

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -83,7 +83,7 @@
     "gradient-string": "^3.0.0",
     "handlebars": "^4.7.9",
     "jsonc-parser": "^3.3.1",
-    "oxfmt": "^0.61.0",
+    "oxfmt": "^0.63.0",
     "picocolors": "^1.1.1",
     "semver": "catalog:",
     "tinyglobby": "^0.2.17",

--- a/apps/cli/src/helpers/addons/skills-setup.ts
+++ b/apps/cli/src/helpers/addons/skills-setup.ts
@@ -331,7 +331,7 @@ function getRecommendedSourceKeys(config: ProjectConfig): SourceKey[] {
   return sources;
 }
 
-const CURATED_SKILLS_BY_SOURCE: Record<SourceKey, (config: ProjectConfig) => string[]> = {
+const CURATED_SKILLS_BY_SOURCE = {
   "vercel-labs/agent-skills": (config) => {
     const skills: string[] = [];
     if (hasReactBasedFrontend(config.frontend)) {
@@ -435,7 +435,7 @@ const CURATED_SKILLS_BY_SOURCE: Record<SourceKey, (config: ProjectConfig) => str
     "build-audit-logs",
     ...(supportsEvlogLocalLogs(config) ? ["analyze-logs"] : []),
   ],
-};
+} satisfies Record<SourceKey, (config: ProjectConfig) => string[]>;
 
 function getCuratedSkillNamesForSourceKey(sourceKey: SourceKey, config: ProjectConfig): string[] {
   return CURATED_SKILLS_BY_SOURCE[sourceKey](config);

--- a/apps/cli/src/helpers/addons/ultracite-setup.ts
+++ b/apps/cli/src/helpers/addons/ultracite-setup.ts
@@ -154,24 +154,24 @@ const DEFAULT_HOOKS: UltraciteHook[] = [];
 
 function getFrameworksFromFrontend(frontend: string[]): string[] {
   // Tags mirror ultracite's own package.json detection (react-router -> remix rules)
-  const frameworkMap: Record<string, string[]> = {
-    "tanstack-router": ["react", "tanstack"],
-    "react-router": ["react", "remix"],
-    "tanstack-start": ["react", "tanstack"],
-    next: ["react", "next"],
-    nuxt: ["vue"],
-    "native-bare": ["react"],
-    "native-uniwind": ["react"],
-    "native-unistyles": ["react"],
-    svelte: ["svelte"],
-    solid: ["solid"],
-    astro: ["astro"],
-  };
+  const frameworkMap = new Map<string, string[]>([
+    ["tanstack-router", ["react", "tanstack"]],
+    ["react-router", ["react", "remix"]],
+    ["tanstack-start", ["react", "tanstack"]],
+    ["next", ["react", "next"]],
+    ["nuxt", ["vue"]],
+    ["native-bare", ["react"]],
+    ["native-uniwind", ["react"]],
+    ["native-unistyles", ["react"]],
+    ["svelte", ["svelte"]],
+    ["solid", ["solid"]],
+    ["astro", ["astro"]],
+  ]);
 
   const frameworks = new Set<string>();
 
   for (const f of frontend) {
-    for (const framework of frameworkMap[f] ?? []) {
+    for (const framework of frameworkMap.get(f) ?? []) {
       frameworks.add(framework);
     }
   }

--- a/apps/cli/src/helpers/core/add-handler.ts
+++ b/apps/cli/src/helpers/core/add-handler.ts
@@ -76,29 +76,22 @@ function mergeAddonOptions(
     return undefined;
   }
 
-  const mergedAddonOptions: Partial<AddonOptions> = { ...existingAddonOptions };
+  const mergeOption = <T extends object>(existing: T | undefined, next: T | undefined) => {
+    if (!existing) return next;
+    if (!next) return existing;
+    return { ...existing, ...next };
+  };
 
-  if (nextAddonOptions) {
-    for (const addonKey of Object.keys(nextAddonOptions) as (keyof AddonOptions)[]) {
-      const existingOptionsForAddon = existingAddonOptions?.[addonKey];
-      const nextOptionsForAddon = nextAddonOptions[addonKey];
-      const mergedOptionsForAddon =
-        existingOptionsForAddon && nextOptionsForAddon
-          ? { ...existingOptionsForAddon, ...nextOptionsForAddon }
-          : nextOptionsForAddon;
+  const mergedAddonOptions: AddonOptions = {
+    wxt: mergeOption(existingAddonOptions?.wxt, nextAddonOptions?.wxt),
+    fumadocs: mergeOption(existingAddonOptions?.fumadocs, nextAddonOptions?.fumadocs),
+    opentui: mergeOption(existingAddonOptions?.opentui, nextAddonOptions?.opentui),
+    mcp: mergeOption(existingAddonOptions?.mcp, nextAddonOptions?.mcp),
+    skills: mergeOption(existingAddonOptions?.skills, nextAddonOptions?.skills),
+    ultracite: mergeOption(existingAddonOptions?.ultracite, nextAddonOptions?.ultracite),
+  };
 
-      (
-        mergedAddonOptions as Record<
-          keyof AddonOptions,
-          AddonOptions[keyof AddonOptions] | undefined
-        >
-      )[addonKey] = mergedOptionsForAddon as AddonOptions[keyof AddonOptions];
-    }
-  }
-
-  return Object.keys(mergedAddonOptions).length > 0
-    ? (mergedAddonOptions as AddonOptions)
-    : undefined;
+  return Object.values(mergedAddonOptions).some(Boolean) ? mergedAddonOptions : undefined;
 }
 
 function getSetupAddons(addonsToAdd: Addons[], updatedAddons: Addons[]): Addons[] {
@@ -259,11 +252,11 @@ async function addHandlerInternal(
     // Interactive mode - prompt user to select addons
     const promptResult = await Result.tryPromise({
       try: () => getAddonsToAdd(existingConfig),
-      catch: (e: unknown) => {
-        if (UserCancelledError.is(e)) return e;
+      catch: (cause: unknown) => {
+        if (UserCancelledError.is(cause)) return cause;
         return new CLIError({
-          message: e instanceof Error ? e.message : String(e),
-          cause: e,
+          message: cause instanceof Error ? cause.message : String(cause),
+          cause: cause,
         });
       },
     });
@@ -440,11 +433,11 @@ async function addHandlerInternal(
         ...config,
         addons: getSetupAddons(addonsToAdd, updatedAddons),
       }),
-    catch: (e: unknown) => {
-      if (UserCancelledError.is(e)) return e;
+    catch: (cause: unknown) => {
+      if (UserCancelledError.is(cause)) return cause;
       return new CLIError({
-        message: e instanceof Error ? e.message : String(e),
-        cause: e,
+        message: cause instanceof Error ? cause.message : String(cause),
+        cause: cause,
       });
     },
   });

--- a/apps/cli/src/helpers/core/command-handlers.ts
+++ b/apps/cli/src/helpers/core/command-handlers.ts
@@ -211,11 +211,11 @@ async function createProjectHandlerInternal(
       const projectNameResult = yield* Result.await(
         Result.tryPromise({
           try: async () => getProjectName(input.projectName),
-          catch: (e: unknown) => {
-            if (e instanceof UserCancelledError) return e;
+          catch: (cause: unknown) => {
+            if (cause instanceof UserCancelledError) return cause;
             return new CLIError({
-              message: e instanceof Error ? e.message : String(e),
-              cause: e,
+              message: cause instanceof Error ? cause.message : String(cause),
+              cause: cause,
             });
           },
         }),
@@ -259,12 +259,9 @@ async function createProjectHandlerInternal(
             `${pc.dim("Template")} ${pc.bold(pc.cyan(templateName))}\n${pc.dim(templateDescription)}`,
           );
         }
-        const userOverrides: Record<string, unknown> = {};
-        for (const [key, value] of Object.entries(originalInput)) {
-          if (value !== undefined) {
-            userOverrides[key] = value;
-          }
-        }
+        const userOverrides = Object.fromEntries(
+          Object.entries(originalInput).filter(([, value]) => value !== undefined),
+        );
         cliInput = {
           ...templateConfig,
           ...userOverrides,
@@ -328,11 +325,11 @@ async function createProjectHandlerInternal(
             gatherConfig(flagConfig, finalBaseName, finalResolvedPath, finalPathInput, {
               skipCompatibilityChecks: cliInput.yolo,
             }),
-          catch: (e: unknown) => {
-            if (e instanceof UserCancelledError) return e;
+          catch: (cause: unknown) => {
+            if (cause instanceof UserCancelledError) return cause;
             return new CLIError({
-              message: e instanceof Error ? e.message : String(e),
-              cause: e,
+              message: cause instanceof Error ? cause.message : String(cause),
+              cause: cause,
             });
           },
         }),
@@ -377,11 +374,11 @@ async function createProjectHandlerInternal(
       yield* Result.await(
         Result.tryPromise({
           try: async () => setupProjectDirectory(finalPathInput, shouldClearDirectory),
-          catch: (e: unknown) => {
-            if (e instanceof UserCancelledError) return e;
+          catch: (cause: unknown) => {
+            if (cause instanceof UserCancelledError) return cause;
             return new CLIError({
-              message: e instanceof Error ? e.message : String(e),
-              cause: e,
+              message: cause instanceof Error ? cause.message : String(cause),
+              cause: cause,
             });
           },
         }),
@@ -532,12 +529,12 @@ async function handleDirectoryConflictResult(
   // Use interactive handler
   return Result.tryPromise({
     try: async () => handleDirectoryConflict(currentPathInput),
-    catch: (e: unknown) => {
-      if (e instanceof UserCancelledError) return e;
-      if (e instanceof CLIError) return e;
+    catch: (cause: unknown) => {
+      if (cause instanceof UserCancelledError) return cause;
+      if (cause instanceof CLIError) return cause;
       return new CLIError({
-        message: e instanceof Error ? e.message : String(e),
-        cause: e,
+        message: cause instanceof Error ? cause.message : String(cause),
+        cause: cause,
       });
     },
   });

--- a/apps/cli/src/helpers/core/db-setup-options.ts
+++ b/apps/cli/src/helpers/core/db-setup-options.ts
@@ -64,6 +64,6 @@ export function mergeResolvedDbSetupOptions(
 
   return {
     ...dbSetupOptions,
-    ...(resolvedMode ? { mode: resolvedMode } : {}),
+    mode: resolvedMode,
   };
 }

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -23,7 +23,6 @@ import {
   type Backend,
   BackendSchema,
   type BetterTStackConfig,
-  type CLIInput,
   type CreateInput,
   CreateInputSchema,
   type Database,
@@ -62,7 +61,7 @@ import {
   UserCancelledError,
 } from "./utils/errors";
 import { getLatestCLIVersion } from "./utils/get-latest-cli-version";
-import { validateConfigCompatibility } from "./validation";
+import { validateResolvedConfigCompatibility } from "./validation";
 
 export const SchemaNameSchema = z
   .enum([
@@ -114,7 +113,7 @@ function getCliSchemaJson(): unknown {
   }).toJSON();
 }
 
-export function getSchemaResult(name: SchemaName): unknown {
+export function getSchemaResult(name: SchemaName) {
   const schemas = getAllJsonSchemas();
   if (name === "all") {
     return {
@@ -347,10 +346,7 @@ export async function create(
   projectName?: string,
   options?: Partial<CreateInput>,
 ): Promise<Result<InitResult, CreateError>> {
-  const rawInput =
-    options === undefined || (typeof options === "object" && options !== null)
-      ? { ...options, projectName }
-      : options;
+  const rawInput = { ...options, projectName };
   const parsedInput = CreateInputSchema.safeParse(rawInput);
 
   if (!parsedInput.success) {
@@ -378,14 +374,14 @@ export async function create(
       }
       return result.value as InitResult;
     },
-    catch: (e: unknown) => {
-      if (UserCancelledError.is(e)) return e;
-      if (CLIError.is(e)) return e;
-      if (DirectoryConflictError.is(e)) return e;
-      if (ProjectCreationError.is(e)) return e;
+    catch: (cause: unknown) => {
+      if (UserCancelledError.is(cause)) return cause;
+      if (CLIError.is(cause)) return cause;
+      if (DirectoryConflictError.is(cause)) return cause;
+      if (ProjectCreationError.is(cause)) return cause;
       return new CLIError({
-        message: e instanceof Error ? e.message : String(e),
-        cause: e,
+        message: cause instanceof Error ? cause.message : String(cause),
+        cause: cause,
       });
     },
   });
@@ -487,26 +483,7 @@ export async function createVirtual(
     serverDeploy: virtualOptions.serverDeploy || "none",
   };
 
-  const providedFlags = new Set([
-    "database",
-    "orm",
-    "backend",
-    "runtime",
-    "frontend",
-    "addons",
-    "examples",
-    "auth",
-    "dbSetup",
-    "payments",
-    "api",
-    "webDeploy",
-    "serverDeploy",
-  ]);
-  const validationResult = validateConfigCompatibility(
-    config,
-    providedFlags,
-    config as unknown as CLIInput,
-  );
+  const validationResult = validateResolvedConfigCompatibility(config);
   if (validationResult.isErr()) {
     return Result.err(
       new GeneratorError({

--- a/apps/cli/src/mcp.ts
+++ b/apps/cli/src/mcp.ts
@@ -71,7 +71,7 @@ type SchemaToolInput = {
 type McpCreateProjectInput = z.infer<typeof McpCreateProjectInputSchema>;
 type McpAddInput = z.infer<typeof AddInputSchema>;
 
-function formatToolSuccess(data: unknown) {
+function formatToolSuccess<T>(data: T) {
   return {
     content: [
       {
@@ -86,8 +86,8 @@ function formatToolSuccess(data: unknown) {
   };
 }
 
-function formatToolError(error: unknown) {
-  const message = error instanceof Error ? error.message : String(error);
+function formatToolError(cause: unknown) {
+  const message = cause instanceof Error ? cause.message : String(cause);
   return {
     content: [
       {

--- a/apps/cli/src/prompts/addons.ts
+++ b/apps/cli/src/prompts/addons.ts
@@ -18,12 +18,17 @@ type AddonOption = {
   hint: string;
 };
 
+interface AddonDisplay {
+  label: string;
+  hint: string;
+}
+
 type AddonProjectConfig = Pick<
   ProjectConfig,
   "frontend" | "addons" | "auth" | "backend" | "runtime"
 >;
 
-function getAddonDisplay(addon: Addons): { label: string; hint: string } {
+function getAddonDisplay(addon: Addons): AddonDisplay {
   let label: string;
   let hint: string;
 

--- a/apps/cli/src/prompts/navigable-group.ts
+++ b/apps/cli/src/prompts/navigable-group.ts
@@ -105,7 +105,7 @@ export async function navigableGroup<T>(
       }
 
       if (isCancel(result)) {
-        if (typeof opts?.onCancel === "function") {
+        if (opts?.onCancel) {
           results[name] = "canceled";
           opts.onCancel({ results });
         }

--- a/apps/cli/src/prompts/navigable.ts
+++ b/apps/cli/src/prompts/navigable.ts
@@ -101,7 +101,7 @@ function resolvedPrompt(message: string, value: string, state: "submit" | "cance
   return `${symbol(state)}  ${promptMessage} ${pc.dim("›")} ${value}`;
 }
 
-function canceledPrompt(prompt: object, message: string, value: string): string {
+function canceledPrompt<T extends object>(prompt: T, message: string, value: string): string {
   if (promptsNavigatingBack.has(prompt)) {
     return `${pc.cyan(S_STEP_BACK)}  ${pc.dim(message)}`;
   }
@@ -427,7 +427,7 @@ export async function navigableGroupMultiselect<T>(
     options: (GroupMultiSelectOption<T> & { group: string | boolean })[] = [],
   ) => {
     const label = option.label ?? String(option.value);
-    const isItem = typeof option.group === "string";
+    const isItem = option.group !== true && option.group !== false;
     const next = isItem && (options[options.indexOf(option) + 1] ?? { group: true });
     const isLast = isItem && next && next.group === true;
     const prefix = isItem ? `${isLast ? S_BAR_END : S_BAR} ` : "";
@@ -484,7 +484,8 @@ export async function navigableGroupMultiselect<T>(
           (option.group === true && this.isGroupSelected(`${option.value}`));
         const groupActive =
           !active &&
-          typeof option.group === "string" &&
+          option.group !== true &&
+          option.group !== false &&
           this.options[this.cursor]?.value === option.group;
         if (groupActive) {
           return opt(option, selected ? "group-active-selected" : "group-active", this.options);

--- a/apps/cli/src/prompts/project-name.ts
+++ b/apps/cli/src/prompts/project-name.ts
@@ -7,6 +7,7 @@ import pc from "picocolors";
 import { DEFAULT_CONFIG } from "../constants";
 import { ProjectNameSchema } from "../types";
 import { UserCancelledError } from "../utils/errors";
+import { isMissingPathError } from "../utils/fs-error";
 import { cliConsola } from "../utils/terminal-output";
 
 function isPathWithinCwd(targetPath: string) {
@@ -52,12 +53,7 @@ export async function getProjectName(initialName?: string): Promise<string> {
     try {
       stats = await fs.lstat(defaultPath);
     } catch (error) {
-      if (
-        typeof error === "object" &&
-        error !== null &&
-        "code" in error &&
-        error.code === "ENOENT"
-      ) {
+      if (isMissingPathError(error)) {
         break;
       }
       throw error;

--- a/apps/cli/src/prompts/server-deploy.ts
+++ b/apps/cli/src/prompts/server-deploy.ts
@@ -11,10 +11,12 @@ type DeploymentOption = {
   hint: string;
 };
 
-function getDeploymentDisplay(deployment: ServerDeploy): {
+interface DeploymentDisplay {
   label: string;
   hint: string;
-} {
+}
+
+function getDeploymentDisplay(deployment: ServerDeploy): DeploymentDisplay {
   if (deployment === "cloudflare") {
     return {
       label: "Cloudflare",

--- a/apps/cli/src/prompts/web-deploy.ts
+++ b/apps/cli/src/prompts/web-deploy.ts
@@ -27,10 +27,12 @@ type DeploymentOption = {
   hint: string;
 };
 
-function getDeploymentDisplay(deployment: WebDeploy): {
+interface DeploymentDisplay {
   label: string;
   hint: string;
-} {
+}
+
+function getDeploymentDisplay(deployment: WebDeploy): DeploymentDisplay {
   if (deployment === "cloudflare") {
     return {
       label: "Cloudflare",
@@ -88,7 +90,6 @@ export async function getDeploymentChoice(
     dbSetup,
     database,
     orm,
-    addons,
   }).isOk();
   const availableDeployments = [
     ...(supportsCloudflare ? (["cloudflare"] as const) : []),

--- a/apps/cli/src/utils/analytics.ts
+++ b/apps/cli/src/utils/analytics.ts
@@ -6,7 +6,7 @@ import { isTelemetryEnabled } from "./telemetry";
 
 const CONVEX_INGEST_URL = process.env.CONVEX_INGEST_URL;
 
-async function sendConvexEvent(payload: Record<string, unknown>): Promise<void> {
+async function sendConvexEvent(payload: AnalyticsEvent): Promise<void> {
   if (!CONVEX_INGEST_URL) return;
 
   await Result.tryPromise({

--- a/apps/cli/src/utils/compatibility-rules.ts
+++ b/apps/cli/src/utils/compatibility-rules.ts
@@ -51,10 +51,12 @@ export function isWebFrontend(value: Frontend) {
   return WEB_FRAMEWORKS.includes(value);
 }
 
-export function splitFrontends(values: Frontend[] = []): {
+export interface SplitFrontendsResult {
   web: Frontend[];
   native: Frontend[];
-} {
+}
+
+export function splitFrontends(values: Frontend[] = []): SplitFrontendsResult {
   const web = values.filter((f) => isWebFrontend(f));
   const native = values.filter(
     (f) => f === "native-bare" || f === "native-uniwind" || f === "native-unistyles",
@@ -489,13 +491,18 @@ export function validatePrismaWebDeployDesktopAddons(
   );
 }
 
+export interface AddonCompatibility {
+  isCompatible: boolean;
+  reason?: string;
+}
+
 export function validateAddonCompatibility(
   addon: Addons,
   frontend: Frontend[],
   auth?: Auth,
   backend?: Backend,
   runtime?: Runtime,
-): { isCompatible: boolean; reason?: string } {
+): AddonCompatibility {
   if (addon === "evlog" && !supportsEvlogAddon(frontend, backend, runtime)) {
     return {
       isCompatible: false,

--- a/apps/cli/src/utils/config-validation.ts
+++ b/apps/cli/src/utils/config-validation.ts
@@ -131,10 +131,7 @@ export function validateDatabaseSetup(
     );
   }
 
-  const setupValidations: Record<
-    DatabaseSetup,
-    { database?: Database; runtime?: Runtime; errorMessage: string }
-  > = {
+  const setupValidations = {
     turso: {
       database: "sqlite",
       errorMessage:
@@ -173,7 +170,10 @@ export function validateDatabaseSetup(
         "Docker setup is not compatible with SQLite database or Cloudflare Workers runtime.",
     },
     none: { errorMessage: "" },
-  };
+  } satisfies Record<
+    DatabaseSetup,
+    { database?: Database; runtime?: Runtime; errorMessage: string }
+  >;
 
   if (dbSetup && dbSetup !== "none") {
     const validation = setupValidations[dbSetup];
@@ -183,12 +183,12 @@ export function validateDatabaseSetup(
         return validationErr(validation.errorMessage);
       }
     } else {
-      if (validation.database && database !== validation.database) {
+      if ("database" in validation && validation.database && database !== validation.database) {
         return validationErr(validation.errorMessage);
       }
     }
 
-    if (validation.runtime && runtime !== validation.runtime) {
+    if ("runtime" in validation && validation.runtime && runtime !== validation.runtime) {
       return validationErr(validation.errorMessage);
     }
 

--- a/apps/cli/src/utils/display-config.ts
+++ b/apps/cli/src/utils/display-config.ts
@@ -12,7 +12,15 @@ export type ConfigDisplaySection = {
   rows: ConfigDisplayRow[];
 };
 
-const VALUE_LABELS: Record<string, string> = {
+type ConfigDisplayValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | readonly ConfigDisplayValue[];
+
+const VALUE_LABELS = {
   none: "None",
   "tanstack-router": "TanStack Router",
   "react-router": "React Router",
@@ -78,27 +86,30 @@ const VALUE_LABELS: Record<string, string> = {
   vercel: "Vercel",
   npm: "npm",
   pnpm: "pnpm",
-};
+} satisfies Record<string, string>;
 
-export function formatConfigValue(value: unknown): string {
-  if (typeof value === "boolean") return value ? "Yes" : "No";
+function isKnownValueLabel(value: string): value is keyof typeof VALUE_LABELS {
+  return Object.hasOwn(VALUE_LABELS, value);
+}
+
+export function formatConfigValue(value: ConfigDisplayValue): string {
+  if (value === true) return "Yes";
+  if (value === false) return "No";
   if (Array.isArray(value)) {
     return value.length > 0 ? value.map(formatConfigValue).join(", ") : "None";
   }
 
   const text = String(value);
-  return (
-    VALUE_LABELS[text] ??
-    text
-      .split("-")
-      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-      .join(" ")
-  );
+  if (isKnownValueLabel(text)) return VALUE_LABELS[text];
+  return text
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
 }
 
 function section(
   title: string,
-  entries: Array<[label: string, value: unknown, format?: "raw"]>,
+  entries: Array<[label: string, value: ConfigDisplayValue, format?: "raw"]>,
 ): ConfigDisplaySection | undefined {
   const rows = entries
     .filter(([, value]) => value !== undefined)

--- a/apps/cli/src/utils/errors.ts
+++ b/apps/cli/src/utils/errors.ts
@@ -32,10 +32,10 @@ export class CLIError extends TaggedError("CLIError")<{
  */
 export class ValidationError extends TaggedError("ValidationError")<{
   field?: string;
-  value?: unknown;
+  value?: string | number | boolean | null;
   message: string;
 }> {
-  constructor(args: { field?: string; value?: unknown; message: string }) {
+  constructor(args: { field?: string; value?: string | number | boolean | null; message: string }) {
     super(args);
   }
 }
@@ -140,7 +140,7 @@ export function cliError(message: string): Result<never, CLIError> {
 export function validationError(
   message: string,
   field?: string,
-  value?: unknown,
+  value?: string | number | boolean | null,
 ): Result<never, ValidationError> {
   return Result.err(new ValidationError({ message, field, value }));
 }

--- a/apps/cli/src/utils/fs-error.ts
+++ b/apps/cli/src/utils/fs-error.ts
@@ -1,0 +1,3 @@
+export function isMissingPathError(cause: unknown): boolean {
+  return cause instanceof Error && "code" in cause && cause.code === "ENOENT";
+}

--- a/apps/cli/src/utils/navigation.ts
+++ b/apps/cli/src/utils/navigation.ts
@@ -1,5 +1,5 @@
 export const GO_BACK_SYMBOL = Symbol("clack:goBack");
 
-export function isGoBack(value: unknown): value is symbol {
+export function isGoBack<T>(value: T | symbol): value is symbol {
   return value === GO_BACK_SYMBOL;
 }

--- a/apps/cli/src/utils/project-directory.ts
+++ b/apps/cli/src/utils/project-directory.ts
@@ -8,6 +8,7 @@ import pc from "picocolors";
 import { getProjectName } from "../prompts/project-name";
 import { isSilent } from "./context";
 import { CLIError, UserCancelledError } from "./errors";
+import { isMissingPathError } from "./fs-error";
 
 export type ProjectPathState =
   | "missing"
@@ -136,10 +137,12 @@ export async function handleDirectoryConflict(currentPathInput: string): Promise
   }
 }
 
-export function resolveProjectDirectoryPath(finalPathInput: string): {
+export interface ProjectDirectoryResolution {
   finalResolvedPath: string;
   finalBaseName: string;
-} {
+}
+
+export function resolveProjectDirectoryPath(finalPathInput: string): ProjectDirectoryResolution {
   const finalResolvedPath =
     finalPathInput === "." ? process.cwd() : path.resolve(process.cwd(), finalPathInput);
 
@@ -210,12 +213,7 @@ export async function validateSafeProjectDirectoryPath(
         try {
           stats = await fs.lstat(candidatePath);
         } catch (error) {
-          if (
-            typeof error === "object" &&
-            error !== null &&
-            "code" in error &&
-            error.code === "ENOENT"
-          ) {
+          if (isMissingPathError(error)) {
             break;
           }
           throw error;
@@ -269,12 +267,7 @@ export async function inspectProjectPath(
       try {
         stats = await fs.lstat(targetPath);
       } catch (error) {
-        if (
-          typeof error === "object" &&
-          error !== null &&
-          "code" in error &&
-          error.code === "ENOENT"
-        ) {
+        if (isMissingPathError(error)) {
           return "missing" as const;
         }
         throw error;

--- a/apps/cli/src/utils/sponsors.ts
+++ b/apps/cli/src/utils/sponsors.ts
@@ -270,29 +270,29 @@ async function fetchSponsorsData({
   }
 }
 
-function normalizeSponsorFetchError(error: unknown): CLIError {
-  if (error instanceof Error && error.name === "AbortError") {
+function normalizeSponsorFetchError(cause: unknown): CLIError {
+  if (cause instanceof Error && cause.name === "AbortError") {
     return new CLIError({
       message: "Failed to fetch sponsors: request timed out",
-      cause: error,
+      cause: cause,
     });
   }
 
-  if (CLIError.is(error)) {
-    return error;
+  if (CLIError.is(cause)) {
+    return cause;
   }
 
-  if (error instanceof Error) {
+  if (cause instanceof Error) {
     return new CLIError({
-      message: error.message.startsWith("Failed to fetch sponsors:")
-        ? error.message
-        : `Failed to fetch sponsors: ${error.message}`,
-      cause: error,
+      message: cause.message.startsWith("Failed to fetch sponsors:")
+        ? cause.message
+        : `Failed to fetch sponsors: ${cause.message}`,
+      cause: cause,
     });
   }
 
   return new CLIError({
-    message: `Failed to fetch sponsors: ${String(error)}`,
-    cause: error,
+    message: `Failed to fetch sponsors: ${String(cause)}`,
+    cause: cause,
   });
 }

--- a/apps/cli/src/utils/templates.ts
+++ b/apps/cli/src/utils/templates.ts
@@ -1,6 +1,6 @@
 import type { CreateInput, Template } from "../types";
 
-export const TEMPLATE_PRESETS: Record<Template, CreateInput | null> = {
+export const TEMPLATE_PRESETS = {
   mern: {
     database: "mongodb",
     orm: "mongoose",
@@ -62,7 +62,7 @@ export const TEMPLATE_PRESETS: Record<Template, CreateInput | null> = {
     serverDeploy: "none",
   },
   none: null,
-};
+} satisfies Record<Template, CreateInput | null>;
 
 export function getTemplateConfig(template: Template) {
   if (template === "none" || !template) {
@@ -78,13 +78,13 @@ export function getTemplateConfig(template: Template) {
 }
 
 export function getTemplateDescription(template: Template) {
-  const descriptions: Record<Template, string> = {
+  const descriptions = {
     mern: "MongoDB + Express + React + Node.js - Classic MERN stack",
     pern: "PostgreSQL + Express + React + Node.js - Popular PERN stack",
     t3: "T3 Stack - Next.js + tRPC + Prisma + PostgreSQL + Better Auth",
     uniwind: "Expo + Uniwind native app with no backend services",
     none: "No template - Full customization",
-  };
+  } satisfies Record<Template, string>;
 
   return descriptions[template] || "";
 }

--- a/apps/cli/test/addons.test.ts
+++ b/apps/cli/test/addons.test.ts
@@ -46,7 +46,7 @@ function expectParseableTypeScript(content: string) {
   ).toEqual([]);
 }
 
-function expectDocsShapedEvlogAuth(content: string) {
+function expectDocsWithEvlogAuth(content: string) {
   expect(content).not.toContain("createEvlogAuth");
   expect(content).not.toContain("toHeaders");
   expect(content).not.toContain("GetSessionInput");
@@ -1048,7 +1048,7 @@ describe("Addon Configurations", () => {
       expect(compatibleAddons).toContain("mcp");
     });
 
-    const backendSnippets: Record<Backend, string> = {
+    const backendSnippets = {
       hono: 'import { evlog, type EvlogVariables } from "evlog/hono";',
       express: 'import { evlog } from "evlog/express";',
       fastify: 'import { evlog } from "evlog/fastify";',
@@ -1056,7 +1056,7 @@ describe("Addon Configurations", () => {
       convex: "",
       self: "",
       none: "",
-    };
+    } satisfies Record<Backend, string>;
 
     for (const backend of ["hono", "express", "fastify", "elysia"] as const) {
       it(`should wire evlog middleware for ${backend}`, async () => {
@@ -1307,7 +1307,7 @@ describe("Addon Configurations", () => {
         "await identify(event.context.log, event.headers, event.path);",
       );
       expect(authMiddleware).not.toContain("createAuthIdentifier(");
-      expectDocsShapedEvlogAuth(authMiddleware);
+      expectDocsWithEvlogAuth(authMiddleware);
       expectParseableTypeScript(authMiddleware);
 
       expect(authClient).not.toContain("baseURL:");
@@ -1390,7 +1390,7 @@ describe("Addon Configurations", () => {
         expect(authFile).toContain(webCase.expected);
         expect(authFile).toContain('exclude: ["/api/auth/**"]');
         expect(authFile).toContain("maskEmail: true");
-        expectDocsShapedEvlogAuth(authFile);
+        expectDocsWithEvlogAuth(authFile);
         expectParseableTypeScript(authFile);
       });
     }
@@ -1464,7 +1464,7 @@ describe("Addon Configurations", () => {
         );
         expect(authFile).toContain('exclude: ["/api/auth/**"]');
         expect(authFile).toContain("maskEmail: true");
-        expectDocsShapedEvlogAuth(authFile);
+        expectDocsWithEvlogAuth(authFile);
         expectParseableTypeScript(authFile);
       });
     }
@@ -1523,7 +1523,7 @@ describe("Addon Configurations", () => {
       expect(serverIndex).toContain(
         'await identifyUser(c.get("log"), c.req.raw.headers, c.req.path);',
       );
-      expectDocsShapedEvlogAuth(serverIndex);
+      expectDocsWithEvlogAuth(serverIndex);
       expect(serverIndex).toContain(
         'import { createAILogger, createEvlogIntegration } from "evlog/ai";',
       );
@@ -1691,7 +1691,7 @@ describe("Addon Configurations", () => {
         'import { createAuthMiddleware, type BetterAuthInstance } from "evlog/better-auth";',
       );
       expect(evlogAuth).toContain("createAuthMiddleware(auth as BetterAuthInstance");
-      expectDocsShapedEvlogAuth(evlogAuth);
+      expectDocsWithEvlogAuth(evlogAuth);
       expect(trpcRoute).toContain("withEvlog(handler)");
       expect(trpcRoute).toContain("await identifyEvlogUser(req);");
       expect(aiRoute).toContain("withEvlog(async (req: Request)");
@@ -1742,7 +1742,7 @@ describe("Addon Configurations", () => {
           'import { createAuthMiddleware, type BetterAuthInstance } from "evlog/better-auth";',
         );
         expect(serverIndex).toContain("createAuthMiddleware(auth as BetterAuthInstance");
-        expectDocsShapedEvlogAuth(serverIndex);
+        expectDocsWithEvlogAuth(serverIndex);
         expect(serverIndex).toContain("maskEmail: true");
         expect(webPackageJson).not.toContain(`"@${projectName}/auth"`);
         expect(webPackageJson).not.toContain('"@libsql/client"');

--- a/apps/cli/test/deployment.test.ts
+++ b/apps/cli/test/deployment.test.ts
@@ -376,7 +376,10 @@ describe("Deployment Configurations", () => {
             framework?: string;
             entrypoint?: string;
             buildCommand?: string;
-            routes?: Array<Record<string, unknown>>;
+            routes?: Array<{
+              src?: string;
+              transforms?: Array<{ type?: string; op?: string; args?: string }>;
+            }>;
           }
         >;
         rewrites?: Array<{
@@ -779,7 +782,10 @@ describe("Deployment Configurations", () => {
       const files = collectFiles(result.value.root, result.value.root.path);
       const web = (
         JSON.parse(files.get("vercel.json") ?? "{}") as {
-          services?: Record<string, Record<string, unknown>>;
+          services?: Record<
+            string,
+            { framework?: string; outputDirectory?: string; rewrites?: Array<{ source: string }> }
+          >;
         }
       ).services?.web;
 

--- a/apps/cli/test/external-commands.test.ts
+++ b/apps/cli/test/external-commands.test.ts
@@ -91,7 +91,7 @@ describe("External Command Guards", () => {
     const updated = await Bun.file(pkgJsonPath).json();
 
     expect(updated.scripts?.check).toBe("oxlint && oxfmt --write");
-    expect(updated.devDependencies?.oxlint).toBe("^1.76.0");
-    expect(updated.devDependencies?.oxfmt).toBe("^0.61.0");
+    expect(updated.devDependencies?.oxlint).toBe("^1.78.0");
+    expect(updated.devDependencies?.oxfmt).toBe("^0.63.0");
   });
 });

--- a/apps/cli/test/generated-builds.test.ts
+++ b/apps/cli/test/generated-builds.test.ts
@@ -4,12 +4,19 @@ import path from "node:path";
 
 import { execa } from "execa";
 import fs from "fs-extra";
+import { z } from "zod";
 
 import type { CreateInput } from "../src";
 import { create } from "../src";
 import { SMOKE_DIR } from "./setup";
 
 type PackageManager = NonNullable<CreateInput["packageManager"]>;
+
+const packageScriptsSchema = z.object({
+  scripts: z.record(z.string(), z.string()).optional(),
+});
+
+const serverAddressSchema = z.object({ port: z.number().int().positive() });
 
 const shouldRunBuildSamples = process.env.BTS_BUILD_SAMPLES === "1";
 const sampleFilter = process.env.BTS_BUILD_SAMPLE_FILTER;
@@ -595,13 +602,12 @@ async function runWorkspaceTypeChecks(
       const packageJsonPath = path.join(workspaceDir, "package.json");
       if (!(await fs.pathExists(packageJsonPath))) continue;
 
-      const packageJson = await fs.readJson(packageJsonPath);
-      const typecheckScript =
-        typeof packageJson.scripts?.["check-types"] === "string"
-          ? "check-types"
-          : typeof packageJson.scripts?.typecheck === "string"
-            ? "typecheck"
-            : undefined;
+      const packageJson = packageScriptsSchema.parse(await fs.readJson(packageJsonPath));
+      const typecheckScript = packageJson.scripts?.["check-types"]
+        ? "check-types"
+        : packageJson.scripts?.typecheck
+          ? "typecheck"
+          : undefined;
       if (!typecheckScript) continue;
 
       await runCommand(
@@ -721,8 +727,8 @@ async function getAvailablePort(): Promise<number> {
     server.unref();
     server.once("error", reject);
     server.listen(0, "127.0.0.1", () => {
-      const address = server.address();
-      if (!address || typeof address === "string") {
+      const address = serverAddressSchema.safeParse(server.address());
+      if (!address.success) {
         server.close();
         reject(new Error("Could not allocate a port for the generated runtime probe"));
         return;
@@ -730,7 +736,7 @@ async function getAvailablePort(): Promise<number> {
 
       server.close((error) => {
         if (error) reject(error);
-        else resolve(address.port);
+        else resolve(address.data.port);
       });
     });
   });

--- a/apps/cli/test/input-schemas.test.ts
+++ b/apps/cli/test/input-schemas.test.ts
@@ -124,7 +124,7 @@ describe("Input schemas", () => {
   it("imports the MCP module without schema-construction crashes", async () => {
     const module = await import("../src/mcp");
 
-    expect(typeof module.createBtsMcpServer).toBe("function");
+    expect(module.createBtsMcpServer).toBeInstanceOf(Function);
   });
 
   it("exposes the Better T Stack config file JSON schema by name", () => {

--- a/apps/cli/test/matrix/oracle.ts
+++ b/apps/cli/test/matrix/oracle.ts
@@ -155,17 +155,14 @@ function validateDatabaseSetup(config: ProjectConfig, rules: Set<MatrixRule>) {
 
   const expectedDatabase = expectedDatabaseForSetup(config.dbSetup);
   if (expectedDatabase && config.database !== expectedDatabase) {
-    const ruleBySetup: Record<
-      Exclude<DatabaseSetup, "docker" | "none" | "planetscale">,
-      MatrixRule
-    > = {
+    const ruleBySetup = {
       d1: "db-setup-d1-requires-sqlite",
       "mongodb-atlas": "db-setup-mongodb-atlas-requires-mongodb",
       neon: "db-setup-neon-requires-postgres",
       "prisma-postgres": "db-setup-prisma-postgres-requires-postgres",
       supabase: "db-setup-supabase-requires-postgres",
       turso: "db-setup-turso-requires-sqlite",
-    };
+    } satisfies Record<Exclude<DatabaseSetup, "docker" | "none" | "planetscale">, MatrixRule>;
     rules.add(ruleBySetup[config.dbSetup as keyof typeof ruleBySetup]);
   }
 

--- a/apps/cli/test/mcp.test.ts
+++ b/apps/cli/test/mcp.test.ts
@@ -11,6 +11,11 @@ import { createBtsMcpServer } from "../src/mcp";
 import { readBtsConfig } from "../src/utils/bts-config";
 import { SMOKE_DIR } from "./setup";
 
+interface JsonSchemaView {
+  type?: string;
+  properties?: Record<string, JsonSchemaView>;
+}
+
 async function connectInMemoryClient() {
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   const server = createBtsMcpServer();
@@ -180,7 +185,7 @@ describe("MCP server", () => {
 
     const payload = result.structuredContent as {
       ok: boolean;
-      data?: { cli?: unknown; schemas?: Record<string, unknown> };
+      data?: { cli?: JsonSchemaView; schemas?: Record<string, JsonSchemaView> };
     };
 
     expect(payload.ok).toBe(true);
@@ -201,7 +206,7 @@ describe("MCP server", () => {
 
     const payload = result.structuredContent as {
       ok: boolean;
-      data?: { type?: string; properties?: Record<string, unknown> };
+      data?: JsonSchemaView;
     };
 
     expect(payload.ok).toBe(true);

--- a/apps/cli/test/silent-create-output.test.ts
+++ b/apps/cli/test/silent-create-output.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { execa } from "execa";
 import fs from "fs-extra";
 
+import type { CreateInput } from "../src/types";
 import { SMOKE_DIR } from "./setup";
 
 const CLI_INDEX_PATH = path.join(import.meta.dir, "..", "src", "index.ts");
@@ -11,7 +12,7 @@ const CLI_INDEX_PATH = path.join(import.meta.dir, "..", "src", "index.ts");
 type SilentCreateCase = {
   name: string;
   projectName: string;
-  options: Record<string, unknown>;
+  options: CreateInput;
   existingFile?: string;
 };
 

--- a/apps/web/src/app/(home)/_components/rail/_hooks/use-npm-version.ts
+++ b/apps/web/src/app/(home)/_components/rail/_hooks/use-npm-version.ts
@@ -1,6 +1,9 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { z } from "zod";
+
+const npmVersionResponseSchema = z.object({ version: z.string().trim().min(1) });
 
 export function useNpmVersion(): string {
   const [version, setVersion] = useState("0.0.0");
@@ -12,13 +15,9 @@ export function useNpmVersion(): string {
       try {
         const res = await fetch("https://registry.npmjs.org/create-better-t-stack/latest");
         if (!res.ok) throw new Error("Failed to fetch version");
-        const data = await res.json();
+        const data = npmVersionResponseSchema.safeParse(await res.json());
         if (cancelled) return;
-        setVersion(
-          typeof data?.version === "string" && data.version.trim().length > 0
-            ? data.version
-            : "latest",
-        );
+        setVersion(data.success ? data.data.version : "latest");
       } catch {
         if (!cancelled) setVersion("latest");
       }

--- a/apps/web/src/app/(home)/_components/rail/use-fit-text.ts
+++ b/apps/web/src/app/(home)/_components/rail/use-fit-text.ts
@@ -4,7 +4,7 @@ import { type RefObject, useEffect, useLayoutEffect } from "react";
 
 // Correct before paint on the client so a clipped frame is never shown,
 // without tripping the SSR warning.
-const useIsomorphicLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect;
+const useIsomorphicLayoutEffect = globalThis.window === undefined ? useEffect : useLayoutEffect;
 
 /**
  * Shrinks a <pre> until it actually fits its parent.

--- a/apps/web/src/app/(home)/analytics/_components/bklit-charts.tsx
+++ b/apps/web/src/app/(home)/analytics/_components/bklit-charts.tsx
@@ -79,9 +79,11 @@ export type ChartSeries = {
   line?: boolean;
 };
 
-type Row = Record<string, unknown>;
+type RowValue = string | number | boolean | Date | null | undefined;
 
-const num = (value: unknown) => Number(value ?? 0);
+interface Row extends Record<string, RowValue> {}
+
+const num = (value: RowValue) => Number(value ?? 0);
 
 /**
  * Time-series area chart (x is a `Date`). Filled series plus optional overlay

--- a/apps/web/src/app/(home)/analytics/_components/live-logs.tsx
+++ b/apps/web/src/app/(home)/analytics/_components/live-logs.tsx
@@ -2,6 +2,7 @@
 
 import { api } from "@better-t-stack/backend/convex/_generated/api";
 import { useQuery } from "convex/react";
+import type { FunctionReturnType } from "convex/server";
 import { Activity, ChevronRight, Radio } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import { useState } from "react";
@@ -31,6 +32,9 @@ const LOG_FIELD_ORDER = [
   "install",
 ] as const;
 
+type RecentAnalyticsEvent = FunctionReturnType<typeof api.analytics.getRecentEvents>[number];
+type LogValue = RecentAnalyticsEvent[(typeof LOG_FIELD_ORDER)[number]];
+
 const eventTimeFormatter = new Intl.DateTimeFormat("en-US", {
   month: "short",
   day: "numeric",
@@ -39,28 +43,25 @@ const eventTimeFormatter = new Intl.DateTimeFormat("en-US", {
   hour12: false,
 });
 
-function formatValue(value: unknown): string {
+function formatValue(value: LogValue): string {
   if (Array.isArray(value)) return value.length > 0 ? value.join(",") : "none";
-  if (typeof value === "boolean") return value ? "true" : "false";
-  if (typeof value === "string") return value;
+  if (value === true) return "true";
+  if (value === false) return "false";
   return String(value);
 }
 
-function hasLogValue(value: unknown): boolean {
+function hasLogValue(value: LogValue): boolean {
   if (value === undefined || value === null) return false;
   if (Array.isArray(value)) return value.length > 0;
   return true;
 }
 
-function formatStackSummary(event: Record<string, unknown>) {
-  const frontend = Array.isArray(event.frontend)
-    ? event.frontend.join("+")
-    : (event.frontend as string | undefined);
-  const backend = typeof event.backend === "string" ? event.backend : "none";
-  const database = typeof event.database === "string" ? event.database : "none";
-  const orm = typeof event.orm === "string" ? event.orm : "none";
-  const packageManager =
-    typeof event.packageManager === "string" ? event.packageManager : "unknown package manager";
+function formatStackSummary(event: RecentAnalyticsEvent) {
+  const frontend = event.frontend?.join("+");
+  const backend = event.backend ?? "none";
+  const database = event.database ?? "none";
+  const orm = event.orm ?? "none";
+  const packageManager = event.packageManager ?? "unknown package manager";
 
   return `${frontend || "none"} / ${backend} -> ${database} + ${orm} via ${packageManager}`;
 }
@@ -138,11 +139,8 @@ export function LiveLogs() {
                   <AnimatePresence initial={false} mode="popLayout">
                     {events.map((event, index) => {
                       const time = eventTimeFormatter.format(new Date(event._creationTime));
-                      const eventRecord = event as Record<string, unknown>;
                       const logFields = LOG_FIELD_ORDER.flatMap((key) =>
-                        hasLogValue(eventRecord[key])
-                          ? [{ key, value: formatValue(eventRecord[key]) }]
-                          : [],
+                        hasLogValue(event[key]) ? [{ key, value: formatValue(event[key]) }] : [],
                       );
                       const eventId = String(event._id).slice(-6);
 
@@ -172,7 +170,7 @@ export function LiveLogs() {
                                 project.start
                               </span>
                               <span className="min-w-0 break-words text-[13px] leading-[1.55]">
-                                {formatStackSummary(eventRecord)}
+                                {formatStackSummary(event)}
                               </span>
                               <span className="text-[10px] text-fd-muted-foreground/70">
                                 id={eventId}

--- a/apps/web/src/app/(home)/analytics/_components/preference-chart-card.tsx
+++ b/apps/web/src/app/(home)/analytics/_components/preference-chart-card.tsx
@@ -96,13 +96,13 @@ type PreferenceChartCardProps = {
   columnGridClassName?: string;
 };
 
-const colorByKey: Record<NonNullable<PreferenceChartCardProps["colorKey"]>, string> = {
+const colorByKey = {
   chart1: "var(--chart-1)",
   chart2: "var(--chart-2)",
   chart3: "var(--chart-3)",
   chart4: "var(--chart-4)",
   chart5: "var(--chart-5)",
-};
+} satisfies Record<NonNullable<PreferenceChartCardProps["colorKey"]>, string>;
 
 export function PreferenceChartCard({
   title,
@@ -116,7 +116,7 @@ export function PreferenceChartCard({
   columnCount = 1,
   columnGridClassName,
 }: PreferenceChartCardProps) {
-  const ranking = typeof maxItems === "number" ? data.slice(0, maxItems) : data;
+  const ranking = maxItems === undefined ? data : data.slice(0, maxItems);
   const chunks = columnCount > 1 ? chunkItems(ranking, columnCount) : [ranking];
   const color = colorByKey[colorKey];
   const labelWidth = columnCount >= 3 ? 70 : columnCount === 2 ? 96 : 120;

--- a/apps/web/src/app/(home)/layout.tsx
+++ b/apps/web/src/app/(home)/layout.tsx
@@ -1,22 +1,21 @@
 "use client";
 
 import { HomeLayout } from "fumadocs-ui/layouts/home";
-import type { ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 
 import { baseOptions } from "@/app/layout.config";
 import { HomeSiteHeader } from "@/components/site-header";
 
+type HomeLayoutStyle = CSSProperties & { "--fd-layout-width": string };
+
+const homeLayoutStyle = {
+  width: "100%",
+  "--fd-layout-width": "100%",
+} satisfies HomeLayoutStyle;
+
 export default function Layout({ children }: { children: ReactNode }) {
   return (
-    <HomeLayout
-      {...baseOptions}
-      slots={{ header: HomeSiteHeader }}
-      style={
-        {
-          "--fd-layout-width": "100%",
-        } as object
-      }
-    >
+    <HomeLayout {...baseOptions} slots={{ header: HomeSiteHeader }} style={homeLayoutStyle}>
       <main className="h-full w-full">{children}</main>
     </HomeLayout>
   );

--- a/apps/web/src/app/(home)/new/_components/code-viewer.tsx
+++ b/apps/web/src/app/(home)/new/_components/code-viewer.tsx
@@ -20,9 +20,13 @@ interface CodeViewerProps {
   extension: string;
 }
 
+function hasOwnKey<T extends object>(object: T, key: PropertyKey): key is keyof T {
+  return Object.hasOwn(object, key);
+}
+
 // Map file extensions to Shiki language IDs
-function getLanguage(extension: string): BundledLanguage {
-  const languageMap: Record<string, BundledLanguage> = {
+function getLanguage(extension: string): BundledLanguage | null {
+  const languageMap = {
     ts: "typescript",
     tsx: "tsx",
     js: "javascript",
@@ -49,8 +53,9 @@ function getLanguage(extension: string): BundledLanguage {
     dockerfile: "dockerfile",
     env: "shellscript",
     hbs: "handlebars",
-  };
-  return languageMap[extension.toLowerCase()] || "text";
+  } satisfies Record<string, BundledLanguage>;
+  const normalizedExtension = extension.toLowerCase();
+  return hasOwnKey(languageMap, normalizedExtension) ? languageMap[normalizedExtension] : null;
 }
 
 export const CodeViewer = memo(function CodeViewer({
@@ -59,17 +64,18 @@ export const CodeViewer = memo(function CodeViewer({
   extension,
 }: CodeViewerProps) {
   const language = useMemo(() => getLanguage(extension), [extension]);
+  const languageId = language ?? "text";
   const filename = useMemo(() => filePath.split("/").pop() || filePath, [filePath]);
 
   const codeData = useMemo(
     () => [
       {
-        language,
+        language: languageId,
         filename,
         code: content,
       },
     ],
-    [language, filename, content],
+    [languageId, filename, content],
   );
 
   return (
@@ -77,7 +83,7 @@ export const CodeViewer = memo(function CodeViewer({
       <CodeBlock
         key={filePath}
         data={codeData}
-        defaultValue={language}
+        defaultValue={languageId}
         className="flex h-full flex-col rounded-[4px] bg-fd-background"
       >
         <CodeBlockHeader>
@@ -94,7 +100,8 @@ export const CodeViewer = memo(function CodeViewer({
           {(item) => (
             <CodeBlockItem key={item.language} value={item.language}>
               <CodeBlockContent
-                language={item.language as BundledLanguage}
+                language={language ?? undefined}
+                syntaxHighlighting={language !== null}
                 themes={{
                   light: "catppuccin-latte",
                   dark: "catppuccin-mocha",

--- a/apps/web/src/app/(home)/new/_components/stack-builder/selected-stack-badges.tsx
+++ b/apps/web/src/app/(home)/new/_components/stack-builder/selected-stack-badges.tsx
@@ -53,7 +53,7 @@ export function SelectedStackBadges({ stack, onRemove, onJump }: SelectedStackBa
               <TechIcon
                 icon={tech.icon}
                 name={tech.name}
-                className={cn("h-3 w-3", tech.className)}
+                className={cn("h-3 w-3", "className" in tech ? tech.className : undefined)}
               />
             )}
             {tech.name}

--- a/apps/web/src/app/(home)/new/_components/stack-builder/tech-categories.tsx
+++ b/apps/web/src/app/(home)/new/_components/stack-builder/tech-categories.tsx
@@ -133,7 +133,10 @@ export function TechCategories({
                               <TechIcon
                                 icon={tech.icon}
                                 name={tech.name}
-                                className={cn("mr-1.5 h-4 w-4 shrink-0", tech.className)}
+                                className={cn(
+                                  "mr-1.5 h-4 w-4 shrink-0",
+                                  "className" in tech ? tech.className : undefined,
+                                )}
                               />
                             )}
                             <span

--- a/apps/web/src/app/(home)/new/_components/stack-builder/use-stack-builder.ts
+++ b/apps/web/src/app/(home)/new/_components/stack-builder/use-stack-builder.ts
@@ -75,7 +75,7 @@ export function applyStackUpdate(
   update: StackUpdate,
 ): ResolvedStackCompatibility {
   const resolvedCurrentStack = resolveStackCompatibility(currentStack).stack;
-  const partialUpdate = typeof update === "function" ? update(resolvedCurrentStack) : update;
+  const partialUpdate = update instanceof Function ? update(resolvedCurrentStack) : update;
   const requestedStack = sanitizeStackState({ ...resolvedCurrentStack, ...partialUpdate });
   return resolveStackCompatibility(requestedStack);
 }

--- a/apps/web/src/app/(home)/page.tsx
+++ b/apps/web/src/app/(home)/page.tsx
@@ -24,35 +24,44 @@ export default async function HomePage() {
 
   // Keyed by pane id, not array position: PANES lives in another file and
   // reordering one list must not silently pair a title with the wrong body.
-  const content: Record<string, { body: ReactNode; count?: number; footer?: ReactNode }> = {
-    "pane-init": { body: <InitPane /> },
-    "pane-sponsors": {
-      body: <SponsorsPane sponsorsData={sponsorsData} />,
-      footer: <SponsorsPaneFooter />,
-    },
-    "pane-videos": { body: <VideosPane videos={videos} />, count: videos.length },
-    "pane-tweets": {
-      body: <TweetsPane tweets={tweets} />,
-      count: tweets.length,
-      footer: <ColophonFooter />,
-    },
-  };
+  const content = new Map<string, { body: ReactNode; count?: number; footer?: ReactNode }>([
+    ["pane-init", { body: <InitPane /> }],
+    [
+      "pane-sponsors",
+      {
+        body: <SponsorsPane sponsorsData={sponsorsData} />,
+        footer: <SponsorsPaneFooter />,
+      },
+    ],
+    ["pane-videos", { body: <VideosPane videos={videos} />, count: videos.length }],
+    [
+      "pane-tweets",
+      {
+        body: <TweetsPane tweets={tweets} />,
+        count: tweets.length,
+        footer: <ColophonFooter />,
+      },
+    ],
+  ]);
 
   return (
     <Rail>
-      {PANES.map((pane, index) => (
-        <Pane
-          key={pane.id}
-          id={pane.id}
-          index={index}
-          title={pane.title}
-          width={pane.width}
-          count={content[pane.id]?.count}
-          footer={content[pane.id]?.footer}
-        >
-          {content[pane.id]?.body}
-        </Pane>
-      ))}
+      {PANES.map((pane, index) => {
+        const paneContent = content.get(pane.id);
+        return (
+          <Pane
+            key={pane.id}
+            id={pane.id}
+            index={index}
+            title={pane.title}
+            width={pane.width}
+            count={paneContent?.count}
+            footer={paneContent?.footer}
+          >
+            {paneContent?.body}
+          </Pane>
+        );
+      })}
     </Rail>
   );
 }

--- a/apps/web/src/app/(home)/stack/_components/stack-display.tsx
+++ b/apps/web/src/app/(home)/stack/_components/stack-display.tsx
@@ -27,10 +27,8 @@ export function StackDisplay({ stackState }: StackDisplayProps) {
   const [editUrl, setEditUrl] = useState<string>("");
 
   useEffect(() => {
-    if (typeof window !== "undefined") {
-      setStackUrl(generateStackSharingUrl(stackState, window.location.origin));
-      setEditUrl(generateStackUrlFromState(stackState, window.location.origin));
-    }
+    setStackUrl(generateStackSharingUrl(stackState, window.location.origin));
+    setEditUrl(generateStackUrlFromState(stackState, window.location.origin));
   }, [stackState]);
 
   const stack = stackState;

--- a/apps/web/src/app/api/preview/route.ts
+++ b/apps/web/src/app/api/preview/route.ts
@@ -52,7 +52,24 @@ export async function POST(request: Request) {
 /**
  * Transform VirtualFileTree format to web's expected tree format
  */
-function transformTree(node: VirtualNode): Record<string, unknown> {
+interface PreviewFileNode {
+  name: string;
+  path: string;
+  type: "file";
+  content: string;
+  extension: string;
+}
+
+interface PreviewDirectoryNode {
+  name: string;
+  path: string;
+  type: "directory";
+  children: PreviewNode[];
+}
+
+type PreviewNode = PreviewFileNode | PreviewDirectoryNode;
+
+function transformTree(node: VirtualNode): PreviewNode {
   if (node.type === "file") {
     return {
       name: node.name,
@@ -72,9 +89,8 @@ function transformTree(node: VirtualNode): Record<string, unknown> {
 }
 
 function normalizeBoolean(value: boolean | string | undefined, fallback: boolean): boolean {
-  if (typeof value === "boolean") return value;
-  if (typeof value === "string") return value === "true";
-  return fallback;
+  if (value === true || value === false) return value;
+  return value === undefined ? fallback : value === "true";
 }
 
 function normalizeBackend(value?: string): ProjectConfig["backend"] {

--- a/apps/web/src/app/api/tweet/[id]/route.ts
+++ b/apps/web/src/app/api/tweet/[id]/route.ts
@@ -1,15 +1,14 @@
 import { NextResponse } from "next/server";
 import { fetchTweet, TwitterApiError, type Tweet } from "react-tweet/api";
+import { z } from "zod";
 
 export const revalidate = 86_400;
 
-type TweetEntityArrays = {
-  hashtags?: unknown[];
-  media?: unknown[];
-  symbols?: unknown[];
-  urls?: unknown[];
-  user_mentions?: unknown[];
-};
+type TweetEntityArrays = Partial<NonNullable<Tweet["entities"]>>;
+
+const entityWithIndicesSchema = z.object({
+  indices: z.tuple([z.number(), z.number()]),
+});
 
 type TweetWithEntities = {
   entities?: TweetEntityArrays;
@@ -72,18 +71,6 @@ function normalizeEntities(entities?: TweetEntityArrays): Tweet["entities"] {
   } as Tweet["entities"];
 }
 
-function normalizeEntityArray(entities?: unknown[]) {
-  if (!Array.isArray(entities)) return [];
-
-  return entities.filter((entity) => {
-    if (!entity || typeof entity !== "object" || !("indices" in entity)) return false;
-
-    const indices = entity.indices;
-    return (
-      Array.isArray(indices) &&
-      indices.length === 2 &&
-      typeof indices[0] === "number" &&
-      typeof indices[1] === "number"
-    );
-  });
+function normalizeEntityArray<T>(entities?: T[]): T[] {
+  return entities?.filter((entity) => entityWithIndicesSchema.safeParse(entity).success) ?? [];
 }

--- a/apps/web/src/app/og/site/[page]/route.tsx
+++ b/apps/web/src/app/og/site/[page]/route.tsx
@@ -5,10 +5,7 @@ import { OG_SIZE, OgShell, ogColors, ogFonts } from "@/lib/og";
 
 export const revalidate = false;
 
-const PAGES: Record<
-  string,
-  { path: string; section: string; title: string; description: string; command?: string }
-> = {
+const PAGES = {
   home: {
     path: "~",
     section: "home",
@@ -41,12 +38,20 @@ const PAGES: Record<
     title: "Sponsors",
     description: "The companies and developers funding Better-T-Stack development",
   },
-};
+} satisfies Record<
+  string,
+  { path: string; section: string; title: string; description: string; command?: string }
+>;
+
+function isPageKey(page: string): page is keyof typeof PAGES {
+  return Object.hasOwn(PAGES, page);
+}
 
 export async function GET(_req: Request, { params }: RouteContext<"/og/site/[page]">) {
   const { page: pageParam } = await params;
-  const page = PAGES[pageParam.replace(/\.png$/, "")];
-  if (!page) notFound();
+  const pageKey = pageParam.replace(/\.png$/, "");
+  if (!isPageKey(pageKey)) notFound();
+  const page = PAGES[pageKey];
 
   return new ImageResponse(
     <OgShell path={page.path} section={page.section}>
@@ -60,7 +65,7 @@ export async function GET(_req: Request, { params }: RouteContext<"/og/site/[pag
           gap: "20px",
         }}
       >
-        {page.command && (
+        {"command" in page && page.command && (
           <div
             style={{
               display: "flex",

--- a/apps/web/src/app/og/stack/route.tsx
+++ b/apps/web/src/app/og/stack/route.tsx
@@ -8,7 +8,7 @@ import { getSelectedTechs } from "@/lib/stack-utils";
 
 const MAX_CHIPS = 15;
 
-const categoryChipColors: Partial<Record<string, string>> = {
+const categoryChipColors = {
   webFrontend: "#89b4fa",
   nativeFrontend: "#89b4fa",
   runtime: "#fab387",
@@ -22,7 +22,11 @@ const categoryChipColors: Partial<Record<string, string>> = {
   packageManager: "#f9e2af",
   addons: "#cba6f7",
   examples: "#94e2d5",
-};
+} satisfies Partial<Record<string, string>>;
+
+function hasCategoryColor(category: string): category is keyof typeof categoryChipColors {
+  return Object.hasOwn(categoryChipColors, category);
+}
 
 function commandBase(packageManager: StackState["packageManager"]) {
   if (packageManager === "npm") return "npx create-better-t-stack@latest";
@@ -84,7 +88,9 @@ export async function GET(req: NextRequest) {
 
         <div style={{ display: "flex", flexWrap: "wrap", gap: "10px", maxWidth: "1020px" }}>
           {visible.map((tech) => {
-            const color = categoryChipColors[tech.category] ?? "#a6adc8";
+            const color = hasCategoryColor(tech.category)
+              ? categoryChipColors[tech.category]
+              : "#a6adc8";
             return (
               <div
                 key={`${tech.category}-${tech.id}`}

--- a/apps/web/src/components/ai/page-actions.tsx
+++ b/apps/web/src/components/ai/page-actions.tsx
@@ -79,8 +79,8 @@ export function ViewOptions({
   githubUrl: string;
 }) {
   const items = useMemo(() => {
-    const fullMarkdownUrl =
-      typeof window !== "undefined" ? new URL(markdownUrl, window.location.origin) : "loading";
+    const origin = globalThis.window?.location.origin;
+    const fullMarkdownUrl = origin ? new URL(markdownUrl, origin) : "loading";
     const q = `Read ${fullMarkdownUrl}, I want to ask questions about it.`;
 
     return [

--- a/apps/web/src/components/charts/animation.ts
+++ b/apps/web/src/components/charts/animation.ts
@@ -1,5 +1,7 @@
 import type { Transition } from "motion/react";
 
+import { parseChartNumber } from "./chart-data";
+
 /** Default clip-reveal easing for cartesian charts. */
 export const DEFAULT_ANIMATION_EASING = "cubic-bezier(0.85, 0, 0.15, 1)";
 
@@ -24,9 +26,7 @@ export function clipRevealTransition(enterTransition?: Transition): Transition {
   }
 
   const duration =
-    typeof enterTransition?.duration === "number"
-      ? enterTransition.duration
-      : DEFAULT_ANIMATION_DURATION_MS / 1000;
+    parseChartNumber(enterTransition?.duration) ?? DEFAULT_ANIMATION_DURATION_MS / 1000;
 
   return {
     type: "tween",

--- a/apps/web/src/components/charts/area-chart.tsx
+++ b/apps/web/src/components/charts/area-chart.tsx
@@ -18,6 +18,8 @@ import { cn } from "@/lib/utils";
 
 import { Area, type AreaProps } from "./area";
 import type { LineConfig, Margin } from "./chart-context";
+import type { ChartDatum } from "./chart-data";
+import { getChartChildComponentName } from "./chart-defs";
 import { ChartLoadingLabel } from "./chart-loading-label";
 import {
   type ChartPhase,
@@ -31,7 +33,7 @@ import { TimeSeriesChartInner } from "./time-series-chart-shell";
 
 export interface AreaChartProps {
   /** Data array - each item should have a date field and numeric values */
-  data: Record<string, unknown>[];
+  data: ChartDatum[];
   /** Key in data for the x-axis (date). Default: "date" */
   xDataKey?: string;
   /** Chart margins */
@@ -80,19 +82,14 @@ function extractAreaConfigs(children: ReactNode): LineConfig[] {
       return;
     }
 
-    const childType = child.type as {
-      displayName?: string;
-      name?: string;
-    };
-    const componentName =
-      typeof child.type === "function" ? childType.displayName || childType.name || "" : "";
+    const componentName = getChartChildComponentName(child);
 
     const props = child.props as AreaProps | undefined;
     const isPatternArea = componentName === "PatternArea" || child.type === PatternArea;
     const isAreaComponent =
       componentName === "Area" ||
       child.type === Area ||
-      (props && typeof props.dataKey === "string" && props.dataKey.length > 0 && !isPatternArea);
+      (Boolean(props?.dataKey) && !isPatternArea);
 
     if (isAreaComponent && props?.dataKey) {
       configs.push({
@@ -110,7 +107,7 @@ function extractAreaConfigs(children: ReactNode): LineConfig[] {
 interface ChartInnerProps {
   width: number;
   height: number;
-  data: Record<string, unknown>[];
+  data: ChartDatum[];
   xDataKey: string;
   margin: Margin;
   animationDuration: number;

--- a/apps/web/src/components/charts/area.tsx
+++ b/apps/web/src/components/charts/area.tsx
@@ -11,6 +11,8 @@ import { useCallback, useId, useMemo, useRef, useState } from "react";
 
 import { AreaGradientDefs } from "./area-gradient-defs";
 import { chartCssVars, useChartStable, useYScale } from "./chart-context";
+import { parseChartNumber } from "./chart-data";
+import type { ChartDatum } from "./chart-data";
 import type { ChartPhase, LoadingStyle } from "./chart-phase";
 import { type FadeEdges, resolveFadeSides } from "./fade-edges";
 import {
@@ -202,9 +204,9 @@ export function Area({
   const resolvedStroke = stroke || (isPatternFill ? chartCssVars.linePrimary : fill);
 
   const getY = useCallback(
-    (d: Record<string, unknown>) => {
-      const value = d[dataKey];
-      return typeof value === "number" ? (yScale(value) ?? 0) : 0;
+    (d: ChartDatum) => {
+      const value = parseChartNumber(d[dataKey]);
+      return value === null ? 0 : (yScale(value) ?? 0);
     },
     [dataKey, yScale],
   );

--- a/apps/web/src/components/charts/bar-chart-loading.tsx
+++ b/apps/web/src/components/charts/bar-chart-loading.tsx
@@ -2,8 +2,9 @@
 
 import { BarChart } from "./bar-chart";
 import type { Margin } from "./chart-context";
+import type { ChartDatum } from "./chart-data";
 
-const EMPTY_DATA: Record<string, unknown>[] = [];
+const EMPTY_DATA: ChartDatum[] = [];
 
 export interface BarChartLoadingProps {
   /** Chart margins. */

--- a/apps/web/src/components/charts/bar-chart.tsx
+++ b/apps/web/src/components/charts/bar-chart.tsx
@@ -2,7 +2,7 @@
 
 import { localPoint } from "@visx/event";
 import { ParentSize } from "@visx/responsive";
-import { scaleBand, scaleLinear } from "@visx/scale";
+import { scaleBand, scaleLinear, scaleTime } from "@visx/scale";
 import type { Transition } from "motion/react";
 import {
   memo,
@@ -29,7 +29,12 @@ import {
   resolveChartChildElement,
 } from "./chart-child-passthrough";
 import { ChartProvider, type LineConfig, type Margin, type TooltipData } from "./chart-context";
-import { isGradientDefComponent, isPatternDefComponent } from "./chart-defs";
+import { parseChartNumber, type ChartDatum } from "./chart-data";
+import {
+  getChartChildComponentName,
+  isGradientDefComponent,
+  isPatternDefComponent,
+} from "./chart-defs";
 import { shortDateFmt } from "./chart-formatters";
 import {
   type ChartPhase,
@@ -54,7 +59,7 @@ export type BarOrientation = "vertical" | "horizontal";
 
 export interface BarChartProps {
   /** Data array - each item should have an x-axis key and numeric values */
-  data: Record<string, unknown>[];
+  data: ChartDatum[];
   /** Key in data for the categorical axis. Default: "name" */
   xDataKey?: string;
   /** Chart margins */
@@ -98,24 +103,16 @@ function extractBarConfigs(children: ReactNode): LineConfig[] {
   const configs: LineConfig[] = [];
 
   forEachChartChild(children, (child) => {
-    const childType = child.type as {
-      displayName?: string;
-      name?: string;
-      __isBarDepthLayer?: boolean;
-    };
     // Bar-depth surface layers (BarDepthBack/Front, BarPulse) carry a
     // `dataKey` to pair with a Bar but are not series themselves — skip them
     // so they don't inflate the series count and shrink the real bars.
-    if (childType.__isBarDepthLayer) {
+    if (child.type instanceof Function && Reflect.get(child.type, "__isBarDepthLayer") === true) {
       return;
     }
-    const componentName =
-      typeof child.type === "function" ? childType.displayName || childType.name || "" : "";
+    const componentName = getChartChildComponentName(child);
 
     const props = child.props as BarProps | undefined;
-    const isBarComponent =
-      componentName === "Bar" ||
-      (props && typeof props.dataKey === "string" && props.dataKey.length > 0);
+    const isBarComponent = componentName === "Bar" || Boolean(props?.dataKey);
 
     if (isBarComponent && props?.dataKey) {
       // Use stroke for tooltip dot color if provided, otherwise fall back to fill
@@ -136,7 +133,7 @@ function extractBarConfigs(children: ReactNode): LineConfig[] {
 interface ChartInnerProps {
   width: number;
   height: number;
-  data: Record<string, unknown>[];
+  data: ChartDatum[];
   xDataKey: string;
   margin: Margin;
   animationDuration: number;
@@ -198,7 +195,7 @@ const ChartCore = memo(function ChartCore({
 
   // Category accessor function - returns string for categorical scale
   const categoryAccessor = useCallback(
-    (d: Record<string, unknown>): string => {
+    (d: ChartDatum): string => {
       const value = d[xDataKey];
       if (value instanceof Date) {
         return shortDateFmt.format(value);
@@ -210,7 +207,7 @@ const ChartCore = memo(function ChartCore({
 
   // For compatibility with ChartContext, provide a Date-based xAccessor
   const xAccessorDate = useCallback(
-    (d: Record<string, unknown>): Date => {
+    (d: ChartDatum): Date => {
       const value = d[xDataKey];
       if (value instanceof Date) {
         return value;
@@ -242,8 +239,8 @@ const ChartCore = memo(function ChartCore({
       for (const d of data) {
         let sum = 0;
         for (const line of lines) {
-          const value = d[line.dataKey];
-          if (typeof value === "number") {
+          const value = parseChartNumber(d[line.dataKey]);
+          if (value !== null) {
             sum += value;
           }
         }
@@ -257,8 +254,8 @@ const ChartCore = memo(function ChartCore({
     let max = 0;
     for (const line of lines) {
       for (const d of data) {
-        const value = d[line.dataKey];
-        if (typeof value === "number" && value > max) {
+        const value = parseChartNumber(d[line.dataKey]);
+        if (value !== null && value > max) {
           max = value;
         }
       }
@@ -288,8 +285,8 @@ const ChartCore = memo(function ChartCore({
         let max = 0;
         for (const d of data) {
           for (const key of dataKeys) {
-            const value = d[key];
-            if (typeof value === "number" && value > max) {
+            const value = parseChartNumber(d[key]);
+            if (value !== null && value > max) {
               max = value;
             }
           }
@@ -316,8 +313,8 @@ const ChartCore = memo(function ChartCore({
       let cumulative = 0;
       for (const line of lines) {
         pointOffsets.set(line.dataKey, cumulative);
-        const value = d[line.dataKey];
-        if (typeof value === "number") {
+        const value = parseChartNumber(d[line.dataKey]);
+        if (value !== null) {
           cumulative += value;
         }
       }
@@ -341,15 +338,11 @@ const ChartCore = memo(function ChartCore({
   const fakeTimeScale = useMemo(() => {
     const now = Date.now();
     const start = now - data.length * 24 * 60 * 60 * 1000;
-    const scale = {
-      ...categoryScale,
-      domain: () => [new Date(start), new Date(now)],
-      range: () => [0, innerWidth] as [number, number],
-      invert: (x: number) => new Date(start + (x / innerWidth) * (now - start)),
-      copy: () => scale,
-    };
-    return scale;
-  }, [categoryScale, innerWidth, data.length]);
+    return scaleTime<number>({
+      domain: [new Date(start), new Date(now)],
+      range: [0, innerWidth],
+    });
+  }, [innerWidth, data.length]);
 
   // Animation timing — replay when motion settings change
   // biome-ignore lint/correctness/useExhaustiveDependencies: revealSignature
@@ -406,8 +399,8 @@ const ChartCore = memo(function ChartCore({
           // Stacked horizontal: all bars same y, x at cumulative end
           let cumulative = 0;
           for (const line of lines) {
-            const value = d[line.dataKey];
-            if (typeof value === "number") {
+            const value = parseChartNumber(d[line.dataKey]);
+            if (value !== null) {
               cumulative += value;
               const axisScale = yScales[normalizeYAxisId(line.yAxisId)] ?? valueScale;
               xPositions[line.dataKey] = axisScale(cumulative) ?? 0;
@@ -417,8 +410,8 @@ const ChartCore = memo(function ChartCore({
         } else {
           // Grouped horizontal: each bar at its own y position
           lines.forEach((line, idx) => {
-            const value = d[line.dataKey];
-            if (typeof value === "number") {
+            const value = parseChartNumber(d[line.dataKey]);
+            if (value !== null) {
               const axisScale = yScales[normalizeYAxisId(line.yAxisId)] ?? valueScale;
               xPositions[line.dataKey] = axisScale(value) ?? 0;
               yPositions[line.dataKey] =
@@ -431,8 +424,8 @@ const ChartCore = memo(function ChartCore({
         let cumulative = 0;
         let seriesIdx = 0;
         for (const line of lines) {
-          const value = d[line.dataKey];
-          if (typeof value === "number") {
+          const value = parseChartNumber(d[line.dataKey]);
+          if (value !== null) {
             cumulative += value;
             const axisScale = yScales[normalizeYAxisId(line.yAxisId)] ?? primaryYScale;
             const gapOffset = seriesIdx * stackGap;
@@ -448,8 +441,8 @@ const ChartCore = memo(function ChartCore({
           seriesCount > 0 ? (bandWidth - groupGap * (seriesCount - 1)) / seriesCount : bandWidth;
 
         lines.forEach((line, idx) => {
-          const value = d[line.dataKey];
-          if (typeof value === "number") {
+          const value = parseChartNumber(d[line.dataKey]);
+          if (value !== null) {
             const axisScale = yScales[normalizeYAxisId(line.yAxisId)] ?? primaryYScale;
             yPositions[line.dataKey] = axisScale(value) ?? 0;
             xPositions[line.dataKey] =
@@ -534,7 +527,7 @@ const ChartCore = memo(function ChartCore({
     chartStatus: status,
     data,
     renderData: data,
-    xScale: fakeTimeScale as unknown as ReturnType<typeof import("@visx/scale").scaleTime<number>>,
+    xScale: fakeTimeScale,
     yScale: isHorizontal ? valueScale : primaryYScale,
     yScales,
     width,

--- a/apps/web/src/components/charts/bar-depth-geometry.ts
+++ b/apps/web/src/components/charts/bar-depth-geometry.ts
@@ -3,6 +3,11 @@ export const BAR_DEPTH_MAX_PX = 7;
  * subtle head-on perspective slope. */
 export const BAR_DEPTH_PERSPECTIVE_RATIO = 0.45;
 
+export interface BarDepthGeometry {
+  depth: number;
+  perspectiveRise: number;
+}
+
 /**
  * Maximum side-face depth in px for a chart, clamped so depth never spills past
  * the gap between bars. `stepWidth` is d3-scaleBand's `step()` (bandwidth +
@@ -26,7 +31,7 @@ export function barDepthAndRise(
   absOffset: number,
   naturalHeight: number,
   maxDepth: number,
-): { depth: number; perspectiveRise: number } {
+): BarDepthGeometry {
   const offset = Math.min(1, Math.max(0, absOffset));
   const cappedMaxDepth = Math.min(maxDepth, Math.max(0, naturalHeight));
   const depth = offset * cappedMaxDepth;

--- a/apps/web/src/components/charts/bar.tsx
+++ b/apps/web/src/components/charts/bar.tsx
@@ -7,6 +7,7 @@ import { memo, useId, useMemo } from "react";
 
 import { barDepthAndRise, barDepthMaxDepth } from "./bar-depth-geometry";
 import { chartCssVars, useChart, useChartStable, useYScale } from "./chart-context";
+import { parseChartNumber, type ChartDatum } from "./chart-data";
 import { useChartLegendHover } from "./chart-legend-hover";
 import { transitionWithDelay } from "./motion-utils";
 
@@ -25,9 +26,9 @@ export type BarAnimationType = "grow" | "fade";
 function barDepthPerspectiveRise(
   barScale: ScaleBand<string>,
   bandWidth: number,
-  barXAccessor: (d: Record<string, unknown>) => string,
+  barXAccessor: (d: ChartDatum) => string,
   innerWidth: number,
-  datum: Record<string, unknown>,
+  datum: ChartDatum,
   topY: number,
   baselineY: number,
 ): number {
@@ -35,7 +36,7 @@ function barDepthPerspectiveRise(
   if (centerX <= 0) {
     return 0;
   }
-  const step = (barScale as unknown as { step?: () => number }).step?.() ?? bandWidth;
+  const step = barScale.step();
   const maxDepth = barDepthMaxDepth(step, bandWidth);
   const bandX = barScale(barXAccessor(datum)) ?? 0;
   const cx = bandX + bandWidth / 2;
@@ -81,7 +82,7 @@ export interface BarProps {
 interface BarInnerProps extends BarProps {
   barScale: ScaleBand<string>;
   bandWidth: number;
-  barXAccessor: (d: Record<string, unknown>) => string;
+  barXAccessor: (d: ChartDatum) => string;
 }
 
 interface AnimatedBarProps {
@@ -244,8 +245,9 @@ const BarInner = memo(function BarInner({
     if (perspective) {
       return 0;
     }
-    if (typeof lineCap === "number") {
-      return lineCap;
+    const numericLineCap = parseChartNumber(lineCap);
+    if (numericLineCap !== null) {
+      return numericLineCap;
     }
     if (lineCap === "round" && barWidth) {
       return Math.min(barWidth / 2, 8);
@@ -256,8 +258,8 @@ const BarInner = memo(function BarInner({
   return (
     <g className={`bar-series-${uniqueId}`}>
       {data.map((d, i) => {
-        const value = d[dataKey];
-        if (typeof value !== "number") {
+        const value = parseChartNumber(d[dataKey]);
+        if (value === null) {
           return null;
         }
 

--- a/apps/web/src/components/charts/chart-child-passthrough.ts
+++ b/apps/web/src/components/charts/chart-child-passthrough.ts
@@ -7,13 +7,16 @@ import {
   type ReactNode,
 } from "react";
 
+import { getChartChildComponentName } from "./chart-defs";
+
 /** Marker on wrapper components whose single child should inherit clip classification. */
 export const CHART_CLIP_PASSTHROUGH = "__chartClipPassthrough" as const;
 
-export function isChartClipPassthrough(type: unknown): boolean {
+export function isChartClipPassthrough(type: ReactElement["type"]): boolean {
   return (
-    typeof type === "function" &&
-    (type as { [CHART_CLIP_PASSTHROUGH]?: boolean })[CHART_CLIP_PASSTHROUGH] === true
+    type instanceof Function &&
+    Object.hasOwn(type, CHART_CLIP_PASSTHROUGH) &&
+    Reflect.get(type, CHART_CLIP_PASSTHROUGH) === true
   );
 }
 
@@ -65,19 +68,15 @@ const UNDERLAY_COMPONENT_NAMES = new Set(["ReferenceArea"]);
 
 /** Markers render after the interaction overlay so they stay clickable. */
 export function isPostOverlayComponent(child: ReactElement): boolean {
-  const childType = child.type as {
-    displayName?: string;
-    name?: string;
-    __isChartMarkers?: boolean;
-    __isPostOverlay?: boolean;
-  };
-
-  if (childType.__isChartMarkers || childType.__isPostOverlay) {
+  if (
+    child.type instanceof Function &&
+    (Reflect.get(child.type, "__isChartMarkers") === true ||
+      Reflect.get(child.type, "__isPostOverlay") === true)
+  ) {
     return true;
   }
 
-  const componentName =
-    typeof child.type === "function" ? childType.displayName || childType.name || "" : "";
+  const componentName = getChartChildComponentName(child);
 
   return (
     componentName === "ChartMarkers" ||
@@ -88,18 +87,12 @@ export function isPostOverlayComponent(child: ReactElement): boolean {
 
 /** Renders above grid/axes but below series; excluded from grow-clip reveal. */
 export function isUnderlayComponent(child: ReactElement): boolean {
-  const childType = child.type as { displayName?: string; name?: string };
-  const componentName =
-    typeof child.type === "function" ? childType.displayName || childType.name || "" : "";
-  return UNDERLAY_COMPONENT_NAMES.has(componentName);
+  return UNDERLAY_COMPONENT_NAMES.has(getChartChildComponentName(child));
 }
 
 /** Grid and axes stay visible during series clip reveal (e.g. loading → ready). */
 export function isClipExcludedComponent(child: ReactElement): boolean {
-  const childType = child.type as { displayName?: string; name?: string };
-  const componentName =
-    typeof child.type === "function" ? childType.displayName || childType.name || "" : "";
-  return CLIP_EXCLUDED_COMPONENT_NAMES.has(componentName);
+  return CLIP_EXCLUDED_COMPONENT_NAMES.has(getChartChildComponentName(child));
 }
 
 /** SVG layer lists from chart shells need stable keys when rendered as arrays. */

--- a/apps/web/src/components/charts/chart-config-context.tsx
+++ b/apps/web/src/components/charts/chart-config-context.tsx
@@ -29,6 +29,11 @@ export interface ChartConfigProviderProps {
   children: ReactNode;
 }
 
+export interface TooltipBoxMotion {
+  animate: boolean;
+  springConfig: SpringConfig;
+}
+
 export function ChartConfigProvider({ value, children }: ChartConfigProviderProps) {
   const merged = useMemo<ChartConfigValue>(
     () => ({
@@ -48,10 +53,7 @@ export function useChartConfig(): ChartConfigValue {
 const DEFAULT_TOOLTIP_BOX_DAMPING = DEFAULT_CHART_CONFIG.tooltipBoxSpring.damping;
 
 /** Maps a damping slider to the floating tooltip panel follow spring. `0` = instant. */
-export function resolveTooltipBoxMotion(damping?: number): {
-  animate: boolean;
-  springConfig: SpringConfig;
-} {
+export function resolveTooltipBoxMotion(damping?: number): TooltipBoxMotion {
   if (damping === 0) {
     return {
       animate: false,

--- a/apps/web/src/components/charts/chart-context.tsx
+++ b/apps/web/src/components/charts/chart-context.tsx
@@ -17,6 +17,7 @@ import {
   useMemo,
 } from "react";
 
+import type { ChartDatum } from "./chart-data";
 import type { ChartPhase, ChartStatus } from "./chart-phase";
 import type { ReferenceAreaConfig } from "./reference-area-config";
 import type { ChartSelection } from "./use-chart-interaction";
@@ -64,7 +65,7 @@ export interface Margin {
 
 export interface TooltipData {
   /** The data point being hovered */
-  point: Record<string, unknown>;
+  point: ChartDatum;
   /** Index in the data array */
   index: number;
   /** X position in pixels (relative to chart area) */
@@ -114,9 +115,9 @@ export interface ChartHoverContextValue {
 
 export interface ChartContextValue extends ChartHoverContextValue {
   // Data
-  data: Record<string, unknown>[];
+  data: ChartDatum[];
   /** Decimated subset for SVG path rendering; equals `data` when no decimation is needed. */
-  renderData: Record<string, unknown>[];
+  renderData: ChartDatum[];
 
   // Scales
   xScale: ScaleTime<number, number>;
@@ -169,7 +170,7 @@ export interface ChartContextValue extends ChartHoverContextValue {
   notifyLoadingPulseComplete?: () => void;
 
   // X accessor - how to get the x value from data points
-  xAccessor: (d: Record<string, unknown>) => Date;
+  xAccessor: (d: ChartDatum) => Date;
 
   // Pre-computed date labels for ticker animation
   dateLabels: string[];
@@ -185,7 +186,7 @@ export interface ChartContextValue extends ChartHoverContextValue {
   /** Width of each bar band */
   bandWidth?: number;
   /** X accessor for bar charts (returns string instead of Date) */
-  barXAccessor?: (d: Record<string, unknown>) => string;
+  barXAccessor?: (d: ChartDatum) => string;
   /** Bar chart orientation */
   orientation?: "vertical" | "horizontal";
   /** Whether bars are stacked */

--- a/apps/web/src/components/charts/chart-data.ts
+++ b/apps/web/src/components/charts/chart-data.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+
+export const chartDatumValueSchema = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.date(),
+  z.null(),
+  z.undefined(),
+]);
+
+export type ChartDatumValue = z.infer<typeof chartDatumValueSchema>;
+
+export interface ChartDatum extends Record<string, ChartDatumValue> {}
+
+const finiteNumberSchema = z.number().finite();
+const stringSchema = z.string();
+const dateSchema = z
+  .union([z.date(), z.string(), z.number()])
+  .pipe(z.coerce.date())
+  .refine((value) => !Number.isNaN(value.getTime()));
+
+export function parseChartNumber<T>(value: T): number | null {
+  const result = finiteNumberSchema.safeParse(value);
+  return result.success ? result.data : null;
+}
+
+export function parseChartString<T>(value: T): string | null {
+  const result = stringSchema.safeParse(value);
+  return result.success ? result.data : null;
+}
+
+export function parseChartDate<T>(value: T): Date | null {
+  const result = dateSchema.safeParse(value);
+  return result.success ? result.data : null;
+}

--- a/apps/web/src/components/charts/chart-defs.ts
+++ b/apps/web/src/components/charts/chart-defs.ts
@@ -1,8 +1,9 @@
 import { Children, isValidElement, type ReactElement, type ReactNode } from "react";
 
 export function getChartChildComponentName(child: ReactElement): string {
-  const childType = child.type as { displayName?: string; name?: string };
-  return typeof child.type === "function" ? childType.displayName || childType.name || "" : "";
+  if (!(child.type instanceof Function)) return "";
+  const displayName = Reflect.get(child.type, "displayName");
+  return displayName == null ? child.type.name : String(displayName);
 }
 
 const VISX_PATTERN_COMPONENT_NAMES = new Set([
@@ -13,6 +14,11 @@ const VISX_PATTERN_COMPONENT_NAMES = new Set([
   "Path",
   "Pattern",
 ]);
+
+export interface PartitionedChartDefNodes {
+  patternDefNodes: ReactElement[];
+  gradientDefNodes: ReactElement[];
+}
 
 /** @visx/pattern default exports use short names (e.g. `Lines`); also match *Pattern* displayNames. */
 export function isPatternDefComponent(child: ReactElement): boolean {
@@ -30,10 +36,7 @@ export function isChartDefsComponent(child: ReactElement): boolean {
 }
 
 /** Split hoisted defs: @visx/pattern nodes already wrap `<defs>` and render at the svg root. */
-export function partitionChartDefNodes(defNodes: ReactElement[]): {
-  patternDefNodes: ReactElement[];
-  gradientDefNodes: ReactElement[];
-} {
+export function partitionChartDefNodes(defNodes: ReactElement[]): PartitionedChartDefNodes {
   const patternDefNodes: ReactElement[] = [];
   const gradientDefNodes: ReactElement[] = [];
 

--- a/apps/web/src/components/charts/decimate-time-series.ts
+++ b/apps/web/src/components/charts/decimate-time-series.ts
@@ -1,4 +1,6 @@
-export function decimateTimeSeries<T extends Record<string, unknown>>(
+import { parseChartNumber, type ChartDatum } from "./chart-data";
+
+export function decimateTimeSeries<T extends ChartDatum>(
   data: T[],
   maxPoints: number,
   valueKeys: string[] = [],
@@ -11,8 +13,9 @@ export function decimateTimeSeries<T extends Record<string, unknown>>(
   const getY = (point: T, index: number): number => {
     if (valueKeys.length === 0) {
       for (const val of Object.values(point)) {
-        if (typeof val === "number") {
-          return val;
+        const numericValue = parseChartNumber(val);
+        if (numericValue !== null) {
+          return numericValue;
         }
       }
       return index;
@@ -21,9 +24,9 @@ export function decimateTimeSeries<T extends Record<string, unknown>>(
     let sum = 0;
     let count = 0;
     for (const key of valueKeys) {
-      const val = point[key];
-      if (typeof val === "number") {
-        sum += val;
+      const value = parseChartNumber(point[key]);
+      if (value !== null) {
+        sum += value;
         count++;
       }
     }
@@ -85,10 +88,7 @@ export function maxRenderPointsForWidth(innerWidth: number): number {
 }
 
 /** Bucket OHLC rows into fewer candles while preserving high/low extremes. */
-export function decimateOhlcData<T extends Record<string, unknown>>(
-  data: T[],
-  maxPoints: number,
-): T[] {
+export function decimateOhlcData<T extends ChartDatum>(data: T[], maxPoints: number): T[] {
   const len = data.length;
   if (maxPoints >= len || maxPoints < 2) {
     return data;
@@ -111,12 +111,12 @@ export function decimateOhlcData<T extends Record<string, unknown>>(
     let high = Number.NEGATIVE_INFINITY;
     let low = Number.POSITIVE_INFINITY;
     for (const row of bucket) {
-      const rowHigh = row.high;
-      const rowLow = row.low;
-      if (typeof rowHigh === "number" && rowHigh > high) {
+      const rowHigh = parseChartNumber(row.high);
+      const rowLow = parseChartNumber(row.low);
+      if (rowHigh !== null && rowHigh > high) {
         high = rowHigh;
       }
-      if (typeof rowLow === "number" && rowLow < low) {
+      if (rowLow !== null && rowLow < low) {
         low = rowLow;
       }
     }

--- a/apps/web/src/components/charts/filter-data-by-x-domain.ts
+++ b/apps/web/src/components/charts/filter-data-by-x-domain.ts
@@ -1,8 +1,10 @@
+import type { ChartDatum } from "./chart-data";
+
 export function filterDataByXDomain(
-  data: Record<string, unknown>[],
+  data: ChartDatum[],
   xDomain: [Date, Date],
-  xAccessor: (d: Record<string, unknown>) => Date,
-): Record<string, unknown>[] {
+  xAccessor: (d: ChartDatum) => Date,
+): ChartDatum[] {
   const start = xDomain[0].getTime();
   const end = xDomain[1].getTime();
   const minTime = Math.min(start, end);
@@ -15,8 +17,8 @@ export function filterDataByXDomain(
 }
 
 export function resolveDataXExtent(
-  data: Record<string, unknown>[],
-  xAccessor: (d: Record<string, unknown>) => Date,
+  data: ChartDatum[],
+  xAccessor: (d: ChartDatum) => Date,
 ): [Date, Date] | null {
   if (data.length === 0) {
     return null;
@@ -44,8 +46,8 @@ export function resolveDataXExtent(
 
 /** Brush track extent — optionally extends past the last data row (e.g. projections). */
 export function resolveBrushTrackXExtent(
-  data: Record<string, unknown>[],
-  xAccessor: (d: Record<string, unknown>) => Date,
+  data: ChartDatum[],
+  xAccessor: (d: ChartDatum) => Date,
   xExtentMax?: Date,
 ): [Date, Date] | null {
   const extent = resolveDataXExtent(data, xAccessor);

--- a/apps/web/src/components/charts/generate-chart-skeleton-data.ts
+++ b/apps/web/src/components/charts/generate-chart-skeleton-data.ts
@@ -1,3 +1,5 @@
+import type { ChartDatum } from "./chart-data";
+
 const DEFAULT_SKELETON_DATA_KEY = "value";
 const DEFAULT_SKELETON_POINT_COUNT = 7;
 
@@ -13,7 +15,7 @@ export interface GenerateChartSkeletonDataOptions {
 /** Placeholder series used while `status="loading"` and data is empty. */
 export function generateChartSkeletonData(
   options: GenerateChartSkeletonDataOptions = {},
-): Record<string, unknown>[] {
+): ChartDatum[] {
   const dataKey = options.dataKey ?? DEFAULT_SKELETON_DATA_KEY;
   const pointCount = options.pointCount ?? DEFAULT_SKELETON_POINT_COUNT;
   const baseDate = options.baseDate ?? new Date("2025-01-01");
@@ -30,9 +32,9 @@ export function generateChartSkeletonData(
 
 /** Skeleton rows that mirror target dates/count with lower magnitudes for Y tween. */
 export function generateChartSkeletonFromTarget(
-  targetData: Record<string, unknown>[],
+  targetData: ChartDatum[],
   dataKey: string,
-): Record<string, unknown>[] {
+): ChartDatum[] {
   return targetData.map((row, index) => ({
     ...row,
     [dataKey]: Math.round(95 + Math.sin(index * 1.05) * 28 + index * 7),

--- a/apps/web/src/components/charts/grid.tsx
+++ b/apps/web/src/components/charts/grid.tsx
@@ -144,9 +144,9 @@ export function Grid({
     yScale,
   });
   const columnTickValuesResolved =
-    vertical && columnScale && typeof columnScale === "function" && hideVerticalEdgeLines
+    vertical && hideVerticalEdgeLines
       ? (() => {
-          const ticks = columnScale.ticks?.(numTicksColumns) ?? [];
+          const ticks = columnScale.ticks(numTicksColumns);
           const filtered = hideEdgeTicks<number | Date>(ticks, true);
           return filtered.length > 0 ? filtered : undefined;
         })()
@@ -277,7 +277,7 @@ export function Grid({
           })}
         </g>
       ) : null}
-      {vertical && columnScale && typeof columnScale === "function" && (
+      {vertical && columnScale && (
         <g mask={fadeVertical ? `url(#${vMaskId})` : undefined}>
           <GridColumns
             height={innerHeight}

--- a/apps/web/src/components/charts/highlight-segment-bounds.ts
+++ b/apps/web/src/components/charts/highlight-segment-bounds.ts
@@ -1,4 +1,5 @@
 import type { TooltipData } from "./chart-context";
+import type { ChartDatum } from "./chart-data";
 import type { ChartSelection } from "./use-chart-interaction";
 
 // Pure geometry for the hover-highlight band, split out from the hook so it can
@@ -33,9 +34,9 @@ export const INACTIVE_SEGMENT: SegmentBounds = {
  * directly and takes priority over hover.
  */
 export function computeSegmentBounds(
-  data: Record<string, unknown>[],
+  data: ChartDatum[],
   xScale: (value: Date) => number | undefined,
-  xAccessor: (d: Record<string, unknown>) => Date,
+  xAccessor: (d: ChartDatum) => Date,
   tooltipData: Pick<TooltipData, "index"> | null | undefined,
   selection: Pick<ChartSelection, "active" | "startX" | "endX"> | null | undefined,
 ): SegmentBounds {

--- a/apps/web/src/components/charts/loading-sweep.tsx
+++ b/apps/web/src/components/charts/loading-sweep.tsx
@@ -108,7 +108,7 @@ function LoadingSweepMask({
 
   const handleUpdate = useCallback(
     (latest: { x?: number }) => {
-      const xValue = typeof latest.x === "number" ? latest.x : SWEEP_START_X;
+      const xValue = latest.x ?? SWEEP_START_X;
       // Re-roll once the band has cleared the visible area (crossed past 1),
       // so the silhouette never changes shape under the user's eye.
       if (xValue >= 1 && lastXRef.current < 1) {

--- a/apps/web/src/components/charts/motion-utils.ts
+++ b/apps/web/src/components/charts/motion-utils.ts
@@ -1,6 +1,7 @@
 import type { Transition } from "motion/react";
 
 import { DEFAULT_CHART_ENTER_TRANSITION } from "./animation";
+import { parseChartNumber } from "./chart-data";
 
 export function transitionWithDelay(
   transition: Transition | undefined,
@@ -25,22 +26,19 @@ export function springOptionsFromTransition(
     return fallback;
   }
   if (transition.type === "spring") {
-    const bounce = typeof transition.bounce === "number" ? transition.bounce : undefined;
-    const baseStiffness =
-      typeof transition.stiffness === "number" ? transition.stiffness : fallback.stiffness;
-    const baseDamping =
-      typeof transition.damping === "number" ? transition.damping : fallback.damping;
+    const bounce = parseChartNumber(transition.bounce) ?? undefined;
+    const baseStiffness = parseChartNumber(transition.stiffness) ?? fallback.stiffness;
+    const baseDamping = parseChartNumber(transition.damping) ?? fallback.damping;
     return {
       stiffness:
         bounce == null
           ? baseStiffness
           : Math.min(400, Math.max(80, baseStiffness * (1 + bounce * 0.35))),
       damping: bounce == null ? baseDamping : Math.max(8, baseDamping * (1 - bounce * 0.25)),
-      mass: typeof transition.mass === "number" ? transition.mass : fallback.mass,
+      mass: parseChartNumber(transition.mass) ?? fallback.mass,
     };
   }
-  const duration =
-    "duration" in transition && typeof transition.duration === "number" ? transition.duration : 0.8;
+  const duration = parseChartNumber(transition.duration) ?? 0.8;
   return {
     stiffness: Math.min(500, Math.max(40, 280 / duration)),
     damping: Math.min(40, Math.max(12, 18 + duration * 4)),

--- a/apps/web/src/components/charts/path-stroke-utils.ts
+++ b/apps/web/src/components/charts/path-stroke-utils.ts
@@ -1,5 +1,7 @@
 import { type RefObject, useEffect, useState } from "react";
 
+import type { ChartDatum } from "./chart-data";
+
 export function findPathLengthAtX(
   path: SVGPathElement | null,
   pathLength: number,
@@ -69,10 +71,10 @@ export function resolveDashTailBounds(
 }
 
 export function resolveDashStartX(
-  data: Record<string, unknown>[],
+  data: ChartDatum[],
   dashFromIndex: number,
   xScale: (value: Date | number) => number | undefined,
-  xAccessor: (datum: Record<string, unknown>) => Date | number,
+  xAccessor: (datum: ChartDatum) => Date | number,
 ): number {
   const dashFromPoint = data[dashFromIndex];
   if (!dashFromPoint) {

--- a/apps/web/src/components/charts/pattern-area.tsx
+++ b/apps/web/src/components/charts/pattern-area.tsx
@@ -4,6 +4,7 @@ import { curveMonotoneX } from "@visx/curve";
 import { AreaClosed } from "@visx/shape";
 
 import { useChartStable } from "./chart-context";
+import { parseChartNumber } from "./chart-data";
 
 // biome-ignore lint/suspicious/noExplicitAny: d3 curve factory type
 type CurveFactory = any;
@@ -33,8 +34,8 @@ export function PatternArea({ dataKey, fill, curve = curveMonotoneX }: PatternAr
       fill={fill}
       x={(d) => xScale(xAccessor(d)) ?? 0}
       y={(d) => {
-        const v = d[dataKey];
-        return typeof v === "number" ? (yScale(v) ?? 0) : 0;
+        const value = parseChartNumber(d[dataKey]);
+        return value === null ? 0 : (yScale(value) ?? 0);
       }}
       yScale={yScale}
     />

--- a/apps/web/src/components/charts/projection-config.ts
+++ b/apps/web/src/components/charts/projection-config.ts
@@ -1,6 +1,7 @@
 import { Children, Fragment, isValidElement, type ReactElement, type ReactNode } from "react";
 
 import { isChartClipPassthrough } from "./chart-child-passthrough";
+import { getChartChildComponentName } from "./chart-defs";
 import type { ProjectionPoint } from "./projection-utils";
 import { projectionDateExtents, projectionValueExtents } from "./projection-utils";
 import { normalizeYAxisId } from "./y-axis-scales";
@@ -16,8 +17,7 @@ interface ProjectionLineConfigProps {
 }
 
 function getChildComponentName(child: ReactElement) {
-  const childType = child.type as { displayName?: string; name?: string };
-  return typeof child.type === "function" ? childType.displayName || childType.name || "" : "";
+  return getChartChildComponentName(child);
 }
 
 function isProjectionLineElement(child: ReactElement): boolean {

--- a/apps/web/src/components/charts/projection-utils.ts
+++ b/apps/web/src/components/charts/projection-utils.ts
@@ -1,3 +1,5 @@
+import { parseChartDate, parseChartNumber, type ChartDatum } from "./chart-data";
+
 export type ProjectionMode = "auto" | "target" | "manual";
 export type ProjectionAutoMethod = "linearRegression" | "lastSegment";
 /** How the projection segment is drawn between anchor and horizon. */
@@ -11,7 +13,7 @@ export interface ProjectionPoint {
 }
 
 export interface BuildProjectionPathOptions {
-  sourceData: Record<string, unknown>[];
+  sourceData: ChartDatum[];
   seriesKey: string;
   xDataKey?: string;
   mode: ProjectionMode;
@@ -28,31 +30,15 @@ export interface BuildProjectionPathOptions {
   points?: ProjectionPoint[];
 }
 
-function readDate(row: Record<string, unknown>, xDataKey: string): Date | null {
-  const raw = row[xDataKey];
-  if (raw instanceof Date && !Number.isNaN(raw.getTime())) {
-    return raw;
-  }
-  if (typeof raw === "number" && Number.isFinite(raw)) {
-    const date = new Date(raw);
-    return Number.isNaN(date.getTime()) ? null : date;
-  }
-  if (typeof raw === "string") {
-    const date = new Date(raw);
-    return Number.isNaN(date.getTime()) ? null : date;
-  }
-  return null;
+function readDate(row: ChartDatum, xDataKey: string): Date | null {
+  return parseChartDate(row[xDataKey]);
 }
 
-function readValue(row: Record<string, unknown>, seriesKey: string): number | null {
-  const raw = row[seriesKey];
-  return typeof raw === "number" && Number.isFinite(raw) ? raw : null;
+function readValue(row: ChartDatum, seriesKey: string): number | null {
+  return parseChartNumber(row[seriesKey]);
 }
 
-function resolveStartIndex(
-  sourceData: Record<string, unknown>[],
-  startIndex: number | undefined,
-): number {
+function resolveStartIndex(sourceData: ChartDatum[], startIndex: number | undefined): number {
   if (startIndex == null || !Number.isFinite(startIndex)) {
     return Math.max(0, sourceData.length - 1);
   }
@@ -60,7 +46,7 @@ function resolveStartIndex(
 }
 
 function intervalFromAdjacentRows(
-  sourceData: Record<string, unknown>[],
+  sourceData: ChartDatum[],
   xDataKey: string,
   startIndex: number,
 ): number | null {
@@ -78,10 +64,7 @@ function intervalFromAdjacentRows(
   return delta > 0 ? delta : null;
 }
 
-function intervalFromSeriesSpan(
-  sourceData: Record<string, unknown>[],
-  xDataKey: string,
-): number | null {
+function intervalFromSeriesSpan(sourceData: ChartDatum[], xDataKey: string): number | null {
   if (sourceData.length < 2) {
     return null;
   }
@@ -96,11 +79,7 @@ function intervalFromSeriesSpan(
   return span > 0 ? span / (sourceData.length - 1) : null;
 }
 
-function resolveIntervalMs(
-  sourceData: Record<string, unknown>[],
-  xDataKey: string,
-  startIndex: number,
-): number {
+function resolveIntervalMs(sourceData: ChartDatum[], xDataKey: string, startIndex: number): number {
   return (
     intervalFromAdjacentRows(sourceData, xDataKey, startIndex) ??
     intervalFromSeriesSpan(sourceData, xDataKey) ??
@@ -184,7 +163,7 @@ function buildAutoFutureValues(options: {
 
 /** Slope (value change per ms) at the projection anchor from the last data segment. */
 export function computeProjectionAnchorTangentSlope(
-  sourceData: Record<string, unknown>[],
+  sourceData: ChartDatum[],
   seriesKey: string,
   xDataKey = "date",
   startIndexProp?: number,

--- a/apps/web/src/components/charts/reference-area-config.ts
+++ b/apps/web/src/components/charts/reference-area-config.ts
@@ -1,5 +1,6 @@
 import { Children, isValidElement, type ReactElement, type ReactNode } from "react";
 
+import { getChartChildComponentName } from "./chart-defs";
 import { normalizeYAxisId } from "./y-axis-scales";
 
 export interface ReferenceAreaConfig {
@@ -17,8 +18,7 @@ interface ReferenceAreaConfigProps {
 }
 
 function getChildComponentName(child: ReactElement) {
-  const childType = child.type as { displayName?: string; name?: string };
-  return typeof child.type === "function" ? childType.displayName || childType.name || "" : "";
+  return getChartChildComponentName(child);
 }
 
 function isReferenceAreaElement(child: ReactElement): boolean {

--- a/apps/web/src/components/charts/series-dash-tail-overlay.tsx
+++ b/apps/web/src/components/charts/series-dash-tail-overlay.tsx
@@ -2,13 +2,14 @@
 
 import { memo, useMemo } from "react";
 
+import type { ChartDatum } from "./chart-data";
 import { DashTailStroke } from "./dash-tail-stroke";
 import { resolveDashStartX, resolveDashTailBounds } from "./path-stroke-utils";
 
 interface SeriesDashTailOverlayProps {
   dashFromIndex?: number;
   dashArray: string;
-  data: Record<string, unknown>[];
+  data: ChartDatum[];
   pathD: string | null;
   pathLength: number;
   innerWidth: number;
@@ -16,7 +17,7 @@ interface SeriesDashTailOverlayProps {
   stroke: string;
   strokeWidth: number;
   xScale: (value: Date | number) => number | undefined;
-  xAccessor: (datum: Record<string, unknown>) => Date | number;
+  xAccessor: (datum: ChartDatum) => Date | number;
 }
 
 function SeriesDashTailOverlayImpl({

--- a/apps/web/src/components/charts/series-markers.tsx
+++ b/apps/web/src/components/charts/series-markers.tsx
@@ -4,6 +4,7 @@ import { type ReactNode, useCallback, useMemo } from "react";
 
 import { clipRevealTransition } from "./animation";
 import { defaultScatterColors, useChartHover, useChartStable, useYScale } from "./chart-context";
+import { parseChartNumber, type ChartDatum } from "./chart-data";
 import { useChartLegendHover } from "./chart-legend-hover";
 import {
   getSeriesMarkerVisualExtent,
@@ -99,9 +100,9 @@ export function SeriesMarkers({
   const isRevealing = animate && !isLoaded;
 
   const getY = useCallback(
-    (d: Record<string, unknown>) => {
-      const value = d[dataKey];
-      return typeof value === "number" ? (yScale(value) ?? 0) : null;
+    (d: ChartDatum) => {
+      const value = parseChartNumber(d[dataKey]);
+      return value === null ? null : (yScale(value) ?? 0);
     },
     [dataKey, yScale],
   );

--- a/apps/web/src/components/charts/time-series-chart-shell.tsx
+++ b/apps/web/src/components/charts/time-series-chart-shell.tsx
@@ -24,6 +24,7 @@ import {
   resolveChartChildElement,
 } from "./chart-child-passthrough";
 import { ChartProvider, type LineConfig, type Margin } from "./chart-context";
+import { parseChartNumber, type ChartDatum } from "./chart-data";
 import { isGradientDefComponent, isPatternDefComponent } from "./chart-defs";
 import { shortDateFmt } from "./chart-formatters";
 import {
@@ -60,14 +61,14 @@ import {
 } from "./y-axis-scales";
 import { computeYDomainsByAxis } from "./y-domain-utils";
 
-function collectNumericExtents(data: Record<string, unknown>[], dataKeys: string[]) {
+function collectNumericExtents(data: ChartDatum[], dataKeys: string[]) {
   let minValue = Number.POSITIVE_INFINITY;
   let maxValue = Number.NEGATIVE_INFINITY;
 
   for (const d of data) {
     for (const key of dataKeys) {
-      const value = d[key];
-      if (typeof value === "number") {
+      const value = parseChartNumber(d[key]);
+      if (value !== null) {
         if (value < minValue) {
           minValue = value;
         }
@@ -86,7 +87,7 @@ function collectNumericExtents(data: Record<string, unknown>[], dataKeys: string
 }
 
 function resolveTimeSeriesYDomain(
-  data: Record<string, unknown>[],
+  data: ChartDatum[],
   dataKeys: string[],
   yScaleDomainMax: number | undefined,
 ): [number, number] {
@@ -115,7 +116,7 @@ function ensureChildKey(child: ReactElement, index: number): ReactElement {
 export interface TimeSeriesChartInnerProps {
   width: number;
   height: number;
-  data: Record<string, unknown>[];
+  data: ChartDatum[];
   xDataKey: string;
   margin: Margin;
   animationDuration: number;
@@ -198,7 +199,7 @@ const TimeSeriesChartCore = memo(function TimeSeriesChartCore({
   const innerHeight = height - margin.top - margin.bottom;
 
   const resolveYDomain = useCallback(
-    (sourceData: Record<string, unknown>[], dataKeys: string[]) => {
+    (sourceData: ChartDatum[], dataKeys: string[]) => {
       const axisGroups = groupLinesByYAxisId(lines);
       const usesDefaultOnly = axisGroups.size === 1 && axisGroups.has(DEFAULT_Y_AXIS_ID);
       const domainMax = usesDefaultOnly && yScaleDomainMax != null ? yScaleDomainMax : undefined;
@@ -239,7 +240,7 @@ const TimeSeriesChartCore = memo(function TimeSeriesChartCore({
   }, [chartPhase, onPhaseChange]);
 
   const xAccessor = useCallback(
-    (d: Record<string, unknown>): Date => {
+    (d: ChartDatum): Date => {
       const value = d[xDataKey];
       return value instanceof Date ? value : new Date(value as string | number);
     },
@@ -247,7 +248,7 @@ const TimeSeriesChartCore = memo(function TimeSeriesChartCore({
   );
 
   const bisectDate = useMemo(
-    () => bisector<Record<string, unknown>, Date>((d) => xAccessor(d)).left,
+    () => bisector<ChartDatum, Date>((d) => xAccessor(d)).left,
     [xAccessor],
   );
 
@@ -315,7 +316,7 @@ const TimeSeriesChartCore = memo(function TimeSeriesChartCore({
     if (projectionConfigs.length === 0) {
       return base;
     }
-    const merged: Record<string, [number, number]> = { ...base };
+    const merged = { ...base } satisfies Record<string, [number, number]>;
     for (const axisId of Object.keys(base)) {
       merged[axisId] = mergeProjectionYDomain(base[axisId] ?? [0, 100], projectionConfigs, axisId);
     }

--- a/apps/web/src/components/charts/tooltip/chart-tooltip.tsx
+++ b/apps/web/src/components/charts/tooltip/chart-tooltip.tsx
@@ -10,6 +10,7 @@ import {
   useChartConfig,
 } from "../chart-config-context";
 import { chartCssVars, type LineConfig, useChart, useChartStable } from "../chart-context";
+import { parseChartNumber, type ChartDatum } from "../chart-data";
 import { weekdayDateFmt } from "../chart-formatters";
 import type { IndicatorFadeEdges } from "../indicator-fade";
 import { DateTicker } from "./date-ticker";
@@ -29,16 +30,16 @@ export interface ChartTooltipProps {
    * Color for the crosshair/indicator line. When a function, receives the hovered point
    * (e.g. for candlestick: match candle color from close vs open). Default: --chart-crosshair.
    */
-  indicatorColor?: string | ((point: Record<string, unknown>) => string);
+  indicatorColor?: string | ((point: ChartDatum) => string);
   /** Custom content renderer for the tooltip box */
-  content?: (props: { point: Record<string, unknown>; index: number }) => React.ReactNode;
+  content?: (props: { point: ChartDatum; index: number }) => React.ReactNode;
   /** Custom row renderer - return array of TooltipRow */
-  rows?: (point: Record<string, unknown>) => TooltipRow[];
+  rows?: (point: ChartDatum) => TooltipRow[];
   /**
    * Override tooltip dot fill. When omitted and `rows` is set, dot colors match row colors.
    * When a function, receives the hovered point and line config.
    */
-  dotColor?: string | ((point: Record<string, unknown>, line: LineConfig) => string);
+  dotColor?: string | ((point: ChartDatum, line: LineConfig) => string);
   /** Additional content to show below rows (e.g., markers) */
   children?: React.ReactNode;
   /** Custom class name */
@@ -153,7 +154,7 @@ const ChartTooltipInner = memo(function ChartTooltipInner({
     return lines.map((line) => ({
       color: line.stroke,
       label: line.dataKey,
-      value: (tooltipData.point[line.dataKey] as number) ?? 0,
+      value: parseChartNumber(tooltipData.point[line.dataKey]) ?? 0,
     }));
   }, [tooltipData, lines, rowsRenderer]);
 
@@ -163,12 +164,10 @@ const ChartTooltipInner = memo(function ChartTooltipInner({
         return tooltipRows[index].color;
       }
       if (dotColorProp != null) {
-        if (typeof dotColorProp === "function" && tooltipData) {
-          return dotColorProp(tooltipData.point, line);
+        if (dotColorProp instanceof Function) {
+          return tooltipData ? dotColorProp(tooltipData.point, line) : line.stroke;
         }
-        if (typeof dotColorProp === "string") {
-          return dotColorProp;
-        }
+        return dotColorProp;
       }
       return line.stroke;
     };
@@ -179,7 +178,7 @@ const ChartTooltipInner = memo(function ChartTooltipInner({
     if (indicatorColorProp == null) {
       return chartCssVars.crosshair;
     }
-    if (typeof indicatorColorProp === "function") {
+    if (indicatorColorProp instanceof Function) {
       return tooltipData ? indicatorColorProp(tooltipData.point) : chartCssVars.crosshair;
     }
     return indicatorColorProp;

--- a/apps/web/src/components/charts/tooltip/tooltip-content.tsx
+++ b/apps/web/src/components/charts/tooltip/tooltip-content.tsx
@@ -2,6 +2,7 @@
 
 import type { ReactNode } from "react";
 
+import { parseChartNumber } from "../chart-data";
 import { intFmt } from "../chart-formatters";
 
 export interface TooltipRow {
@@ -27,23 +28,26 @@ export function TooltipContent({ title, rows, children }: TooltipContentProps) {
           </div>
         )}
         <div className="space-y-1.5">
-          {rows.map((row) => (
-            <div
-              className="flex items-center justify-between gap-4"
-              key={`${row.label}-${row.color}`}
-            >
-              <div className="flex items-center gap-2">
-                <span
-                  className="h-2.5 w-2.5 shrink-0 rounded-full"
-                  style={{ backgroundColor: row.color }}
-                />
-                <span className="text-chart-tooltip-muted text-sm">{row.label}</span>
+          {rows.map((row) => {
+            const numericValue = parseChartNumber(row.value);
+            return (
+              <div
+                className="flex items-center justify-between gap-4"
+                key={`${row.label}-${row.color}`}
+              >
+                <div className="flex items-center gap-2">
+                  <span
+                    className="h-2.5 w-2.5 shrink-0 rounded-full"
+                    style={{ backgroundColor: row.color }}
+                  />
+                  <span className="text-chart-tooltip-muted text-sm">{row.label}</span>
+                </div>
+                <span className="font-medium text-chart-tooltip-foreground text-sm tabular-nums">
+                  {numericValue === null ? row.value : intFmt(numericValue)}
+                </span>
               </div>
-              <span className="font-medium text-chart-tooltip-foreground text-sm tabular-nums">
-                {typeof row.value === "number" ? intFmt(row.value) : row.value}
-              </span>
-            </div>
-          ))}
+            );
+          })}
         </div>
 
         {children && (

--- a/apps/web/src/components/charts/tooltip/tooltip-indicator.tsx
+++ b/apps/web/src/components/charts/tooltip/tooltip-indicator.tsx
@@ -5,6 +5,7 @@ import { useEffect } from "react";
 
 import { type SpringConfig, useChartConfig } from "../chart-config-context";
 import { chartCssVars } from "../chart-context";
+import { parseChartNumber } from "../chart-data";
 import {
   type IndicatorFadeEdges,
   indicatorFadeGradientStops,
@@ -56,9 +57,8 @@ export interface TooltipIndicatorProps {
 }
 
 function resolveWidth(width: IndicatorWidth): number {
-  if (typeof width === "number") {
-    return width;
-  }
+  const numericWidth = parseChartNumber(width);
+  if (numericWidth !== null) return numericWidth;
   switch (width) {
     case "line":
       return 1;

--- a/apps/web/src/components/charts/use-chart-interaction.ts
+++ b/apps/web/src/components/charts/use-chart-interaction.ts
@@ -5,11 +5,22 @@ import type { scaleLinear, scaleTime } from "@visx/scale";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { LineConfig, Margin, TooltipData } from "./chart-context";
+import { parseChartNumber, type ChartDatum } from "./chart-data";
 import { useScheduledTooltip } from "./use-scheduled-tooltip";
 import { normalizeYAxisId } from "./y-axis-scales";
 
 type ScaleTime = ReturnType<typeof scaleTime<number>>;
 type ScaleLinear = ReturnType<typeof scaleLinear<number>>;
+
+function getLocalTouchPoint(
+  svg: SVGSVGElement,
+  touch: React.Touch,
+): { x: number; y: number } | null {
+  const screenMatrix = svg.getScreenCTM();
+  if (!screenMatrix) return null;
+  const point = new DOMPoint(touch.clientX, touch.clientY).matrixTransform(screenMatrix.inverse());
+  return { x: point.x, y: point.y };
+}
 
 export interface ChartSelection {
   startX: number;
@@ -23,11 +34,11 @@ interface UseChartInteractionParams {
   xScale: ScaleTime;
   yScale: ScaleLinear;
   yScales: Record<string, ScaleLinear>;
-  data: Record<string, unknown>[];
+  data: ChartDatum[];
   lines: LineConfig[];
   margin: Margin;
-  xAccessor: (d: Record<string, unknown>) => Date;
-  bisectDate: (data: Record<string, unknown>[], date: Date, lo: number) => number;
+  xAccessor: (d: ChartDatum) => Date;
+  bisectDate: (data: ChartDatum[], date: Date, lo: number) => number;
   canInteract: boolean;
 }
 
@@ -91,8 +102,8 @@ export function useChartInteraction({
 
       const yPositions: Record<string, number> = {};
       for (const line of lines) {
-        const value = d[line.dataKey];
-        if (typeof value === "number") {
+        const value = parseChartNumber(d[line.dataKey]);
+        if (value !== null) {
           const axisScale = yScales[normalizeYAxisId(line.yAxisId)] ?? yScale;
           yPositions[line.dataKey] = axisScale(value) ?? 0;
         }
@@ -145,7 +156,7 @@ export function useChartInteraction({
         if (!svg) {
           return null;
         }
-        point = localPoint(svg, touch as unknown as MouseEvent);
+        point = getLocalTouchPoint(svg, touch);
       } else {
         point = localPoint(event);
       }

--- a/apps/web/src/components/charts/use-chart-phase-orchestrator.ts
+++ b/apps/web/src/components/charts/use-chart-phase-orchestrator.ts
@@ -2,12 +2,13 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import type { ChartDatum } from "./chart-data";
 import { type ChartPhase, type ChartStatus, resolveRestingChartPhase } from "./chart-phase";
 
 export interface UseChartPhaseOrchestratorOptions {
   chartStatus: ChartStatus;
-  targetData: Record<string, unknown>[];
-  skeletonData: Record<string, unknown>[];
+  targetData: ChartDatum[];
+  skeletonData: ChartDatum[];
   animationDuration: number;
   yDomainTweenDuration: number;
   /** Signature of motion URL state — replays clip reveal in Studio. */
@@ -28,7 +29,7 @@ export function useChartPhaseOrchestrator({
   const [chartPhase, setChartPhase] = useState<ChartPhase>(() =>
     resolveRestingChartPhase(chartStatus),
   );
-  const [plotData, setPlotData] = useState<Record<string, unknown>[]>(() =>
+  const [plotData, setPlotData] = useState<ChartDatum[]>(() =>
     chartStatus === "loading" ? skeletonData : targetData,
   );
   const [revealEpoch, setRevealEpoch] = useState(0);

--- a/apps/web/src/components/charts/use-scheduled-tooltip.ts
+++ b/apps/web/src/components/charts/use-scheduled-tooltip.ts
@@ -2,7 +2,12 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
-export interface ScheduledTooltipControls<T> {
+interface TooltipIdentity {
+  index: number;
+  x?: number;
+}
+
+export interface ScheduledTooltipControls<T extends TooltipIdentity> {
   tooltipData: T | null;
   setTooltipData: React.Dispatch<React.SetStateAction<T | null>>;
   scheduleTooltip: (tooltip: T, dedupeKey?: string) => void;
@@ -10,23 +15,13 @@ export interface ScheduledTooltipControls<T> {
   resetTooltipDedupe: () => void;
 }
 
-function defaultDedupeKey<T>(tooltip: T): string {
-  if (
-    typeof tooltip === "object" &&
-    tooltip !== null &&
-    "index" in tooltip &&
-    typeof (tooltip as { index: unknown }).index === "number"
-  ) {
-    const { index, x } = tooltip as { index: number; x?: number };
-    if (typeof x === "number") {
-      return `${index}:${Math.round(x)}`;
-    }
-    return String(index);
-  }
-  return JSON.stringify(tooltip);
+function defaultDedupeKey<T extends TooltipIdentity>(tooltip: T): string {
+  return tooltip.x === undefined
+    ? String(tooltip.index)
+    : `${tooltip.index}:${Math.round(tooltip.x)}`;
 }
 
-export function useScheduledTooltip<T>(): ScheduledTooltipControls<T> {
+export function useScheduledTooltip<T extends TooltipIdentity>(): ScheduledTooltipControls<T> {
   const [tooltipData, setTooltipData] = useState<T | null>(null);
   const lastKeyRef = useRef<string | null>(null);
   const pendingRef = useRef<T | null>(null);

--- a/apps/web/src/components/charts/x-axis.tsx
+++ b/apps/web/src/components/charts/x-axis.tsx
@@ -6,6 +6,7 @@ import { createPortal } from "react-dom";
 import { cn } from "@/lib/utils";
 
 import { useChart, useChartStable } from "./chart-context";
+import type { ChartDatum } from "./chart-data";
 import { shortDateFmt } from "./chart-formatters";
 import { DEFAULT_Y_DOMAIN_TWEEN_MS } from "./chart-phase";
 import { LINE_LOADING_PULSE_EASE } from "./line-loading-timing";
@@ -171,9 +172,9 @@ function allIndexLayouts(length: number, tickCount: number): number[][] {
 
 function dedupeIndicesByLabel(
   indices: number[],
-  data: Record<string, unknown>[],
+  data: ChartDatum[],
   dateLabels: string[],
-  xAccessor: (d: Record<string, unknown>) => Date,
+  xAccessor: (d: ChartDatum) => Date,
 ): number[] {
   const seenLabels = new Set<string>();
   const deduped: number[] = [];
@@ -311,9 +312,9 @@ export function selectEvenlySpacedIndices(
   length: number,
   targetCount: number,
   options?: {
-    data?: Record<string, unknown>[];
+    data?: ChartDatum[];
     dateLabels?: string[];
-    xAccessor?: (d: Record<string, unknown>) => Date;
+    xAccessor?: (d: ChartDatum) => Date;
     resolveXPx?: (index: number) => number;
   },
 ): number[] {
@@ -369,11 +370,11 @@ function buildDataAlignedTicks({
   xAccessor,
   xScale,
 }: {
-  data: Record<string, unknown>[];
+  data: ChartDatum[];
   dateLabels: string[];
   marginLeft: number;
   targetTickCount: number;
-  xAccessor: (d: Record<string, unknown>) => Date;
+  xAccessor: (d: ChartDatum) => Date;
   xScale: (date: Date) => number | undefined;
 }): AxisTick[] {
   const seenLabels = new Set<string>();
@@ -459,8 +460,8 @@ function buildDomainTicks({
 }
 
 function domainExtendsPastData(
-  data: Record<string, unknown>[],
-  xAccessor: (d: Record<string, unknown>) => Date,
+  data: ChartDatum[],
+  xAccessor: (d: ChartDatum) => Date,
   xScale: { domain: () => Date[] },
 ): boolean {
   if (data.length === 0) {
@@ -477,8 +478,8 @@ function domainExtendsPastData(
 /** Domain ticks for the projection tail when brush keeps data-aligned labels. */
 function appendProjectionTailTicks(
   ticks: AxisTick[],
-  data: Record<string, unknown>[],
-  xAccessor: (d: Record<string, unknown>) => Date,
+  data: ChartDatum[],
+  xAccessor: (d: ChartDatum) => Date,
   xScale: {
     domain: () => Date[];
     (date: Date): number | undefined;

--- a/apps/web/src/components/charts/y-axis-scales.ts
+++ b/apps/web/src/components/charts/y-axis-scales.ts
@@ -1,6 +1,7 @@
 import { scaleLinear } from "@visx/scale";
 
 import type { LineConfig } from "./chart-context";
+import type { ChartDatum } from "./chart-data";
 
 /** Default axis id when `yAxisId` is omitted (Recharts-style `0` / primary left axis). */
 export const DEFAULT_Y_AXIS_ID = "left";
@@ -27,6 +28,8 @@ export function groupLinesByYAxisId(lines: LineConfig[]): Map<string, LineConfig
 
 type YScale = ReturnType<typeof scaleLinear<number>>;
 
+export interface YScaleMap extends Record<string, YScale> {}
+
 export function getPrimaryYScale(yScales: Record<string, YScale>, fallback: YScale): YScale {
   const primary = yScales[DEFAULT_Y_AXIS_ID];
   if (primary) {
@@ -43,12 +46,12 @@ export function buildYScalesForLines({
 }: {
   lines: LineConfig[];
   /** Passed by callers; domain is resolved via `resolveDomain`. */
-  data?: Record<string, unknown>[];
+  data?: ChartDatum[];
   innerHeight: number;
   resolveDomain: (dataKeys: string[]) => [number, number];
-}): Record<string, YScale> {
+}): YScaleMap {
   const groups = groupLinesByYAxisId(lines);
-  const scales: Record<string, YScale> = {};
+  const scales: YScaleMap = {};
 
   for (const [axisId, axisLines] of groups) {
     const dataKeys = axisLines.map((line) => line.dataKey);
@@ -80,9 +83,9 @@ export function buildYScalesFromDomains({
   lines: LineConfig[];
   innerHeight: number;
   domainsByAxis: Record<string, [number, number]>;
-}): Record<string, YScale> {
+}): YScaleMap {
   const groups = groupLinesByYAxisId(lines);
-  const scales: Record<string, YScale> = {};
+  const scales: YScaleMap = {};
 
   for (const [axisId] of groups) {
     const domain =
@@ -104,6 +107,6 @@ export function buildYScalesFromDomains({
 }
 
 /** Single-axis charts (bar, scatter, candlestick, live line). */
-export function wrapSingleYScale(yScale: YScale): Record<string, YScale> {
+export function wrapSingleYScale(yScale: YScale): YScaleMap {
   return { [DEFAULT_Y_AXIS_ID]: yScale };
 }

--- a/apps/web/src/components/charts/y-domain-utils.ts
+++ b/apps/web/src/components/charts/y-domain-utils.ts
@@ -6,6 +6,8 @@ import { groupLinesByYAxisId, normalizeYAxisId } from "./y-axis-scales";
 
 export type YDomain = [number, number];
 
+export interface YDomainMap extends Record<string, YDomain> {}
+
 /** Apply visx `nice()` to raw domain endpoints for stable grid ticks. */
 export function niceYDomain(domain: YDomain): YDomain {
   const scale = scaleLinear({ domain, range: [0, 1], nice: true });
@@ -70,9 +72,9 @@ export function computeYDomainsByAxis({
 }: {
   lines: LineConfig[];
   resolveDomain: (dataKeys: string[]) => YDomain;
-}): Record<string, YDomain> {
+}): YDomainMap {
   const groups = groupLinesByYAxisId(lines);
-  const domains: Record<string, YDomain> = {};
+  const domains: YDomainMap = {};
 
   for (const [axisId, axisLines] of groups) {
     const dataKeys = axisLines.map((line) => line.dataKey);
@@ -87,10 +89,8 @@ export function computeYDomainsByAxis({
 }
 
 /** Merge domain maps, normalizing axis ids to strings. */
-export function mergeYDomainRecords(
-  ...records: Record<string, YDomain>[]
-): Record<string, YDomain> {
-  const merged: Record<string, YDomain> = {};
+export function mergeYDomainRecords(...records: YDomainMap[]): YDomainMap {
+  const merged: YDomainMap = {};
   for (const record of records) {
     for (const [axisId, domain] of Object.entries(record)) {
       merged[normalizeYAxisId(axisId)] = domain;

--- a/apps/web/src/components/site-header.tsx
+++ b/apps/web/src/components/site-header.tsx
@@ -23,7 +23,7 @@ function isSecondary(item: LinkItemType) {
 const items = resolveLinkItems({
   links: baseOptions.links,
   githubUrl: baseOptions.githubUrl,
-}).filter((item): item is HrefItem => "url" in item && typeof item.url === "string");
+}).filter((item): item is HrefItem => "url" in item);
 
 const primaryItems = items.filter((item) => !isSecondary(item));
 const secondaryItems = items.filter(isSecondary);
@@ -85,7 +85,7 @@ function IconLink({
 
 function NavTitle() {
   const className = "inline-flex shrink-0 items-center gap-2.5 text-fd-foreground";
-  if (typeof navTitle === "function") {
+  if (navTitle instanceof Function) {
     const Title = navTitle;
     return <Title className={className} href="/" />;
   }

--- a/apps/web/src/components/ui/kibo-ui/code-block/index.tsx
+++ b/apps/web/src/components/ui/kibo-ui/code-block/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { SelectRootProps } from "@base-ui/react/select";
 import { useControlled } from "@base-ui/utils/useControlled";
 import {
   transformerNotationDiff,
@@ -383,17 +384,17 @@ export const CodeBlockFilename = ({
   );
 };
 
-export type CodeBlockSelectProps = ComponentProps<typeof Select>;
+export type CodeBlockSelectProps = SelectRootProps<string>;
 
 export const CodeBlockSelect = (props: CodeBlockSelectProps) => {
   const { value, onValueChange } = useContext(CodeBlockContext);
 
   return (
-    <Select
+    <Select<string>
       onValueChange={
         onValueChange
-          ? (newValue: unknown) => {
-              onValueChange(newValue as string);
+          ? (newValue) => {
+              if (newValue !== null) onValueChange(newValue);
             }
           : undefined
       }
@@ -453,7 +454,7 @@ export const CodeBlockCopyButton = ({
   const code = data.find((item) => item.language === value)?.code;
 
   const copyToClipboard = () => {
-    if (typeof window === "undefined" || !navigator.clipboard.writeText || !code) {
+    if (!navigator.clipboard?.writeText || !code) {
       return;
     }
 

--- a/apps/web/src/components/ui/share-dialog.tsx
+++ b/apps/web/src/components/ui/share-dialog.tsx
@@ -89,7 +89,7 @@ export function ShareDialog({ children, stackUrl, stackState }: ShareDialogProps
   const selectedTechs = getSelectedTechs(stackState);
 
   useEffect(() => {
-    setCanNativeShare(typeof navigator !== "undefined" && !!navigator.share);
+    setCanNativeShare(Boolean(navigator.share));
     return () => {
       if (copyResetTimer.current) clearTimeout(copyResetTimer.current);
     };

--- a/apps/web/src/lib/constant.ts
+++ b/apps/web/src/lib/constant.ts
@@ -2,18 +2,7 @@ import type { TechCategory } from "./types";
 
 export const ICON_BASE_URL = "https://r2.better-t-stack.dev/icons";
 
-export const TECH_OPTIONS: Record<
-  TechCategory,
-  {
-    id: string;
-    name: string;
-    description: string;
-    icon: string;
-    color: string;
-    default?: boolean;
-    className?: string;
-  }[]
-> = {
+export const TECH_OPTIONS = {
   api: [
     {
       id: "trpc",
@@ -745,7 +734,18 @@ export const TECH_OPTIONS: Record<
       color: "from-yellow-400 to-yellow-600",
     },
   ],
-};
+} satisfies Record<
+  TechCategory,
+  {
+    id: string;
+    name: string;
+    description: string;
+    icon: string;
+    color: string;
+    default?: boolean;
+    className?: string;
+  }[]
+>;
 
 export const PRESET_TEMPLATES = [
   {

--- a/apps/web/src/lib/stack-url-keys.ts
+++ b/apps/web/src/lib/stack-url-keys.ts
@@ -2,9 +2,9 @@ import type { UrlKeys } from "nuqs";
 
 import type { StackState } from "@/lib/constant";
 
-export const stackUrlKeys: UrlKeys<
-  Record<keyof StackState, unknown> & { viewMode: unknown; selectedFile: unknown }
-> = {
+type StackUrlState = StackState & { viewMode: string; selectedFile: string };
+
+export const stackUrlKeys: UrlKeys<StackUrlState> = {
   projectName: "name",
   webFrontend: "fe-w",
   nativeFrontend: "fe-n",

--- a/apps/web/src/lib/stack-url-state.client.ts
+++ b/apps/web/src/lib/stack-url-state.client.ts
@@ -98,7 +98,7 @@ export function useStackState() {
     async (updates: Partial<StackState> | ((prev: StackState) => Partial<StackState>)) => {
       await setQueryState((currentQueryState) => {
         const currentStack = getStackFromQueryState(currentQueryState);
-        const newStack = typeof updates === "function" ? updates(currentStack) : updates;
+        const newStack = updates instanceof Function ? updates(currentStack) : updates;
         const finalStack = sanitizeStackState({ ...currentStack, ...newStack });
 
         return finalStack;

--- a/apps/web/test/stack-compatibility-invariant.test.ts
+++ b/apps/web/test/stack-compatibility-invariant.test.ts
@@ -80,13 +80,10 @@ function randomStack(rand: () => number): StackState {
 function selectedEntries(stack: StackState): Array<{ category: TechCategory; id: string }> {
   const entries: Array<{ category: TechCategory; id: string }> = [];
   for (const category of Object.keys(TECH_OPTIONS) as TechCategory[]) {
-    const value = stack[category as keyof StackState];
-    if (value === undefined) continue;
+    const value = stack[category];
     const ids = Array.isArray(value) ? value : [value];
     for (const id of ids) {
-      if (typeof id === "string") {
-        entries.push({ category, id });
-      }
+      entries.push({ category, id });
     }
   }
   return entries;
@@ -146,21 +143,23 @@ function getResolvedSelectionErrors(stack: StackState): string[] {
 
 describe("compatibility adjustment invariants", () => {
   test("exposes exactly the ORM choices offered by the CLI for every database", () => {
-    const expectedOrmChoices: Record<string, string[]> = {
-      none: ["none"],
-      sqlite: ["drizzle", "prisma"],
-      postgres: ["drizzle", "prisma"],
-      mysql: ["drizzle", "prisma"],
-      mongodb: ["prisma", "mongoose"],
-    };
+    const expectedOrmChoices = new Map<string, string[]>([
+      ["none", ["none"]],
+      ["sqlite", ["drizzle", "prisma"]],
+      ["postgres", ["drizzle", "prisma"]],
+      ["mysql", ["drizzle", "prisma"]],
+      ["mongodb", ["prisma", "mongoose"]],
+    ]);
 
     for (const database of TECH_OPTIONS.database.map((option) => option.id)) {
       const stack = applyStackUpdate(DEFAULT_STACK, { database }).stack;
       const enabledOrms = TECH_OPTIONS.orm
         .map((option) => option.id)
         .filter((orm) => !getDisabledReason(stack, "orm", orm));
+      const expectedOrms = expectedOrmChoices.get(database);
+      if (!expectedOrms) throw new Error(`Missing expected ORM choices for ${database}`);
 
-      expect(enabledOrms).toEqual(expectedOrmChoices[database]);
+      expect(enabledOrms).toEqual(expectedOrms);
     }
   });
 

--- a/bun.lock
+++ b/bun.lock
@@ -8,12 +8,13 @@
         "@clack/prompts": "^1.7.0",
       },
       "devDependencies": {
+        "@oxlint/plugins": "1.78.0",
         "@types/bun": "^1.3.14",
         "changelogithub": "^14.0.0",
         "lefthook": "^2.1.10",
         "lint-staged": "^17.2.0",
         "oxfmt": "catalog:",
-        "oxlint": "^1.76.0",
+        "oxlint": "1.78.0",
         "turbo": "^2.10.7",
         "typescript": "catalog:",
       },
@@ -39,7 +40,7 @@
         "gradient-string": "^3.0.0",
         "handlebars": "^4.7.9",
         "jsonc-parser": "^3.3.1",
-        "oxfmt": "^0.61.0",
+        "oxfmt": "^0.63.0",
         "picocolors": "^1.1.1",
         "semver": "catalog:",
         "tinyglobby": "^0.2.17",
@@ -198,7 +199,7 @@
     "convex": "^1.43.0",
     "convex-helpers": "^0.1.120",
     "handlebars": "^4.7.9",
-    "oxfmt": "^0.61.0",
+    "oxfmt": "^0.63.0",
     "semver": "^7.8.5",
     "ts-morph": "^28.0.0",
     "tsdown": "^0.22.14",
@@ -543,81 +544,83 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.140.0", "", {}, "sha512-h5LUOzGArYemnW1NMz/DuuQhBi96J6JL2Bk8zE4kvqxB5Sg3jxmCiH4uyOWHDkiKSt5vWlG4FIwCR/DbstcNRQ=="],
 
-    "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.61.0", "", { "os": "android", "cpu": "arm" }, "sha512-BaS+1OVvg9sr+Xav0+KdWedQRcAzrdoEcwMZeqoc2F6ieC1s/t5eM35YQoRPQ7vAqkZ+p3tbQb1r9I9mrV5oGA=="],
+    "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.63.0", "", { "os": "android", "cpu": "arm" }, "sha512-YmRth4ZPGgEXcgmkhvANbC9uD67dxmSobW7DQuyt5tOBOKvPnIpk5SVHBj88E+7wMNRI2FhqaDbOhQFBix+b8A=="],
 
-    "@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.61.0", "", { "os": "android", "cpu": "arm64" }, "sha512-of8atAV0M1egGcVOMbgZCvc10sFOP3ayQBNQV5h5G3fNq8gACdEswfFk9bzGrdbM23rtg0Coxi7np7oPLcueNw=="],
+    "@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.63.0", "", { "os": "android", "cpu": "arm64" }, "sha512-icbahX8X2X3sRamOMecvdYeZXWjPDazRDIfvWfy7Ca1nc/ZDT2Y9k5Nt7s46EqFd7NQPdgk+CM3/SgIT5LPCaQ=="],
 
-    "@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.61.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-7l8+5ov4BGwtAcmpzvEik/TG3bciwyw/S3e6j5GKH7pcQqcgCVxD3AuJeP6upto+SOTBKQ4wrrdbMt0gq8fHSQ=="],
+    "@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.63.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-WV+Ze5v5gI2qoj8jpAovt8KBTW8pjEz/AiMXXjeTQS+Bmf/MmZXTS40S8xNPDszX+W8WDv2Bbk6qKrMTtUGu1A=="],
 
-    "@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.61.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-Fnz4dDDXBb7udk+DmwelNjxbD6yptyxwCqwCH2ebo4RVLxVsRfFsn/AHJC49KIltPrVokamGv4SSOsiV50DTxQ=="],
+    "@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.63.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-CJGSBdDxXOWIpoFXHpverimCvz084KA7L483rqJ44c3jDtzv6d4qOSoR/V9ywSHfV+Ks1lwIj2P49BFhunLNAA=="],
 
-    "@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.61.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-mddOebKNCP+AucmzfNsk3jgbr681qAUvgMqi865GW5gWLJ/AnzXbvjQRrny0e++NAN8aphav/aRSrfFxNsNjpA=="],
+    "@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.63.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-BDfKY+KhL2078cgswBBFQPAYuxCy93bS/iC5frdSeSbTLcGrR6VC2hsuPTanoJmg84+wSyWl0wWC1eR+uTnkRg=="],
 
-    "@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.61.0", "", { "os": "linux", "cpu": "arm" }, "sha512-svx59iYL+DbaZGZUIoice4W0CjRXGExnbz7Re+awIb60rVxBS2KrU7Hnlx+nZYanLGLpjneUEgo/VFEKkSZAyQ=="],
+    "@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.63.0", "", { "os": "linux", "cpu": "arm" }, "sha512-Ov1cQEXT4mj7cojAokWSS1eoxkoyvbDfAbxNsGIKY2o36kvdAaFzPxRN6NxFRk9fD72B8oCoTTX/NuYTUWlpsg=="],
 
-    "@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.61.0", "", { "os": "linux", "cpu": "arm" }, "sha512-BYK9MPJPCf6d+fLKMTruThmEyCtHzQ1zLcsrTlUVkmnoXIaHAbfpeLYQwX1tkjs7W11dyzoi6HFvKcdnvX1zNg=="],
+    "@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.63.0", "", { "os": "linux", "cpu": "arm" }, "sha512-0LE7ro3+6L79jcMANycAZfRaC7zxr9YZ2+vEL5uMD9QlEep+rS/r1kSJsnuLl991NXJZD60euh0PC1GHrR20vw=="],
 
-    "@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.61.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-QUaCNLq2/EC6G5ljOuFanl9Lgw6ZWp4co7rs4+KOMUzbGfA4Lq58FHRjjF9sVIG+93XSbo343MxFATrOU1qctA=="],
+    "@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.63.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-izPk+2Z4gjuZK32Fqh5qXoMpT/2NXzLh++ob57HiEiVSQZ1iYXu8EKMzb+K5AvWyIEXhdDIt7ADjGGtFhkT9Bw=="],
 
-    "@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.61.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-S6uvJ6MXnRXl+zTs0CARNDvkE+cymj0EVWEKKsyKnlLlqTyQJBjw5s4D2pSIOZc+S46cy4STefzcr/sm0VzVPA=="],
+    "@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.63.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-alPmbOuWXFXiSo+lOtv6X71C7SYMEDW2WVvywOvf9BwKgEhSNGhMTLeFVSjKUMCamcjbbgVdsWF8GN1uy8xshg=="],
 
-    "@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.61.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-6VDlRcytvZG6UlSIdAFKDLbppo9tvPxrWzle6vHldYFMeuDPQEfMKrkwezp7FaBq1wik9ra554ZZeRPsyIkFpg=="],
+    "@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.63.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-BdzCPvolJc4AWZ+YMzgUDJcDzbQWrFjYuqBHoNHNqP1aCaluQRJNs4k3vNU5IG7vTpjf9zeD73D7MFM1TecZpg=="],
 
-    "@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.61.0", "", { "os": "linux", "cpu": "none" }, "sha512-KkBTYbzExpbmn15XjKPLu2fRV2PVlq+KWt+brad5rwIa03vdYoaDRWiS7raHII/dCTR6Ro4UpYUCH4t6lif4WQ=="],
+    "@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.63.0", "", { "os": "linux", "cpu": "none" }, "sha512-7sIgfLzqtNKSkMGsGVyRpHwpjNezRg2XONvUOheFZs95TSZpM0JAuPpA8KrQFsWc4wPU95roX2O69JgH8igOgw=="],
 
-    "@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.61.0", "", { "os": "linux", "cpu": "none" }, "sha512-69tzIq7sJLVB9dxYYtvMzcSSsnZHSO+U2U19O2RqDqgj6+Q4O7HjSXdaszbcgqzhsUwzSH7z5kWvk8nmf6BHTg=="],
+    "@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.63.0", "", { "os": "linux", "cpu": "none" }, "sha512-9Tcg0y0WcVa6Mm9AgcgFMseDS+VkFJZpKZ8We9SpDY4gg5jewSwln+0sO04QLcTS1BtfDl9MwR+NfID8L7PUTg=="],
 
-    "@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.61.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-Oqi/N0OvtOVXsPKAOOhKgGH3msRYF8BLJaNBbWiupRiKoKVyc8JRKPCfarkQJC+RgP9U8raUKLe+bNwd0HUMiA=="],
+    "@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.63.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-qWKC1pEOpx1qYhXaugPhHUeXwSfqEOk2wJH2LqVXGPV5iQYfdAZdt+d2XDiX4DTSWA2QDMUcFB+wEORh3Xn/sA=="],
 
-    "@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.61.0", "", { "os": "linux", "cpu": "x64" }, "sha512-3TKwv/ed4uwJSemAA8P9XcoqETpjQI4waquF9UilhA9Mn/dhr1PdUEXWlL74mtc6ZNfmKPA9+NEJm01nRF8CVA=="],
+    "@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.63.0", "", { "os": "linux", "cpu": "x64" }, "sha512-S9wXYOiGSqYGS4Fx/TFsY+xDd/7dE5s+rUgbA4TsHiVF9e8J3ZcKmP7dsP/7iqLI9Wz7Ic7TzEr3mdthRCTdrA=="],
 
-    "@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.61.0", "", { "os": "linux", "cpu": "x64" }, "sha512-uFso4u4nLkVSlMCpgjyvWV60Gt7GvDQHnk1mmRxHIkZTMB0ljpUKwCD9FYGgN9H97x2wYl0UwEjgRZaPIuhEhw=="],
+    "@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.63.0", "", { "os": "linux", "cpu": "x64" }, "sha512-5eGyTJuMZNwBSHCivXt8Yuta6GeTYksOPXRk2MIhajiyFGQx7bjaHIwY+ZusAoFHhT157A9x6sktLjYo9D5oMQ=="],
 
-    "@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.61.0", "", { "os": "none", "cpu": "arm64" }, "sha512-keGLkzeOvkMpNmPp4hffXWpfoSsY6e1K8++KXD4mSSfxdvM8q9QUDsYY689TB1k6Co832DZn1MnaaVx6cIBMWQ=="],
+    "@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.63.0", "", { "os": "none", "cpu": "arm64" }, "sha512-Rz7hx+Dv3DoW/S6pwVAyjfFXp7/trdQ1zg+vNmsdsdDNlUccugp4XNqambSuEAeP0DaG9k72AtNyfDXCEg0AGw=="],
 
-    "@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.61.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-VzsAISkFxmNhJ5LBDEL9VuH6tJsVJMtqYit2LyIUf/HLnsCe4Pg9SMOjjVQzGWt0bnpyfJ94CrqTqcpNZzK+ug=="],
+    "@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.63.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-T/IuizKN9mr4Xw6YYnptkXRNdLkyIlUZ7c8zfTOBpoytZyJ1BAsMUvsMDEx0X4YvSMpaivm+DR8112rQfzC25g=="],
 
-    "@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.61.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-xv4t7yzwJoYaLB6Zv28B3W+j7brEjsyv50rLTAQgmxJzddce9fAMCxed8dSAkbWES0zz2J29nYK5FaTuD2YBHg=="],
+    "@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.63.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-XjrO5FJ5Wl9vsAxtCP1G/eaeT6y1K2s9CICUHGE42cEjou32/J6S+B1KnrOAboj6E7uhJnwPbRSvznWcxNdA0g=="],
 
-    "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.61.0", "", { "os": "win32", "cpu": "x64" }, "sha512-6EZXFkqOwxdDYjIn3TSNnPk3ST5E5GiYd4FiM6UF/mCL/LZSfr6D6UygTfW3R1PCQP2quCKpCEGRlij8E3VYbg=="],
+    "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.63.0", "", { "os": "win32", "cpu": "x64" }, "sha512-sgsHCQy432OTQH4Ikk3tZptp3GqwnhwUDuY0loBH41zyHWfMZY9v8Dy78wsnSofHejvFozZGgJgBB1A0LQRwMQ=="],
 
-    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.76.0", "", { "os": "android", "cpu": "arm" }, "sha512-ZHIE5Zt9AsPDcY4nOlofXt0YfneEeo+QrKMPcPzLf2Z6Q8VtV2W73d7SFJ920WUwyik783u/doKCs3KXdwG+7w=="],
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.78.0", "", { "os": "android", "cpu": "arm" }, "sha512-Bu819lmAfZMUHErrpe0cEWj3iaefuUODHSU8+UbXy67V/r7/7f4K3FL0NmbD85E+wiFLDYuhP8Zlv0XnVeXshw=="],
 
-    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.76.0", "", { "os": "android", "cpu": "arm64" }, "sha512-shm/ngQilHK6bs+ElJWa4oHfNj5vL1Gl/iVEJldTQjpr0/67oSgr0KUpbmcnLig5Fo0v/l6j2567A7TOL89ONA=="],
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.78.0", "", { "os": "android", "cpu": "arm64" }, "sha512-CDfxZgB61B7buRdY2FJoAYYPPXCZ1EoC1LKscnC5dg3kjobdxiconvAvvN1BmHyW4PyFT3jRLDag/BY/roSNBQ=="],
 
-    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.76.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-rvJmrAPKSQ9aWJ6wIS6CK2tJjwzfW0ApQH9qokq6sfDvmHwoyIHxHFMq7z7i7GiV6fdE6s8qvBqWKPTu8RmT6Q=="],
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.78.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-2Y2U9Ahrz+OO0Ej88f9SJYq51/jUBp1Mc7iZu0ukrbeeZ3gpRGfzIFnoqfHDY96xr0GEfNrPUBFEy0nN5aD7HA=="],
 
-    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.76.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U/zYdb7VYKGY6pA9Vd2rYl9O/HlCylcOlb5PGPvVLtg+oLGsk6H3XGKEMHKyqD3nmmtmlmwb/8SwU2vfSAtvMw=="],
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.78.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-rpych6eJq6m9jDRypTEaPD1xysaEW5h9+xuxhGK/QhOg+/xaqPZrCrTNoIl/f3nEjuJeCEmstNDlrE9rJi/3/g=="],
 
-    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.76.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-WvKG9CAriuo0XNiFzpXjDngUZcRGFNpaK2kLyMUsnJlShxkT96u+BpJQ3KqdQwGOrvI14L6V8bAwXwAYNNY6Jg=="],
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.78.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-IcMGrQT3QizkOESUJd5et+rOhVqSkNDfNik1cvrKDqIbzqx9KMtRswpFgkCuNTSwylCFLKhGUu8KmqY1ZnC0Dg=="],
 
-    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.76.0", "", { "os": "linux", "cpu": "arm" }, "sha512-qJ5+RH99TqFRq3UCDxkW0zJJu9c+OAHFY72vGlxZLEpuO+MpKo3POgqb8sYipL9KYm8XY6ofb0HsOuvY6hQNqQ=="],
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.78.0", "", { "os": "linux", "cpu": "arm" }, "sha512-/uLdoJ0IXE6vo/0f0LKjinQAp+re+VMaCWaNT8ENIv2EOCkSsc8SGaflXAuW0Jua2dq5+GLVWm1NQK7P3UFSNQ=="],
 
-    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.76.0", "", { "os": "linux", "cpu": "arm" }, "sha512-PvPCVptkgVARsucgIqFQQcSmJ6xc6GtnVB5bRBekRahTc9eObMtjHfMjy5M+C2tHt5UCMttWM9RuSk/H9NqYeg=="],
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.78.0", "", { "os": "linux", "cpu": "arm" }, "sha512-7xi4Wb/O8NRJhLoUXmDJMUVpNYvB5kefdhFU1Jb8rtae4QoXlTiLwI14X4YvAXVZLNZChP8m5qO9SQAlWQTbkQ=="],
 
-    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.76.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-3KeFDx8Bu4HPAXbuHZOr/oHvN+QT+JQhMw/NYPz7Z071xLSsG27Jfh9PIQVEY7hk1I+jr43ExqRIeJ6VKk2yLw=="],
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.78.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-4hFW0+fVXa3OIh1Y4A5SPkmvI4wuuBSrCVKzOyE7PTjhc7yEqZ1pmvEEeS5Lj/MaqvegFxXyF33N+6jkehxdyg=="],
 
-    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.76.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-oPFkkKTgl0K/EIg9fQ8oA3IGcI05/Mq1en04iFa41mmNPT+6KEiByVazTOZZJiHMBBrbsns1YJ2e1Scqwzesjw=="],
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.78.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-oC0mvsgBJjlMijSDEhx9KuvR9zYeHXceA9MjbuXB1F8NSR78Yj2unOBrstEvTVaq+pko+kuue6DajC00eqvTdg=="],
 
-    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.76.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gN7yZ0eqflA5Fhf1wvHxGUltIV3FsvmB1zhNMDEK9vSHhc7E6qg9CuPeBgPZab66Tjzq6w6kHAtNEvnTHf4cyw=="],
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.78.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-XAllT5SUZS+ohjuZ3/5S0cwe0r7eboiuigeStCZ5DXRYx/2KVM2UvQXvAfyzXEimtQjAB7cDQ2YxDe2Zl2WNQQ=="],
 
-    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.76.0", "", { "os": "linux", "cpu": "none" }, "sha512-S/HqMbn22mQrjtErUxEoS/a55u8kIeXvreIxiJu5G7Le3UecEd6SQZxrDIpuhtgaFnsY/nVra3ytP+pRljDilA=="],
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.78.0", "", { "os": "linux", "cpu": "none" }, "sha512-trucMER/0QtecoXvc1y/UVqE3kwJipDwrx4oHfj+nNm3dq2zjP44WT0CfHNDPM3G1DXIkx/gY6lAD21NSCZVhA=="],
 
-    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.76.0", "", { "os": "linux", "cpu": "none" }, "sha512-ZIga3097VJZolGZk6SrIAUokIGfRkxRlhiHDUznZptGBfwrhD7pNfD1rzEzsCwvk/1DX0A1bLz+liuNh5QKIVQ=="],
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.78.0", "", { "os": "linux", "cpu": "none" }, "sha512-cm3O4F/HQbdzOUX5mKHqG5KDL6E5w0pnlZ+fbBy2rmLryPOowkuLagFHTopQsEIpjcaZoPOrL+BmmAytAG9HFg=="],
 
-    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.76.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-ZGiiA7pFzMJSyMWYZTVlPgbTsx+Vl8ihLGMIujPwaslUF7kIPPWAbVmAlTc+9lWDV+DCiB8Ikixu+lSHeOIIWQ=="],
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.78.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-33wRf6HqGNsybJ3qX4cGaQN2ODPxNmc1rMa0mrTmx3eFq1VzOnvQooi9bIGVYakW8a/wmqVx1mgsUm8R2xfTiw=="],
 
-    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.76.0", "", { "os": "linux", "cpu": "x64" }, "sha512-JLiy5WuvEBFTT6ErIFV35SLzi0R7Iri6MKU6dZbTxfIx8pndbbPs3Mj780nMipBFcPkti+okAPOJ9POKkHFEgg=="],
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.78.0", "", { "os": "linux", "cpu": "x64" }, "sha512-rRdISSYegj6VganMZ9tjRjijowfHJ09IZU01i0toBAqr6n5LEtwHq2IeS4FjW2RoskOHlb6efB26H5izYb3GEQ=="],
 
-    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.76.0", "", { "os": "linux", "cpu": "x64" }, "sha512-z7lgKQtbo/I1NIe8G5NHLesxJDv0tRSUWTpXKb9Pm3E9nKFKfO4IOSDtFroKgXtOYb0jQbcdH+0wzTyMXVes+A=="],
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.78.0", "", { "os": "linux", "cpu": "x64" }, "sha512-GmsP4rW0xTL6u5CVdcDsaN5Fbc7hBc382Wmar1kttbnwSEviM+rSINKOMQ+UQ6iH+AGwC+8gaAiwu134Tgh6Lg=="],
 
-    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.76.0", "", { "os": "none", "cpu": "arm64" }, "sha512-JOjKymIpb9QcYfEhZsN6h4V9Ivd474W38cNIBRv6bg2TbIvogbMTH0Mg6YWW9TiRDqfcX+/Hyfsbo5vcSE5guQ=="],
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.78.0", "", { "os": "none", "cpu": "arm64" }, "sha512-sy9yeYuADc8a+n4TLBayzMCZiHPW78DcIFVpOXTmdKHWQeM9xe5uzkqIIZmi326D5hY9XVwacipEB1p7tQjPAg=="],
 
-    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.76.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-pqDWZiwcmByWUEm1NFUBNiT6aentCcaoMWJv0HbXEmuYermJ4sg8ppVrshubYP2MZ6SHccJJcpr6x469PuDFIw=="],
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.78.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-rjc2hF1KfMi8fZj1X/m3AmnHbdsF3rL0v6KQg0Uc880Yb2khjz+3U14sfdZ7jWTpRnN1m1NQa/TT7uU9lJWPrA=="],
 
-    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.76.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-Ba0O659kgMv6pwO3z9PdO+K3aMxQRaw9HnG+e6AtOfgwcKFvYilciQYBoUBmxfQvOCKZe1SwjMkuB542NkuDMQ=="],
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.78.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-zcuXFVrEFHIafRfkCQT8w/Xe41o07ozl/vwHq7p94vB29xVzsB0sZGYORU1jhcYKv3Lr0J3HbJ2T4fHH5rWmvA=="],
 
-    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.76.0", "", { "os": "win32", "cpu": "x64" }, "sha512-5qcirPHO8nKfkoowEVWtpAoVTcYDy6g0UT0NGic450Qv8J2NrOqg4uQ8QppRP4MDTC7Xx47lbZnmadTH03CGGA=="],
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.78.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Sb5ocmLSuYeOuXd+CFOToGKp/gjXUEWDnvIGwhnh8aq8wY4TMmEnKnvbogSW7RdMZv77JSARduS7/gv+khYEjA=="],
+
+    "@oxlint/plugins": ["@oxlint/plugins@1.78.0", "", {}, "sha512-Ypt8KeRYw+4jUtlPirfcHWMrn5ms12VrrFPD+Mds477/7tJxG1Kcz2Yrg2nVcTQEUx/GdlhS+BUg1kmxNm04Ug=="],
 
     "@publint/pack": ["@publint/pack@0.1.6", "", { "dependencies": { "tinyexec": "^1.2.4" } }, "sha512-3uVNyGcVplhPZSLVyeIpL7+cIRn1YCSNHLG/rUIlBQMVH8YuN9++YF+5+UDIIO9RW98dujiUoTltO7RDB5bFJA=="],
 
@@ -2101,9 +2104,9 @@
 
     "own-keys": ["own-keys@1.0.1", "", { "dependencies": { "get-intrinsic": "^1.2.6", "object-keys": "^1.1.1", "safe-push-apply": "^1.0.0" } }, "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg=="],
 
-    "oxfmt": ["oxfmt@0.61.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.61.0", "@oxfmt/binding-android-arm64": "0.61.0", "@oxfmt/binding-darwin-arm64": "0.61.0", "@oxfmt/binding-darwin-x64": "0.61.0", "@oxfmt/binding-freebsd-x64": "0.61.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.61.0", "@oxfmt/binding-linux-arm-musleabihf": "0.61.0", "@oxfmt/binding-linux-arm64-gnu": "0.61.0", "@oxfmt/binding-linux-arm64-musl": "0.61.0", "@oxfmt/binding-linux-ppc64-gnu": "0.61.0", "@oxfmt/binding-linux-riscv64-gnu": "0.61.0", "@oxfmt/binding-linux-riscv64-musl": "0.61.0", "@oxfmt/binding-linux-s390x-gnu": "0.61.0", "@oxfmt/binding-linux-x64-gnu": "0.61.0", "@oxfmt/binding-linux-x64-musl": "0.61.0", "@oxfmt/binding-openharmony-arm64": "0.61.0", "@oxfmt/binding-win32-arm64-msvc": "0.61.0", "@oxfmt/binding-win32-ia32-msvc": "0.61.0", "@oxfmt/binding-win32-x64-msvc": "0.61.0" }, "peerDependencies": { "svelte": "^5.0.0", "vite-plus": "*" }, "optionalPeers": ["svelte", "vite-plus"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-DxdHBEMYpcEnHoUHjjOigUqV2TYKsvxLwUPXnVYBjgFdqrcQ/91OtwubtZ2PUodCs3sStI8R5Qw3fKNGK4e8wQ=="],
+    "oxfmt": ["oxfmt@0.63.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.63.0", "@oxfmt/binding-android-arm64": "0.63.0", "@oxfmt/binding-darwin-arm64": "0.63.0", "@oxfmt/binding-darwin-x64": "0.63.0", "@oxfmt/binding-freebsd-x64": "0.63.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.63.0", "@oxfmt/binding-linux-arm-musleabihf": "0.63.0", "@oxfmt/binding-linux-arm64-gnu": "0.63.0", "@oxfmt/binding-linux-arm64-musl": "0.63.0", "@oxfmt/binding-linux-ppc64-gnu": "0.63.0", "@oxfmt/binding-linux-riscv64-gnu": "0.63.0", "@oxfmt/binding-linux-riscv64-musl": "0.63.0", "@oxfmt/binding-linux-s390x-gnu": "0.63.0", "@oxfmt/binding-linux-x64-gnu": "0.63.0", "@oxfmt/binding-linux-x64-musl": "0.63.0", "@oxfmt/binding-openharmony-arm64": "0.63.0", "@oxfmt/binding-win32-arm64-msvc": "0.63.0", "@oxfmt/binding-win32-ia32-msvc": "0.63.0", "@oxfmt/binding-win32-x64-msvc": "0.63.0" }, "peerDependencies": { "svelte": "^5.0.0", "vite-plus": "*" }, "optionalPeers": ["svelte", "vite-plus"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-kgdDwv35wvVf6554U2Ab8Jnd0zTM+TsEQWwaB70RAjK3gICFAFGO+2Hd3Be27GMoXj3XRL9IKSNRVl7KBQL6iw=="],
 
-    "oxlint": ["oxlint@1.76.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.76.0", "@oxlint/binding-android-arm64": "1.76.0", "@oxlint/binding-darwin-arm64": "1.76.0", "@oxlint/binding-darwin-x64": "1.76.0", "@oxlint/binding-freebsd-x64": "1.76.0", "@oxlint/binding-linux-arm-gnueabihf": "1.76.0", "@oxlint/binding-linux-arm-musleabihf": "1.76.0", "@oxlint/binding-linux-arm64-gnu": "1.76.0", "@oxlint/binding-linux-arm64-musl": "1.76.0", "@oxlint/binding-linux-ppc64-gnu": "1.76.0", "@oxlint/binding-linux-riscv64-gnu": "1.76.0", "@oxlint/binding-linux-riscv64-musl": "1.76.0", "@oxlint/binding-linux-s390x-gnu": "1.76.0", "@oxlint/binding-linux-x64-gnu": "1.76.0", "@oxlint/binding-linux-x64-musl": "1.76.0", "@oxlint/binding-openharmony-arm64": "1.76.0", "@oxlint/binding-win32-arm64-msvc": "1.76.0", "@oxlint/binding-win32-ia32-msvc": "1.76.0", "@oxlint/binding-win32-x64-msvc": "1.76.0" }, "peerDependencies": { "oxlint-tsgolint": ">=7.0.2001", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-6QoFioEU4fNdiUx/2Eo6TRd6NG7H7njnRCz8rhB66cZmMHDTqcm1Rjvl8Wry+ZTQMBAmyb4Mlf62Mk5X+eHSOw=="],
+    "oxlint": ["oxlint@1.78.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.78.0", "@oxlint/binding-android-arm64": "1.78.0", "@oxlint/binding-darwin-arm64": "1.78.0", "@oxlint/binding-darwin-x64": "1.78.0", "@oxlint/binding-freebsd-x64": "1.78.0", "@oxlint/binding-linux-arm-gnueabihf": "1.78.0", "@oxlint/binding-linux-arm-musleabihf": "1.78.0", "@oxlint/binding-linux-arm64-gnu": "1.78.0", "@oxlint/binding-linux-arm64-musl": "1.78.0", "@oxlint/binding-linux-ppc64-gnu": "1.78.0", "@oxlint/binding-linux-riscv64-gnu": "1.78.0", "@oxlint/binding-linux-riscv64-musl": "1.78.0", "@oxlint/binding-linux-s390x-gnu": "1.78.0", "@oxlint/binding-linux-x64-gnu": "1.78.0", "@oxlint/binding-linux-x64-musl": "1.78.0", "@oxlint/binding-openharmony-arm64": "1.78.0", "@oxlint/binding-win32-arm64-msvc": "1.78.0", "@oxlint/binding-win32-ia32-msvc": "1.78.0", "@oxlint/binding-win32-x64-msvc": "1.78.0" }, "peerDependencies": { "oxlint-tsgolint": ">=7.0.2001", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-QgQePuxIqKOzo1KSjG2EnITEeWvWnKAm77eq8nrMtf6AGoA+zyGc4PFYtDNJSD25g/ibOwfQ851hZ4/SPkMVoA=="],
 
     "p-limit": ["p-limit@6.2.0", "", { "dependencies": { "yocto-queue": "^1.1.1" } }, "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA=="],
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
       "convex": "^1.43.0",
       "convex-helpers": "^0.1.120",
       "handlebars": "^4.7.9",
-      "oxfmt": "^0.61.0",
+      "oxfmt": "^0.63.0",
       "semver": "^7.8.5",
       "ts-morph": "^28.0.0",
       "tsdown": "^0.22.14",
@@ -54,12 +54,13 @@
     "@clack/prompts": "^1.7.0"
   },
   "devDependencies": {
+    "@oxlint/plugins": "1.78.0",
     "@types/bun": "^1.3.14",
     "changelogithub": "^14.0.0",
     "lefthook": "^2.1.10",
     "lint-staged": "^17.2.0",
     "oxfmt": "catalog:",
-    "oxlint": "^1.76.0",
+    "oxlint": "1.78.0",
     "turbo": "^2.10.7",
     "typescript": "catalog:"
   },

--- a/packages/backend/convex/analytics.ts
+++ b/packages/backend/convex/analytics.ts
@@ -195,7 +195,7 @@ export const getDailyStats = query({
     const today = new Date(now).toISOString().slice(0, 10);
     const requestedDays = args.days;
     const sanitizedDays =
-      typeof requestedDays === "number" && Number.isFinite(requestedDays) && requestedDays > 0
+      requestedDays !== undefined && Number.isFinite(requestedDays) && requestedDays > 0
         ? Math.min(Math.floor(requestedDays), MAX_DAILY_STATS_WINDOW)
         : 30;
     const cutoffDate = new Date(now - (sanitizedDays - 1) * 24 * 60 * 60 * 1000)
@@ -288,7 +288,7 @@ export const getRecentEvents = query({
   ),
   handler: async (ctx, args) => {
     const limit =
-      typeof args.limit === "number" && Number.isFinite(args.limit) && args.limit > 0
+      args.limit !== undefined && Number.isFinite(args.limit) && args.limit > 0
         ? Math.min(Math.floor(args.limit), 50)
         : 20;
 

--- a/packages/backend/convex/testimonials.ts
+++ b/packages/backend/convex/testimonials.ts
@@ -30,9 +30,9 @@ export const getTweets = query({
   handler: async (ctx) => {
     const rows = await ctx.db.query("tweets").collect();
     return rows.sort((a, b) => {
-      const aHas = typeof a.order === "number";
-      const bHas = typeof b.order === "number";
-      if (aHas && bHas) return (a.order as number) - (b.order as number);
+      const aHas = a.order !== undefined;
+      const bHas = b.order !== undefined;
+      if (a.order !== undefined && b.order !== undefined) return a.order - b.order;
       if (aHas && !bHas) return -1;
       if (!aHas && bHas) return 1;
       return b._creationTime - a._creationTime;

--- a/packages/template-generator/src/core/json-types.ts
+++ b/packages/template-generator/src/core/json-types.ts
@@ -1,0 +1,7 @@
+export type JsonPrimitive = string | number | boolean | null;
+
+export type JsonValue = JsonPrimitive | JsonObject | readonly JsonValue[];
+
+export interface JsonObject {
+  [key: string]: JsonValue | undefined;
+}

--- a/packages/template-generator/src/core/virtual-fs.ts
+++ b/packages/template-generator/src/core/virtual-fs.ts
@@ -4,6 +4,7 @@ import { memfs } from "memfs";
 import { dirname, extname, normalize, join } from "pathe";
 
 import type { VirtualDirectory, VirtualFile } from "../types";
+import type { JsonValue } from "./json-types";
 
 export class VirtualFileSystem {
   private _fs: ReturnType<typeof memfs>["fs"];
@@ -92,7 +93,7 @@ export class VirtualFileSystem {
     }
   }
 
-  writeJson(filePath: string, data: unknown, spaces = 2): void {
+  writeJson(filePath: string, data: JsonValue, spaces = 2): void {
     this.writeFile(filePath, JSON.stringify(data, null, spaces));
   }
 

--- a/packages/template-generator/src/fs-writer.ts
+++ b/packages/template-generator/src/fs-writer.ts
@@ -9,6 +9,10 @@ import type { VirtualFileTree, VirtualNode, VirtualFile, VirtualDirectory } from
 
 const BINARY_FILE_MARKER = "[Binary file]";
 
+function isMissingPathError(cause: unknown): boolean {
+  return cause instanceof Error && "code" in cause && cause.code === "ENOENT";
+}
+
 /**
  * Error class for filesystem write failures
  */
@@ -155,12 +159,7 @@ async function assertSafeWritePath(baseDir: string, destinationPath: string): Pr
     try {
       stats = await fs.lstat(currentPath);
     } catch (error) {
-      if (
-        typeof error === "object" &&
-        error !== null &&
-        "code" in error &&
-        error.code === "ENOENT"
-      ) {
+      if (isMissingPathError(error)) {
         return;
       }
       throw error;

--- a/packages/template-generator/src/generators/alchemy/web.ts
+++ b/packages/template-generator/src/generators/alchemy/web.ts
@@ -198,11 +198,13 @@ function prismaFramework(framework: DeployedWebFramework): string | undefined {
   }
 }
 
-function prismaCustomBuild(framework: DeployedWebFramework): {
+interface PrismaCustomBuild {
   script: "build";
   outdir: ".output" | "build";
   entrypoint: "server/index.mjs" | "server/index.js" | "index.js";
-} {
+}
+
+function prismaCustomBuild(framework: DeployedWebFramework): PrismaCustomBuild {
   switch (framework) {
     case "solid":
       return {

--- a/packages/template-generator/src/post-process/catalogs.ts
+++ b/packages/template-generator/src/post-process/catalogs.ts
@@ -6,6 +6,7 @@
 import type { ProjectConfig } from "@better-t-stack/types";
 import yaml from "yaml";
 
+import type { JsonValue } from "../core/json-types";
 import type { VirtualFileSystem } from "../core/virtual-fs";
 
 type PackageJson = {
@@ -15,13 +16,15 @@ type PackageJson = {
   devDependencies?: Record<string, string>;
   workspaces?: string[] | { packages?: string[]; catalog?: Record<string, string> };
   packageManager?: string;
-  [key: string]: unknown;
+  [key: string]: JsonValue | undefined;
 };
 
 type CatalogEntry = {
   versions: Set<string>;
   packages: string[];
 };
+
+interface DependencyCatalog extends Record<string, string> {}
 
 type PackageInfo = {
   path: string;
@@ -84,7 +87,7 @@ export function processCatalogs(vfs: VirtualFileSystem, config: ProjectConfig): 
 function findDuplicateDependencies(
   packagesInfo: PackageInfo[],
   projectName: string,
-): Record<string, string> {
+): DependencyCatalog {
   const depCount = new Map<string, CatalogEntry>();
   const projectScope = `@${projectName}/`;
 
@@ -108,7 +111,7 @@ function findDuplicateDependencies(
     }
   }
 
-  const catalog: Record<string, string> = {};
+  const catalog: DependencyCatalog = {};
   for (const [depName, info] of depCount.entries()) {
     if (info.packages.length > 1 && info.versions.size === 1) {
       const version = Array.from(info.versions)[0];
@@ -134,7 +137,7 @@ function setupBunCatalogs(vfs: VirtualFileSystem, catalog: Record<string, string
       packages: pkgJson.workspaces,
       catalog,
     };
-  } else if (typeof pkgJson.workspaces === "object") {
+  } else {
     if (!pkgJson.workspaces.catalog) {
       pkgJson.workspaces.catalog = {};
     }

--- a/packages/template-generator/src/post-process/package-configs.ts
+++ b/packages/template-generator/src/post-process/package-configs.ts
@@ -5,6 +5,7 @@
 
 import { getLocalD1Owner, webFrontends, type ProjectConfig } from "@better-t-stack/types";
 
+import type { JsonValue } from "../core/json-types";
 import type { VirtualFileSystem } from "../core/virtual-fs";
 import { dependencyVersionMap } from "../utils/add-deps";
 import { getDbScriptSupport } from "../utils/db-scripts";
@@ -18,7 +19,7 @@ type PackageJson = {
   overrides?: Record<string, string>;
   workspaces?: string[] | { packages?: string[]; catalog?: Record<string, string> };
   packageManager?: string;
-  [key: string]: unknown;
+  [key: string]: JsonValue | undefined;
 };
 
 type PackageManagerConfig = {
@@ -272,8 +273,10 @@ function updateRootPackageJson(vfs: VirtualFileSystem, config: ProjectConfig): v
   vfs.writeJson("package.json", pkgJson);
 }
 
-function getNpmAllowedScripts(config: ProjectConfig): Record<string, boolean> {
-  const allowed: Record<string, boolean> = {};
+interface NpmAllowedScripts extends Record<string, boolean> {}
+
+function getNpmAllowedScripts(config: ProjectConfig): NpmAllowedScripts {
+  const allowed: NpmAllowedScripts = {};
   const hasCloudflareDeploy =
     config.webDeploy === "cloudflare" || config.serverDeploy === "cloudflare";
   const hasPrismaDeploy = config.webDeploy === "prisma" || config.serverDeploy === "prisma";
@@ -335,7 +338,7 @@ function getWorkspacePackages(workspaces: PackageJson["workspaces"]): string[] {
     return workspaces;
   }
 
-  if (workspaces && typeof workspaces === "object" && workspaces.packages) {
+  if (workspaces && !Array.isArray(workspaces) && workspaces.packages) {
     return workspaces.packages;
   }
 
@@ -346,12 +349,7 @@ function getUpdatedWorkspaces(
   existingWorkspaces: PackageJson["workspaces"],
   packages: string[],
 ): WorkspacesConfig {
-  if (
-    existingWorkspaces &&
-    !Array.isArray(existingWorkspaces) &&
-    typeof existingWorkspaces === "object" &&
-    existingWorkspaces.catalog
-  ) {
+  if (existingWorkspaces && !Array.isArray(existingWorkspaces) && existingWorkspaces.catalog) {
     return {
       ...existingWorkspaces,
       packages,
@@ -744,17 +742,20 @@ function updateVitePlusPackageScripts(vfs: VirtualFileSystem, config: ProjectCon
     return;
   }
 
-  const viteScriptReplacements: Record<string, string> = {
+  const viteScriptReplacements = {
     vite: "vp dev",
     "vite dev": "vp dev",
     "vite build": "vp build",
     "vite preview": "vp preview",
     "vitest run": "vp test",
     "vite build && tsc --noEmit": "vp build && tsc --noEmit",
-  };
+  } satisfies Record<string, string>;
 
   for (const [scriptName, command] of Object.entries(webPkg.scripts)) {
-    webPkg.scripts[scriptName] = viteScriptReplacements[command] ?? command;
+    const replacement = Object.entries(viteScriptReplacements).find(
+      ([viteCommand]) => viteCommand === command,
+    )?.[1];
+    webPkg.scripts[scriptName] = replacement ?? command;
   }
 
   vfs.writeJson(webPkgPath, webPkg);

--- a/packages/template-generator/src/post-process/vercel-config.ts
+++ b/packages/template-generator/src/post-process/vercel-config.ts
@@ -111,7 +111,7 @@ export function processVercelConfig(vfs: VirtualFileSystem, config: ProjectConfi
 
   vfs.writeJson("vercel.json", {
     $schema: "https://openapi.vercel.sh/vercel.json",
-    ...(runtime === "bun" ? { bunVersion: "1.x" } : {}),
+    bunVersion: runtime === "bun" ? "1.x" : undefined,
     services,
     rewrites,
   });

--- a/packages/template-generator/src/processors/addons-deps.ts
+++ b/packages/template-generator/src/processors/addons-deps.ts
@@ -1,5 +1,6 @@
 import type { ProjectConfig } from "@better-t-stack/types";
 
+import type { JsonValue } from "../core/json-types";
 import type { VirtualFileSystem } from "../core/virtual-fs";
 import { addPackageDependency } from "../utils/add-deps";
 
@@ -9,7 +10,7 @@ type PackageJson = {
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
   "lint-staged"?: Record<string, string | string[]>;
-  [key: string]: unknown;
+  [key: string]: JsonValue | undefined;
 };
 
 export function processAddonsDeps(vfs: VirtualFileSystem, config: ProjectConfig): void {

--- a/packages/template-generator/src/processors/env-vars.ts
+++ b/packages/template-generator/src/processors/env-vars.ts
@@ -18,26 +18,15 @@ const CONVEX_SITE_URL_PLACEHOLDER = "https://example.convex.site";
 
 function generateRandomString(length: number, charset: string) {
   let result = "";
-  if (
-    typeof globalThis.crypto !== "undefined" &&
-    typeof globalThis.crypto.getRandomValues === "function"
-  ) {
-    const values = new Uint8Array(length);
-    globalThis.crypto.getRandomValues(values);
-    for (let i = 0; i < length; i++) {
-      const value = values[i];
-      if (value !== undefined) {
-        result += charset[value % charset.length];
-      }
+  const values = new Uint8Array(length);
+  globalThis.crypto.getRandomValues(values);
+  for (let i = 0; i < length; i++) {
+    const value = values[i];
+    if (value !== undefined) {
+      result += charset[value % charset.length];
     }
-    return result;
-  } else {
-    // Fallback for environments without crypto
-    for (let i = 0; i < length; i++) {
-      result += charset[Math.floor(Math.random() * charset.length)];
-    }
-    return result;
   }
+  return result;
 }
 
 function generateAuthSecret() {

--- a/packages/template-generator/src/processors/nx-generator.ts
+++ b/packages/template-generator/src/processors/nx-generator.ts
@@ -16,10 +16,12 @@ type NxTargetDefaults = {
   continuous?: boolean;
 };
 
+interface NxTargetMap extends Record<string, NxTargetDefaults> {}
+
 type NxConfig = {
   $schema: string;
   namedInputs: Record<string, string[]>;
-  targetDefaults: Record<string, NxTargetDefaults>;
+  targetDefaults: NxTargetMap;
 };
 
 export function processNxConfig(vfs: VirtualFileSystem, config: ProjectConfig): void {
@@ -39,7 +41,7 @@ export function generateNxConfig(config: ProjectConfig): NxConfig {
   const hasAlchemy = isAlchemyDeployTarget(webDeploy) || isAlchemyDeployTarget(serverDeploy);
   const hasLocalD1 = getLocalD1Owner(config) === "wrangler";
 
-  const targetDefaults: Record<string, NxTargetDefaults> = {
+  const targetDefaults: NxTargetMap = {
     build: {
       dependsOn: ["^build"],
       inputs: ["production", "^production"],
@@ -52,14 +54,15 @@ export function generateNxConfig(config: ProjectConfig): NxConfig {
       cache: false,
       continuous: true,
     },
-    ...(config.addons.includes("electrobun") ? getElectrobunTargets() : {}),
-    ...(isConvex ? getConvexTargets() : {}),
-    ...(!isConvex && hasDatabase ? getDatabaseTargets(dbSupport) : {}),
-    ...(isDocker ? getDockerTargets() : {}),
-    ...(isSqliteLocal ? getSqliteLocalTarget() : {}),
-    ...(hasLocalD1 ? getLocalD1Target() : {}),
-    ...(hasAlchemy ? getDeployTargets() : {}),
   };
+
+  if (config.addons.includes("electrobun")) Object.assign(targetDefaults, getElectrobunTargets());
+  if (isConvex) Object.assign(targetDefaults, getConvexTargets());
+  if (!isConvex && hasDatabase) Object.assign(targetDefaults, getDatabaseTargets(dbSupport));
+  if (isDocker) Object.assign(targetDefaults, getDockerTargets());
+  if (isSqliteLocal) Object.assign(targetDefaults, getSqliteLocalTarget());
+  if (hasLocalD1) Object.assign(targetDefaults, getLocalD1Target());
+  if (hasAlchemy) Object.assign(targetDefaults, getDeployTargets());
 
   return {
     $schema: "./node_modules/nx/schemas/nx-schema.json",
@@ -77,7 +80,7 @@ export function generateNxConfig(config: ProjectConfig): NxConfig {
   };
 }
 
-function getElectrobunTargets(): Record<string, NxTargetDefaults> {
+function getElectrobunTargets(): NxTargetMap {
   return {
     "dev:hmr": {
       cache: false,
@@ -90,7 +93,7 @@ export function getNxProductionInputExclusions(config: ProjectConfig): string[] 
   return getStackGeneratedIgnorePatterns(config).map((pattern) => `!{workspaceRoot}/${pattern}`);
 }
 
-function getConvexTargets(): Record<string, NxTargetDefaults> {
+function getConvexTargets(): NxTargetMap {
   return {
     "dev:setup": {
       cache: false,
@@ -98,8 +101,8 @@ function getConvexTargets(): Record<string, NxTargetDefaults> {
   };
 }
 
-function getDatabaseTargets(dbSupport: DbScriptSupport): Record<string, NxTargetDefaults> {
-  const targets: Record<string, NxTargetDefaults> = {};
+function getDatabaseTargets(dbSupport: DbScriptSupport): NxTargetMap {
+  const targets: NxTargetMap = {};
 
   if (dbSupport.hasDbPush) {
     targets["db:push"] = { cache: false };
@@ -120,7 +123,7 @@ function getDatabaseTargets(dbSupport: DbScriptSupport): Record<string, NxTarget
   return targets;
 }
 
-function getDockerTargets(): Record<string, NxTargetDefaults> {
+function getDockerTargets(): NxTargetMap {
   return {
     "db:start": { cache: false },
     "db:stop": { cache: false },
@@ -129,19 +132,19 @@ function getDockerTargets(): Record<string, NxTargetDefaults> {
   };
 }
 
-function getSqliteLocalTarget(): Record<string, NxTargetDefaults> {
+function getSqliteLocalTarget(): NxTargetMap {
   return {
     "db:local": { cache: false, continuous: true },
   };
 }
 
-function getLocalD1Target(): Record<string, NxTargetDefaults> {
+function getLocalD1Target(): NxTargetMap {
   return {
     "db:migrate:local": { cache: false },
   };
 }
 
-function getDeployTargets(): Record<string, NxTargetDefaults> {
+function getDeployTargets(): NxTargetMap {
   return {
     deploy: { cache: false },
     destroy: { cache: false },

--- a/packages/template-generator/src/processors/readme-generator.ts
+++ b/packages/template-generator/src/processors/readme-generator.ts
@@ -264,6 +264,10 @@ ${generateScriptsList(packageManagerRunCmd, options, hasNative)}
 `;
 }
 
+function hasOwnKey<T extends object>(object: T, key: PropertyKey): key is keyof T {
+  return Object.hasOwn(object, key);
+}
+
 function generateStackDescription(
   frontend: ProjectConfig["frontend"],
   backend: ProjectConfig["backend"],
@@ -272,7 +276,7 @@ function generateStackDescription(
 ): string {
   const parts: string[] = [];
 
-  const frontendMap: Record<string, string> = {
+  const frontendMap = {
     "tanstack-router": "React, TanStack Router",
     "react-router": "React, React Router",
     next: "Next.js",
@@ -284,10 +288,10 @@ function generateStackDescription(
     "native-bare": "React Native, Expo",
     "native-uniwind": "React Native, Expo",
     "native-unistyles": "React Native, Expo",
-  };
+  } satisfies Record<string, string>;
 
   for (const fe of frontend) {
-    if (frontendMap[fe]) {
+    if (hasOwnKey(frontendMap, fe)) {
       parts.push(frontendMap[fe]);
       break;
     }
@@ -380,7 +384,7 @@ function generateProjectStructure(config: ProjectConfig): string {
   const hasDbPackage = !isConvex && database !== "none" && orm !== "none";
 
   if (hasAppWebFrontend) {
-    const frontendTypes: Record<string, string> = {
+    const frontendTypes = {
       "tanstack-router": "React + TanStack Router",
       "react-router": "React + React Router",
       next: "Next.js",
@@ -389,10 +393,14 @@ function generateProjectStructure(config: ProjectConfig): string {
       nuxt: "Nuxt",
       solid: "SolidStart",
       astro: "Astro",
-    };
-    const frontendType = frontend.find((f) => frontendTypes[f])
-      ? frontendTypes[frontend.find((f) => frontendTypes[f]) || ""]
-      : "";
+    } satisfies Record<string, string>;
+    let frontendType = "";
+    for (const selectedFrontend of frontend) {
+      if (hasOwnKey(frontendTypes, selectedFrontend)) {
+        frontendType = frontendTypes[selectedFrontend];
+        break;
+      }
+    }
 
     const prefix = isBackendSelf ? "└──" : "├──";
     const desc = isBackendSelf ? "Fullstack application" : "Frontend application";
@@ -468,7 +476,7 @@ function generateFeaturesList(
 
   const features = ["- **TypeScript** - For type safety and improved developer experience"];
 
-  const frontendFeatures: Record<string, string> = {
+  const frontendFeatures = {
     "tanstack-router": "- **TanStack Router** - File-based routing with full type safety",
     "react-router": "- **React Router** - Declarative routing for React",
     next: "- **Next.js** - Full-stack React framework",
@@ -477,10 +485,10 @@ function generateFeaturesList(
     nuxt: "- **Nuxt** - The Intuitive Vue Framework",
     solid: "- **SolidStart** - Full-stack Solid framework with file-based routing and SSR",
     astro: "- **Astro** - The web framework for content-driven websites",
-  };
+  } satisfies Record<string, string>;
 
   for (const fe of frontend) {
-    if (frontendFeatures[fe]) {
+    if (hasOwnKey(frontendFeatures, fe)) {
       features.push(frontendFeatures[fe]);
       break;
     }
@@ -501,15 +509,15 @@ function generateFeaturesList(
     features.push("- **Shared UI package** - shadcn/ui primitives live in `packages/ui`");
   }
 
-  const backendFeatures: Record<string, string> = {
+  const backendFeatures = {
     convex: "- **Convex** - Reactive backend-as-a-service platform",
     hono: "- **Hono** - Lightweight, performant server framework",
     express: "- **Express** - Fast, unopinionated web framework",
     fastify: "- **Fastify** - Fast, low-overhead web framework",
     elysia: "- **Elysia** - Type-safe, high-performance framework",
-  };
+  } satisfies Record<string, string>;
 
-  if (backendFeatures[backend]) {
+  if (hasOwnKey(backendFeatures, backend)) {
     features.push(backendFeatures[backend]);
   }
 
@@ -525,21 +533,20 @@ function generateFeaturesList(
   }
 
   if (database !== "none" && !isConvex) {
-    const ormNames: Record<string, string> = {
+    const ormNames = {
       drizzle: "Drizzle",
       prisma: "Prisma",
       mongoose: "Mongoose",
-    };
-    const dbNames: Record<string, string> = {
+    } satisfies Record<string, string>;
+    const dbNames = {
       sqlite: dbSetup === "d1" ? "Cloudflare D1" : "SQLite/Turso",
       postgres: "PostgreSQL",
       mysql: "MySQL",
       mongodb: "MongoDB",
-    };
-    features.push(
-      `- **${ormNames[orm] || "ORM"}** - TypeScript-first ORM`,
-      `- **${dbNames[database] || "Database"}** - Database engine`,
-    );
+    } satisfies Record<string, string>;
+    const ormName = hasOwnKey(ormNames, orm) ? ormNames[orm] : "ORM";
+    const dbName = hasOwnKey(dbNames, database) ? dbNames[database] : "Database";
+    features.push(`- **${ormName}** - TypeScript-first ORM`, `- **${dbName}** - Database engine`);
   }
 
   if (auth !== "none") {
@@ -547,7 +554,7 @@ function generateFeaturesList(
     features.push(`- **Authentication** - ${authLabel}`);
   }
 
-  const addonFeatures: Record<string, string> = {
+  const addonFeatures = {
     pwa: "- **PWA** - Progressive Web App support",
     tauri: "- **Tauri** - Build native desktop applications",
     electrobun: "- **Electrobun** - Lightweight desktop shell for web frontends",
@@ -559,10 +566,10 @@ function generateFeaturesList(
     nx: "- **Nx** - Smart monorepo task orchestration and caching",
     "vite-plus":
       "- **Vite+** - Unified Vite toolchain, workspace task runner, linting, and formatting",
-  };
+  } satisfies Record<string, string>;
 
   for (const addon of addons) {
-    if (addonFeatures[addon]) {
+    if (hasOwnKey(addonFeatures, addon)) {
       features.push(addonFeatures[addon]);
     }
   }
@@ -576,12 +583,12 @@ function generateDatabaseSetup(config: ProjectConfig, packageManagerRunCmd: stri
 
   const isBackendSelf = backend === "self";
   const envPath = isBackendSelf ? "apps/web/.env" : "apps/server/.env";
-  const ormLabels: Record<ProjectConfig["orm"], string> = {
+  const ormLabels = {
     drizzle: "Drizzle ORM",
     prisma: "Prisma",
     mongoose: "Mongoose",
     none: "ORM",
-  };
+  } satisfies Record<ProjectConfig["orm"], string>;
   const ormDesc = orm === "none" ? "" : ` with ${ormLabels[orm] || orm}`;
   const dbSupport = getDbScriptSupport(config);
   const isD1Alchemy = dbSupport.isD1Alchemy;
@@ -650,7 +657,7 @@ ${steps.join("\n\n")}
 `;
   }
 
-  const dbDescriptions: Record<string, string> = {
+  const dbDescriptions = {
     sqlite: `This project uses SQLite${ormDesc}.
 
 1. Start the local SQLite database (optional):
@@ -678,7 +685,7 @@ ${packageManagerRunCmd} db:local
 
 1. Make sure you have MongoDB set up.
 2. Update your \`${envPath}\` file with your MongoDB connection URI.`,
-  };
+  } satisfies Record<string, string>;
 
   setup += dbDescriptions[database] || "";
 

--- a/packages/template-generator/src/processors/runtime-deps.ts
+++ b/packages/template-generator/src/processors/runtime-deps.ts
@@ -1,11 +1,12 @@
 import type { ProjectConfig } from "@better-t-stack/types";
 
+import type { JsonValue } from "../core/json-types";
 import type { VirtualFileSystem } from "../core/virtual-fs";
 import { addPackageDependency } from "../utils/add-deps";
 
 type PackageJson = {
   scripts?: Record<string, string>;
-  [key: string]: unknown;
+  [key: string]: JsonValue | undefined;
 };
 
 export function processRuntimeDeps(vfs: VirtualFileSystem, config: ProjectConfig): void {

--- a/packages/template-generator/src/processors/turbo-generator.ts
+++ b/packages/template-generator/src/processors/turbo-generator.ts
@@ -17,10 +17,12 @@ interface TurboTask {
   interactive?: boolean;
 }
 
+interface TurboTasks extends Record<string, TurboTask> {}
+
 interface TurboConfig {
   $schema: string;
   ui: string;
-  tasks: Record<string, TurboTask>;
+  tasks: TurboTasks;
 }
 
 export function processTurboConfig(vfs: VirtualFileSystem, config: ProjectConfig): void {
@@ -41,16 +43,15 @@ export function generateTurboConfig(config: ProjectConfig): TurboConfig {
   const hasAlchemy = isAlchemyDeployTarget(webDeploy) || isAlchemyDeployTarget(serverDeploy);
   const hasLocalD1 = getLocalD1Owner(config) === "wrangler";
 
-  const tasks: Record<string, TurboTask> = {
-    ...getBaseTasks(frontend, config.addons),
-    ...(config.addons.includes("electrobun") ? getElectrobunTasks() : {}),
-    ...(isConvex ? getConvexTasks() : {}),
-    ...(!isConvex && hasDatabase ? getDatabaseTasks(dbSupport) : {}),
-    ...(isDocker ? getDockerTasks() : {}),
-    ...(isSqliteLocal ? getSqliteLocalTask() : {}),
-    ...(hasLocalD1 ? getLocalD1Task() : {}),
-    ...(hasAlchemy ? getDeployTasks() : {}),
-  };
+  const tasks: TurboTasks = getBaseTasks(frontend, config.addons);
+
+  if (config.addons.includes("electrobun")) Object.assign(tasks, getElectrobunTasks());
+  if (isConvex) Object.assign(tasks, getConvexTasks());
+  if (!isConvex && hasDatabase) Object.assign(tasks, getDatabaseTasks(dbSupport));
+  if (isDocker) Object.assign(tasks, getDockerTasks());
+  if (isSqliteLocal) Object.assign(tasks, getSqliteLocalTask());
+  if (hasLocalD1) Object.assign(tasks, getLocalD1Task());
+  if (hasAlchemy) Object.assign(tasks, getDeployTasks());
 
   return {
     $schema: "https://turbo.build/schema.json",
@@ -59,7 +60,7 @@ export function generateTurboConfig(config: ProjectConfig): TurboConfig {
   };
 }
 
-function getBaseTasks(frontend: string[], addons: string[]): Record<string, TurboTask> {
+function getBaseTasks(frontend: string[], addons: string[]): TurboTasks {
   // Build outputs per framework:
   // - Vite-based client apps: dist/**
   // - Next.js: .next/** excluding .next/cache/**
@@ -111,7 +112,7 @@ function getBaseTasks(frontend: string[], addons: string[]): Record<string, Turb
   };
 }
 
-function getElectrobunTasks(): Record<string, TurboTask> {
+function getElectrobunTasks(): TurboTasks {
   return {
     "dev:hmr": {
       cache: false,
@@ -130,7 +131,7 @@ function getElectrobunTasks(): Record<string, TurboTask> {
   };
 }
 
-function getConvexTasks(): Record<string, TurboTask> {
+function getConvexTasks(): TurboTasks {
   return {
     "dev:setup": {
       cache: false,
@@ -139,8 +140,8 @@ function getConvexTasks(): Record<string, TurboTask> {
   };
 }
 
-function getDatabaseTasks(dbSupport: DbScriptSupport): Record<string, TurboTask> {
-  const tasks: Record<string, TurboTask> = {};
+function getDatabaseTasks(dbSupport: DbScriptSupport): TurboTasks {
+  const tasks: TurboTasks = {};
 
   if (dbSupport.hasDbPush) {
     tasks["db:push"] = { cache: false, interactive: true };
@@ -161,7 +162,7 @@ function getDatabaseTasks(dbSupport: DbScriptSupport): Record<string, TurboTask>
   return tasks;
 }
 
-function getDockerTasks(): Record<string, TurboTask> {
+function getDockerTasks(): TurboTasks {
   return {
     "db:start": {
       cache: false,
@@ -179,7 +180,7 @@ function getDockerTasks(): Record<string, TurboTask> {
   };
 }
 
-function getSqliteLocalTask(): Record<string, TurboTask> {
+function getSqliteLocalTask(): TurboTasks {
   return {
     "db:local": {
       cache: false,
@@ -188,7 +189,7 @@ function getSqliteLocalTask(): Record<string, TurboTask> {
   };
 }
 
-function getLocalD1Task(): Record<string, TurboTask> {
+function getLocalD1Task(): TurboTasks {
   return {
     "db:migrate:local": {
       cache: false,
@@ -197,7 +198,7 @@ function getLocalD1Task(): Record<string, TurboTask> {
   };
 }
 
-function getDeployTasks(): Record<string, TurboTask> {
+function getDeployTasks(): TurboTasks {
   return {
     deploy: {
       cache: false,

--- a/packages/template-generator/src/processors/workspace-deps.ts
+++ b/packages/template-generator/src/processors/workspace-deps.ts
@@ -51,7 +51,7 @@ export function processWorkspaceDeps(vfs: VirtualFileSystem, config: ProjectConf
   });
 
   if (packages.env) {
-    const envDevDeps: Record<string, string> = { ...configDep };
+    const envDevDeps = { ...configDep } satisfies Record<string, string>;
     if (
       isAlchemy &&
       packages.infra &&
@@ -90,7 +90,7 @@ export function processWorkspaceDeps(vfs: VirtualFileSystem, config: ProjectConf
   }
 
   if (packages.auth) {
-    const authDeps: Record<string, string> = { ...envDep };
+    const authDeps = { ...envDep } satisfies Record<string, string>;
     if (database !== "none" && packages.db) {
       authDeps[`@${projectName}/db`] = workspaceVersion;
     }
@@ -105,7 +105,7 @@ export function processWorkspaceDeps(vfs: VirtualFileSystem, config: ProjectConf
   }
 
   if (packages.api) {
-    const apiPackageDeps: Record<string, string> = { ...envDep };
+    const apiPackageDeps = { ...envDep } satisfies Record<string, string>;
     if (auth !== "none" && packages.auth) {
       apiPackageDeps[`@${projectName}/auth`] = workspaceVersion;
     }
@@ -137,7 +137,7 @@ export function processWorkspaceDeps(vfs: VirtualFileSystem, config: ProjectConf
     if (runtime === "workers" && orm === "prisma") {
       serverDevDependencies.push("unwasm");
     }
-    const serverDeps: Record<string, string> = { ...envDep };
+    const serverDeps = { ...envDep } satisfies Record<string, string>;
     if (api !== "none" && packages.api) serverDeps[`@${projectName}/api`] = workspaceVersion;
     if (auth !== "none" && packages.auth) serverDeps[`@${projectName}/auth`] = workspaceVersion;
     if (database !== "none" && packages.db) serverDeps[`@${projectName}/db`] = workspaceVersion;
@@ -152,7 +152,7 @@ export function processWorkspaceDeps(vfs: VirtualFileSystem, config: ProjectConf
   }
 
   if (packages.web) {
-    const webPackageDeps: Record<string, string> = { ...envDep, ...uiDep };
+    const webPackageDeps = { ...envDep, ...uiDep } satisfies Record<string, string>;
 
     if (api !== "none" && packages.api) webPackageDeps[`@${projectName}/api`] = workspaceVersion;
     if (backend === "self" && auth !== "none" && packages.auth) {
@@ -181,7 +181,7 @@ export function processWorkspaceDeps(vfs: VirtualFileSystem, config: ProjectConf
   }
 
   if (packages.native) {
-    const nativeDeps: Record<string, string> = { ...envDep };
+    const nativeDeps = { ...envDep } satisfies Record<string, string>;
     if (api !== "none" && packages.api) nativeDeps[`@${projectName}/api`] = workspaceVersion;
     if (backend === "convex" && packages.backend)
       nativeDeps[`@${projectName}/backend`] = workspaceVersion;

--- a/packages/template-generator/src/template-handlers/deploy.ts
+++ b/packages/template-generator/src/template-handlers/deploy.ts
@@ -4,6 +4,10 @@ import type { VirtualFileSystem } from "../core/virtual-fs";
 import { processAlchemyRun } from "../generators/alchemy/render";
 import { type TemplateData, processTemplatesFromPrefix } from "./utils";
 
+function hasOwnKey<T extends object>(object: T, key: PropertyKey): key is keyof T {
+  return Object.hasOwn(object, key);
+}
+
 export async function processDeployTemplates(
   vfs: VirtualFileSystem,
   templates: TemplateData,
@@ -28,13 +32,13 @@ export async function processDeployTemplates(
   }
 
   if (config.webDeploy === "prisma") {
-    const templateMap: Partial<Record<ProjectConfig["frontend"][number], string>> = {
+    const templateMap = {
       "react-router": "react/react-router",
-    };
+    } satisfies Partial<Record<ProjectConfig["frontend"][number], string>>;
 
     for (const frontend of config.frontend) {
-      const templatePath = templateMap[frontend];
-      if (templatePath) {
+      if (hasOwnKey(templateMap, frontend)) {
+        const templatePath = templateMap[frontend];
         processTemplatesFromPrefix(
           vfs,
           templates,
@@ -52,7 +56,7 @@ export async function processDeployTemplates(
     config.webDeploy !== "prisma" &&
     config.webDeploy !== "vercel"
   ) {
-    const templateMap: Record<string, string> = {
+    const templateMap = {
       "tanstack-router": "react/tanstack-router",
       "tanstack-start": "react/tanstack-start",
       "react-router": "react/react-router",
@@ -61,10 +65,10 @@ export async function processDeployTemplates(
       nuxt: "nuxt",
       svelte: "svelte",
       astro: "astro",
-    };
+    } satisfies Record<string, string>;
 
     for (const f of config.frontend) {
-      if (templateMap[f]) {
+      if (hasOwnKey(templateMap, f)) {
         processTemplatesFromPrefix(
           vfs,
           templates,

--- a/packages/template-generator/src/utils/add-deps.ts
+++ b/packages/template-generator/src/utils/add-deps.ts
@@ -2,13 +2,14 @@
  * Add dependencies to a package.json in the virtual filesystem
  */
 
+import type { JsonValue } from "../core/json-types";
 import type { VirtualFileSystem } from "../core/virtual-fs";
 
 type PackageJson = {
   name?: string;
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
-  [key: string]: unknown;
+  [key: string]: JsonValue | undefined;
 };
 
 export const dependencyVersionMap = {
@@ -64,8 +65,8 @@ export const dependencyVersionMap = {
 
   "@biomejs/biome": "^2.5.6",
 
-  oxlint: "^1.76.0",
-  oxfmt: "^0.61.0",
+  oxlint: "^1.78.0",
+  oxfmt: "^0.63.0",
 
   husky: "^9.1.7",
   lefthook: "^2.1.10",

--- a/packages/types/src/schemas.ts
+++ b/packages/types/src/schemas.ts
@@ -573,11 +573,9 @@ export const BetterTStackConfigSchema = z.object({
   serverDeploy: ServerDeploySchema,
 });
 
-export const BetterTStackConfigFileSchema = z
-  .object({
-    $schema: z.string().optional().describe("JSON Schema reference for validation"),
-  })
-  .extend(BetterTStackConfigSchema.shape)
+export const BetterTStackConfigFileSchema = BetterTStackConfigSchema.safeExtend({
+  $schema: z.string().optional().describe("JSON Schema reference for validation"),
+})
   .strict()
   .meta({
     id: "https://r2.better-t-stack.dev/schema.json",

--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -1,7 +1,7 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
-import { confirm, select, text } from "@clack/prompts";
+import { confirm, isCancel, select, text } from "@clack/prompts";
 import { $ } from "bun";
 
 const CLI_PACKAGE_JSON_PATH = join(process.cwd(), "apps/cli/package.json");
@@ -39,8 +39,8 @@ async function main(): Promise<void> {
         message: "Enter the version (e.g., 2.34.0):",
         placeholder: "2.34.0",
       });
-      versionInput = typeof customVersion === "string" ? customVersion : undefined;
-    } else if (typeof bumpType === "string") {
+      versionInput = isCancel(customVersion) ? undefined : customVersion;
+    } else if (!isCancel(bumpType)) {
       versionInput = bumpType;
     }
 
@@ -230,8 +230,8 @@ async function ensurePreviewLabelExists(): Promise<void> {
   await $`gh label create ${PREVIEW_LABEL} --description "Publish an npm preview release for a PR" --color 2EA44F`;
 }
 
-function formatError(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
+function formatError(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause);
 }
 
 main().catch(console.error);

--- a/scripts/canary-release.ts
+++ b/scripts/canary-release.ts
@@ -62,8 +62,8 @@ async function main(): Promise<void> {
         try {
           const deprecatedJson =
             await $`npm view ${`${packageName}@${v}`} deprecated --json`.text();
-          const deprecatedMsg = deprecatedJson ? JSON.parse(deprecatedJson) : null;
-          if (!deprecatedMsg || (typeof deprecatedMsg === "string" && deprecatedMsg.length === 0)) {
+          const deprecatedMsg = deprecatedJson.trim();
+          if (!deprecatedMsg || deprecatedMsg === '""') {
             nonDeprecated.push(v);
           }
         } catch {
@@ -85,13 +85,13 @@ async function main(): Promise<void> {
         return;
       }
 
-      const selected = (await multiselect({
+      const selected = await multiselect({
         message: "Select canary versions to deprecate:",
         options: nonDeprecated
           .sort()
           .reverse()
           .map((v) => ({ value: v, label: v })),
-      })) as unknown as string[] | symbol;
+      });
 
       if (isCancel(selected) || !Array.isArray(selected) || selected.length === 0) {
         console.log("❌ No selections made. Aborting.");

--- a/scripts/cleanup-previews.ts
+++ b/scripts/cleanup-previews.ts
@@ -91,10 +91,10 @@ async function main(): Promise<void> {
     return;
   }
 
-  const selected = (await multiselect({
+  const selected = await multiselect({
     message: "Select PR tags to clean up:",
     options: tagOptions,
-  })) as unknown as string[] | symbol;
+  });
 
   if (isCancel(selected) || !Array.isArray(selected) || selected.length === 0) {
     console.log("\nNo selections made. Aborting.");

--- a/scripts/publish-smoke.ts
+++ b/scripts/publish-smoke.ts
@@ -16,6 +16,15 @@ import { join, resolve } from "node:path";
 
 import { $ } from "bun";
 
+interface PackageFixture {
+  name: string;
+  private: boolean;
+  version: string;
+  dependencies: Record<string, string>;
+  pnpm?: { overrides: Record<string, string> };
+  overrides?: Record<string, string>;
+}
+
 const ROOT = resolve(import.meta.dir, "..");
 
 type Publishable = {
@@ -83,11 +92,11 @@ async function installAndRun(
   rmSync(dir, { recursive: true, force: true });
   mkdirSync(dir, { recursive: true });
 
-  const overrides: Record<string, string> = {
+  const overrides = {
     "@better-t-stack/types": `file:${tarballs["@better-t-stack/types"]}`,
     "@better-t-stack/template-generator": `file:${tarballs["@better-t-stack/template-generator"]}`,
-  };
-  const fixture: Record<string, unknown> = {
+  } satisfies Record<string, string>;
+  const fixture: PackageFixture = {
     name: `smoke-${pm}`,
     private: true,
     version: "0.0.0",

--- a/tools/oxlint/anti-slop/index.ts
+++ b/tools/oxlint/anti-slop/index.ts
@@ -1,0 +1,31 @@
+import { definePlugin } from "@oxlint/plugins";
+
+import { noChainedTypeAssertionsRule } from "./rules/no-chained-type-assertions.ts";
+import { noConditionalEmptyObjectSpreadRule } from "./rules/no-conditional-empty-object-spread.ts";
+import { noKnownValueWideningRule } from "./rules/no-known-value-widening.ts";
+import { noObjectParametersRule } from "./rules/no-object-parameters.ts";
+import { noRuntimeTypeofRule } from "./rules/no-runtime-typeof.ts";
+import { noForbiddenTermInSymbolNamesRule } from "./rules/no-shape-in-symbol-names.ts";
+import { noUnknownParametersRule } from "./rules/no-unknown-parameters.ts";
+import { noUnknownTypeAliasesRule } from "./rules/no-unknown-type-aliases.ts";
+import { noUnsafeDictionaryTypeRule } from "./rules/no-unsafe-dictionary-type.ts";
+import { noWidenThenAssertRule } from "./rules/no-widen-then-assert.ts";
+
+/** Generic Oxlint rules that reject low-evidence and low-signal implementation patterns. */
+const antiSlopPlugin = definePlugin({
+  meta: { name: "anti-slop" },
+  rules: {
+    "no-chained-type-assertions": noChainedTypeAssertionsRule,
+    "no-conditional-empty-object-spread": noConditionalEmptyObjectSpreadRule,
+    "no-known-value-widening": noKnownValueWideningRule,
+    "no-object-parameters": noObjectParametersRule,
+    "no-runtime-typeof": noRuntimeTypeofRule,
+    "no-unsafe-dictionary-type": noUnsafeDictionaryTypeRule,
+    "no-shape-in-symbol-names": noForbiddenTermInSymbolNamesRule,
+    "no-unknown-parameters": noUnknownParametersRule,
+    "no-unknown-type-aliases": noUnknownTypeAliasesRule,
+    "no-widen-then-assert": noWidenThenAssertRule,
+  },
+});
+
+export default antiSlopPlugin;

--- a/tools/oxlint/anti-slop/package.json
+++ b/tools/oxlint/anti-slop/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/tools/oxlint/anti-slop/rules/no-chained-type-assertions.ts
+++ b/tools/oxlint/anti-slop/rules/no-chained-type-assertions.ts
@@ -1,0 +1,77 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree } from "@oxlint/plugins";
+
+type TypeAssertionExpression = ESTree.TSAsExpression | ESTree.TSTypeAssertion;
+
+function isTypeAssertionExpression(node: ESTree.Node): node is TypeAssertionExpression {
+  return node.type === "TSAsExpression" || node.type === "TSTypeAssertion";
+}
+
+function unwrapParenthesizedExpression(expression: ESTree.Expression): ESTree.Expression {
+  let current = expression;
+  while (current.type === "ParenthesizedExpression") {
+    current = current.expression;
+  }
+  return current;
+}
+
+function isConstAssertion(node: TypeAssertionExpression): boolean {
+  const { typeAnnotation } = node;
+  return (
+    typeAnnotation.type === "TSTypeReference" &&
+    typeAnnotation.typeName.type === "Identifier" &&
+    typeAnnotation.typeName.name === "const"
+  );
+}
+
+function isOutermostAssertionInChain(node: TypeAssertionExpression): boolean {
+  let current: ESTree.Expression = node;
+  let parent = node.parent;
+
+  while (parent.type === "ParenthesizedExpression" && parent.expression === current) {
+    current = parent;
+    parent = parent.parent;
+  }
+
+  return !isTypeAssertionExpression(parent) || parent.expression !== current;
+}
+
+function isForbiddenAssertionChain(node: TypeAssertionExpression): boolean {
+  let assertionCount = 0;
+  let hasNonConstAssertion = false;
+  let current: ESTree.Expression = node;
+
+  while (isTypeAssertionExpression(current)) {
+    assertionCount += 1;
+    hasNonConstAssertion ||= !isConstAssertion(current);
+    current = unwrapParenthesizedExpression(current.expression);
+  }
+
+  return assertionCount > 1 && hasNonConstAssertion;
+}
+
+/** Disallow nested TypeScript type assertions, while permitting chains made only of const assertions. */
+export const noChainedTypeAssertionsRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow chained TypeScript as and angle-bracket assertions, including parenthesized chains.",
+    },
+    messages: {
+      chained:
+        "Chained type assertions discard existing type evidence and fabricate the target type without parsing. Preserve the value's original precise type, or parse genuinely unknown input at its boundary before using it.",
+    },
+  },
+  create(context) {
+    const checkTypeAssertion = (node: TypeAssertionExpression) => {
+      if (!isOutermostAssertionInChain(node) || !isForbiddenAssertionChain(node)) return;
+      context.report({ node, messageId: "chained" });
+    };
+
+    return {
+      TSAsExpression: checkTypeAssertion,
+      TSTypeAssertion: checkTypeAssertion,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-conditional-empty-object-spread.ts
+++ b/tools/oxlint/anti-slop/rules/no-conditional-empty-object-spread.ts
@@ -1,0 +1,131 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree, SourceCode } from "@oxlint/plugins";
+
+type ConditionalEmptyObjectSpread = {
+  readonly conditional: ESTree.ConditionalExpression;
+  readonly property: ESTree.ObjectProperty | null;
+};
+
+type UndefinedCheckedExpression = {
+  readonly expression: ESTree.Expression;
+  readonly isDefinedWhenTrue: boolean;
+};
+
+function unwrapParentheses(node: ESTree.Expression): ESTree.Expression {
+  let current = node;
+  while (current.type === "ParenthesizedExpression") {
+    current = current.expression;
+  }
+  return current;
+}
+
+function isEmptyObjectExpression(node: ESTree.Expression): boolean {
+  return node.type === "ObjectExpression" && node.properties.length === 0;
+}
+
+function singleObjectProperty(node: ESTree.Expression): ESTree.ObjectProperty | null {
+  if (node.type !== "ObjectExpression" || node.properties.length !== 1) return null;
+
+  const [property] = node.properties;
+  if (
+    property?.type !== "Property" ||
+    property.kind !== "init" ||
+    property.method ||
+    property.computed
+  ) {
+    return null;
+  }
+
+  return property;
+}
+
+function conditionalEmptyObjectSpread(
+  node: ESTree.Expression,
+): ConditionalEmptyObjectSpread | null {
+  const conditional = unwrapParentheses(node);
+  if (conditional.type !== "ConditionalExpression") return null;
+
+  if (isEmptyObjectExpression(conditional.consequent)) {
+    return { conditional, property: singleObjectProperty(conditional.alternate) };
+  }
+
+  if (isEmptyObjectExpression(conditional.alternate)) {
+    return { conditional, property: singleObjectProperty(conditional.consequent) };
+  }
+
+  return null;
+}
+
+function undefinedCheckedExpression(test: ESTree.Expression): UndefinedCheckedExpression | null {
+  const binary = unwrapParentheses(test);
+  if (binary.type !== "BinaryExpression") return null;
+  if (binary.operator !== "===" && binary.operator !== "!==") return null;
+
+  const left = unwrapParentheses(binary.left);
+  const right = unwrapParentheses(binary.right);
+  const leftIsUndefined = left.type === "Identifier" && left.name === "undefined";
+  const rightIsUndefined = right.type === "Identifier" && right.name === "undefined";
+  if (leftIsUndefined === rightIsUndefined) return null;
+
+  return {
+    expression: leftIsUndefined ? right : left,
+    isDefinedWhenTrue: binary.operator === "!==",
+  };
+}
+
+function canAutofixConditionalEmptyObjectSpread(
+  sourceCode: SourceCode,
+  conditional: ESTree.ConditionalExpression,
+  property: ESTree.ObjectProperty,
+): boolean {
+  const checked = undefinedCheckedExpression(conditional.test);
+  if (checked === null) return false;
+
+  const propertyIsConsequent = conditional.consequent === property.parent;
+  if (propertyIsConsequent !== checked.isDefinedWhenTrue) return false;
+
+  return (
+    sourceCode.getText(unwrapParentheses(checked.expression)) === sourceCode.getText(property.value)
+  );
+}
+
+/** Ban conditional empty-object spreads and autofix equivalent direct property declarations. */
+export const noConditionalEmptyObjectSpreadRule = defineRule({
+  meta: {
+    type: "suggestion",
+    fixable: "code",
+    docs: {
+      description:
+        "Disallow object spreads that conditionally spread an empty object to omit fields.",
+    },
+    messages: {
+      avoid:
+        "Do not use conditional empty-object spreads. Prefer a direct property or build the object in separate statements.",
+    },
+  },
+  create(context) {
+    return {
+      SpreadElement(node) {
+        if (node.parent.type !== "ObjectExpression") return;
+
+        const match = conditionalEmptyObjectSpread(node.argument);
+        if (match === null) return;
+
+        const { conditional, property } = match;
+        if (
+          property !== null &&
+          canAutofixConditionalEmptyObjectSpread(context.sourceCode, conditional, property)
+        ) {
+          context.report({
+            node,
+            messageId: "avoid",
+            fix: (fixer) => fixer.replaceText(node, context.sourceCode.getText(property)),
+          });
+          return;
+        }
+
+        context.report({ node, messageId: "avoid" });
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-known-value-widening.ts
+++ b/tools/oxlint/anti-slop/rules/no-known-value-widening.ts
@@ -1,0 +1,249 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree, Scope, SourceCode, Variable } from "@oxlint/plugins";
+
+import {
+  classifyWideningTarget,
+  createTypeEnvironment,
+  isKnownEvidenceExpression,
+  type TypeEnvironment,
+  type WideningTarget,
+} from "../shared/dictionary-types.ts";
+
+type FunctionExpression = ESTree.ArrowFunctionExpression | ESTree.Function;
+
+function unwrapExpression(expression: ESTree.Expression): ESTree.Expression {
+  let current = expression;
+  while (
+    current.type === "ParenthesizedExpression" ||
+    current.type === "TSAsExpression" ||
+    current.type === "TSSatisfiesExpression" ||
+    current.type === "TSTypeAssertion" ||
+    current.type === "TSNonNullExpression"
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
+function resolveVariable(
+  sourceCode: SourceCode,
+  identifier: ESTree.IdentifierReference,
+): Variable | null {
+  let scope: Scope | null = sourceCode.getScope(identifier);
+  while (scope !== null) {
+    const variable = scope.set.get(identifier.name);
+    if (variable !== undefined) return variable;
+    scope = scope.upper;
+  }
+  return null;
+}
+
+function variableDeclarator(variable: Variable): ESTree.VariableDeclarator | null {
+  if (variable.defs.length !== 1) return null;
+  const [definition] = variable.defs;
+  return definition?.type === "Variable" && definition.node.type === "VariableDeclarator"
+    ? definition.node
+    : null;
+}
+
+function isStableConstVariable(variable: Variable, declarator: ESTree.VariableDeclarator): boolean {
+  return (
+    declarator.parent.type === "VariableDeclaration" &&
+    declarator.parent.kind === "const" &&
+    variable.references.every((reference) => reference.init || !reference.isWrite())
+  );
+}
+
+function hasKnownEvidence(
+  sourceCode: SourceCode,
+  expression: ESTree.Expression,
+  visitedVariables = new Set<Variable>(),
+): boolean {
+  if (isKnownEvidenceExpression(expression)) return true;
+  const unwrapped = unwrapExpression(expression);
+  if (unwrapped.type !== "Identifier") return false;
+  const variable = resolveVariable(sourceCode, unwrapped);
+  if (variable === null || visitedVariables.has(variable)) return false;
+  const declarator = variableDeclarator(variable);
+  if (
+    declarator === null ||
+    declarator.init === null ||
+    !isStableConstVariable(variable, declarator)
+  ) {
+    return false;
+  }
+  visitedVariables.add(variable);
+  return hasKnownEvidence(sourceCode, declarator.init, visitedVariables);
+}
+
+function annotationTarget(
+  annotation: ESTree.TSTypeAnnotation | null | undefined,
+  environment: TypeEnvironment,
+): WideningTarget | null {
+  return annotation === null || annotation === undefined
+    ? null
+    : classifyWideningTarget(annotation.typeAnnotation, environment);
+}
+
+function enclosingFunction(node: ESTree.Node): FunctionExpression | null {
+  let current: ESTree.Node | null = node.parent;
+  while (current !== null && current.type !== "Program") {
+    if (
+      current.type === "ArrowFunctionExpression" ||
+      current.type === "FunctionDeclaration" ||
+      current.type === "FunctionExpression"
+    ) {
+      return current;
+    }
+    current = current.parent;
+  }
+  return null;
+}
+
+function sourceKeyName(sourceCode: SourceCode, key: ESTree.PropertyKey): string {
+  if (key.type === "Identifier" || key.type === "PrivateIdentifier") return key.name;
+  if (key.type === "Literal") return String(key.value);
+  return sourceCode.getText(key);
+}
+
+function functionName(sourceCode: SourceCode, owner: FunctionExpression | null): string {
+  if (owner === null) return "anonymous function";
+  if (owner.id !== null) return owner.id.name;
+  const parent = owner.parent;
+  if (parent.type === "VariableDeclarator" && parent.id.type === "Identifier")
+    return parent.id.name;
+  if (parent.type === "MethodDefinition") return sourceKeyName(sourceCode, parent.key);
+  return "anonymous function";
+}
+
+function isEmptyObjectExpression(expression: ESTree.Expression): boolean {
+  const unwrapped = unwrapExpression(expression);
+  return unwrapped.type === "ObjectExpression" && unwrapped.properties.length === 0;
+}
+
+function isDictionaryAccumulatorTarget(destination: WideningTarget): boolean {
+  return destination.kind === "open dictionary" || destination.kind === "generic container";
+}
+
+function hasParentAssertion(node: ESTree.Node): boolean {
+  return node.parent?.type === "TSAsExpression" || node.parent?.type === "TSTypeAssertion";
+}
+
+/** Detect sound syntactic cases where a known value is explicitly widened and loses evidence. */
+export const noKnownValueWideningRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow syntactically established values from flowing into explicitly broad or anonymous target types that discard useful evidence.",
+    },
+    messages: {
+      widening:
+        "The known initializer supplying {{subject}} carries established type evidence, but the explicit {{target}} target type discards it. Preserve inference, use `satisfies`, or introduce/use a named owner contract; parse genuinely external data once at its boundary.",
+    },
+  },
+  createOnce(context) {
+    let environment: TypeEnvironment | null = null;
+
+    const reportFlow = (
+      expression: ESTree.Expression,
+      destination: WideningTarget | null,
+      subject: string,
+      options: Readonly<{ allowEmptyDictionaryAccumulator?: boolean }> = {},
+    ) => {
+      if (destination === null) return;
+      if (
+        options.allowEmptyDictionaryAccumulator === true &&
+        isDictionaryAccumulatorTarget(destination) &&
+        isEmptyObjectExpression(expression)
+      ) {
+        return;
+      }
+      if (!hasKnownEvidence(context.sourceCode, expression)) return;
+      context.report({
+        node: expression,
+        messageId: "widening",
+        data: { subject, target: destination.kind },
+      });
+    };
+
+    const targetFromAnnotation = (annotation: ESTree.TSTypeAnnotation | null | undefined) =>
+      environment === null ? null : annotationTarget(annotation, environment);
+
+    return {
+      Program(node) {
+        environment = createTypeEnvironment(node);
+      },
+      VariableDeclarator(node) {
+        if (node.init === null || node.id.type !== "Identifier") return;
+        reportFlow(
+          node.init,
+          targetFromAnnotation(node.id.typeAnnotation),
+          `binding \`${node.id.name}\``,
+          { allowEmptyDictionaryAccumulator: true },
+        );
+      },
+      PropertyDefinition(node) {
+        if (node.value === null) return;
+        reportFlow(
+          node.value,
+          targetFromAnnotation(node.typeAnnotation),
+          `property \`${sourceKeyName(context.sourceCode, node.key)}\``,
+        );
+      },
+      AccessorProperty(node) {
+        if (node.value === null) return;
+        reportFlow(
+          node.value,
+          targetFromAnnotation(node.typeAnnotation),
+          `property \`${sourceKeyName(context.sourceCode, node.key)}\``,
+        );
+      },
+      AssignmentExpression(node) {
+        if (node.operator !== "=" || node.left.type !== "Identifier") return;
+        const variable = resolveVariable(context.sourceCode, node.left);
+        if (variable === null) return;
+        const declarator = variableDeclarator(variable);
+        if (declarator === null || declarator.id.type !== "Identifier") return;
+        reportFlow(
+          node.right,
+          targetFromAnnotation(declarator.id.typeAnnotation),
+          `binding \`${declarator.id.name}\``,
+        );
+      },
+      ReturnStatement(node) {
+        if (node.argument === null) return;
+        const owner = enclosingFunction(node);
+        reportFlow(
+          node.argument,
+          targetFromAnnotation(owner?.returnType),
+          `return value of \`${functionName(context.sourceCode, owner)}\``,
+        );
+      },
+      ArrowFunctionExpression(node) {
+        if (node.body.type === "BlockStatement") return;
+        reportFlow(
+          node.body,
+          targetFromAnnotation(node.returnType),
+          `return value of \`${functionName(context.sourceCode, node)}\``,
+        );
+      },
+      TSAsExpression(node) {
+        if (environment === null || hasParentAssertion(node)) return;
+        reportFlow(
+          node.expression,
+          classifyWideningTarget(node.typeAnnotation, environment),
+          "assertion",
+        );
+      },
+      TSTypeAssertion(node) {
+        if (environment === null || hasParentAssertion(node)) return;
+        reportFlow(
+          node.expression,
+          classifyWideningTarget(node.typeAnnotation, environment),
+          "assertion",
+        );
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-object-parameters.ts
+++ b/tools/oxlint/anti-slop/rules/no-object-parameters.ts
@@ -1,0 +1,111 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree, SourceCode } from "@oxlint/plugins";
+
+type Parameter = ESTree.ParamPattern;
+type ParameterOwner =
+  | ESTree.ArrowFunctionExpression
+  | ESTree.Function
+  | ESTree.TSCallSignatureDeclaration
+  | ESTree.TSConstructSignatureDeclaration
+  | ESTree.TSConstructorType
+  | ESTree.TSFunctionType
+  | ESTree.TSMethodSignature;
+
+function parameterAnnotation(parameter: Parameter): ESTree.TSTypeAnnotation | null | undefined {
+  if (parameter.type === "TSParameterProperty") {
+    return parameterAnnotation(parameter.parameter);
+  }
+  if (parameter.type === "RestElement") {
+    return parameter.typeAnnotation ?? parameterAnnotation(parameter.argument);
+  }
+  if (parameter.type === "AssignmentPattern") {
+    return parameter.typeAnnotation ?? parameter.left.typeAnnotation;
+  }
+  return parameter.typeAnnotation;
+}
+
+function parameterName(parameter: Parameter, sourceCode: SourceCode): string {
+  return parameter.type === "Identifier"
+    ? parameter.name
+    : sourceCode.getText(parameter).replace(/\s*:\s*object\s*$/u, "");
+}
+
+/** Ban the broad object type on function inputs, including local aliases to object. */
+export const noObjectParametersRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow object function parameters; inputs must use an owner-provided type and be parsed at their boundary.",
+    },
+    messages: {
+      objectParameter:
+        "Parameter `{{parameter}}` accepts the broad `object` type. Use the expected owner type or decode the external input at its boundary.",
+    },
+  },
+  create(context) {
+    const aliases = new Map<string, ESTree.TSType>();
+
+    const resolvesToObject = (type: ESTree.TSType, visited = new Set<string>()): boolean => {
+      if (type.type === "TSObjectKeyword") return true;
+      if (type.type === "TSParenthesizedType")
+        return resolvesToObject(type.typeAnnotation, visited);
+      if (type.type === "TSUnionType") {
+        return type.types.some((member) => resolvesToObject(member, visited));
+      }
+      if (
+        type.type !== "TSTypeReference" ||
+        type.typeName.type !== "Identifier" ||
+        (type.typeArguments !== null &&
+          type.typeArguments !== undefined &&
+          type.typeArguments.params.length > 0) ||
+        visited.has(type.typeName.name)
+      ) {
+        return false;
+      }
+      const alias = aliases.get(type.typeName.name);
+      if (alias === undefined) return false;
+      const nextVisited = new Set(visited);
+      nextVisited.add(type.typeName.name);
+      return resolvesToObject(alias, nextVisited);
+    };
+
+    const checkParameters = (node: ParameterOwner) => {
+      for (const parameter of node.params) {
+        const annotation = parameterAnnotation(parameter);
+        if (annotation === null || annotation === undefined) continue;
+        if (!resolvesToObject(annotation.typeAnnotation)) continue;
+        context.report({
+          node: annotation.typeAnnotation,
+          messageId: "objectParameter",
+          data: { parameter: parameterName(parameter, context.sourceCode) },
+        });
+      }
+    };
+
+    return {
+      Program(node) {
+        for (const statement of node.body) {
+          const declaration =
+            statement.type === "ExportNamedDeclaration" ? statement.declaration : statement;
+          if (
+            declaration?.type === "TSTypeAliasDeclaration" &&
+            (declaration.typeParameters === null || declaration.typeParameters === undefined)
+          ) {
+            aliases.set(declaration.id.name, declaration.typeAnnotation);
+          }
+        }
+      },
+      ArrowFunctionExpression: checkParameters,
+      FunctionDeclaration: checkParameters,
+      FunctionExpression: checkParameters,
+      TSCallSignatureDeclaration: checkParameters,
+      TSConstructSignatureDeclaration: checkParameters,
+      TSConstructorType: checkParameters,
+      TSDeclareFunction: checkParameters,
+      TSEmptyBodyFunctionExpression: checkParameters,
+      TSFunctionType: checkParameters,
+      TSMethodSignature: checkParameters,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-runtime-typeof.ts
+++ b/tools/oxlint/anti-slop/rules/no-runtime-typeof.ts
@@ -1,0 +1,25 @@
+import { defineRule } from "@oxlint/plugins";
+
+/** Disallow runtime typeof checks that narrow unparsed values instead of decoding them. */
+export const noRuntimeTypeofRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow runtime typeof checks; external values must be decoded into meaningful types at their I/O boundary.",
+    },
+    messages: {
+      runtimeTypeof:
+        "A runtime `typeof` check only narrows an unparsed representation; it does not establish the expected contract. Parse the value into a strongly typed domain type at the earliest possible point, as close as possible to the I/O boundary where the data originated.",
+    },
+  },
+  create(context) {
+    return {
+      UnaryExpression(node) {
+        if (node.operator === "typeof") {
+          context.report({ node, messageId: "runtimeTypeof" });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-shape-in-symbol-names.ts
+++ b/tools/oxlint/anti-slop/rules/no-shape-in-symbol-names.ts
@@ -1,0 +1,39 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree } from "@oxlint/plugins";
+
+const FORBIDDEN_SYMBOL_NAME = "shape";
+
+function containsForbiddenSymbolName(name: string): boolean {
+  return name.toLowerCase().includes(FORBIDDEN_SYMBOL_NAME);
+}
+
+/** Ban the case-insensitive substring "shape" in every JavaScript and TypeScript symbol name. */
+export const noForbiddenTermInSymbolNamesRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        'Disallow the case-insensitive substring "shape" in JavaScript, TypeScript, private, and JSX symbol names.',
+    },
+    messages: {
+      forbiddenSymbolName:
+        'Do not use the case-insensitive substring "shape" in symbol names (found "{{name}}").',
+    },
+  },
+  create(context) {
+    const reportForbiddenSymbolName = (node: ESTree.Node & { name: string }) => {
+      if (!containsForbiddenSymbolName(node.name)) return;
+      context.report({
+        node,
+        messageId: "forbiddenSymbolName",
+        data: { name: node.name },
+      });
+    };
+
+    return {
+      Identifier: reportForbiddenSymbolName,
+      PrivateIdentifier: reportForbiddenSymbolName,
+      JSXIdentifier: reportForbiddenSymbolName,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-unknown-parameters.ts
+++ b/tools/oxlint/anti-slop/rules/no-unknown-parameters.ts
@@ -1,0 +1,83 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree } from "@oxlint/plugins";
+
+type Parameter = ESTree.ParamPattern;
+type ParameterOwner =
+  | ESTree.ArrowFunctionExpression
+  | ESTree.Function
+  | ESTree.TSCallSignatureDeclaration
+  | ESTree.TSConstructSignatureDeclaration
+  | ESTree.TSConstructorType
+  | ESTree.TSFunctionType
+  | ESTree.TSMethodSignature;
+
+function parameterAnnotation(parameter: Parameter): ESTree.TSTypeAnnotation | null | undefined {
+  if (parameter.type === "TSParameterProperty") {
+    return parameterAnnotation(parameter.parameter);
+  }
+  if (parameter.type === "RestElement") {
+    return parameter.typeAnnotation ?? parameterAnnotation(parameter.argument);
+  }
+  if (parameter.type === "AssignmentPattern") {
+    return parameter.typeAnnotation ?? parameter.left.typeAnnotation;
+  }
+  return parameter.typeAnnotation;
+}
+
+function parameterName(parameter: Parameter, sourceText: string): string {
+  if (parameter.type === "TSParameterProperty") {
+    return parameterName(parameter.parameter, sourceText);
+  }
+  if (parameter.type === "AssignmentPattern") {
+    return parameterName(parameter.left, sourceText);
+  }
+  if (parameter.type === "RestElement") {
+    return parameterName(parameter.argument, sourceText);
+  }
+  return parameter.type === "Identifier"
+    ? parameter.name
+    : sourceText.replace(/\s*:\s*unknown\s*$/u, "");
+}
+
+/** Disallow unknown inputs except explicitly named error-cause enrichment. */
+export const noUnknownParametersRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow explicitly unknown function parameters except `cause`; decode unknown input at its I/O boundary instead.",
+    },
+    messages: {
+      unknownParameter:
+        "Parameter `{{parameter}}` accepts `unknown` without establishing its contract. Define the expected schema or parser so the value becomes a strongly typed domain type at the earliest possible point, as close as possible to the I/O boundary where the data originated.",
+    },
+  },
+  create(context) {
+    const checkParameters = (node: ParameterOwner) => {
+      for (const parameter of node.params) {
+        const annotation = parameterAnnotation(parameter);
+        if (annotation?.typeAnnotation.type !== "TSUnknownKeyword") continue;
+        const name = parameterName(parameter, context.sourceCode.getText(parameter));
+        if (name === "cause") continue;
+        context.report({
+          node: annotation.typeAnnotation,
+          messageId: "unknownParameter",
+          data: { parameter: name },
+        });
+      }
+    };
+
+    return {
+      ArrowFunctionExpression: checkParameters,
+      FunctionDeclaration: checkParameters,
+      FunctionExpression: checkParameters,
+      TSCallSignatureDeclaration: checkParameters,
+      TSConstructSignatureDeclaration: checkParameters,
+      TSConstructorType: checkParameters,
+      TSDeclareFunction: checkParameters,
+      TSEmptyBodyFunctionExpression: checkParameters,
+      TSFunctionType: checkParameters,
+      TSMethodSignature: checkParameters,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-unknown-type-aliases.ts
+++ b/tools/oxlint/anti-slop/rules/no-unknown-type-aliases.ts
@@ -1,0 +1,68 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree } from "@oxlint/plugins";
+
+function referencedAliasName(type: ESTree.TSType): string | null {
+  if (type.type === "TSParenthesizedType") return referencedAliasName(type.typeAnnotation);
+  if (type.type !== "TSTypeReference" || type.typeName.type !== "Identifier") return null;
+  return type.typeArguments === null ||
+    type.typeArguments === undefined ||
+    type.typeArguments.params.length === 0
+    ? type.typeName.name
+    : null;
+}
+
+/** Ban named aliases that merely conceal TypeScript's unknown top type. */
+export const noUnknownTypeAliasesRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow type aliases whose resolved type is unknown; unknown must remain visible at an allowed boundary.",
+    },
+    messages: {
+      unknownAlias:
+        "Type alias `{{alias}}` only renames `unknown`. Keep `unknown` explicit on an allowed `cause` field or replace it with the parsed owner type.",
+    },
+  },
+  create(context) {
+    const aliases = new Map<string, ESTree.TSTypeAliasDeclaration>();
+
+    const resolvesToUnknown = (type: ESTree.TSType, visited = new Set<string>()): boolean => {
+      if (type.type === "TSUnknownKeyword") return true;
+      if (type.type === "TSParenthesizedType")
+        return resolvesToUnknown(type.typeAnnotation, visited);
+      const name = referencedAliasName(type);
+      if (name === null || visited.has(name)) return false;
+      const alias = aliases.get(name);
+      if (
+        alias === undefined ||
+        (alias.typeParameters !== null && alias.typeParameters !== undefined)
+      ) {
+        return false;
+      }
+      const nextVisited = new Set(visited);
+      nextVisited.add(name);
+      return resolvesToUnknown(alias.typeAnnotation, nextVisited);
+    };
+
+    return {
+      Program(node) {
+        for (const statement of node.body) {
+          const declaration =
+            statement.type === "ExportNamedDeclaration" ? statement.declaration : statement;
+          if (declaration?.type === "TSTypeAliasDeclaration") {
+            aliases.set(declaration.id.name, declaration);
+          }
+        }
+        for (const alias of aliases.values()) {
+          if (!resolvesToUnknown(alias.typeAnnotation, new Set([alias.id.name]))) continue;
+          context.report({
+            node: alias.id,
+            messageId: "unknownAlias",
+            data: { alias: alias.id.name },
+          });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-unsafe-dictionary-type.ts
+++ b/tools/oxlint/anti-slop/rules/no-unsafe-dictionary-type.ts
@@ -1,0 +1,93 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree } from "@oxlint/plugins";
+
+import {
+  classifyUnsafeDictionary,
+  classifyUnsafeDictionaryValue,
+  createTypeEnvironment,
+  type TypeEnvironment,
+} from "../shared/dictionary-types.ts";
+
+function isTypeNode(node: ESTree.Node): node is ESTree.TSType {
+  return node.type.startsWith("TS") && node.type !== "TSTypeAnnotation";
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+  return type.typeName.type === "Identifier" ? type.typeName.name : null;
+}
+
+function isInsideTypeAliasDeclaration(node: ESTree.Node): boolean {
+  let current: ESTree.Node | null = node.parent;
+  while (current !== null && current.type !== "Program") {
+    if (current.type === "TSTypeAliasDeclaration") return true;
+    current = current.parent;
+  }
+  return false;
+}
+
+function isPlainAliasConsumerUse(node: ESTree.TSType, environment: TypeEnvironment): boolean {
+  if (node.type !== "TSTypeReference" || node.typeArguments?.params.length) return false;
+  const name = typeReferenceName(node);
+  return name !== null && environment.aliases.has(name) && !isInsideTypeAliasDeclaration(node);
+}
+
+function shouldReportType(node: ESTree.TSType, environment: TypeEnvironment): boolean {
+  if (isPlainAliasConsumerUse(node, environment)) return false;
+  if (classifyUnsafeDictionary(node, environment) === null) return false;
+  let current: ESTree.Node | null = node.parent;
+  while (current !== null && current.type !== "Program") {
+    if (isTypeNode(current) && classifyUnsafeDictionary(current, environment) !== null)
+      return false;
+    current = current.parent;
+  }
+  return true;
+}
+
+/** Disallow object-dictionary contracts whose direct value type is an unsafe escape hatch. */
+export const noUnsafeDictionaryTypeRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow object-dictionary contracts whose direct value type is unknown, any, object, {}, or a union/alias containing one of those escape hatches.",
+    },
+    messages: {
+      unsafeDictionary:
+        "This object dictionary's direct value type is an unsafe {{value}} escape hatch. Replace it with a concrete owner/schema-derived value type and parse external data at its boundary.",
+    },
+  },
+  createOnce(context) {
+    let environment: TypeEnvironment | null = null;
+    const report = (node: ESTree.Node, value: string) => {
+      context.report({ node, messageId: "unsafeDictionary", data: { value } });
+    };
+    const reportIfUnsafe = (node: ESTree.TSType) => {
+      if (environment === null || !shouldReportType(node, environment)) return;
+      const unsafe = classifyUnsafeDictionary(node, environment);
+      if (unsafe === null) return;
+      report(node, unsafe.unsafeValue);
+    };
+
+    return {
+      Program(node) {
+        environment = createTypeEnvironment(node);
+      },
+      TSTypeReference: reportIfUnsafe,
+      TSTypeLiteral: reportIfUnsafe,
+      TSMappedType: reportIfUnsafe,
+      TSIndexSignature(node) {
+        if (
+          environment === null ||
+          node.typeAnnotation === null ||
+          node.parent.type === "TSTypeLiteral"
+        )
+          return;
+        const unsafe = classifyUnsafeDictionaryValue(
+          node.typeAnnotation.typeAnnotation,
+          environment,
+        );
+        if (unsafe !== null) report(node, unsafe.unsafeValue);
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-widen-then-assert.ts
+++ b/tools/oxlint/anti-slop/rules/no-widen-then-assert.ts
@@ -1,0 +1,363 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree, Variable } from "@oxlint/plugins";
+
+type BroadTypeKind = "top" | "object" | "record";
+
+type KnownValueEvidence = {
+  readonly type: ESTree.TSType | null;
+};
+
+const functionBoundaryTypes = new Set([
+  "ArrowFunctionExpression",
+  "FunctionDeclaration",
+  "FunctionExpression",
+  "TSDeclareFunction",
+  "TSEmptyBodyFunctionExpression",
+]);
+
+function unwrapExpressionParentheses(expression: ESTree.Expression): ESTree.Expression {
+  let current = expression;
+  while (current.type === "ParenthesizedExpression") current = current.expression;
+  return current;
+}
+
+function unwrapTypeParentheses(type: ESTree.TSType): ESTree.TSType {
+  let current = type;
+  while (current.type === "TSParenthesizedType") current = current.typeAnnotation;
+  return current;
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+  return type.typeName.type === "Identifier" ? type.typeName.name : null;
+}
+
+function isUnknownOrAnyType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  return unwrapped.type === "TSUnknownKeyword" || unwrapped.type === "TSAnyKeyword";
+}
+
+function isBroadRecordKeyType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  if (
+    unwrapped.type === "TSStringKeyword" ||
+    unwrapped.type === "TSNumberKeyword" ||
+    unwrapped.type === "TSSymbolKeyword"
+  ) {
+    return true;
+  }
+  if (unwrapped.type === "TSUnionType") return unwrapped.types.every(isBroadRecordKeyType);
+  return unwrapped.type === "TSTypeReference" && typeReferenceName(unwrapped) === "PropertyKey";
+}
+
+function isBroadRecordType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+
+  if (unwrapped.type === "TSTypeReference") {
+    if (typeReferenceName(unwrapped) === "Readonly") {
+      const [inner] = unwrapped.typeArguments?.params ?? [];
+      return inner !== undefined && isBroadRecordType(inner);
+    }
+
+    if (typeReferenceName(unwrapped) !== "Record") return false;
+    const parameters = unwrapped.typeArguments?.params ?? [];
+    return (
+      parameters.length === 2 &&
+      parameters[0] !== undefined &&
+      parameters[1] !== undefined &&
+      isBroadRecordKeyType(parameters[0]) &&
+      isUnknownOrAnyType(parameters[1])
+    );
+  }
+
+  if (unwrapped.type !== "TSTypeLiteral" || unwrapped.members.length !== 1) return false;
+  const [member] = unwrapped.members;
+  const [parameter] = member?.type === "TSIndexSignature" ? member.parameters : [];
+  return (
+    member?.type === "TSIndexSignature" &&
+    member.parameters.length === 1 &&
+    parameter !== undefined &&
+    isBroadRecordKeyType(parameter.typeAnnotation.typeAnnotation) &&
+    isUnknownOrAnyType(member.typeAnnotation.typeAnnotation)
+  );
+}
+
+function broadTypeKind(type: ESTree.TSType): BroadTypeKind | null {
+  const unwrapped = unwrapTypeParentheses(type);
+  if (unwrapped.type === "TSUnknownKeyword" || unwrapped.type === "TSAnyKeyword") return "top";
+  if (unwrapped.type === "TSObjectKeyword") return "object";
+  return isBroadRecordType(unwrapped) ? "record" : null;
+}
+
+function assertedExpression(
+  node: ESTree.TSAsExpression | ESTree.TSTypeAssertion,
+): ESTree.Expression {
+  return unwrapExpressionParentheses(node.expression);
+}
+
+function assertionFromExpression(
+  expression: ESTree.Expression,
+): ESTree.TSAsExpression | ESTree.TSTypeAssertion | null {
+  const unwrapped = unwrapExpressionParentheses(expression);
+  return unwrapped.type === "TSAsExpression" || unwrapped.type === "TSTypeAssertion"
+    ? unwrapped
+    : null;
+}
+
+function normalizedTypeText(sourceText: string, type: ESTree.TSType): string {
+  return sourceText.slice(type.start, type.end).replaceAll(/\s+/gu, "");
+}
+
+function typesHaveSameSyntax(
+  sourceText: string,
+  left: ESTree.TSType | null,
+  right: ESTree.TSType,
+): boolean {
+  return (
+    left !== null &&
+    normalizedTypeText(sourceText, unwrapTypeParentheses(left)) ===
+      normalizedTypeText(sourceText, unwrapTypeParentheses(right))
+  );
+}
+
+function isDefinitelyObjectType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  switch (unwrapped.type) {
+    case "TSArrayType":
+    case "TSConstructorType":
+    case "TSFunctionType":
+    case "TSMappedType":
+    case "TSObjectKeyword":
+    case "TSTupleType":
+      return true;
+    case "TSTypeLiteral":
+      return unwrapped.members.length > 0;
+    case "TSIntersectionType":
+      return unwrapped.types.every(isDefinitelyObjectType);
+    case "TSTypeOperator":
+      return unwrapped.operator === "readonly" && isDefinitelyObjectType(unwrapped.typeAnnotation);
+    default:
+      return false;
+  }
+}
+
+function isDefinitelyNarrowerRecordType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  if (unwrapped.type === "TSTypeLiteral") {
+    return unwrapped.members.some((member) => member.type !== "TSIndexSignature");
+  }
+
+  if (unwrapped.type !== "TSTypeReference") return false;
+  if (typeReferenceName(unwrapped) === "Readonly") {
+    const [inner] = unwrapped.typeArguments?.params ?? [];
+    return inner !== undefined && isDefinitelyNarrowerRecordType(inner);
+  }
+  if (typeReferenceName(unwrapped) !== "Record") return false;
+
+  const parameters = unwrapped.typeArguments?.params ?? [];
+  return (
+    parameters.length === 2 && parameters[1] !== undefined && !isUnknownOrAnyType(parameters[1])
+  );
+}
+
+function functionBoundary(node: ESTree.Node): ESTree.Node | null {
+  let current = node.parent;
+  while (current !== null && current.type !== "Program") {
+    if (functionBoundaryTypes.has(current.type)) return current;
+    current = current.parent;
+  }
+  return null;
+}
+
+function resolvedVariableForIdentifier(
+  scopes: readonly {
+    readonly references: readonly {
+      readonly identifier: ESTree.Node;
+      readonly resolved: Variable | null;
+    }[];
+  }[],
+  identifier: ESTree.IdentifierReference,
+): Variable | null {
+  for (const scope of scopes) {
+    const reference = scope.references.find(
+      (candidate) =>
+        candidate.identifier.start === identifier.start &&
+        candidate.identifier.end === identifier.end,
+    );
+    if (reference !== undefined) return reference.resolved;
+  }
+  return null;
+}
+
+function variableDeclarator(variable: Variable): ESTree.VariableDeclarator | null {
+  for (const definition of variable.defs) {
+    if (definition.type === "Variable" && definition.node.type === "VariableDeclarator") {
+      return definition.node;
+    }
+  }
+  return null;
+}
+
+function knownValueEvidence(
+  expression: ESTree.Expression,
+  scopes: Parameters<typeof resolvedVariableForIdentifier>[0],
+  boundary: ESTree.Node | null,
+  visitedVariables: ReadonlySet<Variable>,
+): KnownValueEvidence | null {
+  const unwrapped = unwrapExpressionParentheses(expression);
+
+  if (unwrapped.type === "TSAsExpression" || unwrapped.type === "TSTypeAssertion") {
+    if (broadTypeKind(unwrapped.typeAnnotation) !== null) return null;
+    return { type: unwrapped.typeAnnotation };
+  }
+
+  if (unwrapped.type === "Literal" || unwrapped.type === "TemplateLiteral") {
+    return { type: null };
+  }
+
+  if (
+    unwrapped.type === "ArrayExpression" ||
+    unwrapped.type === "ArrowFunctionExpression" ||
+    unwrapped.type === "ClassExpression" ||
+    unwrapped.type === "FunctionExpression" ||
+    unwrapped.type === "NewExpression" ||
+    unwrapped.type === "ObjectExpression"
+  ) {
+    return { type: null };
+  }
+
+  if (unwrapped.type !== "Identifier") return null;
+  const variable = resolvedVariableForIdentifier(scopes, unwrapped);
+  if (variable === null || visitedVariables.has(variable)) return null;
+
+  const annotatedIdentifier = variable.identifiers.find(
+    (identifier) => identifier.typeAnnotation !== null && identifier.typeAnnotation !== undefined,
+  );
+  const annotation = annotatedIdentifier?.typeAnnotation?.typeAnnotation;
+  if (annotation !== undefined && annotatedIdentifier !== undefined) {
+    if (functionBoundary(annotatedIdentifier) !== boundary || broadTypeKind(annotation) !== null) {
+      return null;
+    }
+    return { type: annotation };
+  }
+
+  const declarator = variableDeclarator(variable);
+  if (
+    declarator === null ||
+    declarator.parent.type !== "VariableDeclaration" ||
+    declarator.parent.kind !== "const" ||
+    declarator.init === null ||
+    variable.references.some((reference) => reference.isWrite() && !reference.init) ||
+    functionBoundary(declarator) !== boundary
+  ) {
+    return null;
+  }
+
+  return knownValueEvidence(
+    declarator.init,
+    scopes,
+    boundary,
+    new Set([...visitedVariables, variable]),
+  );
+}
+
+function widenedBinding(
+  variable: Variable,
+  scopes: Parameters<typeof resolvedVariableForIdentifier>[0],
+): {
+  readonly broadKind: BroadTypeKind;
+  readonly evidence: KnownValueEvidence;
+  readonly declaredAt: number;
+  readonly boundary: ESTree.Node | null;
+} | null {
+  const declarator = variableDeclarator(variable);
+  if (
+    declarator === null ||
+    declarator.parent.type !== "VariableDeclaration" ||
+    declarator.parent.kind !== "const" ||
+    declarator.id.type !== "Identifier" ||
+    declarator.init === null ||
+    variable.references.some((reference) => reference.isWrite() && !reference.init)
+  ) {
+    return null;
+  }
+
+  const boundary = functionBoundary(declarator);
+  const declaredType = declarator.id.typeAnnotation?.typeAnnotation;
+  const initializerAssertion = assertionFromExpression(declarator.init);
+  const initializerBroadKind =
+    initializerAssertion === null ? null : broadTypeKind(initializerAssertion.typeAnnotation);
+  const declaredBroadKind = declaredType === undefined ? null : broadTypeKind(declaredType);
+  const broadKind = declaredBroadKind ?? initializerBroadKind;
+  if (broadKind === null) return null;
+
+  const originalExpression =
+    initializerAssertion !== null && initializerBroadKind !== null
+      ? assertedExpression(initializerAssertion)
+      : declarator.init;
+  const evidence = knownValueEvidence(originalExpression, scopes, boundary, new Set([variable]));
+  return evidence === null ? null : { broadKind, evidence, declaredAt: declarator.end, boundary };
+}
+
+function assertionIsNarrower(
+  sourceText: string,
+  broadKind: BroadTypeKind,
+  evidence: KnownValueEvidence,
+  assertedType: ESTree.TSType,
+): boolean {
+  if (broadTypeKind(assertedType) !== null) return false;
+  if (broadKind === "top") return true;
+  if (typesHaveSameSyntax(sourceText, evidence.type, assertedType)) return true;
+  if (broadKind === "object") return isDefinitelyObjectType(assertedType);
+  return isDefinitelyNarrowerRecordType(assertedType);
+}
+
+/** Detect immutable local bindings that erase a known type and are later asserted back to a narrower type. */
+export const noWidenThenAssertRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow local const flows that explicitly widen a known value before asserting the widened binding to a narrower type.",
+    },
+    messages: {
+      widenThenAssert:
+        'Binding "{{name}}" erases established type evidence by widening the value, then reconstructs that evidence with a type assertion. Preserve the precise type end-to-end; if the input is genuinely unknown, parse it once at the boundary instead.',
+    },
+  },
+  create(context) {
+    const scopes = context.sourceCode.scopeManager.scopes;
+
+    const checkAssertion = (node: ESTree.TSAsExpression | ESTree.TSTypeAssertion) => {
+      const expression = assertedExpression(node);
+      if (expression.type !== "Identifier") return;
+
+      const variable = resolvedVariableForIdentifier(scopes, expression);
+      if (variable === null) return;
+      const widened = widenedBinding(variable, scopes);
+      if (
+        widened === null ||
+        node.start <= widened.declaredAt ||
+        functionBoundary(node) !== widened.boundary ||
+        !assertionIsNarrower(
+          context.sourceCode.text,
+          widened.broadKind,
+          widened.evidence,
+          node.typeAnnotation,
+        )
+      ) {
+        return;
+      }
+
+      context.report({
+        node,
+        messageId: "widenThenAssert",
+        data: { name: expression.name },
+      });
+    };
+
+    return {
+      TSAsExpression: checkAssertion,
+      TSTypeAssertion: checkAssertion,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/shared/dictionary-types.ts
+++ b/tools/oxlint/anti-slop/shared/dictionary-types.ts
@@ -1,0 +1,443 @@
+import type { ESTree } from "@oxlint/plugins";
+
+const BUILT_INS = new Set([
+  "Record",
+  "Readonly",
+  "Partial",
+  "Required",
+  "Pick",
+  "Omit",
+  "PropertyKey",
+  "NonNullable",
+]);
+const TRANSPARENT_WRAPPERS = new Set(["Readonly", "Partial", "Required", "NonNullable"]);
+
+type TypeAliasEnvironment = ReadonlyMap<string, ESTree.TSType>;
+
+type ResolvedType = {
+  readonly type: ESTree.TSType;
+  readonly substitutions: TypeAliasEnvironment;
+};
+
+export type UnsafeDictionary = {
+  readonly kind: "unsafe-dictionary";
+  readonly unsafeValue: "any" | "empty-object" | "object" | "union" | "unknown";
+};
+
+export type WideningTargetKind =
+  | "anonymous object"
+  | "generic container"
+  | "object"
+  | "open dictionary"
+  | "unknown";
+
+export type WideningTarget = {
+  readonly kind: WideningTargetKind;
+};
+
+export type TypeEnvironment = {
+  readonly aliases: ReadonlyMap<string, ESTree.TSTypeAliasDeclaration>;
+  readonly interfaces: ReadonlyMap<string, readonly ESTree.TSInterfaceDeclaration[]>;
+  readonly shadowedBuiltIns: ReadonlySet<string>;
+};
+
+function declaredStatement(statement: ESTree.Statement): ESTree.Node | null {
+  return statement.type === "ExportNamedDeclaration" ||
+    statement.type === "ExportDefaultDeclaration"
+    ? (statement.declaration ?? null)
+    : statement;
+}
+
+export function createTypeEnvironment(program: ESTree.Program): TypeEnvironment {
+  const aliases = new Map<string, ESTree.TSTypeAliasDeclaration>();
+  const interfaces = new Map<string, ESTree.TSInterfaceDeclaration[]>();
+  const shadowedBuiltIns = new Set<string>();
+
+  for (const statement of program.body) {
+    const declaration = declaredStatement(statement);
+    if (declaration?.type === "ImportDeclaration") {
+      for (const specifier of declaration.specifiers) {
+        if (BUILT_INS.has(specifier.local.name)) shadowedBuiltIns.add(specifier.local.name);
+      }
+      continue;
+    }
+
+    if (declaration?.type === "TSTypeAliasDeclaration") {
+      const existing = aliases.get(declaration.id.name);
+      if (existing === undefined) aliases.set(declaration.id.name, declaration);
+      else shadowedBuiltIns.add(declaration.id.name);
+      if (BUILT_INS.has(declaration.id.name)) shadowedBuiltIns.add(declaration.id.name);
+      continue;
+    }
+
+    if (declaration?.type === "TSInterfaceDeclaration") {
+      const declarations = interfaces.get(declaration.id.name) ?? [];
+      declarations.push(declaration);
+      interfaces.set(declaration.id.name, declarations);
+      if (BUILT_INS.has(declaration.id.name)) shadowedBuiltIns.add(declaration.id.name);
+      continue;
+    }
+
+    if (declaration?.type === "TSEnumDeclaration") {
+      if (BUILT_INS.has(declaration.id.name)) shadowedBuiltIns.add(declaration.id.name);
+      continue;
+    }
+
+    if (
+      (declaration?.type === "ClassDeclaration" || declaration?.type === "FunctionDeclaration") &&
+      declaration.id !== null
+    ) {
+      if (BUILT_INS.has(declaration.id.name)) shadowedBuiltIns.add(declaration.id.name);
+    }
+  }
+
+  return { aliases, interfaces, shadowedBuiltIns };
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+  return type.typeName.type === "Identifier" ? type.typeName.name : null;
+}
+
+function isBuiltIn(name: string, environment: TypeEnvironment): boolean {
+  return BUILT_INS.has(name) && !environment.shadowedBuiltIns.has(name);
+}
+
+function isUnappliedReferenceTo(type: ESTree.TSType, name: string): boolean {
+  const unwrapped = unwrapTransparentType(type);
+  return (
+    unwrapped.type === "TSTypeReference" &&
+    typeReferenceName(unwrapped) === name &&
+    (unwrapped.typeArguments === null ||
+      unwrapped.typeArguments === undefined ||
+      unwrapped.typeArguments.params.length === 0)
+  );
+}
+
+function unwrapTransparentType(type: ESTree.TSType): ESTree.TSType {
+  let current = type;
+  while (
+    current.type === "TSParenthesizedType" ||
+    (current.type === "TSTypeOperator" && current.operator === "readonly")
+  ) {
+    current = current.typeAnnotation;
+  }
+  return current;
+}
+
+function isNeverType(type: ESTree.TSType): boolean {
+  return unwrapTransparentType(type).type === "TSNeverKeyword";
+}
+
+function isEffectivelyEmptyMember(member: ESTree.TSSignature): boolean {
+  return (
+    member.type === "TSPropertySignature" &&
+    member.optional === true &&
+    member.typeAnnotation !== null &&
+    member.typeAnnotation !== undefined &&
+    isNeverType(member.typeAnnotation.typeAnnotation)
+  );
+}
+
+function isEffectivelyEmptyTypeLiteral(type: ESTree.TSTypeLiteral): boolean {
+  return type.members.length === 0 || type.members.every(isEffectivelyEmptyMember);
+}
+
+function isEffectivelyEmptyInterface(
+  declarations: readonly ESTree.TSInterfaceDeclaration[],
+): boolean {
+  if (declarations.length !== 1) return false;
+  const [type] = declarations;
+  return (
+    type !== undefined &&
+    type.extends.length === 0 &&
+    (type.body.body.length === 0 || type.body.body.every(isEffectivelyEmptyMember))
+  );
+}
+
+function resolvedSubstitutionArgument(
+  type: ESTree.TSType,
+  base: TypeAliasEnvironment,
+): ESTree.TSType {
+  const unwrapped = unwrapTransparentType(type);
+  if (unwrapped.type !== "TSTypeReference") return type;
+  const name = typeReferenceName(unwrapped);
+  if (name === null) return type;
+  const substitution = base.get(name);
+  return substitution === undefined ? type : resolvedSubstitutionArgument(substitution, base);
+}
+
+function aliasSubstitution(
+  alias: ESTree.TSTypeAliasDeclaration,
+  type: ESTree.TSTypeReference,
+  base: TypeAliasEnvironment,
+): TypeAliasEnvironment | null {
+  const parameters = alias.typeParameters?.params ?? [];
+  const arguments_ = type.typeArguments?.params ?? [];
+  const next = new Map(base);
+  for (const [index, parameter] of parameters.entries()) {
+    const argument = arguments_[index] ?? parameter.default;
+    if (argument === null || argument === undefined) return null;
+    next.set(parameter.name.name, resolvedSubstitutionArgument(argument, next));
+  }
+  return next;
+}
+
+function unsafeDirectValue(
+  type: ESTree.TSType,
+  environment: TypeEnvironment,
+  substitutions: TypeAliasEnvironment,
+  resolvingAliases: ReadonlySet<string>,
+): UnsafeDictionary["unsafeValue"] | null {
+  const unwrapped = unwrapTransparentType(type);
+  if (unwrapped.type === "TSUnknownKeyword") return "unknown";
+  if (unwrapped.type === "TSAnyKeyword") return "any";
+  if (unwrapped.type === "TSObjectKeyword") return "object";
+  if (unwrapped.type === "TSTypeLiteral" && isEffectivelyEmptyTypeLiteral(unwrapped))
+    return "empty-object";
+  if (unwrapped.type === "TSUnionType") {
+    return unwrapped.types.some(
+      (member) => unsafeDirectValue(member, environment, substitutions, resolvingAliases) !== null,
+    )
+      ? "union"
+      : null;
+  }
+  if (unwrapped.type === "TSIntersectionType") {
+    const unsafeMembers = unwrapped.types.map((member) =>
+      unsafeDirectValue(member, environment, substitutions, resolvingAliases),
+    );
+    if (unsafeMembers.includes("any")) return "any";
+    return unsafeMembers.length > 0 && unsafeMembers.every((member) => member !== null)
+      ? unsafeMembers[0]
+      : null;
+  }
+  if (unwrapped.type !== "TSTypeReference") return null;
+  const name = typeReferenceName(unwrapped);
+  if (name === null) return null;
+  if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, environment)) {
+    const wrapped = unwrapped.typeArguments?.params[0];
+    return wrapped === undefined
+      ? null
+      : unsafeDirectValue(wrapped, environment, substitutions, resolvingAliases);
+  }
+  const substitution = substitutions.get(name);
+  if (substitution !== undefined) {
+    return isUnappliedReferenceTo(substitution, name)
+      ? null
+      : unsafeDirectValue(substitution, environment, substitutions, resolvingAliases);
+  }
+  const interfaceDeclarations = environment.interfaces.get(name);
+  if (interfaceDeclarations !== undefined) {
+    return isEffectivelyEmptyInterface(interfaceDeclarations) ? "empty-object" : null;
+  }
+  const alias = environment.aliases.get(name);
+  if (alias === undefined || resolvingAliases.has(name)) return null;
+  const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+  if (nextSubstitutions === null) return null;
+  const nextResolving = new Set(resolvingAliases);
+  nextResolving.add(name);
+  return unsafeDirectValue(alias.typeAnnotation, environment, nextSubstitutions, nextResolving);
+}
+
+function dictionaryValueTypes(
+  type: ESTree.TSType,
+  environment: TypeEnvironment,
+  substitutions: TypeAliasEnvironment,
+  resolvingAliases: ReadonlySet<string>,
+): readonly ResolvedType[] {
+  const unwrapped = unwrapTransparentType(type);
+
+  if (unwrapped.type === "TSTypeLiteral") {
+    return unwrapped.members.flatMap((member): readonly ResolvedType[] =>
+      member.type === "TSIndexSignature" && member.typeAnnotation !== null
+        ? [{ type: member.typeAnnotation.typeAnnotation, substitutions }]
+        : [],
+    );
+  }
+
+  if (unwrapped.type === "TSMappedType") {
+    return unwrapped.typeAnnotation === null
+      ? []
+      : [{ type: unwrapped.typeAnnotation, substitutions }];
+  }
+
+  if (unwrapped.type !== "TSTypeReference") return [];
+  const name = typeReferenceName(unwrapped);
+  if (name === null) return [];
+
+  const substitution = substitutions.get(name);
+  if (substitution !== undefined) {
+    return isUnappliedReferenceTo(substitution, name)
+      ? []
+      : dictionaryValueTypes(substitution, environment, substitutions, resolvingAliases);
+  }
+
+  if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, environment)) {
+    const wrapped = unwrapped.typeArguments?.params[0];
+    return wrapped === undefined
+      ? []
+      : dictionaryValueTypes(wrapped, environment, substitutions, resolvingAliases);
+  }
+
+  if (name === "Record" && isBuiltIn(name, environment)) {
+    const value = unwrapped.typeArguments?.params[1] ?? null;
+    return value === null ? [] : [{ type: value, substitutions }];
+  }
+
+  if ((name === "Pick" || name === "Omit") && isBuiltIn(name, environment)) {
+    const source = unwrapped.typeArguments?.params[0];
+    return source === undefined
+      ? []
+      : dictionaryValueTypes(source, environment, substitutions, resolvingAliases);
+  }
+
+  const alias = environment.aliases.get(name);
+  if (alias === undefined || resolvingAliases.has(name)) return [];
+  const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+  if (nextSubstitutions === null) return [];
+  const nextResolving = new Set(resolvingAliases);
+  nextResolving.add(name);
+  return dictionaryValueTypes(alias.typeAnnotation, environment, nextSubstitutions, nextResolving);
+}
+
+export function classifyUnsafeDictionaryValue(
+  valueType: ESTree.TSType,
+  environment: TypeEnvironment,
+): UnsafeDictionary | null {
+  const unsafeValue = unsafeDirectValue(valueType, environment, new Map(), new Set());
+  return unsafeValue === null ? null : { kind: "unsafe-dictionary", unsafeValue };
+}
+
+export function classifyUnsafeDictionary(
+  type: ESTree.TSType,
+  environment: TypeEnvironment,
+): UnsafeDictionary | null {
+  for (const valueType of dictionaryValueTypes(type, environment, new Map(), new Set())) {
+    const unsafeValue = unsafeDirectValue(
+      valueType.type,
+      environment,
+      valueType.substitutions,
+      new Set(),
+    );
+    if (unsafeValue !== null) return { kind: "unsafe-dictionary", unsafeValue };
+  }
+  return null;
+}
+
+function resolvesToDictionary(
+  type: ESTree.TSType,
+  environment: TypeEnvironment,
+  substitutions: TypeAliasEnvironment,
+  resolvingAliases: ReadonlySet<string>,
+): boolean {
+  return dictionaryValueTypes(type, environment, substitutions, resolvingAliases).length > 0;
+}
+
+export function classifyWideningTarget(
+  type: ESTree.TSType,
+  environment: TypeEnvironment,
+): WideningTarget | null {
+  const unwrapped = unwrapTransparentType(type);
+  if (unwrapped.type === "TSUnknownKeyword") return { kind: "unknown" };
+  if (unwrapped.type === "TSObjectKeyword") return { kind: "object" };
+  if (unwrapped.type === "TSTypeLiteral") {
+    return unwrapped.members.some((member) => member.type === "TSIndexSignature")
+      ? { kind: "open dictionary" }
+      : unwrapped.members.length > 0
+        ? { kind: "anonymous object" }
+        : null;
+  }
+  if (unwrapped.type === "TSMappedType") return { kind: "open dictionary" };
+  if (unwrapped.type !== "TSTypeReference") return null;
+  const name = typeReferenceName(unwrapped);
+  if (name === null) return null;
+  if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, environment)) {
+    const wrapped = unwrapped.typeArguments?.params[0];
+    return wrapped === undefined ? null : classifyWideningTarget(wrapped, environment);
+  }
+  if (name === "Record" && isBuiltIn(name, environment)) return { kind: "open dictionary" };
+  const alias = environment.aliases.get(name);
+  if (alias === undefined) return null;
+  if ((alias.typeParameters?.params.length ?? 0) > 0) {
+    const substitutions = aliasSubstitution(alias, unwrapped, new Map());
+    return substitutions !== null &&
+      resolvesToDictionary(alias.typeAnnotation, environment, substitutions, new Set([name]))
+      ? { kind: "generic container" }
+      : null;
+  }
+  const substitutions = aliasSubstitution(alias, unwrapped, new Map());
+  if (substitutions === null) return null;
+  const resolved = classifyAliasBroadTarget(
+    alias.typeAnnotation,
+    environment,
+    substitutions,
+    new Set([name]),
+  );
+  return resolved;
+}
+
+function classifyAliasBroadTarget(
+  type: ESTree.TSType,
+  environment: TypeEnvironment,
+  substitutions: TypeAliasEnvironment,
+  resolvingAliases: ReadonlySet<string>,
+): WideningTarget | null {
+  const unwrapped = unwrapTransparentType(type);
+  if (unwrapped.type === "TSUnknownKeyword") return { kind: "unknown" };
+  if (unwrapped.type === "TSObjectKeyword") return { kind: "object" };
+  if (unwrapped.type !== "TSTypeReference") return null;
+  const name = typeReferenceName(unwrapped);
+  if (name === null) return null;
+  const substitution = substitutions.get(name);
+  if (substitution !== undefined) {
+    return classifyAliasBroadTarget(substitution, environment, substitutions, resolvingAliases);
+  }
+  const alias = environment.aliases.get(name);
+  if (alias === undefined || resolvingAliases.has(name)) return null;
+  const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+  if (nextSubstitutions === null) return null;
+  const nextResolving = new Set(resolvingAliases);
+  nextResolving.add(name);
+  return classifyAliasBroadTarget(
+    alias.typeAnnotation,
+    environment,
+    nextSubstitutions,
+    nextResolving,
+  );
+}
+
+export function isPopulatedObjectExpression(expression: ESTree.Expression): boolean {
+  let current = expression;
+  while (
+    current.type === "ParenthesizedExpression" ||
+    current.type === "TSAsExpression" ||
+    current.type === "TSTypeAssertion" ||
+    current.type === "TSNonNullExpression"
+  ) {
+    current = current.expression;
+  }
+  return current.type === "ObjectExpression" && current.properties.length > 0;
+}
+
+export function isKnownEvidenceExpression(expression: ESTree.Expression): boolean {
+  let current = expression;
+  while (
+    current.type === "ParenthesizedExpression" ||
+    current.type === "TSAsExpression" ||
+    current.type === "TSTypeAssertion" ||
+    current.type === "TSNonNullExpression" ||
+    current.type === "TSSatisfiesExpression"
+  ) {
+    current = current.expression;
+  }
+  if (current.type === "ObjectExpression") return true;
+  return (
+    current.type === "ArrayExpression" ||
+    current.type === "ArrowFunctionExpression" ||
+    current.type === "ClassExpression" ||
+    current.type === "FunctionExpression" ||
+    current.type === "NewExpression" ||
+    current.type === "Literal" ||
+    current.type === "TemplateLiteral" ||
+    current.type === "UnaryExpression"
+  );
+}


### PR DESCRIPTION
## Summary

- add the anti-slop Oxlint plugin with all ten rules enforced as errors
- replace unsafe dictionary, assertion, runtime-type, and widened-value patterns with explicit contracts and boundary validation
- update Oxlint and `@oxlint/plugins` to 1.78.0 and Oxfmt to 0.63.0 in the repository and generated projects
- keep Zod on the current 4.4.3 release

## Why

The initial scan found 329 low-signal type and implementation patterns across the CLI, template generator, and web app. Enforcing these rules prevents the same patterns from returning while making external data parsing and dynamic lookups explicit.

## Verification

- `bun run check`
- `bun run build`
- CLI and template-generator TypeScript checks
- CLI tests: 651 passed, 29 generated build samples skipped
- Web tests: 42 passed
- Focused affected suites: 181 passed
- Oxlint scan: 0 diagnostics across 469 files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added stricter code-quality checks to catch unsafe type usage, overly broad values, and other low-signal patterns.
  - Added validation for chart data, preview responses, package metadata, and npm version responses.

- **Bug Fixes**
  - Improved chart rendering and interaction with parseable numeric values and touch coordinates.
  - Improved handling of unsupported code languages, missing filesystem paths, invalid server addresses, and malformed responses.
  - Preserved original error causes for clearer diagnostics.

- **Chores**
  - Updated formatting and linting tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->