### PR TITLE
fix(cli): correct SolidStart runtime behavior

### DIFF
--- a/apps/cli/test/api.test.ts
+++ b/apps/cli/test/api.test.ts
@@ -120,8 +120,13 @@ describe("API Configurations", () => {
       const files = collectFiles(result.value.root, result.value.root.path);
       const rpcRoute = files.get("apps/web/src/routes/rpc/[...rest].ts");
       const rpcIndex = files.get("apps/web/src/routes/rpc/index.ts");
+      const appFile = files.get("apps/web/src/app.tsx");
+      const homeRoute = files.get("apps/web/src/routes/index.tsx");
       const orpcClient = files.get("apps/web/src/utils/orpc.ts");
       const orpcServer = files.get("apps/web/src/utils/orpc.server.ts");
+
+      expect(appFile).toBeDefined();
+      if (!appFile) throw new Error("Expected SolidStart app template");
 
       expect(rpcRoute).toContain('import type { APIEvent } from "@solidjs/start/server";');
       expect(rpcRoute).toContain('prefix: "/rpc"');
@@ -133,6 +138,12 @@ describe("API Configurations", () => {
       expect(orpcServer).toContain("createRouterClient(appRouter");
       expect(orpcServer).toContain("globalThis.$client");
       expect(orpcServer).toContain("getRequestEvent()?.request.headers");
+      expect(homeRoute).toContain('healthCheck.data === "OK"');
+      expect(homeRoute).toContain("healthCheck.isPending");
+      expect(homeRoute).toContain("deferStream: true");
+      expect(appFile.indexOf("root={(props)")).toBeLessThan(
+        appFile.indexOf("<QueryClientProvider"),
+      );
     });
 
     const frontends = [

--- a/apps/cli/test/deployment.test.ts
+++ b/apps/cli/test/deployment.test.ts
@@ -1958,6 +1958,35 @@ describe("Deployment Configurations", () => {
       expect(compose).toContain('"3001:3001"');
     });
 
+    it("should expose SolidStart Prisma SQLite native dependencies to Nitro", async () => {
+      const result = await createVirtual({
+        projectName: "docker-solid-prisma-sqlite",
+        webDeploy: "docker",
+        serverDeploy: "none",
+        backend: "self",
+        runtime: "none",
+        database: "sqlite",
+        orm: "prisma",
+        auth: "better-auth",
+        payments: "none",
+        api: "orpc",
+        frontend: ["solid"],
+        addons: ["none"],
+        examples: ["none"],
+        dbSetup: "none",
+        install: false,
+        git: false,
+        packageManager: "pnpm",
+      });
+
+      if (result.isErr()) throw result.error;
+
+      const files = collectFiles(result.value.root, result.value.root.path);
+      const webPkg = JSON.parse(files.get("apps/web/package.json") ?? "{}");
+
+      expect(webPkg.dependencies.libsql).toBeDefined();
+    });
+
     it("should route SolidStart SSR requests through the internal Docker server URL", async () => {
       const result = await createVirtual({
         projectName: "docker-solid-external-server",

--- a/apps/cli/test/deployment.test.ts
+++ b/apps/cli/test/deployment.test.ts
@@ -1983,8 +1983,56 @@ describe("Deployment Configurations", () => {
 
       const files = collectFiles(result.value.root, result.value.root.path);
       const webPkg = JSON.parse(files.get("apps/web/package.json") ?? "{}");
+      const compose = files.get("docker-compose.yml") ?? "";
+      const readme = files.get("README.md") ?? "";
 
       expect(webPkg.dependencies.libsql).toBeDefined();
+      expect(compose).toContain("DATABASE_URL: file:/data/local.db");
+      expect(compose).toContain("source: ./local.db");
+      expect(compose).toContain("target: /data/local.db");
+      expect(compose).toContain("create_host_path: false");
+      expect(compose).not.toContain("db-init:");
+      expect(files.get(".dockerignore")).toContain("local.db-*");
+      expect(files.get(".gitignore")).toContain("local.db-*");
+      expect(readme).toContain(
+        "Docker Compose uses the local `./local.db` file. Run `pnpm run db:push` before starting the stack.",
+      );
+    });
+
+    it("should mount SQLite in the Docker server that consumes it", async () => {
+      const result = await createVirtual({
+        projectName: "docker-server-sqlite",
+        webDeploy: "docker",
+        serverDeploy: "docker",
+        backend: "hono",
+        runtime: "node",
+        database: "sqlite",
+        orm: "drizzle",
+        auth: "better-auth",
+        payments: "none",
+        api: "trpc",
+        frontend: ["tanstack-router"],
+        addons: ["none"],
+        examples: ["none"],
+        dbSetup: "none",
+        install: false,
+        git: false,
+        packageManager: "bun",
+      });
+
+      if (result.isErr()) throw result.error;
+
+      const files = collectFiles(result.value.root, result.value.root.path);
+      const compose = files.get("docker-compose.yml") ?? "";
+      const serverPkg = JSON.parse(files.get("apps/server/package.json") ?? "{}");
+
+      expect(compose).toContain("dockerfile: apps/server/Dockerfile");
+      expect(compose).toContain("DATABASE_URL: file:/data/local.db");
+      expect(compose).toContain("source: ./local.db");
+      expect(compose).toContain("target: /data/local.db");
+      expect(compose).toContain("create_host_path: false");
+      expect(compose).not.toContain("db-init:");
+      expect(serverPkg.dependencies.libsql).toBeDefined();
     });
 
     it("should route SolidStart SSR requests through the internal Docker server URL", async () => {

--- a/apps/cli/test/frontend.test.ts
+++ b/apps/cli/test/frontend.test.ts
@@ -191,6 +191,7 @@ describe("Frontend Configurations", () => {
       expect(appFile).toContain("<FileRoutes />");
       expect(viteConfig).toContain("solidStart()");
       expect(viteConfig).toContain("nitro()");
+      expect(viteConfig).toContain('dedupe: ["solid-js"]');
 
       for (const file of [
         "src/app.tsx",

--- a/packages/template-generator/src/processors/db-deps.ts
+++ b/packages/template-generator/src/processors/db-deps.ts
@@ -78,7 +78,11 @@ function processPrismaDeps(
   });
 
   if (webExists) {
-    addPackageDependency({ vfs, packagePath: webPkgPath, dependencies: ["@prisma/client"] });
+    const webDeps: AvailableDependencies[] = ["@prisma/client"];
+    if (database === "sqlite" && dbSetup !== "d1") {
+      webDeps.push("libsql");
+    }
+    addPackageDependency({ vfs, packagePath: webPkgPath, dependencies: webDeps });
   }
 }
 

--- a/packages/template-generator/src/processors/db-deps.ts
+++ b/packages/template-generator/src/processors/db-deps.ts
@@ -4,12 +4,13 @@ import type { VirtualFileSystem } from "../core/virtual-fs";
 import { addPackageDependency, type AvailableDependencies } from "../utils/add-deps";
 
 export function processDatabaseDeps(vfs: VirtualFileSystem, config: ProjectConfig): void {
-  const { database, orm, backend } = config;
+  const { database, orm, backend, dbSetup } = config;
 
   if (backend === "convex" || database === "none") return;
 
   const dbPkgPath = "packages/db/package.json";
   const webPkgPath = "apps/web/package.json";
+  const serverPkgPath = "apps/server/package.json";
 
   if (!vfs.exists(dbPkgPath)) return;
   const webNeedsDbRuntime = backend === "self" && vfs.exists(webPkgPath);
@@ -20,6 +21,15 @@ export function processDatabaseDeps(vfs: VirtualFileSystem, config: ProjectConfi
     processDrizzleDeps(vfs, config, dbPkgPath, webPkgPath, webNeedsDbRuntime);
   } else if (orm === "mongoose") {
     addPackageDependency({ vfs, packagePath: dbPkgPath, dependencies: ["mongoose"] });
+  }
+
+  if (
+    backend !== "self" &&
+    database === "sqlite" &&
+    dbSetup !== "d1" &&
+    vfs.exists(serverPkgPath)
+  ) {
+    addPackageDependency({ vfs, packagePath: serverPkgPath, dependencies: ["libsql"] });
   }
 }
 

--- a/packages/template-generator/src/processors/readme-generator.ts
+++ b/packages/template-generator/src/processors/readme-generator.ts
@@ -249,7 +249,14 @@ ${
     ? "\n## PWA Support with React Router v7\n\nThere is a known compatibility issue between VitePWA and React Router v7.\nSee: https://github.com/vite-pwa/vite-plugin-pwa/issues/809\n"
     : ""
 }
-${generateDeploymentCommands(packageManagerRunCmd, webDeploy, serverDeploy, backend)}
+${generateDeploymentCommands(
+  packageManagerRunCmd,
+  webDeploy,
+  serverDeploy,
+  backend,
+  database,
+  dbSetup,
+)}
 ${generateGitHooksSection(packageManagerRunCmd, addons)}
 
 ## Project Structure
@@ -833,6 +840,8 @@ function generateDeploymentCommands(
   webDeploy: ProjectConfig["webDeploy"],
   serverDeploy: ProjectConfig["serverDeploy"],
   backend: ProjectConfig["backend"],
+  database: ProjectConfig["database"],
+  dbSetup: ProjectConfig["dbSetup"],
 ): string {
   const hasCloudflare = webDeploy === "cloudflare" || serverDeploy === "cloudflare";
   const hasPrismaCompute = webDeploy === "prisma" || serverDeploy === "prisma";
@@ -906,6 +915,16 @@ function generateDeploymentCommands(
       `- Stop: ${packageManagerRunCmd} docker:down`,
       "",
       "Environment variables are read from each app's `.env` file (baked into web builds for public variables) and overridden in `docker-compose.yml` for container networking.",
+    );
+
+    if (database === "sqlite" && dbSetup === "none") {
+      lines.push(
+        "",
+        `Docker Compose uses the local \`./local.db\` file. Run \`${packageManagerRunCmd} db:push\` before starting the stack.`,
+      );
+    }
+
+    lines.push(
       "",
       "For more details, see the guide on [Deploying with Docker Compose](https://www.better-t-stack.dev/docs/guides/docker).",
     );

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -32628,26 +32628,28 @@ export default function App() {
 {{/if}}
 
   return (
+    <Router
+      root={(props) => (
 {{#if (eq api "orpc")}}
-    <QueryClientProvider client={queryClient}>
+        <QueryClientProvider client={queryClient}>
 {{/if}}
-      <Router
-        root={(props) => (
           <MetaProvider>
             <Title>{{projectName}}</Title>
             <div class="grid h-svh grid-rows-[auto_1fr]">
               <Header />
               <Suspense>{props.children}</Suspense>
             </div>
-          </MetaProvider>
-        )}
-      >
-        <FileRoutes />
-      </Router>
 {{#if (eq api "orpc")}}
-      <SolidQueryDevtools />
-    </QueryClientProvider>
+            <SolidQueryDevtools />
 {{/if}}
+          </MetaProvider>
+{{#if (eq api "orpc")}}
+        </QueryClientProvider>
+{{/if}}
+      )}
+    >
+      <FileRoutes />
+    </Router>
   );
 }
 `],
@@ -32744,7 +32746,6 @@ export default function NotFound() {
   ["frontend/solid/src/routes/index.tsx.hbs", `{{#if (eq api "orpc")}}
 import { useQuery } from "@tanstack/solid-query";
 import { orpc } from "~/utils/orpc";
-import { Match, Switch } from "solid-js";
 {{/if}}
 
 const TITLE_TEXT = \`
@@ -32765,7 +32766,11 @@ const TITLE_TEXT = \`
 
 export default function Home() {
   {{#if (eq api "orpc")}}
-  const healthCheck = useQuery(() => orpc.healthCheck.queryOptions());
+  const healthCheck = useQuery(() => ({
+    ...orpc.healthCheck.queryOptions(),
+    deferStream: true,
+  }));
+  const isConnected = () => healthCheck.data === "OK";
   {{/if}}
 
   return (
@@ -32775,32 +32780,18 @@ export default function Home() {
         {{#if (eq api "orpc")}}
         <section class="rounded-lg border p-4">
           <h2 class="mb-2 font-medium">API Status</h2>
-          <Switch>
-            <Match when={healthCheck.isPending}>
-              <div class="flex items-center gap-2">
-                <div class="h-2 w-2 rounded-full bg-gray-500 animate-pulse" />{" "}
-                <span class="text-sm text-muted-foreground">Checking...</span>
-              </div>
-            </Match>
-            <Match when={healthCheck.isError}>
-              <div class="flex items-center gap-2">
-                <div class="h-2 w-2 rounded-full bg-red-500" />
-                <span class="text-sm text-muted-foreground">Disconnected</span>
-              </div>
-            </Match>
-            <Match when={healthCheck.isSuccess}>
-              <div class="flex items-center gap-2">
-                <div
-                  class={\`h-2 w-2 rounded-full \${healthCheck.data ? "bg-green-500" : "bg-red-500"}\`}
-                />
-                <span class="text-sm text-muted-foreground">
-                  {healthCheck.data
-                    ? "Connected"
-                    : "Disconnected"}
-                </span>
-              </div>
-            </Match>
-          </Switch>
+          <div class="flex items-center gap-2">
+            <div
+              class={\`h-2 w-2 rounded-full \${healthCheck.isPending ? "bg-orange-400" : isConnected() ? "bg-green-500" : "bg-red-500"}\`}
+            />
+            <span class="text-sm text-muted-foreground">
+              {healthCheck.isPending
+                ? "Checking..."
+                : isConnected()
+                  ? "Connected"
+                  : "Disconnected"}
+            </span>
+          </div>
         </section>
         {{/if}}
       </div>
@@ -32893,10 +32884,13 @@ export default defineConfig({
       external: ["cloudflare:workers"],
     },
   },
-  resolve: {
-    alias: cloudflareWorkersAlias,
-  },
 {{/if}}
+  resolve: {
+{{#if (eq webDeploy "cloudflare")}}
+    alias: cloudflareWorkersAlias,
+{{/if}}
+    dedupe: ["solid-js"],
+  },
 {{#if (eq webDeploy "cloudflare")}}
   };
 {{else}}

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -15305,6 +15305,8 @@ build
 
 # Generated files
 apps/web/src/routeTree.gen.ts
+local.db
+local.db-*
 
 # Environment variables
 .env
@@ -16372,6 +16374,9 @@ docker-compose.yml
 **/.env
 **/.env.*
 !**/.env.example
+
+local.db
+local.db-*
 `],
   ["deploy/docker/compose/docker-compose.yml.hbs", `name: {{projectName}}
 
@@ -16404,11 +16409,14 @@ services:
       - path: apps/web/.env
         required: false
 {{#if (eq backend "self")}}
-{{#if (or (eq dbSetup "docker") (eq auth "better-auth"))}}
+{{#if (or (eq dbSetup "docker") (eq auth "better-auth") (and (eq database "sqlite") (eq dbSetup "none")))}}
     environment:
 {{#if (eq auth "better-auth")}}
       BETTER_AUTH_URL: http://localhost:3001
       CORS_ORIGIN: http://localhost:3001
+{{/if}}
+{{#if (and (eq database "sqlite") (eq dbSetup "none"))}}
+      DATABASE_URL: file:/data/local.db
 {{/if}}
 {{#if (and (eq dbSetup "docker") (eq database "postgres"))}}
       DATABASE_URL: postgresql://postgres:\${POSTGRES_PASSWORD:-password}@postgres:5432/{{projectName}}
@@ -16424,6 +16432,13 @@ services:
     depends_on:
       {{database}}:
         condition: service_healthy
+{{else if (and (eq database "sqlite") (eq dbSetup "none"))}}
+    volumes:
+      - type: bind
+        source: ./local.db
+        target: /data/local.db
+        bind:
+          create_host_path: false
 {{/if}}
 {{else}}
 {{#if (eq serverDeploy "docker")}}
@@ -16476,10 +16491,13 @@ services:
     env_file:
       - path: apps/server/.env
         required: false
-{{#if (or (eq webDeploy "docker") (eq dbSetup "docker"))}}
+{{#if (or (eq webDeploy "docker") (eq dbSetup "docker") (and (eq database "sqlite") (eq dbSetup "none")))}}
     environment:
 {{#if (eq webDeploy "docker")}}
       CORS_ORIGIN: http://localhost:3001
+{{/if}}
+{{#if (and (eq database "sqlite") (eq dbSetup "none"))}}
+      DATABASE_URL: file:/data/local.db
 {{/if}}
 {{#if (and (eq dbSetup "docker") (eq database "postgres"))}}
       DATABASE_URL: postgresql://postgres:\${POSTGRES_PASSWORD:-password}@postgres:5432/{{projectName}}
@@ -16511,6 +16529,13 @@ services:
     depends_on:
       {{database}}:
         condition: service_healthy
+{{else if (and (eq database "sqlite") (eq dbSetup "none"))}}
+    volumes:
+      - type: bind
+        source: ./local.db
+        target: /data/local.db
+        bind:
+          create_host_path: false
 {{/if}}
     restart: unless-stopped
 

--- a/packages/template-generator/templates/base/_gitignore
+++ b/packages/template-generator/templates/base/_gitignore
@@ -10,6 +10,8 @@ build
 
 # Generated files
 apps/web/src/routeTree.gen.ts
+local.db
+local.db-*
 
 # Environment variables
 .env

--- a/packages/template-generator/templates/deploy/docker/compose/_dockerignore
+++ b/packages/template-generator/templates/deploy/docker/compose/_dockerignore
@@ -26,3 +26,6 @@ docker-compose.yml
 **/.env
 **/.env.*
 !**/.env.example
+
+local.db
+local.db-*

--- a/packages/template-generator/templates/deploy/docker/compose/docker-compose.yml.hbs
+++ b/packages/template-generator/templates/deploy/docker/compose/docker-compose.yml.hbs
@@ -29,11 +29,14 @@ services:
       - path: apps/web/.env
         required: false
 {{#if (eq backend "self")}}
-{{#if (or (eq dbSetup "docker") (eq auth "better-auth"))}}
+{{#if (or (eq dbSetup "docker") (eq auth "better-auth") (and (eq database "sqlite") (eq dbSetup "none")))}}
     environment:
 {{#if (eq auth "better-auth")}}
       BETTER_AUTH_URL: http://localhost:3001
       CORS_ORIGIN: http://localhost:3001
+{{/if}}
+{{#if (and (eq database "sqlite") (eq dbSetup "none"))}}
+      DATABASE_URL: file:/data/local.db
 {{/if}}
 {{#if (and (eq dbSetup "docker") (eq database "postgres"))}}
       DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD:-password}@postgres:5432/{{projectName}}
@@ -49,6 +52,13 @@ services:
     depends_on:
       {{database}}:
         condition: service_healthy
+{{else if (and (eq database "sqlite") (eq dbSetup "none"))}}
+    volumes:
+      - type: bind
+        source: ./local.db
+        target: /data/local.db
+        bind:
+          create_host_path: false
 {{/if}}
 {{else}}
 {{#if (eq serverDeploy "docker")}}
@@ -101,10 +111,13 @@ services:
     env_file:
       - path: apps/server/.env
         required: false
-{{#if (or (eq webDeploy "docker") (eq dbSetup "docker"))}}
+{{#if (or (eq webDeploy "docker") (eq dbSetup "docker") (and (eq database "sqlite") (eq dbSetup "none")))}}
     environment:
 {{#if (eq webDeploy "docker")}}
       CORS_ORIGIN: http://localhost:3001
+{{/if}}
+{{#if (and (eq database "sqlite") (eq dbSetup "none"))}}
+      DATABASE_URL: file:/data/local.db
 {{/if}}
 {{#if (and (eq dbSetup "docker") (eq database "postgres"))}}
       DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD:-password}@postgres:5432/{{projectName}}
@@ -136,6 +149,13 @@ services:
     depends_on:
       {{database}}:
         condition: service_healthy
+{{else if (and (eq database "sqlite") (eq dbSetup "none"))}}
+    volumes:
+      - type: bind
+        source: ./local.db
+        target: /data/local.db
+        bind:
+          create_host_path: false
 {{/if}}
     restart: unless-stopped
 

--- a/packages/template-generator/templates/frontend/solid/src/app.tsx.hbs
+++ b/packages/template-generator/templates/frontend/solid/src/app.tsx.hbs
@@ -16,25 +16,27 @@ export default function App() {
 {{/if}}
 
   return (
+    <Router
+      root={(props) => (
 {{#if (eq api "orpc")}}
-    <QueryClientProvider client={queryClient}>
+        <QueryClientProvider client={queryClient}>
 {{/if}}
-      <Router
-        root={(props) => (
           <MetaProvider>
             <Title>{{projectName}}</Title>
             <div class="grid h-svh grid-rows-[auto_1fr]">
               <Header />
               <Suspense>{props.children}</Suspense>
             </div>
-          </MetaProvider>
-        )}
-      >
-        <FileRoutes />
-      </Router>
 {{#if (eq api "orpc")}}
-      <SolidQueryDevtools />
-    </QueryClientProvider>
+            <SolidQueryDevtools />
 {{/if}}
+          </MetaProvider>
+{{#if (eq api "orpc")}}
+        </QueryClientProvider>
+{{/if}}
+      )}
+    >
+      <FileRoutes />
+    </Router>
   );
 }

--- a/packages/template-generator/templates/frontend/solid/src/routes/index.tsx.hbs
+++ b/packages/template-generator/templates/frontend/solid/src/routes/index.tsx.hbs
@@ -1,7 +1,6 @@
 {{#if (eq api "orpc")}}
 import { useQuery } from "@tanstack/solid-query";
 import { orpc } from "~/utils/orpc";
-import { Match, Switch } from "solid-js";
 {{/if}}
 
 const TITLE_TEXT = `
@@ -22,7 +21,11 @@ const TITLE_TEXT = `
 
 export default function Home() {
   {{#if (eq api "orpc")}}
-  const healthCheck = useQuery(() => orpc.healthCheck.queryOptions());
+  const healthCheck = useQuery(() => ({
+    ...orpc.healthCheck.queryOptions(),
+    deferStream: true,
+  }));
+  const isConnected = () => healthCheck.data === "OK";
   {{/if}}
 
   return (
@@ -32,32 +35,18 @@ export default function Home() {
         {{#if (eq api "orpc")}}
         <section class="rounded-lg border p-4">
           <h2 class="mb-2 font-medium">API Status</h2>
-          <Switch>
-            <Match when={healthCheck.isPending}>
-              <div class="flex items-center gap-2">
-                <div class="h-2 w-2 rounded-full bg-gray-500 animate-pulse" />{" "}
-                <span class="text-sm text-muted-foreground">Checking...</span>
-              </div>
-            </Match>
-            <Match when={healthCheck.isError}>
-              <div class="flex items-center gap-2">
-                <div class="h-2 w-2 rounded-full bg-red-500" />
-                <span class="text-sm text-muted-foreground">Disconnected</span>
-              </div>
-            </Match>
-            <Match when={healthCheck.isSuccess}>
-              <div class="flex items-center gap-2">
-                <div
-                  class={`h-2 w-2 rounded-full ${healthCheck.data ? "bg-green-500" : "bg-red-500"}`}
-                />
-                <span class="text-sm text-muted-foreground">
-                  {healthCheck.data
-                    ? "Connected"
-                    : "Disconnected"}
-                </span>
-              </div>
-            </Match>
-          </Switch>
+          <div class="flex items-center gap-2">
+            <div
+              class={`h-2 w-2 rounded-full ${healthCheck.isPending ? "bg-orange-400" : isConnected() ? "bg-green-500" : "bg-red-500"}`}
+            />
+            <span class="text-sm text-muted-foreground">
+              {healthCheck.isPending
+                ? "Checking..."
+                : isConnected()
+                  ? "Connected"
+                  : "Disconnected"}
+            </span>
+          </div>
         </section>
         {{/if}}
       </div>

--- a/packages/template-generator/templates/frontend/solid/vite.config.ts.hbs
+++ b/packages/template-generator/templates/frontend/solid/vite.config.ts.hbs
@@ -55,10 +55,13 @@ export default defineConfig({
       external: ["cloudflare:workers"],
     },
   },
-  resolve: {
-    alias: cloudflareWorkersAlias,
-  },
 {{/if}}
+  resolve: {
+{{#if (eq webDeploy "cloudflare")}}
+    alias: cloudflareWorkersAlias,
+{{/if}}
+    dedupe: ["solid-js"],
+  },
 {{#if (eq webDeploy "cloudflare")}}
   };
 {{else}}


### PR DESCRIPTION
## Summary

- keep Solid Query context inside the SolidStart router root
- make the starter health check render the real API state during SSR
- deduplicate Solid across linked workspace packages
- include libSQL native runtime dependencies in SQLite application deployments
- mount the generated root `local.db` into the Docker service that consumes it
- fail clearly when `db:push` has not created the database yet
- exclude local SQLite files from Git and Docker image layers

## Verification

- `bun run check`
- `bun run build`
- `cd apps/cli && bun run test` — 653 passed, 29 skipped
- SolidStart Prisma SQLite Docker signup and persistence verified
- Hono Drizzle SQLite Docker signup and persistence verified
- missing SQLite bind source fails without creating a directory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SQLite support for Docker deployments without an external database service.
  * Added automatic local database mounts, environment configuration, and deployment guidance.
  * Improved generated app health status indicators with checking, connected, and disconnected states.
  * Enabled deferred health-query streaming and improved query provider integration.

* **Bug Fixes**
  * Improved Solid.js module resolution in generated Vite configurations.
  * Prevented local SQLite database files from being included in generated or Docker contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->