### PR TITLE
fix(cli): keep env validation out of browser bundles

### DIFF
--- a/apps/cli/test/deployment.test.ts
+++ b/apps/cli/test/deployment.test.ts
@@ -1589,6 +1589,7 @@ describe("Deployment Configurations", () => {
       // public client values are baked via build args, not .env files in the context
       expect(compose).toContain("VITE_SERVER_URL: http://localhost:3000");
       expect(webDockerfile).toContain("ARG VITE_SERVER_URL");
+      expect(webDockerfile).not.toContain("SKIP_ENV_VALIDATION");
       expect(files.get(".dockerignore")).toContain("**/.env");
       expect(webDockerfile).toContain("FROM node:24-slim AS builder");
       expect(serverDockerfile).toContain("FROM oven/bun:1 AS builder");
@@ -1648,6 +1649,7 @@ describe("Deployment Configurations", () => {
         "DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD:-password}@postgres:5432/docker-self-next",
       );
       expect(webDockerfile).toContain("npm install -g pnpm");
+      expect(webDockerfile).toContain("ENV SKIP_ENV_VALIDATION=1");
       // Next.js Docker deploys use standalone output for a minimal runtime image
       expect(webDockerfile).toContain(".next/standalone");
       expect(webDockerfile).toContain('CMD ["node", "apps/web/server.js"]');
@@ -1688,6 +1690,45 @@ describe("Deployment Configurations", () => {
       expect(svelteConfig).not.toContain("@sveltejs/adapter-auto");
       expect(webPkg.devDependencies["@sveltejs/adapter-node"]).toBeDefined();
       expect(webDockerfile).toContain('CMD ["node", "build/index.js"]');
+    });
+
+    it("should validate Nuxt public variables during Docker builds", async () => {
+      const result = await createVirtual({
+        projectName: "docker-nuxt",
+        webDeploy: "docker",
+        serverDeploy: "docker",
+        backend: "hono",
+        runtime: "bun",
+        database: "sqlite",
+        orm: "drizzle",
+        auth: "none",
+        payments: "none",
+        api: "orpc",
+        frontend: ["nuxt"],
+        addons: ["none"],
+        examples: ["none"],
+        dbSetup: "none",
+        install: false,
+        git: false,
+        packageManager: "bun",
+      });
+
+      if (result.isErr()) {
+        throw result.error;
+      }
+
+      const files = collectFiles(result.value.root, result.value.root.path);
+      const compose = files.get("docker-compose.yml") ?? "";
+      const webDockerfile = files.get("apps/web/Dockerfile") ?? "";
+
+      expect(compose).toContain("NUXT_PUBLIC_SERVER_URL: http://localhost:3000");
+      expect(webDockerfile).toContain("ARG NUXT_PUBLIC_SERVER_URL");
+      expect(webDockerfile).toContain("ENV NUXT_PUBLIC_SERVER_URL=${NUXT_PUBLIC_SERVER_URL}");
+      expect(webDockerfile.indexOf("ARG NUXT_PUBLIC_SERVER_URL")).toBeLessThan(
+        webDockerfile.indexOf("bun install"),
+      );
+      expect(webDockerfile).not.toContain("SKIP_ENV_VALIDATION");
+      expect(files.get("packages/env/src/web.ts")).not.toContain("SKIP_ENV_VALIDATION");
     });
 
     it("should not infer the TanStack Start runtime from the package manager", async () => {

--- a/apps/cli/test/frontend.test.ts
+++ b/apps/cli/test/frontend.test.ts
@@ -168,6 +168,10 @@ describe("Frontend Configurations", () => {
       const envPackageJson = await fs.readJson(
         path.join(result.projectDir, "packages/env/package.json"),
       );
+      const webEnv = await fs.readFile(
+        path.join(result.projectDir, "packages/env/src/web.ts"),
+        "utf8",
+      );
       const appFile = await fs.readFile(path.join(webDir, "src/app.tsx"), "utf8");
       const tsconfig = await fs.readJson(path.join(webDir, "tsconfig.json"));
       const viteConfig = await fs.readFile(path.join(webDir, "vite.config.ts"), "utf8");
@@ -187,6 +191,7 @@ describe("Frontend Configurations", () => {
       expect(tsconfig.exclude).toContain("dist");
       expect(rootPackageJson.scripts["dev:web"]).toBeDefined();
       expect(envPackageJson.exports["./web"]).toBe("./src/web.ts");
+      expect(webEnv).not.toContain("SKIP_ENV_VALIDATION");
       expect(appFile).toContain('import { FileRoutes } from "@solidjs/start/router";');
       expect(appFile).toContain("<FileRoutes />");
       expect(viteConfig).toContain("solidStart()");

--- a/apps/web/content/docs/guides/docker.mdx
+++ b/apps/web/content/docs/guides/docker.mdx
@@ -108,7 +108,7 @@ bun db:watch   # docker compose up postgres      (with logs in the foreground)
 Each Dockerfile is a multi-stage build with the monorepo root as build context:
 
 1. A base stage installs the workspace with your package manager (with a mounted dependency cache, so rebuilds are fast).
-2. The app is built with `SKIP_ENV_VALIDATION=1`, so t3-env doesn't require real secrets at image-build time. Prisma projects get a placeholder `DATABASE_URL` for `prisma generate`; the real value arrives at runtime from compose.
+2. Images containing a self-hosted server are built with `SKIP_ENV_VALIDATION=1`, so t3-env doesn't require real server secrets at image-build time. Public web variables are passed as build arguments and remain validated. Prisma projects get a placeholder `DATABASE_URL` for `prisma generate`; the real value arrives at runtime from compose.
 3. A separate runtime stage copies the built output. SPA frontends are copied into an nginx image; SSR frontends and servers use `oven/bun:1` for the Bun runtime or `node:24-slim` for the Node.js runtime.
 
 ## Environment Variables

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -16387,10 +16387,10 @@ services:
     build:
       context: .
       dockerfile: apps/web/Dockerfile
-{{#if (and (not (includes frontend "nuxt")) (or (and (ne backend "self") (ne backend "none") (ne backend "convex")) (eq backend "convex") (and (eq auth "clerk") (or (includes frontend "next") (includes frontend "react-router") (includes frontend "tanstack-router") (includes frontend "tanstack-start")))))}}
+{{#if (or (and (ne backend "self") (ne backend "none") (ne backend "convex")) (eq backend "convex") (and (eq auth "clerk") (or (includes frontend "next") (includes frontend "react-router") (includes frontend "tanstack-router") (includes frontend "tanstack-start"))))}}
       args:
 {{#if (and (ne backend "self") (ne backend "none") (ne backend "convex"))}}
-        {{#if (includes frontend "next")}}NEXT_PUBLIC_SERVER_URL{{else if (or (includes frontend "svelte") (includes frontend "astro"))}}PUBLIC_SERVER_URL{{else}}VITE_SERVER_URL{{/if}}: http://localhost:3000
+        {{#if (includes frontend "next")}}NEXT_PUBLIC_SERVER_URL{{else if (includes frontend "nuxt")}}NUXT_PUBLIC_SERVER_URL{{else if (or (includes frontend "svelte") (includes frontend "astro"))}}PUBLIC_SERVER_URL{{else}}VITE_SERVER_URL{{/if}}: http://localhost:3000
 {{/if}}
 {{#if (eq backend "convex")}}
         {{#if (includes frontend "next")}}NEXT_PUBLIC_CONVEX_URL: \${NEXT_PUBLIC_CONVEX_URL:-}{{else if (or (includes frontend "svelte") (includes frontend "astro"))}}PUBLIC_CONVEX_URL: \${PUBLIC_CONVEX_URL:-}{{else}}VITE_CONVEX_URL: \${VITE_CONVEX_URL:-}{{/if}}
@@ -16658,7 +16658,9 @@ COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 RUN npm install -g pnpm@11
 {{/if}}
 WORKDIR /app
+{{#if (eq backend "self")}}
 ENV SKIP_ENV_VALIDATION=1
+{{/if}}
 {{#if (and (eq backend "self") (eq auth "better-auth"))}}
 # the build evaluates the auth config; the real secret comes from compose at runtime
 ENV BETTER_AUTH_SECRET=build-time-placeholder-secret-not-used-at-runtime
@@ -16687,7 +16689,9 @@ ENV PUBLIC_CONVEX_URL=\${PUBLIC_CONVEX_URL}
 {{/if}}
 ENV NODE_ENV=production
 RUN cd apps/web && {{packageManager}} run build
+{{#if (eq backend "self")}}
 ENV SKIP_ENV_VALIDATION=
+{{/if}}
 {{#if (and (eq backend "self") (eq auth "better-auth"))}}
 ENV BETTER_AUTH_SECRET=
 {{/if}}
@@ -16710,7 +16714,13 @@ COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 RUN npm install -g pnpm@11
 {{/if}}
 WORKDIR /app
+{{#if (eq backend "self")}}
 ENV SKIP_ENV_VALIDATION=1
+{{/if}}
+{{#if (and (ne backend "self") (ne backend "none") (ne backend "convex"))}}
+ARG NUXT_PUBLIC_SERVER_URL
+ENV NUXT_PUBLIC_SERVER_URL=\${NUXT_PUBLIC_SERVER_URL}
+{{/if}}
 {{#if (and (eq backend "self") (eq auth "better-auth"))}}
 # the build evaluates the auth config; the real secret comes from compose at runtime
 ENV BETTER_AUTH_SECRET=build-time-placeholder-secret-not-used-at-runtime
@@ -16752,7 +16762,9 @@ COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 RUN npm install -g pnpm@11
 {{/if}}
 WORKDIR /app
+{{#if (eq backend "self")}}
 ENV SKIP_ENV_VALIDATION=1
+{{/if}}
 {{#if (and (eq backend "self") (eq auth "better-auth"))}}
 # the build evaluates the auth config; the real secret comes from compose at runtime
 ENV BETTER_AUTH_SECRET=build-time-placeholder-secret-not-used-at-runtime
@@ -16810,7 +16822,6 @@ COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 RUN npm install -g pnpm@11
 {{/if}}
 WORKDIR /app
-ENV SKIP_ENV_VALIDATION=1
 {{#if (and (eq backend "self") (eq auth "better-auth"))}}
 # the build evaluates the auth config; the real secret comes from compose at runtime
 ENV BETTER_AUTH_SECRET=build-time-placeholder-secret-not-used-at-runtime
@@ -16861,7 +16872,6 @@ COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 RUN npm install -g pnpm@11
 {{/if}}
 WORKDIR /app
-ENV SKIP_ENV_VALIDATION=1
 {{#if (and (eq backend "self") (eq auth "better-auth"))}}
 # the build evaluates the auth config; the real secret comes from compose at runtime
 ENV BETTER_AUTH_SECRET=build-time-placeholder-secret-not-used-at-runtime
@@ -16932,7 +16942,9 @@ COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 RUN npm install -g pnpm@11
 {{/if}}
 WORKDIR /app
+{{#if (eq backend "self")}}
 ENV SKIP_ENV_VALIDATION=1
+{{/if}}
 {{#if (and (eq backend "self") (eq auth "better-auth"))}}
 # the build evaluates the auth config; the real secret comes from compose at runtime
 ENV BETTER_AUTH_SECRET=build-time-placeholder-secret-not-used-at-runtime
@@ -16965,7 +16977,9 @@ ENV VITE_CLERK_PUBLISHABLE_KEY=\${VITE_CLERK_PUBLISHABLE_KEY}
 {{/if}}
 ENV NODE_ENV=production
 RUN cd apps/web && {{packageManager}} run build
+{{#if (eq backend "self")}}
 ENV SKIP_ENV_VALIDATION=
+{{/if}}
 {{#if (and (eq backend "self") (eq auth "better-auth"))}}
 ENV BETTER_AUTH_SECRET=
 {{/if}}
@@ -17002,7 +17016,9 @@ COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 RUN npm install -g pnpm@11
 {{/if}}
 WORKDIR /app
+{{#if (eq backend "self")}}
 ENV SKIP_ENV_VALIDATION=1
+{{/if}}
 {{#if (and (eq backend "self") (eq auth "better-auth"))}}
 # the build evaluates the auth config; the real secret comes from compose at runtime
 ENV BETTER_AUTH_SECRET=build-time-placeholder-secret-not-used-at-runtime
@@ -17031,7 +17047,9 @@ ENV VITE_CONVEX_URL=\${VITE_CONVEX_URL}
 {{/if}}
 ENV NODE_ENV=production
 RUN cd apps/web && {{packageManager}} run build
+{{#if (eq backend "self")}}
 ENV SKIP_ENV_VALIDATION=
+{{/if}}
 {{#if (and (eq backend "self") (eq auth "better-auth"))}}
 ENV BETTER_AUTH_SECRET=
 {{/if}}
@@ -17059,7 +17077,9 @@ COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 RUN npm install -g pnpm@11
 {{/if}}
 WORKDIR /app
+{{#if (eq backend "self")}}
 ENV SKIP_ENV_VALIDATION=1
+{{/if}}
 {{#if (and (eq backend "self") (eq auth "better-auth"))}}
 # the build evaluates the auth config; the real secret comes from compose at runtime
 ENV BETTER_AUTH_SECRET=build-time-placeholder-secret-not-used-at-runtime
@@ -17088,7 +17108,9 @@ ENV PUBLIC_CONVEX_URL=\${PUBLIC_CONVEX_URL}
 {{/if}}
 ENV NODE_ENV=production
 RUN cd apps/web && {{packageManager}} run build
+{{#if (eq backend "self")}}
 ENV SKIP_ENV_VALIDATION=
+{{/if}}
 {{#if (and (eq backend "self") (eq auth "better-auth"))}}
 ENV BETTER_AUTH_SECRET=
 {{/if}}
@@ -33690,7 +33712,6 @@ export const env = createEnv({
 	runtimeEnv: (import.meta as any).env,
 {{/if}}
 {{/if}}
-	skipValidation: !!process.env.SKIP_ENV_VALIDATION,
 	emptyStringAsUndefined: true,
 });
 `],

--- a/packages/template-generator/templates/deploy/docker/compose/docker-compose.yml.hbs
+++ b/packages/template-generator/templates/deploy/docker/compose/docker-compose.yml.hbs
@@ -6,10 +6,10 @@ services:
     build:
       context: .
       dockerfile: apps/web/Dockerfile
-{{#if (and (not (includes frontend "nuxt")) (or (and (ne backend "self") (ne backend "none") (ne backend "convex")) (eq backend "convex") (and (eq auth "clerk") (or (includes frontend "next") (includes frontend "react-router") (includes frontend "tanstack-router") (includes frontend "tanstack-start")))))}}
+{{#if (or (and (ne backend "self") (ne backend "none") (ne backend "convex")) (eq backend "convex") (and (eq auth "clerk") (or (includes frontend "next") (includes frontend "react-router") (includes frontend "tanstack-router") (includes frontend "tanstack-start"))))}}
       args:
 {{#if (and (ne backend "self") (ne backend "none") (ne backend "convex"))}}
-        {{#if (includes frontend "next")}}NEXT_PUBLIC_SERVER_URL{{else if (or (includes frontend "svelte") (includes frontend "astro"))}}PUBLIC_SERVER_URL{{else}}VITE_SERVER_URL{{/if}}: http://localhost:3000
+        {{#if (includes frontend "next")}}NEXT_PUBLIC_SERVER_URL{{else if (includes frontend "nuxt")}}NUXT_PUBLIC_SERVER_URL{{else if (or (includes frontend "svelte") (includes frontend "astro"))}}PUBLIC_SERVER_URL{{else}}VITE_SERVER_URL{{/if}}: http://localhost:3000
 {{/if}}
 {{#if (eq backend "convex")}}
         {{#if (includes frontend "next")}}NEXT_PUBLIC_CONVEX_URL: ${NEXT_PUBLIC_CONVEX_URL:-}{{else if (or (includes frontend "svelte") (includes frontend "astro"))}}PUBLIC_CONVEX_URL: ${PUBLIC_CONVEX_URL:-}{{else}}VITE_CONVEX_URL: ${VITE_CONVEX_URL:-}{{/if}}

--- a/packages/template-generator/templates/deploy/docker/web/astro/Dockerfile.hbs
+++ b/packages/template-generator/templates/deploy/docker/web/astro/Dockerfile.hbs
@@ -6,7 +6,9 @@ COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 RUN npm install -g pnpm@11
 {{/if}}
 WORKDIR /app
+{{#if (eq backend "self")}}
 ENV SKIP_ENV_VALIDATION=1
+{{/if}}
 {{#if (and (eq backend "self") (eq auth "better-auth"))}}
 # the build evaluates the auth config; the real secret comes from compose at runtime
 ENV BETTER_AUTH_SECRET=build-time-placeholder-secret-not-used-at-runtime
@@ -35,7 +37,9 @@ ENV PUBLIC_CONVEX_URL=${PUBLIC_CONVEX_URL}
 {{/if}}
 ENV NODE_ENV=production
 RUN cd apps/web && {{packageManager}} run build
+{{#if (eq backend "self")}}
 ENV SKIP_ENV_VALIDATION=
+{{/if}}
 {{#if (and (eq backend "self") (eq auth "better-auth"))}}
 ENV BETTER_AUTH_SECRET=
 {{/if}}

--- a/packages/template-generator/templates/deploy/docker/web/nuxt/Dockerfile.hbs
+++ b/packages/template-generator/templates/deploy/docker/web/nuxt/Dockerfile.hbs
@@ -6,7 +6,13 @@ COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 RUN npm install -g pnpm@11
 {{/if}}
 WORKDIR /app
+{{#if (eq backend "self")}}
 ENV SKIP_ENV_VALIDATION=1
+{{/if}}
+{{#if (and (ne backend "self") (ne backend "none") (ne backend "convex"))}}
+ARG NUXT_PUBLIC_SERVER_URL
+ENV NUXT_PUBLIC_SERVER_URL=${NUXT_PUBLIC_SERVER_URL}
+{{/if}}
 {{#if (and (eq backend "self") (eq auth "better-auth"))}}
 # the build evaluates the auth config; the real secret comes from compose at runtime
 ENV BETTER_AUTH_SECRET=build-time-placeholder-secret-not-used-at-runtime

--- a/packages/template-generator/templates/deploy/docker/web/react/next/Dockerfile.hbs
+++ b/packages/template-generator/templates/deploy/docker/web/react/next/Dockerfile.hbs
@@ -6,7 +6,9 @@ COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 RUN npm install -g pnpm@11
 {{/if}}
 WORKDIR /app
+{{#if (eq backend "self")}}
 ENV SKIP_ENV_VALIDATION=1
+{{/if}}
 {{#if (and (eq backend "self") (eq auth "better-auth"))}}
 # the build evaluates the auth config; the real secret comes from compose at runtime
 ENV BETTER_AUTH_SECRET=build-time-placeholder-secret-not-used-at-runtime

--- a/packages/template-generator/templates/deploy/docker/web/react/react-router/Dockerfile.hbs
+++ b/packages/template-generator/templates/deploy/docker/web/react/react-router/Dockerfile.hbs
@@ -6,7 +6,6 @@ COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 RUN npm install -g pnpm@11
 {{/if}}
 WORKDIR /app
-ENV SKIP_ENV_VALIDATION=1
 {{#if (and (eq backend "self") (eq auth "better-auth"))}}
 # the build evaluates the auth config; the real secret comes from compose at runtime
 ENV BETTER_AUTH_SECRET=build-time-placeholder-secret-not-used-at-runtime

--- a/packages/template-generator/templates/deploy/docker/web/react/tanstack-router/Dockerfile.hbs
+++ b/packages/template-generator/templates/deploy/docker/web/react/tanstack-router/Dockerfile.hbs
@@ -6,7 +6,6 @@ COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 RUN npm install -g pnpm@11
 {{/if}}
 WORKDIR /app
-ENV SKIP_ENV_VALIDATION=1
 {{#if (and (eq backend "self") (eq auth "better-auth"))}}
 # the build evaluates the auth config; the real secret comes from compose at runtime
 ENV BETTER_AUTH_SECRET=build-time-placeholder-secret-not-used-at-runtime

--- a/packages/template-generator/templates/deploy/docker/web/react/tanstack-start/Dockerfile.hbs
+++ b/packages/template-generator/templates/deploy/docker/web/react/tanstack-start/Dockerfile.hbs
@@ -10,7 +10,9 @@ COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 RUN npm install -g pnpm@11
 {{/if}}
 WORKDIR /app
+{{#if (eq backend "self")}}
 ENV SKIP_ENV_VALIDATION=1
+{{/if}}
 {{#if (and (eq backend "self") (eq auth "better-auth"))}}
 # the build evaluates the auth config; the real secret comes from compose at runtime
 ENV BETTER_AUTH_SECRET=build-time-placeholder-secret-not-used-at-runtime
@@ -43,7 +45,9 @@ ENV VITE_CLERK_PUBLISHABLE_KEY=${VITE_CLERK_PUBLISHABLE_KEY}
 {{/if}}
 ENV NODE_ENV=production
 RUN cd apps/web && {{packageManager}} run build
+{{#if (eq backend "self")}}
 ENV SKIP_ENV_VALIDATION=
+{{/if}}
 {{#if (and (eq backend "self") (eq auth "better-auth"))}}
 ENV BETTER_AUTH_SECRET=
 {{/if}}

--- a/packages/template-generator/templates/deploy/docker/web/solid/Dockerfile.hbs
+++ b/packages/template-generator/templates/deploy/docker/web/solid/Dockerfile.hbs
@@ -6,7 +6,9 @@ COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 RUN npm install -g pnpm@11
 {{/if}}
 WORKDIR /app
+{{#if (eq backend "self")}}
 ENV SKIP_ENV_VALIDATION=1
+{{/if}}
 {{#if (and (eq backend "self") (eq auth "better-auth"))}}
 # the build evaluates the auth config; the real secret comes from compose at runtime
 ENV BETTER_AUTH_SECRET=build-time-placeholder-secret-not-used-at-runtime
@@ -35,7 +37,9 @@ ENV VITE_CONVEX_URL=${VITE_CONVEX_URL}
 {{/if}}
 ENV NODE_ENV=production
 RUN cd apps/web && {{packageManager}} run build
+{{#if (eq backend "self")}}
 ENV SKIP_ENV_VALIDATION=
+{{/if}}
 {{#if (and (eq backend "self") (eq auth "better-auth"))}}
 ENV BETTER_AUTH_SECRET=
 {{/if}}

--- a/packages/template-generator/templates/deploy/docker/web/svelte/Dockerfile.hbs
+++ b/packages/template-generator/templates/deploy/docker/web/svelte/Dockerfile.hbs
@@ -6,7 +6,9 @@ COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 RUN npm install -g pnpm@11
 {{/if}}
 WORKDIR /app
+{{#if (eq backend "self")}}
 ENV SKIP_ENV_VALIDATION=1
+{{/if}}
 {{#if (and (eq backend "self") (eq auth "better-auth"))}}
 # the build evaluates the auth config; the real secret comes from compose at runtime
 ENV BETTER_AUTH_SECRET=build-time-placeholder-secret-not-used-at-runtime
@@ -35,7 +37,9 @@ ENV PUBLIC_CONVEX_URL=${PUBLIC_CONVEX_URL}
 {{/if}}
 ENV NODE_ENV=production
 RUN cd apps/web && {{packageManager}} run build
+{{#if (eq backend "self")}}
 ENV SKIP_ENV_VALIDATION=
+{{/if}}
 {{#if (and (eq backend "self") (eq auth "better-auth"))}}
 ENV BETTER_AUTH_SECRET=
 {{/if}}

--- a/packages/template-generator/templates/packages/env/src/web.ts.hbs
+++ b/packages/template-generator/templates/packages/env/src/web.ts.hbs
@@ -133,6 +133,5 @@ export const env = createEnv({
 	runtimeEnv: (import.meta as any).env,
 {{/if}}
 {{/if}}
-	skipValidation: !!process.env.SKIP_ENV_VALIDATION,
 	emptyStringAsUndefined: true,
 });


### PR DESCRIPTION
## Summary

- remove `SKIP_ENV_VALIDATION` from generated browser environment modules
- limit the Docker validation bypass to images that contain a self-hosted server
- pass `NUXT_PUBLIC_SERVER_URL` as a Docker build argument so Nuxt public env remains validated
- add regression coverage and clarify the Docker environment behavior

## Root cause

The shared browser env module read `process.env.SKIP_ENV_VALIDATION`. Vite shipped that expression to the browser, where `process` is unavailable, so SolidStart hydration crashed before the API status query could run.

Self-hosted SSR images still need the documented t3-env build bypass because their server modules are evaluated while building, before runtime secrets are injected. The bypass now stays in that server build context and is never referenced by browser code.

## Verification

- `bun run check`
- `bun run build`
- CLI suite: 655 passed, 29 skipped
- focused deployment/frontend tests: 117 passed
- generated SolidStart app verified in a real browser with API status connected
- generated Nuxt Docker image built successfully with public env validation enabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Docker deployments now validate public environment variables consistently across supported frontend frameworks.
  * Self-hosted server builds continue to support skipped validation where required, without applying it unnecessarily to other deployment types.
  * Nuxt deployments now correctly pass the public server URL during image builds and Compose setup.

* **Documentation**
  * Clarified Docker configuration requirements, including runtime settings and database placeholders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->