### PR TITLE
fix(cli): make database provisioning explicit

### DIFF
--- a/apps/cli/src/helpers/core/command-handlers.ts
+++ b/apps/cli/src/helpers/core/command-handlers.ts
@@ -324,6 +324,7 @@ async function createProjectHandlerInternal(
           try: async () =>
             gatherConfig(flagConfig, finalBaseName, finalResolvedPath, finalPathInput, {
               skipCompatibilityChecks: cliInput.yolo,
+              manualDb: cliInput.manualDb ?? input.manualDb,
             }),
           catch: (cause: unknown) => {
             if (cause instanceof UserCancelledError) return cause;

--- a/apps/cli/src/helpers/core/command-handlers.ts
+++ b/apps/cli/src/helpers/core/command-handlers.ts
@@ -43,7 +43,7 @@ import {
   validateResolvedConfigCompatibility,
 } from "../../validation";
 import { createProject } from "./create-project";
-import { mergeResolvedDbSetupOptions } from "./db-setup-options";
+import { resolveProjectDbSetupOptions } from "./db-setup-options";
 
 export interface CreateHandlerOptions {
   silent?: boolean;
@@ -337,14 +337,10 @@ async function createProjectHandlerInternal(
       config = gatherResult;
     }
 
-    const effectiveDbSetupOptions = mergeResolvedDbSetupOptions(
-      config.dbSetup,
-      config.dbSetupOptions,
-      {
-        manualDb: cliInput.manualDb ?? input.manualDb,
-        dbSetupOptions: cliInput.dbSetupOptions ?? input.dbSetupOptions,
-      },
-    );
+    const effectiveDbSetupOptions = resolveProjectDbSetupOptions(config, {
+      manualDb: cliInput.manualDb ?? input.manualDb,
+      dbSetupOptions: cliInput.dbSetupOptions ?? input.dbSetupOptions,
+    });
 
     if (effectiveDbSetupOptions) {
       config = {

--- a/apps/cli/src/helpers/core/db-setup-options.ts
+++ b/apps/cli/src/helpers/core/db-setup-options.ts
@@ -1,4 +1,9 @@
-import type { DatabaseSetup, DbSetupOptions } from "../../types";
+import {
+  supportsAlchemyManagedDatabase,
+  type DatabaseSetup,
+  type DbSetupOptions,
+  type ProjectConfig,
+} from "../../types";
 import { isSilent } from "../../utils/context";
 
 export interface DatabaseSetupCliOptions {
@@ -66,4 +71,26 @@ export function mergeResolvedDbSetupOptions(
     ...dbSetupOptions,
     mode: resolvedMode,
   };
+}
+
+export function resolveProjectDbSetupOptions(
+  config: Pick<
+    ProjectConfig,
+    "backend" | "dbSetup" | "dbSetupOptions" | "webDeploy" | "serverDeploy"
+  >,
+  cliOptions: DatabaseSetupCliOptions = {},
+): DbSetupOptions | undefined {
+  const dbSetupOptions = config.dbSetupOptions ?? cliOptions.dbSetupOptions;
+  const explicitMode =
+    dbSetupOptions?.mode ?? (cliOptions.manualDb === true ? "manual" : undefined);
+
+  if (!explicitMode && supportsAlchemyManagedDatabase(config)) {
+    return { ...dbSetupOptions, mode: "alchemy" };
+  }
+
+  const resolved = mergeResolvedDbSetupOptions(config.dbSetup, dbSetupOptions, {
+    ...cliOptions,
+    dbSetupOptions,
+  });
+  return resolved;
 }

--- a/apps/cli/src/helpers/core/db-setup-options.ts
+++ b/apps/cli/src/helpers/core/db-setup-options.ts
@@ -13,6 +13,20 @@ export interface DatabaseSetupCliOptions {
 
 export type DbSetupMode = NonNullable<DbSetupOptions["mode"]>;
 
+export function withDbSetupMode(
+  dbSetupOptions: DbSetupOptions | undefined,
+  mode: DbSetupMode | undefined,
+): DbSetupOptions | undefined {
+  const resolved = { ...dbSetupOptions };
+  if (mode === undefined) {
+    delete resolved.mode;
+  } else {
+    resolved.mode = mode;
+  }
+
+  return Object.keys(resolved).length === 0 ? undefined : resolved;
+}
+
 const REMOTE_PROVISIONING_DB_SETUPS: DatabaseSetup[] = [
   "turso",
   "neon",

--- a/apps/cli/src/helpers/core/post-installation.ts
+++ b/apps/cli/src/helpers/core/post-installation.ts
@@ -8,6 +8,7 @@ import type {
   Frontend,
   ORM,
   ProjectConfig,
+  DbSetupOptions,
   Runtime,
   ServerDeploy,
   WebDeploy,
@@ -63,6 +64,7 @@ export async function displayPostInstallInstructions(
     dbSetup,
     webDeploy,
     serverDeploy,
+    dbSetupOptions,
   } = config;
 
   const isConvex = backend === "convex";
@@ -92,6 +94,7 @@ export async function displayPostInstallInstructions(
           webDeploy,
           serverDeploy,
           backend,
+          dbSetupOptions,
         )
       : "";
 
@@ -375,6 +378,7 @@ async function getDatabaseInstructions(
   webDeploy: WebDeploy,
   serverDeploy: ServerDeploy,
   backend: Backend,
+  dbSetupOptions: DbSetupOptions | undefined,
 ) {
   const notes: string[] = [];
   const commands: Array<{ label: string; command: string }> = [];
@@ -386,6 +390,7 @@ async function getDatabaseInstructions(
     dbSetup,
     webDeploy,
     serverDeploy,
+    dbSetupOptions,
   });
 
   if (dbSetup === "docker") {

--- a/apps/cli/src/prompts/config-prompts.ts
+++ b/apps/cli/src/prompts/config-prompts.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_CONFIG } from "../constants";
+import { withDbSetupMode } from "../helpers/core/db-setup-options";
 import type {
   Addons,
   API,
@@ -62,7 +63,7 @@ export async function gatherConfig(
   projectName: string,
   projectDir: string,
   relativePath: string,
-  options: { skipCompatibilityChecks?: boolean } = {},
+  options: { skipCompatibilityChecks?: boolean; manualDb?: boolean } = {},
 ) {
   if (isSilent()) {
     return {
@@ -170,7 +171,7 @@ export async function gatherConfig(
         ),
       dbSetupMode: ({ results, previousAnswer }) =>
         getDbProvisioningChoice(
-          flags.dbSetupOptions?.mode,
+          flags.dbSetupOptions?.mode ?? (options.manualDb === true ? "manual" : undefined),
           results.dbSetup,
           results.backend,
           results.webDeploy,
@@ -204,10 +205,7 @@ export async function gatherConfig(
     projectDir: projectDir,
     relativePath: relativePath,
     addonOptions: flags.addonOptions,
-    dbSetupOptions:
-      result.dbSetupMode === undefined
-        ? flags.dbSetupOptions
-        : { ...flags.dbSetupOptions, mode: result.dbSetupMode },
+    dbSetupOptions: withDbSetupMode(flags.dbSetupOptions, result.dbSetupMode),
     frontend: result.frontend,
     backend: result.backend,
     runtime: result.runtime,

--- a/apps/cli/src/prompts/config-prompts.ts
+++ b/apps/cli/src/prompts/config-prompts.ts
@@ -6,6 +6,7 @@ import type {
   Backend,
   Database,
   DatabaseSetup,
+  DbSetupOptions,
   Examples,
   Frontend,
   ORM,
@@ -23,7 +24,7 @@ import { getApiChoice } from "./api";
 import { getAuthChoice } from "./auth";
 import { getBackendFrameworkChoice } from "./backend";
 import { getDatabaseChoice } from "./database";
-import { getDBSetupChoice } from "./database-setup";
+import { getDBSetupChoice, getDbProvisioningChoice } from "./database-setup";
 import { getExamplesChoice } from "./examples";
 import { getFrontendChoice } from "./frontend";
 import { getGitChoice } from "./git";
@@ -53,6 +54,7 @@ type PromptGroupResults = {
   install: boolean;
   webDeploy: WebDeploy;
   serverDeploy: ServerDeploy;
+  dbSetupMode: DbSetupOptions["mode"];
 };
 
 export async function gatherConfig(
@@ -166,6 +168,15 @@ export async function gatherConfig(
           results.webDeploy,
           previousAnswer,
         ),
+      dbSetupMode: ({ results, previousAnswer }) =>
+        getDbProvisioningChoice(
+          flags.dbSetupOptions?.mode,
+          results.dbSetup,
+          results.backend,
+          results.webDeploy,
+          results.serverDeploy,
+          previousAnswer,
+        ),
       git: ({ previousAnswer }) => getGitChoice(flags.git, previousAnswer),
       packageManager: ({ previousAnswer }) =>
         getPackageManagerChoice(flags.packageManager, previousAnswer),
@@ -179,7 +190,7 @@ export async function gatherConfig(
         { label: "Product", prompts: ["auth", "payments", "addons", "examples"] },
         {
           label: "Ship",
-          prompts: ["webDeploy", "serverDeploy", "git", "packageManager", "install"],
+          prompts: ["webDeploy", "serverDeploy", "dbSetupMode", "git", "packageManager", "install"],
         },
       ],
       onCancel: () => {
@@ -193,7 +204,10 @@ export async function gatherConfig(
     projectDir: projectDir,
     relativePath: relativePath,
     addonOptions: flags.addonOptions,
-    dbSetupOptions: flags.dbSetupOptions,
+    dbSetupOptions:
+      result.dbSetupMode === undefined
+        ? flags.dbSetupOptions
+        : { ...flags.dbSetupOptions, mode: result.dbSetupMode },
     frontend: result.frontend,
     backend: result.backend,
     runtime: result.runtime,

--- a/apps/cli/src/prompts/database-setup.ts
+++ b/apps/cli/src/prompts/database-setup.ts
@@ -123,7 +123,7 @@ export async function getDBSetupChoice(
 
 type DbSetupMode = NonNullable<DbSetupOptions["mode"]>;
 
-const PROVIDER_LABELS = {
+const providerLabels = {
   neon: "Neon",
   planetscale: "PlanetScale",
   "prisma-postgres": "Prisma Postgres",
@@ -152,7 +152,7 @@ export async function getDbProvisioningChoice(
 
   if (mode !== undefined) return mode;
 
-  const provider = PROVIDER_LABELS[dbSetup];
+  const provider = providerLabels[dbSetup];
   if (!provider) return undefined;
 
   const options: Array<{ value: DbSetupMode; label: string; hint: string }> = [

--- a/apps/cli/src/prompts/database-setup.ts
+++ b/apps/cli/src/prompts/database-setup.ts
@@ -1,4 +1,13 @@
-import type { Backend, DatabaseSetup, ORM, Runtime } from "../types";
+import {
+  supportsAlchemyManagedDatabase,
+  type Backend,
+  type DatabaseSetup,
+  type DbSetupOptions,
+  type ORM,
+  type Runtime,
+  type ServerDeploy,
+  type WebDeploy,
+} from "../types";
 import { UserCancelledError } from "../utils/errors";
 import { isCancel, navigableSelect, preferValidInitial } from "./navigable";
 
@@ -105,6 +114,73 @@ export async function getDBSetupChoice(
     message: `Choose a ${databaseType} setup`,
     options,
     initialValue: preferValidInitial(options, previousValue, "none"),
+  });
+
+  if (isCancel(response)) throw new UserCancelledError({ message: "Operation cancelled" });
+
+  return response;
+}
+
+type DbSetupMode = NonNullable<DbSetupOptions["mode"]>;
+
+const PROVIDER_LABELS = {
+  neon: "Neon",
+  planetscale: "PlanetScale",
+  "prisma-postgres": "Prisma Postgres",
+} as const satisfies Partial<Record<DatabaseSetup, string>>;
+
+export async function getDbProvisioningChoice(
+  mode: DbSetupMode | undefined,
+  dbSetup: DatabaseSetup | undefined,
+  backend: Backend | undefined,
+  webDeploy: WebDeploy | undefined,
+  serverDeploy: ServerDeploy | undefined,
+  previousValue?: DbSetupMode,
+): Promise<DbSetupMode | undefined | symbol> {
+  if (!dbSetup || !backend || !webDeploy || !serverDeploy) return mode;
+
+  const supportsAlchemy = supportsAlchemyManagedDatabase({
+    backend,
+    dbSetup,
+    webDeploy,
+    serverDeploy,
+  });
+
+  if (!supportsAlchemy) {
+    return mode === "alchemy" ? undefined : mode;
+  }
+
+  if (mode !== undefined) return mode;
+
+  const provider = PROVIDER_LABELS[dbSetup];
+  if (!provider) return undefined;
+
+  const options: Array<{ value: DbSetupMode; label: string; hint: string }> = [
+    {
+      value: "alchemy",
+      label: "Alchemy",
+      hint: `Provision ${provider} during deploy and inject its credentials`,
+    },
+    ...(dbSetup === "neon" || dbSetup === "prisma-postgres"
+      ? [
+          {
+            value: "auto" as const,
+            label: "Automatic",
+            hint: `Set up ${provider} now and write its connection credentials`,
+          },
+        ]
+      : []),
+    {
+      value: "manual",
+      label: "Manual",
+      hint: `Use an existing ${provider} database and configure credentials yourself`,
+    },
+  ];
+
+  const response = await navigableSelect<DbSetupMode>({
+    message: `How should ${provider} be provisioned?`,
+    options,
+    initialValue: preferValidInitial(options, previousValue, "alchemy"),
   });
 
   if (isCancel(response)) throw new UserCancelledError({ message: "Operation cancelled" });

--- a/apps/cli/src/utils/config-validation.ts
+++ b/apps/cli/src/utils/config-validation.ts
@@ -234,9 +234,13 @@ export function validateDatabaseSetup(
   return Result.ok(undefined);
 }
 
-export function validateAlchemyDatabaseProvisioning(
-  config: Partial<ProjectConfig>,
-): ValidationResult {
+export function validateDatabaseProvisioningMode(config: Partial<ProjectConfig>): ValidationResult {
+  if (config.dbSetup === "planetscale" && config.dbSetupOptions?.mode === "auto") {
+    return validationErr(
+      "PlanetScale does not support automatic database setup. Use dbSetupOptions.mode 'alchemy' or 'manual'.",
+    );
+  }
+
   if (config.dbSetupOptions?.mode !== "alchemy") return Result.ok(undefined);
 
   const { backend, dbSetup, webDeploy, serverDeploy } = config;
@@ -527,7 +531,7 @@ export function validateFullConfig(
   return Result.gen(function* () {
     yield* validateDatabaseOrmAuth(config, providedFlags);
     yield* validateDatabaseSetup(config, providedFlags);
-    yield* validateAlchemyDatabaseProvisioning(config);
+    yield* validateDatabaseProvisioningMode(config);
 
     yield* validateConvexConstraints(config, providedFlags);
     yield* validateBackendNoneConstraints(config, providedFlags);

--- a/apps/cli/src/utils/config-validation.ts
+++ b/apps/cli/src/utils/config-validation.ts
@@ -1,6 +1,13 @@
 import { Result } from "better-result";
 
-import type { CLIInput, Database, DatabaseSetup, ProjectConfig, Runtime } from "../types";
+import {
+  supportsAlchemyManagedDatabase,
+  type CLIInput,
+  type Database,
+  type DatabaseSetup,
+  type ProjectConfig,
+  type Runtime,
+} from "../types";
 import {
   CONVEX_BETTER_AUTH_INCOMPATIBLE_FRONTENDS,
   CONVEX_BETTER_AUTH_SUPPORTED_FRONTENDS,
@@ -222,6 +229,31 @@ export function validateDatabaseSetup(
         );
       }
     }
+  }
+
+  return Result.ok(undefined);
+}
+
+export function validateAlchemyDatabaseProvisioning(
+  config: Partial<ProjectConfig>,
+): ValidationResult {
+  if (config.dbSetupOptions?.mode !== "alchemy") return Result.ok(undefined);
+
+  const { backend, dbSetup, webDeploy, serverDeploy } = config;
+  if (!backend || !dbSetup || !webDeploy || !serverDeploy) return Result.ok(undefined);
+
+  if (
+    !supportsAlchemyManagedDatabase({
+      backend,
+      dbSetup,
+      webDeploy,
+      serverDeploy,
+      dbSetupOptions: config.dbSetupOptions,
+    })
+  ) {
+    return validationErr(
+      "Alchemy database provisioning requires Neon, PlanetScale, or Prisma Postgres and an Alchemy deployment target for the app that consumes the database.",
+    );
   }
 
   return Result.ok(undefined);
@@ -495,6 +527,7 @@ export function validateFullConfig(
   return Result.gen(function* () {
     yield* validateDatabaseOrmAuth(config, providedFlags);
     yield* validateDatabaseSetup(config, providedFlags);
+    yield* validateAlchemyDatabaseProvisioning(config);
 
     yield* validateConvexConstraints(config, providedFlags);
     yield* validateBackendNoneConstraints(config, providedFlags);

--- a/apps/cli/src/utils/display-config.ts
+++ b/apps/cli/src/utils/display-config.ts
@@ -84,6 +84,9 @@ const VALUE_LABELS = {
   docker: "Docker",
   cloudflare: "Cloudflare",
   vercel: "Vercel",
+  alchemy: "Alchemy",
+  auto: "Automatic",
+  manual: "Manual",
   npm: "npm",
   pnpm: "pnpm",
 } satisfies Record<string, string>;
@@ -137,6 +140,7 @@ export function getConfigSections(config: Partial<ProjectConfig>): ConfigDisplay
       ["Database", config.database],
       ["ORM", config.orm],
       ["Setup", config.dbSetup],
+      ["Provisioning", config.dbSetupOptions?.mode],
     ]),
     section("Product", [
       ["Auth", config.auth],

--- a/apps/cli/test/alchemy-providers.test.ts
+++ b/apps/cli/test/alchemy-providers.test.ts
@@ -112,10 +112,13 @@ describe("Alchemy providers", () => {
         runtime: "bun",
       });
       const infra = files.get("packages/infra/alchemy.run.ts") ?? "";
+      const prismaConfig = files.get("packages/db/prisma.config.ts") ?? "";
 
       expect(infra).toContain('export const server = Prisma.Compute("server"');
       expect(infra).toContain('DATABASE_URL: Config.redacted("DATABASE_URL")');
       expect(infra).not.toContain(combination.providerResource);
+      expect(prismaConfig).toContain("env('DATABASE_URL')");
+      expect(prismaConfig).not.toContain("process.env.DATABASE_URL!");
     }
   });
 

--- a/apps/cli/test/alchemy-providers.test.ts
+++ b/apps/cli/test/alchemy-providers.test.ts
@@ -74,6 +74,49 @@ describe("Alchemy providers", () => {
         serverDeploy: "vercel",
       }),
     ).toBe(false);
+    expect(
+      usesAlchemyManagedDatabase({
+        backend: "hono",
+        dbSetup: "neon",
+        webDeploy: "none",
+        serverDeploy: "prisma",
+        dbSetupOptions: { mode: "auto" },
+      }),
+    ).toBe(false);
+    expect(
+      usesAlchemyManagedDatabase({
+        backend: "hono",
+        dbSetup: "neon",
+        webDeploy: "none",
+        serverDeploy: "prisma",
+        dbSetupOptions: { mode: "alchemy" },
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps Alchemy compute while allowing externally provisioned databases", async () => {
+    const combinations = [
+      { dbSetup: "neon", mode: "auto", providerResource: "Neon.Project" },
+      { dbSetup: "planetscale", mode: "manual", providerResource: "Planetscale.PostgresDatabase" },
+      { dbSetup: "prisma-postgres", mode: "auto", providerResource: "Prisma.Postgres" },
+    ] as const;
+
+    for (const combination of combinations) {
+      const files = await generate({
+        projectName: `external-${combination.dbSetup}`,
+        dbSetup: combination.dbSetup,
+        dbSetupOptions: { mode: combination.mode },
+        webDeploy: "none",
+        serverDeploy: "prisma",
+        backend: "hono",
+        runtime: "bun",
+      });
+      const infra = files.get("packages/infra/alchemy.run.ts") ?? "";
+
+      expect(infra).toContain('export const server = Prisma.Compute("server"');
+      expect(infra).toContain('DATABASE_URL: Config.redacted("DATABASE_URL")');
+      expect(infra).not.toContain(combination.providerResource);
+    }
   });
 
   it("provisions Neon and applies checked-in Prisma migrations", async () => {

--- a/apps/cli/test/cli-ux.test.ts
+++ b/apps/cli/test/cli-ux.test.ts
@@ -157,6 +157,7 @@ describe("CLI flow presentation", () => {
       database: "postgres",
       orm: "drizzle",
       dbSetup: "neon",
+      dbSetupOptions: { mode: "alchemy" },
       auth: "better-auth",
       payments: "none",
       addons: ["turborepo", "mcp"],
@@ -189,6 +190,7 @@ describe("CLI flow presentation", () => {
           { label: "Database", value: "PostgreSQL" },
           { label: "ORM", value: "Drizzle" },
           { label: "Setup", value: "Neon" },
+          { label: "Provisioning", value: "Alchemy" },
         ],
       },
       {

--- a/apps/cli/test/cli-ux.test.ts
+++ b/apps/cli/test/cli-ux.test.ts
@@ -146,6 +146,69 @@ describe("CLI flow presentation", () => {
     expect(result.orm).toBe("drizzle");
   });
 
+  it("preserves the legacy manual database flag without opening a provisioning prompt", async () => {
+    const result = await runWithContextAsync({}, () =>
+      gatherConfig(
+        {
+          frontend: ["tanstack-router"],
+          backend: "hono",
+          runtime: "bun",
+          api: "trpc",
+          database: "postgres",
+          orm: "drizzle",
+          dbSetup: "neon",
+          auth: "none",
+          payments: "none",
+          addons: ["none"],
+          examples: ["none"],
+          webDeploy: "none",
+          serverDeploy: "prisma",
+          git: false,
+          packageManager: "bun",
+          install: false,
+        },
+        "manual-db-app",
+        "/tmp/manual-db-app",
+        "manual-db-app",
+        { skipCompatibilityChecks: true, manualDb: true },
+      ),
+    );
+
+    expect(result.dbSetupOptions).toEqual({ mode: "manual" });
+  });
+
+  it("clears a stale Alchemy mode after deployment navigation", async () => {
+    const result = await runWithContextAsync({}, () =>
+      gatherConfig(
+        {
+          frontend: ["tanstack-router"],
+          backend: "hono",
+          runtime: "bun",
+          api: "trpc",
+          database: "postgres",
+          orm: "drizzle",
+          dbSetup: "neon",
+          dbSetupOptions: { mode: "alchemy", neon: { method: "neon-new" } },
+          auth: "none",
+          payments: "none",
+          addons: ["none"],
+          examples: ["none"],
+          webDeploy: "prisma",
+          serverDeploy: "vercel",
+          git: false,
+          packageManager: "bun",
+          install: false,
+        },
+        "external-db-app",
+        "/tmp/external-db-app",
+        "external-db-app",
+        { skipCompatibilityChecks: true },
+      ),
+    );
+
+    expect(result.dbSetupOptions).toEqual({ neon: { method: "neon-new" } });
+  });
+
   it("groups the selected stack and uses product-facing labels", () => {
     const config = {
       projectName: "acme-app",

--- a/apps/cli/test/cli-validation.test.ts
+++ b/apps/cli/test/cli-validation.test.ts
@@ -93,3 +93,31 @@ test("still rejects D1 when the remaining prompt flow cannot resolve it to a val
     );
   }
 });
+
+test("rejects Alchemy database provisioning without a matching deployment", () => {
+  const options = {
+    backend: "hono",
+    frontend: ["tanstack-router"],
+    database: "postgres",
+    orm: "drizzle",
+    dbSetup: "neon",
+    dbSetupOptions: { mode: "alchemy" },
+    api: "trpc",
+    auth: "none",
+    payments: "none",
+    addons: ["none"],
+    examples: ["none"],
+    runtime: "bun",
+    webDeploy: "none",
+    serverDeploy: "vercel",
+  } as const;
+
+  const result = processAndValidateFlags(options, getProvidedFlags(options), "my-app");
+
+  expect(result.isErr()).toBe(true);
+  if (result.isErr()) {
+    expect(result.error.message).toContain(
+      "Alchemy database provisioning requires Neon, PlanetScale, or Prisma Postgres",
+    );
+  }
+});

--- a/apps/cli/test/cli-validation.test.ts
+++ b/apps/cli/test/cli-validation.test.ts
@@ -121,3 +121,30 @@ test("rejects Alchemy database provisioning without a matching deployment", () =
     );
   }
 });
+
+test("rejects automatic PlanetScale provisioning with an actionable alternative", () => {
+  const options = {
+    backend: "hono",
+    frontend: ["tanstack-router"],
+    database: "postgres",
+    orm: "drizzle",
+    dbSetup: "planetscale",
+    dbSetupOptions: { mode: "auto" },
+    api: "trpc",
+    auth: "none",
+    payments: "none",
+    addons: ["none"],
+    examples: ["none"],
+    runtime: "bun",
+    webDeploy: "none",
+    serverDeploy: "prisma",
+  } as const;
+
+  const result = processAndValidateFlags(options, getProvidedFlags(options), "my-app");
+
+  expect(result.isErr()).toBe(true);
+  if (result.isErr()) {
+    expect(result.error.message).toContain("PlanetScale does not support automatic database setup");
+    expect(result.error.message).toContain("'alchemy' or 'manual'");
+  }
+});

--- a/apps/cli/test/db-setup-mode-resolution.test.ts
+++ b/apps/cli/test/db-setup-mode-resolution.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "bun:test";
 import {
   mergeResolvedDbSetupOptions,
   resolveDbSetupMode,
+  resolveProjectDbSetupOptions,
 } from "../src/helpers/core/db-setup-options";
 import { runWithContext } from "../src/utils/context";
 
@@ -27,5 +28,45 @@ describe("DB setup mode resolution", () => {
     );
 
     expect(merged).toBeUndefined();
+  });
+
+  it("defaults to Alchemy when the database consumer deploys with Alchemy", () => {
+    const options = runWithContext({ silent: true }, () =>
+      resolveProjectDbSetupOptions({
+        backend: "hono",
+        dbSetup: "neon",
+        webDeploy: "none",
+        serverDeploy: "prisma",
+      }),
+    );
+
+    expect(options).toEqual({ mode: "alchemy" });
+  });
+
+  it("preserves automatic and manual setup with an Alchemy deployment", () => {
+    const config = {
+      backend: "hono" as const,
+      dbSetup: "neon" as const,
+      webDeploy: "none" as const,
+      serverDeploy: "prisma" as const,
+    };
+
+    expect(resolveProjectDbSetupOptions({ ...config, dbSetupOptions: { mode: "auto" } })).toEqual({
+      mode: "auto",
+    });
+    expect(resolveProjectDbSetupOptions(config, { manualDb: true })).toEqual({ mode: "manual" });
+  });
+
+  it("does not let an unrelated Alchemy web deployment own a split backend database", () => {
+    const options = runWithContext({ silent: true }, () =>
+      resolveProjectDbSetupOptions({
+        backend: "hono",
+        dbSetup: "neon",
+        webDeploy: "prisma",
+        serverDeploy: "vercel",
+      }),
+    );
+
+    expect(options).toEqual({ mode: "manual" });
   });
 });

--- a/apps/cli/test/db-setup-mode-resolution.test.ts
+++ b/apps/cli/test/db-setup-mode-resolution.test.ts
@@ -4,7 +4,9 @@ import {
   mergeResolvedDbSetupOptions,
   resolveDbSetupMode,
   resolveProjectDbSetupOptions,
+  withDbSetupMode,
 } from "../src/helpers/core/db-setup-options";
+import { getDbProvisioningChoice } from "../src/prompts/database-setup";
 import { runWithContext } from "../src/utils/context";
 
 describe("DB setup mode resolution", () => {
@@ -68,5 +70,14 @@ describe("DB setup mode resolution", () => {
     );
 
     expect(options).toEqual({ mode: "manual" });
+  });
+
+  it("removes a stale Alchemy mode while preserving provider options", async () => {
+    const mode = await getDbProvisioningChoice("alchemy", "neon", "hono", "prisma", "vercel");
+
+    expect(mode).toBeUndefined();
+    expect(withDbSetupMode({ mode: "alchemy", neon: { method: "neon-new" } }, mode)).toEqual({
+      neon: { method: "neon-new" },
+    });
   });
 });

--- a/apps/cli/test/db-setup-options.test.ts
+++ b/apps/cli/test/db-setup-options.test.ts
@@ -78,6 +78,7 @@ describe("Database setup options", () => {
     if (result.isErr()) return;
 
     expect(result.value.reproducibleCommand).toContain("--db-setup neon");
+    expect(result.value.reproducibleCommand).toContain(`--db-setup-options '{"mode":"auto"}'`);
     expect(result.value.reproducibleCommand).not.toContain("create-json --input");
     expect(result.value.reproducibleCommand).not.toContain("--manual-db");
   });
@@ -115,6 +116,7 @@ describe("Database setup options", () => {
     if (result.isErr()) return;
 
     expect(result.value.reproducibleCommand).toContain("--db-setup neon");
+    expect(result.value.reproducibleCommand).toContain(`--db-setup-options '{"mode":"auto"}'`);
     expect(result.value.reproducibleCommand).not.toContain("create-json --input");
   });
 

--- a/apps/cli/test/input-schemas.test.ts
+++ b/apps/cli/test/input-schemas.test.ts
@@ -9,6 +9,15 @@ import {
 import { getSchemaResult, SchemaNameSchema } from "../src/index";
 
 describe("Input schemas", () => {
+  it("accepts Alchemy as a database setup mode", () => {
+    const result = CreateInputSchema.safeParse({
+      projectName: "app",
+      dbSetupOptions: { mode: "alchemy" },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
   it("rejects conflicting manualDb and dbSetupOptions.mode inputs", () => {
     const result = CreateInputSchema.safeParse({
       projectName: "app",

--- a/apps/cli/test/post-installation.test.ts
+++ b/apps/cli/test/post-installation.test.ts
@@ -125,4 +125,30 @@ describe("post-install instructions", () => {
       expect(nextSteps).not.toContain("db:migrate:local");
     });
   }
+
+  it("shows external database steps when Alchemy deploys compute only", async () => {
+    const stdout = spyOn(process.stdout, "write").mockImplementation(() => true);
+    spyOn(globalThis, "fetch").mockRejectedValue(new Error("offline in test"));
+
+    await displayPostInstallInstructions({
+      ...baseConfig,
+      projectName: "external-neon",
+      database: "postgres",
+      backend: "hono",
+      runtime: "bun",
+      frontend: ["tanstack-router"],
+      orm: "prisma",
+      dbSetup: "neon",
+      dbSetupOptions: { mode: "manual" },
+      webDeploy: "none",
+      serverDeploy: "prisma",
+      depsInstalled: false,
+    });
+
+    const output = stdout.mock.calls.map(([chunk]) => String(chunk)).join("");
+
+    expect(output).not.toContain("Alchemy provisions Neon");
+    expect(output).toContain("bun run db:push");
+    expect(output).toContain("bun run db:studio");
+  });
 });

--- a/apps/cli/test/programmatic-api.test.ts
+++ b/apps/cli/test/programmatic-api.test.ts
@@ -151,6 +151,65 @@ describe("programmatic API input validation", () => {
     expect(result.error.message).toContain("runtime");
   });
 
+  it("rejects unsupported database modes through create without writing files", async () => {
+    const projectDir = join(SMOKE_DIR, "invalid-planetscale-auto");
+    await fs.remove(projectDir);
+
+    const result = await create(projectDir, {
+      frontend: ["tanstack-router"],
+      backend: "hono",
+      runtime: "bun",
+      database: "postgres",
+      orm: "drizzle",
+      dbSetup: "planetscale",
+      dbSetupOptions: { mode: "auto" },
+      api: "trpc",
+      auth: "none",
+      payments: "none",
+      addons: ["none"],
+      examples: ["none"],
+      webDeploy: "none",
+      serverDeploy: "prisma",
+      git: false,
+      install: false,
+      disableAnalytics: true,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) throw new Error("Expected create() to reject PlanetScale automatic setup");
+    expect(CLIError.is(result.error)).toBe(true);
+    expect(ValidationError.is(result.error.cause)).toBe(true);
+    expect(result.error.message).toContain("PlanetScale does not support automatic database setup");
+    expect(await fs.pathExists(projectDir)).toBe(false);
+  });
+
+  it("rejects unsupported database modes through createVirtual", async () => {
+    const result = await createVirtual({
+      projectName: "invalid-planetscale-auto-virtual",
+      frontend: ["tanstack-router"],
+      backend: "hono",
+      runtime: "bun",
+      database: "postgres",
+      orm: "drizzle",
+      dbSetup: "planetscale",
+      dbSetupOptions: { mode: "auto" },
+      api: "trpc",
+      auth: "none",
+      payments: "none",
+      addons: ["none"],
+      examples: ["none"],
+      webDeploy: "none",
+      serverDeploy: "prisma",
+      git: false,
+      packageManager: "bun",
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) throw new Error("Expected createVirtual() to reject PlanetScale auto setup");
+    expect(result.error.phase).toBe("validation");
+    expect(result.error.message).toContain("PlanetScale does not support automatic database setup");
+  });
+
   it("returns a structured failure instead of throwing for an invalid add input shape", async () => {
     const projectDir = join(SMOKE_DIR, "programmatic-add-invalid-input");
     const createResult = await create(projectDir, {

--- a/apps/web/content/docs/cli/agent-workflows.mdx
+++ b/apps/web/content/docs/cli/agent-workflows.mdx
@@ -260,6 +260,12 @@ Structured addon options are still persisted in `bts.jsonc`, but the printed rep
 
 `dbSetupOptions` controls how database provisioning behaves in automation.
 
+The supported modes are:
+
+- `alchemy`: provision the selected provider through Alchemy
+- `auto`: use the provider's automatic setup flow
+- `manual`: use an existing database and configure its credentials yourself
+
 Example:
 
 ```bash
@@ -280,7 +286,9 @@ create-better-t-stack create-json --input '{
 
 Current behavior:
 
-- Providers with automatic cloud provisioning default to `manual` in silent/agent flows:
+- When the database-consuming application deploys through Alchemy and the selected setup is Neon, PlanetScale, or Prisma Postgres, provisioning defaults to `alchemy`.
+
+- Otherwise, providers with automatic cloud provisioning default to `manual` in silent/agent flows:
   - `turso`
   - `neon`
   - `prisma-postgres`

--- a/apps/web/content/docs/cli/options.mdx
+++ b/apps/web/content/docs/cli/options.mdx
@@ -359,7 +359,7 @@ Web deployment configuration:
 create-better-t-stack --web-deploy docker
 ```
 
-When the app that consumes Neon, PlanetScale, or Prisma Postgres is deployed with Alchemy, the generated stack provisions the database, injects runtime credentials, and applies checked-in migrations. Run `alchemy login --configure` from `packages/infra`; no separate provider setup step is required. See the [Alchemy deployment guide](/docs/guides/cloudflare-alchemy) for details.
+When the app that consumes Neon, PlanetScale, or Prisma Postgres is deployed with Alchemy, the CLI asks how the database should be provisioned and defaults to Alchemy. You can instead choose the provider's automatic setup when available or configure an existing database manually. With Alchemy selected, the generated stack provisions the database, injects runtime credentials, and applies checked-in migrations. Run `alchemy login --configure` from `packages/infra`; no separate provider setup step is required. See the [Alchemy deployment guide](/docs/guides/cloudflare-alchemy) for details.
 
 ## Automation Surfaces
 

--- a/packages/template-generator/src/core/template-processor.ts
+++ b/packages/template-generator/src/core/template-processor.ts
@@ -8,8 +8,10 @@ Handlebars.registerHelper("and", (...args) => args.slice(0, -1).every(Boolean));
 Handlebars.registerHelper("or", (...args) => args.slice(0, -1).some(Boolean));
 Handlebars.registerHelper("not", (a) => !a);
 Handlebars.registerHelper("includes", (arr, val) => Array.isArray(arr) && arr.includes(val));
-Handlebars.registerHelper("usesAlchemyDatabase", (backend, dbSetup, webDeploy, serverDeploy) =>
-  usesAlchemyManagedDatabase({ backend, dbSetup, webDeploy, serverDeploy }),
+Handlebars.registerHelper(
+  "usesAlchemyDatabase",
+  (backend, dbSetup, webDeploy, serverDeploy, dbSetupOptions) =>
+    usesAlchemyManagedDatabase({ backend, dbSetup, webDeploy, serverDeploy, dbSetupOptions }),
 );
 Handlebars.registerHelper(
   "usesRequestScopedCloudflareEnv",

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -15842,7 +15842,7 @@ export default defineConfig({
     path: path.join("prisma", "migrations"),
   },
   datasource: {
-    url: {{#if (usesAlchemyDatabase backend dbSetup webDeploy serverDeploy)}}process.env.DATABASE_URL!{{else}}env("DATABASE_URL"){{/if}},
+    url: {{#if (usesAlchemyDatabase backend dbSetup webDeploy serverDeploy dbSetupOptions)}}process.env.DATABASE_URL!{{else}}env("DATABASE_URL"){{/if}},
   },
 });
 `],
@@ -16037,7 +16037,7 @@ export default defineConfig({
     path: path.join("prisma", "migrations"),
     },
     datasource: {
-        url: {{#if (usesAlchemyDatabase backend dbSetup webDeploy serverDeploy)}}process.env.DATABASE_URL!{{else}}env('DATABASE_URL'){{/if}},
+        url: {{#if (usesAlchemyDatabase backend dbSetup webDeploy serverDeploy dbSetupOptions)}}process.env.DATABASE_URL!{{else}}env('DATABASE_URL'){{/if}},
     },
 })
 `],

--- a/packages/template-generator/src/utils/reproducible-command.ts
+++ b/packages/template-generator/src/utils/reproducible-command.ts
@@ -49,6 +49,8 @@ export function generateReproducibleCommand(config: ProjectConfig): string {
   flags.push(`--db-setup ${config.dbSetup}`);
   if (config.dbSetupOptions?.mode === "manual") {
     flags.push("--manual-db");
+  } else if (config.dbSetupOptions?.mode === "auto") {
+    flags.push(`--db-setup-options '${JSON.stringify({ mode: "auto" })}'`);
   }
   flags.push(`--web-deploy ${config.webDeploy}`);
   flags.push(`--server-deploy ${config.serverDeploy}`);

--- a/packages/template-generator/templates/db/prisma/mysql/prisma.config.ts.hbs
+++ b/packages/template-generator/templates/db/prisma/mysql/prisma.config.ts.hbs
@@ -16,6 +16,6 @@ export default defineConfig({
     path: path.join("prisma", "migrations"),
   },
   datasource: {
-    url: {{#if (usesAlchemyDatabase backend dbSetup webDeploy serverDeploy)}}process.env.DATABASE_URL!{{else}}env("DATABASE_URL"){{/if}},
+    url: {{#if (usesAlchemyDatabase backend dbSetup webDeploy serverDeploy dbSetupOptions)}}process.env.DATABASE_URL!{{else}}env("DATABASE_URL"){{/if}},
   },
 });

--- a/packages/template-generator/templates/db/prisma/postgres/prisma.config.ts.hbs
+++ b/packages/template-generator/templates/db/prisma/postgres/prisma.config.ts.hbs
@@ -16,6 +16,6 @@ export default defineConfig({
     path: path.join("prisma", "migrations"),
     },
     datasource: {
-        url: {{#if (usesAlchemyDatabase backend dbSetup webDeploy serverDeploy)}}process.env.DATABASE_URL!{{else}}env('DATABASE_URL'){{/if}},
+        url: {{#if (usesAlchemyDatabase backend dbSetup webDeploy serverDeploy dbSetupOptions)}}process.env.DATABASE_URL!{{else}}env('DATABASE_URL'){{/if}},
     },
 })

--- a/packages/types/src/deployment.ts
+++ b/packages/types/src/deployment.ts
@@ -1,11 +1,4 @@
-import type {
-  Backend,
-  DatabaseSetup,
-  Frontend,
-  ProjectConfig,
-  ServerDeploy,
-  WebDeploy,
-} from "./types";
+import type { DatabaseSetup, Frontend, ProjectConfig, ServerDeploy, WebDeploy } from "./types";
 
 export const ALCHEMY_DEPLOY_TARGETS = ["cloudflare", "prisma"] as const;
 
@@ -35,17 +28,24 @@ export function isAlchemyDatabaseSetup(
   return ALCHEMY_DATABASE_SETUPS.some((value) => value === setup);
 }
 
-export function usesAlchemyManagedDatabase(config: {
-  backend: Backend;
-  dbSetup: DatabaseSetup;
-  webDeploy: WebDeploy;
-  serverDeploy: ServerDeploy;
-}): boolean {
+type AlchemyDatabaseConfig = Pick<
+  ProjectConfig,
+  "backend" | "dbSetup" | "dbSetupOptions" | "webDeploy" | "serverDeploy"
+>;
+
+export function supportsAlchemyManagedDatabase(config: AlchemyDatabaseConfig): boolean {
   if (!isAlchemyDatabaseSetup(config.dbSetup)) return false;
 
   return config.backend === "self"
     ? isAlchemyDeployTarget(config.webDeploy)
     : isAlchemyDeployTarget(config.serverDeploy);
+}
+
+export function usesAlchemyManagedDatabase(config: AlchemyDatabaseConfig): boolean {
+  if (!supportsAlchemyManagedDatabase(config)) return false;
+
+  const mode = config.dbSetupOptions?.mode;
+  return mode === undefined || mode === "alchemy";
 }
 
 export function getLocalD1Owner(

--- a/packages/types/src/schemas.ts
+++ b/packages/types/src/schemas.ts
@@ -367,7 +367,9 @@ export const UltraciteHookSchema = z
   .enum(["cursor", "windsurf", "codebuddy", "claude", "copilot"])
   .describe("Ultracite hook integration");
 
-export const DbSetupModeSchema = z.enum(["manual", "auto"]).describe("Database setup mode");
+export const DbSetupModeSchema = z
+  .enum(["manual", "auto", "alchemy"])
+  .describe("Database setup mode");
 
 export const NeonSetupMethodSchema = z
   .enum(["neon-new", "neon", "neondb", "neonctl"])


### PR DESCRIPTION
## Summary

- ask how Neon, PlanetScale, or Prisma Postgres should be provisioned when the database-consuming app deploys through Alchemy
- default to Alchemy while preserving automatic and manual database setup
- keep Alchemy compute deployment independent from database provisioning
- persist and display the selected provisioning mode

Neon and Prisma Postgres offer Alchemy, automatic, and manual setup. PlanetScale offers Alchemy or manual setup because it does not currently have a separate automatic provider flow.

## Why

Choosing an Alchemy deployment previously caused the CLI to silently provision the selected database through Alchemy. Users could not explicitly mix Alchemy compute with an externally provisioned database.

## Testing

- `bun run check`
- `bun run build:cli`
- `cd apps/cli && bun test` — 661 passed, 29 skipped
- interactive dry runs for the default Alchemy and explicit automatic flows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Alchemy as a database provisioning option alongside automatic and manual setup.
  - CLI prompts recommend compatible modes based on deployment and database configuration.
  - Configuration output displays the selected provisioning mode.
  - Reproducible commands preserve automatic database setup options.

- **Bug Fixes**
  - Prevented unsupported provisioning combinations, including automatic PlanetScale setup.
  - Improved handling of explicit, previously selected, and stale provisioning choices.

- **Documentation**
  - Updated CLI guidance for provisioning defaults and supported deployment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->