### PR TITLE
fix(cli): serve Solid assets on Cloudflare

### DIFF
--- a/apps/cli/src/helpers/core/post-installation.ts
+++ b/apps/cli/src/helpers/core/post-installation.ts
@@ -726,7 +726,7 @@ function getAlchemyDeployInstructions(
 
     if (!isBackendSelf && hasAlchemyServer && hasWeb) {
       originSteps.push(
-        `${pc.cyan("•")} After the first deploy, set CORS_ORIGIN in apps/server/.env to the deployed web origin, then deploy again`,
+        `${pc.cyan("•")} Required after the first deploy: set CORS_ORIGIN in apps/server/.env to the deployed web origin, then deploy again`,
       );
     }
 

--- a/apps/cli/test/deployment.test.ts
+++ b/apps/cli/test/deployment.test.ts
@@ -1408,7 +1408,7 @@ describe("Deployment Configurations", () => {
       expect(infraFile).toContain('export const web = Cloudflare.Website.Vite("web", {');
       expect(infraFile).toContain('rootDir: "../../apps/web"');
       expect(infraFile).toContain('flags: ["nodejs_compat"]');
-      expect(infraFile).toContain("runWorkerFirst: true");
+      expect(infraFile).not.toContain("runWorkerFirst");
       expect(infraFile).toContain("DB: db");
       expect(webPkg.devDependencies.alchemy).toBeUndefined();
       expect(webPkg.devDependencies["@cloudflare/vite-plugin"]).toBeUndefined();

--- a/apps/cli/test/generated-builds.test.ts
+++ b/apps/cli/test/generated-builds.test.ts
@@ -733,7 +733,7 @@ async function validateSolidScaffold(sample: SelectedBuildSample, projectDir: st
     expect(viteConfig).toContain('external: ["cloudflare:workers"]');
     const infra = await fs.readFile(path.join(projectDir, "packages/infra/alchemy.run.ts"), "utf8");
     expect(infra).toContain('flags: ["nodejs_compat"]');
-    expect(infra).toContain("runWorkerFirst: true");
+    expect(infra).not.toContain("runWorkerFirst");
   }
 
   if (sample.config.webDeploy === "docker") {

--- a/apps/cli/test/post-installation.test.ts
+++ b/apps/cli/test/post-installation.test.ts
@@ -173,7 +173,7 @@ describe("post-install instructions", () => {
 
     const output = stdout.mock.calls.map(([chunk]) => String(chunk)).join("");
 
-    expect(output).toContain("CORS_ORIGIN in apps/server/.env");
+    expect(output).toContain("Required after the first deploy: set CORS_ORIGIN");
     expect(output).toContain("BETTER_AUTH_URL in apps/server/.env");
   });
 

--- a/apps/cli/test/readme.test.ts
+++ b/apps/cli/test/readme.test.ts
@@ -109,7 +109,7 @@ describe("README generation", () => {
     });
 
     expect(readme).toContain(
-      "set `CORS_ORIGIN` in `apps/server/.env` to the exact deployed web origin",
+      "Required after the first deploy: set `CORS_ORIGIN` in `apps/server/.env`",
     );
     expect(readme).toContain(
       "set `BETTER_AUTH_URL` in `apps/server/.env` to the returned server URL",

--- a/packages/template-generator/src/generators/alchemy/web.ts
+++ b/packages/template-generator/src/generators/alchemy/web.ts
@@ -136,16 +136,7 @@ function writeVite(
           "},",
         );
       }
-      if (framework === "solid") {
-        writeObject(
-          writer,
-          "assets: {",
-          () => {
-            writer.writeLine("runWorkerFirst: true,");
-          },
-          "},",
-        );
-      } else if (framework === "tanstack-router") {
+      if (framework === "tanstack-router") {
         writeObject(
           writer,
           "assets: {",

--- a/packages/template-generator/src/processors/readme-generator.ts
+++ b/packages/template-generator/src/processors/readme-generator.ts
@@ -913,7 +913,7 @@ function generateDeploymentCommands(
     }
     if (needsCorsOrigin) {
       lines.push(
-        "- After the first deploy, set `CORS_ORIGIN` in `apps/server/.env` to the exact deployed web origin, such as `https://app.example.com`, then deploy the server again.",
+        "- Required after the first deploy: set `CORS_ORIGIN` in `apps/server/.env` to the exact deployed web origin, such as `https://app.example.com`, then deploy the server again.",
       );
     }
     if (prismaAuthTarget) {


### PR DESCRIPTION
## Summary

- serve Solid 2 client assets before falling through to SSR on Cloudflare
- add regression coverage for the generated Alchemy configuration
- make the required split-deployment CORS follow-up explicit

## Root cause

The Solid 2 template inherited `runWorkerFirst` from a SolidStart example. That routed CSS and JavaScript requests through the Solid SSR worker, which returned HTML/404 responses instead of the uploaded assets.

## Verification

- `bun run check`
- full CLI suite: 675 passed
- generated Solid 2 + Cloudflare project: install, build, and typecheck passed
- live Cloudflare deployment: browser rendered with Tailwind, CSS/JS returned 200, and CORS/RPC/auth/D1 routes passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Alchemy deployment instructions to clarify that `CORS_ORIGIN` must be configured after the first deploy when using separate frontend and backend servers.

* **Bug Fixes**
  * Corrected generated Solid deployment configuration by removing unnecessary SPA asset handling settings.
  * Updated generated README guidance and deployment validation to reflect the corrected configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


