### PR TITLE
fix(cli): persist SQLite state in Docker

### DIFF
--- a/apps/cli/test/deployment.test.ts
+++ b/apps/cli/test/deployment.test.ts
@@ -1988,14 +1988,17 @@ describe("Deployment Configurations", () => {
 
       expect(webPkg.dependencies.libsql).toBeDefined();
       expect(compose).toContain("DATABASE_URL: file:/data/local.db");
-      expect(compose).toContain("source: ./local.db");
-      expect(compose).toContain("target: /data/local.db");
+      expect(compose).toContain("source: ./.data");
+      expect(compose).toContain("target: /data");
       expect(compose).toContain("create_host_path: false");
       expect(compose).not.toContain("db-init:");
+      expect(files.get("apps/web/.env")).toContain("DATABASE_URL=file:../../.data/local.db");
+      expect(files.get(".data/.gitignore")).toBe("*\n!.gitignore\n");
+      expect(files.get(".dockerignore")).toContain(".data");
       expect(files.get(".dockerignore")).toContain("local.db-*");
       expect(files.get(".gitignore")).toContain("local.db-*");
       expect(readme).toContain(
-        "Docker Compose uses the local `./local.db` file. Run `pnpm run db:push` before starting the stack.",
+        "Docker Compose uses the local `./.data/local.db` file. Run `pnpm run db:push` before starting the stack.",
       );
     });
 
@@ -2028,11 +2031,46 @@ describe("Deployment Configurations", () => {
 
       expect(compose).toContain("dockerfile: apps/server/Dockerfile");
       expect(compose).toContain("DATABASE_URL: file:/data/local.db");
-      expect(compose).toContain("source: ./local.db");
-      expect(compose).toContain("target: /data/local.db");
+      expect(compose).toContain("source: ./.data");
+      expect(compose).toContain("target: /data");
       expect(compose).toContain("create_host_path: false");
       expect(compose).not.toContain("db-init:");
+      expect(files.get("apps/server/.env")).toContain("DATABASE_URL=file:../../.data/local.db");
+      expect(files.get(".data/.gitignore")).toBe("*\n!.gitignore\n");
       expect(serverPkg.dependencies.libsql).toBeDefined();
+    });
+
+    it("should only document SQLite setup when Docker runs the database consumer", async () => {
+      const result = await createVirtual({
+        projectName: "docker-web-cloudflare-server-sqlite",
+        webDeploy: "docker",
+        serverDeploy: "cloudflare",
+        backend: "hono",
+        runtime: "workers",
+        database: "sqlite",
+        orm: "drizzle",
+        auth: "none",
+        payments: "none",
+        api: "trpc",
+        frontend: ["tanstack-router"],
+        addons: ["none"],
+        examples: ["none"],
+        dbSetup: "none",
+        install: false,
+        git: false,
+        packageManager: "bun",
+      });
+
+      if (result.isErr()) throw result.error;
+
+      const files = collectFiles(result.value.root, result.value.root.path);
+      const compose = files.get("docker-compose.yml") ?? "";
+      const readme = files.get("README.md") ?? "";
+
+      expect(compose).not.toContain("DATABASE_URL: file:/data/local.db");
+      expect(compose).not.toContain("source: ./.data");
+      expect(files.has(".data/.gitignore")).toBe(false);
+      expect(readme).not.toContain("Docker Compose uses the local");
     });
 
     it("should route SolidStart SSR requests through the internal Docker server URL", async () => {

--- a/packages/template-generator/src/processors/env-vars.ts
+++ b/packages/template-generator/src/processors/env-vars.ts
@@ -1,6 +1,7 @@
 import type { ProjectConfig } from "@better-t-stack/types";
 
 import type { VirtualFileSystem } from "../core/virtual-fs";
+import { isDatabaseConsumedByDocker } from "../utils/docker-database";
 
 export interface EnvVariable {
   key: string;
@@ -480,7 +481,16 @@ function buildServerVars(
         databaseUrl = "mongodb://localhost:27017/mydatabase";
         break;
       case "sqlite":
-        if (runtime === "workers" || webDeploy === "cloudflare" || serverDeploy === "cloudflare") {
+        if (
+          isDatabaseConsumedByDocker({ backend, serverDeploy, webDeploy }) &&
+          dbSetup === "none"
+        ) {
+          databaseUrl = "file:../../.data/local.db";
+        } else if (
+          runtime === "workers" ||
+          webDeploy === "cloudflare" ||
+          serverDeploy === "cloudflare"
+        ) {
           databaseUrl = "http://127.0.0.1:8080";
         } else {
           databaseUrl = "file:../../local.db";

--- a/packages/template-generator/src/processors/readme-generator.ts
+++ b/packages/template-generator/src/processors/readme-generator.ts
@@ -7,6 +7,7 @@ import {
 
 import type { VirtualFileSystem } from "../core/virtual-fs";
 import { getDbScriptSupport } from "../utils/db-scripts";
+import { isDatabaseConsumedByDocker } from "../utils/docker-database";
 
 function getDesktopStaticBuildNote(frontend: ProjectConfig["frontend"]): string {
   const staticBuildFrontends = new Map([
@@ -917,10 +918,14 @@ function generateDeploymentCommands(
       "Environment variables are read from each app's `.env` file (baked into web builds for public variables) and overridden in `docker-compose.yml` for container networking.",
     );
 
-    if (database === "sqlite" && dbSetup === "none") {
+    if (
+      database === "sqlite" &&
+      dbSetup === "none" &&
+      isDatabaseConsumedByDocker({ backend, serverDeploy, webDeploy })
+    ) {
       lines.push(
         "",
-        `Docker Compose uses the local \`./local.db\` file. Run \`${packageManagerRunCmd} db:push\` before starting the stack.`,
+        `Docker Compose uses the local \`./.data/local.db\` file. Run \`${packageManagerRunCmd} db:push\` before starting the stack.`,
       );
     }
 

--- a/packages/template-generator/src/template-handlers/deploy.ts
+++ b/packages/template-generator/src/template-handlers/deploy.ts
@@ -2,6 +2,7 @@ import type { ProjectConfig } from "@better-t-stack/types";
 
 import type { VirtualFileSystem } from "../core/virtual-fs";
 import { processAlchemyRun } from "../generators/alchemy/render";
+import { isDatabaseConsumedByDocker } from "../utils/docker-database";
 import { type TemplateData, processTemplatesFromPrefix } from "./utils";
 
 function hasOwnKey<T extends object>(object: T, key: PropertyKey): key is keyof T {
@@ -25,6 +26,13 @@ export async function processDeployTemplates(
 
   if (config.webDeploy === "docker" || config.serverDeploy === "docker") {
     processTemplatesFromPrefix(vfs, templates, "deploy/docker/compose", "", config);
+    if (
+      config.database === "sqlite" &&
+      config.dbSetup === "none" &&
+      isDatabaseConsumedByDocker(config)
+    ) {
+      vfs.writeFile(".data/.gitignore", "*\n!.gitignore\n");
+    }
   }
 
   if (config.webDeploy === "vercel" || config.serverDeploy === "vercel") {

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -16377,6 +16377,7 @@ docker-compose.yml
 
 local.db
 local.db-*
+.data
 `],
   ["deploy/docker/compose/docker-compose.yml.hbs", `name: {{projectName}}
 
@@ -16435,8 +16436,8 @@ services:
 {{else if (and (eq database "sqlite") (eq dbSetup "none"))}}
     volumes:
       - type: bind
-        source: ./local.db
-        target: /data/local.db
+        source: ./.data
+        target: /data
         bind:
           create_host_path: false
 {{/if}}
@@ -16532,8 +16533,8 @@ services:
 {{else if (and (eq database "sqlite") (eq dbSetup "none"))}}
     volumes:
       - type: bind
-        source: ./local.db
-        target: /data/local.db
+        source: ./.data
+        target: /data
         bind:
           create_host_path: false
 {{/if}}

--- a/packages/template-generator/src/utils/docker-database.ts
+++ b/packages/template-generator/src/utils/docker-database.ts
@@ -1,0 +1,9 @@
+import type { ProjectConfig } from "@better-t-stack/types";
+
+export function isDatabaseConsumedByDocker(
+  config: Pick<ProjectConfig, "backend" | "serverDeploy" | "webDeploy">,
+): boolean {
+  return config.backend === "self"
+    ? config.webDeploy === "docker"
+    : config.serverDeploy === "docker";
+}

--- a/packages/template-generator/templates/deploy/docker/compose/_dockerignore
+++ b/packages/template-generator/templates/deploy/docker/compose/_dockerignore
@@ -29,3 +29,4 @@ docker-compose.yml
 
 local.db
 local.db-*
+.data

--- a/packages/template-generator/templates/deploy/docker/compose/docker-compose.yml.hbs
+++ b/packages/template-generator/templates/deploy/docker/compose/docker-compose.yml.hbs
@@ -55,8 +55,8 @@ services:
 {{else if (and (eq database "sqlite") (eq dbSetup "none"))}}
     volumes:
       - type: bind
-        source: ./local.db
-        target: /data/local.db
+        source: ./.data
+        target: /data
         bind:
           create_host_path: false
 {{/if}}
@@ -152,8 +152,8 @@ services:
 {{else if (and (eq database "sqlite") (eq dbSetup "none"))}}
     volumes:
       - type: bind
-        source: ./local.db
-        target: /data/local.db
+        source: ./.data
+        target: /data
         bind:
           create_host_path: false
 {{/if}}


### PR DESCRIPTION
## Summary

- persist local SQLite databases and journal files through a dedicated `.data` directory mount
- only show Docker SQLite setup instructions when Docker runs the database consumer

Follow-up to review feedback on #1160.

## Verification

- `bun run check`
- full CLI test suite
- generated SolidStart + Prisma Docker build, signup, and forced container recreation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQLite database handling for Docker deployments by using a shared `.data` directory.
  * Updated generated database URLs and Docker mounts to consistently reference the shared database location.
  * Prevented unnecessary SQLite setup instructions when Docker services do not consume the database.
  * Added automatic `.data/.gitignore` generation to keep local database files out of version control.
  * Updated Docker ignore rules to exclude local database data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->