### PR TITLE
feat(cli): add Foldkit as a web frontend option

### DIFF
--- a/apps/cli/src/prompts/backend.ts
+++ b/apps/cli/src/prompts/backend.ts
@@ -20,7 +20,9 @@ export async function getBackendFrameworkChoice(
 ) {
   if (backendFramework !== undefined) return backendFramework;
 
-  const hasIncompatibleFrontend = frontends?.some((f) => f === "solid" || f === "astro");
+  const hasIncompatibleFrontend = frontends?.some(
+    (f) => f === "solid" || f === "astro" || f === "foldkit",
+  );
   const hasFullstackFrontend = frontends?.some((f) => FULLSTACK_FRONTENDS.includes(f));
 
   const backendOptions: Array<{

--- a/apps/cli/src/prompts/frontend.ts
+++ b/apps/cli/src/prompts/frontend.ts
@@ -21,6 +21,7 @@ const WEB_FRONTEND_VALUES: readonly Frontend[] = [
   "svelte",
   "solid",
   "astro",
+  "foldkit",
   "tanstack-start",
 ];
 
@@ -102,6 +103,11 @@ export async function getFrontendChoice(
           value: "astro" as const,
           label: "Astro",
           hint: "The web framework for content-driven websites",
+        },
+        {
+          value: "foldkit" as const,
+          label: "Foldkit",
+          hint: "Effect-powered TypeScript framework architected like Elm",
         },
         {
           value: "tanstack-start" as const,

--- a/apps/cli/src/prompts/payments.ts
+++ b/apps/cli/src/prompts/payments.ts
@@ -7,7 +7,7 @@ export async function getPaymentsChoice(
   payments?: Payments,
   auth?: Auth,
   backend?: Backend,
-  _frontends?: Frontend[],
+  frontends?: Frontend[],
   previousValue?: Payments,
 ) {
   if (payments !== undefined) return payments;
@@ -16,7 +16,7 @@ export async function getPaymentsChoice(
     return "none" as Payments;
   }
 
-  const isPolarCompatible = auth === "better-auth";
+  const isPolarCompatible = auth === "better-auth" && !frontends?.includes("foldkit");
 
   if (!isPolarCompatible) {
     return "none" as Payments;

--- a/apps/cli/src/prompts/web-deploy.ts
+++ b/apps/cli/src/prompts/web-deploy.ts
@@ -11,6 +11,7 @@ import type {
 } from "../types";
 import { WEB_FRAMEWORKS } from "../utils/compatibility";
 import {
+  supportsCloudflareWebDeploy,
   supportsPrismaWebDeploy,
   validateCloudflareWebDeployKnownIssues,
 } from "../utils/compatibility-rules";
@@ -84,13 +85,15 @@ export async function getDeploymentChoice(
   }
 
   const supportsPrismaCompute = supportsPrismaWebDeploy(frontend);
-  const supportsCloudflare = validateCloudflareWebDeployKnownIssues({
-    webDeploy: "cloudflare",
-    frontend,
-    dbSetup,
-    database,
-    orm,
-  }).isOk();
+  const supportsCloudflare =
+    supportsCloudflareWebDeploy(frontend) &&
+    validateCloudflareWebDeployKnownIssues({
+      webDeploy: "cloudflare",
+      frontend,
+      dbSetup,
+      database,
+      orm,
+    }).isOk();
   const availableDeployments = [
     ...(supportsCloudflare ? (["cloudflare"] as const) : []),
     ...(supportsPrismaCompute ? (["prisma"] as const) : []),
@@ -131,7 +134,7 @@ export async function getDeploymentToAdd(frontend: Frontend[], existingDeploymen
 
   const supportsPrismaCompute = supportsPrismaWebDeploy(frontend);
   const deployments = [
-    "cloudflare",
+    ...(supportsCloudflareWebDeploy(frontend) ? (["cloudflare"] as const) : []),
     ...(supportsPrismaCompute ? (["prisma"] as const) : []),
     "docker",
     "vercel",

--- a/apps/cli/src/utils/compatibility-rules.ts
+++ b/apps/cli/src/utils/compatibility-rules.ts
@@ -205,17 +205,25 @@ export function validateWorkersCompatibility(
   return Result.ok(undefined);
 }
 
+// Frontends whose web client templates exist for oRPC only.
+const TRPC_UNSUPPORTED_FRONTENDS: readonly Frontend[] = [
+  "nuxt",
+  "svelte",
+  "solid",
+  "astro",
+  "foldkit",
+];
+
 export function validateApiFrontendCompatibility(
   api: API | undefined,
   frontends: Frontend[] = [],
 ): ValidationResult {
-  const includesNuxt = frontends.includes("nuxt");
-  const includesSvelte = frontends.includes("svelte");
-  const includesSolid = frontends.includes("solid");
-  const includesAstro = frontends.includes("astro");
-  if ((includesNuxt || includesSvelte || includesSolid || includesAstro) && api === "trpc") {
+  if (api !== "trpc") return Result.ok(undefined);
+
+  const unsupported = frontends.find((frontend) => TRPC_UNSUPPORTED_FRONTENDS.includes(frontend));
+  if (unsupported) {
     return validationErr(
-      `tRPC API is not supported with '${includesNuxt ? "nuxt" : includesSvelte ? "svelte" : includesSolid ? "solid" : "astro"}' frontend. Please use --api orpc or --api none or remove '${includesNuxt ? "nuxt" : includesSvelte ? "svelte" : includesSolid ? "solid" : "astro"}' from --frontend.`,
+      `tRPC API is not supported with '${unsupported}' frontend. Please use --api orpc or --api none or remove '${unsupported}' from --frontend.`,
     );
   }
   return Result.ok(undefined);
@@ -236,11 +244,11 @@ export function isFrontendAllowedWithBackend(
       return false;
     }
 
-    if (frontend === "solid" || frontend === "astro") return false;
+    if (frontend === "solid" || frontend === "astro" || frontend === "foldkit") return false;
   }
 
   if (auth === "clerk") {
-    const incompatibleFrontends = ["nuxt", "svelte", "solid", "astro"];
+    const incompatibleFrontends = ["nuxt", "svelte", "solid", "astro", "foldkit"];
     if (incompatibleFrontends.includes(frontend)) return false;
   }
 
@@ -256,12 +264,8 @@ export function supportsConvexBetterAuth(frontends: readonly Frontend[] = []) {
 }
 
 export function allowedApisForFrontends(frontends: Frontend[] = []) {
-  const includesNuxt = frontends.includes("nuxt");
-  const includesSvelte = frontends.includes("svelte");
-  const includesSolid = frontends.includes("solid");
-  const includesAstro = frontends.includes("astro");
   const base: API[] = ["trpc", "orpc", "none"];
-  if (includesNuxt || includesSvelte || includesSolid || includesAstro) {
+  if (frontends.some((frontend) => TRPC_UNSUPPORTED_FRONTENDS.includes(frontend))) {
     return ["orpc", "none"];
   }
   return base;
@@ -284,7 +288,8 @@ export function isExampleAIAllowed(backend?: ProjectConfig["backend"], frontends
 
   const includesSolid = frontends.includes("solid");
   const includesAstro = frontends.includes("astro");
-  if (includesSolid || includesAstro) return false;
+  const includesFoldkit = frontends.includes("foldkit");
+  if (includesSolid || includesAstro || includesFoldkit) return false;
 
   // Convex AI example only supports React-based frontends (not Svelte or Nuxt)
   if (backend === "convex") {
@@ -409,6 +414,31 @@ export function validatePrismaWebDeploy(
   if (!supportsPrismaWebDeploy(frontend)) {
     return validationErr(
       "'--web-deploy prisma' requires a supported server frontend. Choose Next.js, Nuxt, Astro, React Router, TanStack Start, SvelteKit, or Solid. TanStack Router is a static SPA, while Prisma Compute requires an executable server artifact.",
+    );
+  }
+
+  return Result.ok(undefined);
+}
+
+// Frontends the Alchemy generator has no Cloudflare Workers recipe for.
+const CLOUDFLARE_WEB_DEPLOY_UNSUPPORTED_FRONTENDS: readonly Frontend[] = ["foldkit"];
+
+export function supportsCloudflareWebDeploy(frontend: Frontend[] = []): boolean {
+  return !frontend.some((value) => CLOUDFLARE_WEB_DEPLOY_UNSUPPORTED_FRONTENDS.includes(value));
+}
+
+export function validateCloudflareWebDeploy(
+  webDeploy: WebDeploy | undefined,
+  frontend: Frontend[] | undefined,
+): ValidationResult {
+  if (webDeploy !== "cloudflare" || !frontend) return Result.ok(undefined);
+
+  const unsupported = frontend.find((value) =>
+    CLOUDFLARE_WEB_DEPLOY_UNSUPPORTED_FRONTENDS.includes(value),
+  );
+  if (unsupported) {
+    return validationErr(
+      `'--web-deploy cloudflare' has no Alchemy recipe for the '${unsupported}' frontend. Choose '--web-deploy docker', '--web-deploy vercel', or '--web-deploy none'.`,
     );
   }
 
@@ -651,7 +681,7 @@ export function validatePaymentsCompatibility(
   payments: Payments | undefined,
   auth: Auth | undefined,
   _backend: Backend | undefined,
-  _frontends: Frontend[] = [],
+  frontends: Frontend[] = [],
 ): ValidationResult {
   if (!payments || payments === "none") return Result.ok(undefined);
 
@@ -659,6 +689,12 @@ export function validatePaymentsCompatibility(
     if (!auth || auth === "none" || auth !== "better-auth") {
       return validationErr(
         "Polar payments requires Better Auth. Please use '--auth better-auth' or choose a different payments provider.",
+      );
+    }
+
+    if (frontends.includes("foldkit")) {
+      return validationErr(
+        "Polar payments has no Foldkit checkout template yet. Please use '--payments none' or choose a different frontend.",
       );
     }
   }
@@ -695,6 +731,10 @@ export function validateExamplesCompatibility(
 
   if (examplesArr.includes("ai") && (frontend ?? []).includes("astro")) {
     return validationErr("The 'ai' example is not compatible with the Astro frontend.");
+  }
+
+  if (examplesArr.includes("ai") && (frontend ?? []).includes("foldkit")) {
+    return validationErr("The 'ai' example is not compatible with the Foldkit frontend.");
   }
 
   if (examplesArr.includes("ai") && backend === "none") {

--- a/apps/cli/src/utils/compatibility.ts
+++ b/apps/cli/src/utils/compatibility.ts
@@ -9,4 +9,5 @@ export const WEB_FRAMEWORKS: readonly Frontend[] = [
   "svelte",
   "solid",
   "astro",
+  "foldkit",
 ] as const;

--- a/apps/cli/src/utils/config-validation.ts
+++ b/apps/cli/src/utils/config-validation.ts
@@ -24,6 +24,7 @@ import {
   validateServerDeployRequiresBackend,
   validateVercelServerDeploy,
   validatePrismaServerDeploy,
+  validateCloudflareWebDeploy,
   validatePrismaWebDeploy,
   validatePrismaWebDeployDesktopAddons,
   validateCloudflareWebDeployKnownIssues,
@@ -433,7 +434,7 @@ export function validateBackendConstraints(
 
   if (config.auth === "clerk" && config.frontend) {
     const incompatibleFrontends = config.frontend.filter((f) =>
-      ["nuxt", "svelte", "solid", "astro"].includes(f),
+      ["nuxt", "svelte", "solid", "astro", "foldkit"].includes(f),
     );
     if (incompatibleFrontends.length > 0) {
       return validationErr(
@@ -459,7 +460,9 @@ export function validateBackendConstraints(
   }
 
   if (backend === "convex" && providedFlags.has("frontend") && options.frontend) {
-    const incompatibleFrontends = options.frontend.filter((f) => f === "solid" || f === "astro");
+    const incompatibleFrontends = options.frontend.filter(
+      (f) => f === "solid" || f === "astro" || f === "foldkit",
+    );
     if (incompatibleFrontends.length > 0) {
       return validationErr(
         `The following frontends are not compatible with '--backend convex': ${incompatibleFrontends.join(
@@ -547,6 +550,7 @@ export function validateFullConfig(
     yield* validateVercelServerDeploy(config.serverDeploy, config.backend, config.runtime);
     yield* validatePrismaServerDeploy(config.serverDeploy, config.backend, config.runtime);
     yield* validatePrismaWebDeploy(config.webDeploy, config.frontend);
+    yield* validateCloudflareWebDeploy(config.webDeploy, config.frontend);
     yield* validateCloudflareWebDeployKnownIssues(config);
     yield* validateDockerWebDeployDesktopAddons(
       config.webDeploy,

--- a/apps/cli/src/utils/requirements.ts
+++ b/apps/cli/src/utils/requirements.ts
@@ -87,6 +87,9 @@ function getNodeToolingRequirements(config: RequirementConfig): VersionRequireme
       case "solid":
         addNodeRequirement(requirements, ">=24.0.0", "Solid");
         break;
+      case "foldkit":
+        addNodeRequirement(requirements, "^20.19.0 || >=22.12.0", "Foldkit");
+        break;
       case "react-router":
         addNodeRequirement(requirements, ">=22.22.0", "React Router 8");
         break;

--- a/apps/cli/test/frontend.test.ts
+++ b/apps/cli/test/frontend.test.ts
@@ -19,6 +19,7 @@ describe("Frontend Configurations", () => {
       "svelte",
       "solid",
       "astro",
+      "foldkit",
     ] satisfies ReadonlyArray<
       | "tanstack-router"
       | "react-router"
@@ -31,6 +32,7 @@ describe("Frontend Configurations", () => {
       | "svelte"
       | "solid"
       | "astro"
+      | "foldkit"
     >;
 
     for (const frontend of singleFrontends) {
@@ -75,6 +77,19 @@ describe("Frontend Configurations", () => {
           config.orm = "drizzle";
           config.auth = "none";
           config.api = "orpc"; // tRPC not supported with nuxt/svelte
+          config.addons = ["none"];
+          config.examples = ["none"];
+          config.dbSetup = "none";
+          config.webDeploy = "none";
+          config.serverDeploy = "none";
+        } else if (frontend === "foldkit") {
+          // Foldkit is a Vite SPA: oRPC only, no Convex, no self backend
+          config.backend = "hono";
+          config.runtime = "bun";
+          config.database = "sqlite";
+          config.orm = "drizzle";
+          config.auth = "none";
+          config.api = "orpc";
           config.addons = ["none"];
           config.examples = ["none"];
           config.dbSetup = "none";
@@ -793,6 +808,190 @@ describe("Frontend Configurations", () => {
       });
 
       expectError(result, "'--web-deploy' requires a web frontend");
+    });
+  });
+
+  describe("Foldkit Frontend", () => {
+    const foldkitBase = {
+      frontend: ["foldkit"],
+      backend: "hono",
+      runtime: "bun",
+      database: "sqlite",
+      orm: "drizzle",
+      api: "orpc",
+      addons: ["turborepo"],
+      dbSetup: "none",
+      webDeploy: "none",
+      serverDeploy: "none",
+      install: false,
+    } satisfies Partial<TestConfig>;
+
+    it("should generate the Foldkit project structure", async () => {
+      const result = await runTRPCTest({
+        ...foldkitBase,
+        projectName: "foldkit-structure",
+        auth: "better-auth",
+        examples: ["todo"],
+      });
+
+      expectSuccess(result);
+      if (!result.projectDir) {
+        throw new Error("Expected projectDir to be defined");
+      }
+
+      const webDir = path.join(result.projectDir, "apps/web");
+      const packageJson = await fs.readJson(path.join(webDir, "package.json"));
+
+      expect(packageJson.dependencies.foldkit).toBeDefined();
+      expect(packageJson.dependencies.effect).toBeDefined();
+      expect(packageJson.dependencies["@orpc/client"]).toBeDefined();
+      // Foldkit holds server state in the Model, so it pulls in no query cache
+      expect(packageJson.dependencies["@tanstack/react-query"]).toBeUndefined();
+      expect(packageJson.dependencies["@orpc/tanstack-query"]).toBeUndefined();
+      expect(packageJson.devDependencies["@foldkit/vite-plugin"]).toBeDefined();
+
+      for (const file of [
+        "index.html",
+        "src/entry.ts",
+        "src/main.ts",
+        "src/message.ts",
+        "src/route.ts",
+        "src/api/orpc.ts",
+        "src/api/health.ts",
+        "src/auth/client.ts",
+        "src/auth/session.ts",
+        "src/page/login.ts",
+        "src/page/todos.ts",
+        "src/view/header.ts",
+      ]) {
+        expect(await fs.pathExists(path.join(webDir, file))).toBe(true);
+      }
+    });
+
+    it("should omit auth and example modules when they are not selected", async () => {
+      const result = await runTRPCTest({
+        ...foldkitBase,
+        projectName: "foldkit-minimal",
+        auth: "none",
+        examples: ["none"],
+      });
+
+      expectSuccess(result);
+      if (!result.projectDir) {
+        throw new Error("Expected projectDir to be defined");
+      }
+
+      const webDir = path.join(result.projectDir, "apps/web");
+      expect(await fs.pathExists(path.join(webDir, "src/auth/session.ts"))).toBe(false);
+      expect(await fs.pathExists(path.join(webDir, "src/page/todos.ts"))).toBe(false);
+      expect(await fs.pathExists(path.join(webDir, "src/api/orpc.ts"))).toBe(true);
+    });
+
+    it("should serve the built SPA through nginx for Docker web deploy", async () => {
+      const result = await runTRPCTest({
+        ...foldkitBase,
+        projectName: "foldkit-docker",
+        auth: "none",
+        examples: ["none"],
+        webDeploy: "docker",
+        serverDeploy: "docker",
+      });
+
+      expectSuccess(result);
+      if (!result.projectDir) {
+        throw new Error("Expected projectDir to be defined");
+      }
+
+      const webDir = path.join(result.projectDir, "apps/web");
+      expect(await fs.pathExists(path.join(webDir, "nginx.conf"))).toBe(true);
+
+      const dockerfile = await fs.readFile(path.join(webDir, "Dockerfile"), "utf8");
+      expect(dockerfile).toContain("FROM nginx:alpine AS runner");
+      expect(dockerfile).toContain("/app/apps/web/dist");
+
+      const compose = await fs.readFile(path.join(result.projectDir, "docker-compose.yml"), "utf8");
+      expect(compose).toContain('"3001:80"');
+    });
+
+    it("should fail Foldkit + tRPC", async () => {
+      const result = await runTRPCTest({
+        ...foldkitBase,
+        projectName: "foldkit-trpc-fail",
+        auth: "none",
+        examples: ["none"],
+        api: "trpc",
+      });
+
+      expectError(result, "tRPC API is not supported with 'foldkit' frontend");
+    });
+
+    it("should fail Foldkit + Convex", async () => {
+      const result = await runTRPCTest({
+        projectName: "foldkit-convex-fail",
+        frontend: ["foldkit"],
+        backend: "convex",
+        runtime: "none",
+        database: "none",
+        orm: "none",
+        auth: "none",
+        api: "none",
+        addons: ["none"],
+        examples: ["none"],
+        dbSetup: "none",
+        webDeploy: "none",
+        serverDeploy: "none",
+        install: false,
+      });
+
+      expectError(result);
+    });
+
+    it("should fail Foldkit + Clerk", async () => {
+      const result = await runTRPCTest({
+        ...foldkitBase,
+        projectName: "foldkit-clerk-fail",
+        auth: "clerk",
+        examples: ["none"],
+      });
+
+      expectError(result);
+    });
+
+    it("should fail Foldkit + Polar payments", async () => {
+      const result = await runTRPCTest({
+        ...foldkitBase,
+        projectName: "foldkit-polar-fail",
+        auth: "better-auth",
+        payments: "polar",
+        examples: ["none"],
+      });
+
+      expectError(result, "Polar payments has no Foldkit checkout template yet");
+    });
+
+    it("should fail Foldkit + Cloudflare web deploy", async () => {
+      const result = await runTRPCTest({
+        ...foldkitBase,
+        projectName: "foldkit-cloudflare-fail",
+        auth: "none",
+        examples: ["none"],
+        webDeploy: "cloudflare",
+      });
+
+      expectError(result, "has no Alchemy recipe for the 'foldkit' frontend");
+    });
+
+    it("should fail Foldkit + self backend", async () => {
+      const result = await runTRPCTest({
+        ...foldkitBase,
+        projectName: "foldkit-self-fail",
+        backend: "self",
+        runtime: "none",
+        auth: "none",
+        examples: ["none"],
+      });
+
+      expectError(result);
     });
   });
 });

--- a/apps/cli/test/matrix/cases.ts
+++ b/apps/cli/test/matrix/cases.ts
@@ -22,6 +22,7 @@ export const MATRIX_WEB_FRONTENDS = [
   "svelte",
   "solid",
   "astro",
+  "foldkit",
 ] as const;
 export const MATRIX_NATIVE_FRONTENDS = [
   "native-bare",
@@ -386,6 +387,11 @@ export function createSmokeMatrixCases(): MatrixCase[] {
     pushUnique(configs, seen, {
       examples: [...examples],
       frontend: ["astro"],
+      api: "orpc",
+    });
+    pushUnique(configs, seen, {
+      examples: [...examples],
+      frontend: ["foldkit"],
       api: "orpc",
     });
   }

--- a/apps/cli/test/matrix/oracle.ts
+++ b/apps/cli/test/matrix/oracle.ts
@@ -31,9 +31,11 @@ export type MatrixRule =
   | "orm-mongodb-requires-mongoose-or-prisma"
   | "orm-requires-database"
   | "payments-polar-requires-better-auth"
+  | "payments-polar-frontend-incompatible"
   | "runtime-none-requires-terminal-backend"
   | "server-deploy-requires-backend"
   | "server-deploy-requires-workers-runtime"
+  | "web-deploy-cloudflare-frontend-incompatible"
   | "web-deploy-requires-web-frontend"
   | "workers-requires-hono"
   | "workers-requires-server-deploy"
@@ -53,6 +55,7 @@ const WEB_FRONTENDS: readonly Frontend[] = [
   "svelte",
   "solid",
   "astro",
+  "foldkit",
 ] as const;
 
 const FULLSTACK_FRONTENDS: readonly Frontend[] = [
@@ -64,7 +67,7 @@ const FULLSTACK_FRONTENDS: readonly Frontend[] = [
   "astro",
 ] as const;
 
-const CONVEX_INCOMPATIBLE_FRONTENDS: readonly Frontend[] = ["solid", "astro"] as const;
+const CONVEX_INCOMPATIBLE_FRONTENDS: readonly Frontend[] = ["solid", "astro", "foldkit"] as const;
 
 const CONVEX_BETTER_AUTH_SUPPORTED_FRONTENDS: readonly Frontend[] = [
   "tanstack-router",
@@ -81,9 +84,30 @@ const CONVEX_BETTER_AUTH_INCOMPATIBLE_FRONTENDS: readonly Frontend[] = [
   "svelte",
   "solid",
   "astro",
+  "foldkit",
 ] as const;
 
-const CLERK_INCOMPATIBLE_FRONTENDS: readonly Frontend[] = ["nuxt", "svelte", "solid", "astro"];
+const CLERK_INCOMPATIBLE_FRONTENDS: readonly Frontend[] = [
+  "nuxt",
+  "svelte",
+  "solid",
+  "astro",
+  "foldkit",
+];
+
+const TRPC_UNSUPPORTED_FRONTENDS: readonly Frontend[] = [
+  "nuxt",
+  "svelte",
+  "solid",
+  "astro",
+  "foldkit",
+];
+
+const AI_EXAMPLE_INCOMPATIBLE_FRONTENDS: readonly Frontend[] = ["solid", "astro", "foldkit"];
+
+const POLAR_INCOMPATIBLE_FRONTENDS: readonly Frontend[] = ["foldkit"];
+
+const CLOUDFLARE_WEB_DEPLOY_INCOMPATIBLE_FRONTENDS: readonly Frontend[] = ["foldkit"];
 
 function hasFrontend(frontends: readonly Frontend[], values: readonly Frontend[]) {
   return frontends.some((frontend) => values.includes(frontend));
@@ -286,12 +310,19 @@ function validateRuntimeAndDeploy(config: ProjectConfig, rules: Set<MatrixRule>)
     config.webDeploy !== "none" && !hasWebFrontend(config.frontend),
     "web-deploy-requires-web-frontend",
   );
+
+  addRule(
+    rules,
+    config.webDeploy === "cloudflare" &&
+      hasFrontend(config.frontend, CLOUDFLARE_WEB_DEPLOY_INCOMPATIBLE_FRONTENDS),
+    "web-deploy-cloudflare-frontend-incompatible",
+  );
 }
 
 function validateFrontendApi(config: ProjectConfig, rules: Set<MatrixRule>) {
   addRule(
     rules,
-    config.api === "trpc" && hasFrontend(config.frontend, ["nuxt", "svelte", "solid", "astro"]),
+    config.api === "trpc" && hasFrontend(config.frontend, TRPC_UNSUPPORTED_FRONTENDS),
     "api-trpc-frontend-incompatible",
   );
 }
@@ -304,6 +335,12 @@ function validatePayments(config: ProjectConfig, rules: Set<MatrixRule>) {
     config.payments === "polar" && config.auth !== "better-auth",
     "payments-polar-requires-better-auth",
   );
+
+  addRule(
+    rules,
+    config.payments === "polar" && hasFrontend(config.frontend, POLAR_INCOMPATIBLE_FRONTENDS),
+    "payments-polar-frontend-incompatible",
+  );
 }
 
 function validateExamples(config: ProjectConfig, rules: Set<MatrixRule>) {
@@ -315,7 +352,7 @@ function validateExamples(config: ProjectConfig, rules: Set<MatrixRule>) {
   if (config.examples.includes("ai")) {
     addRule(
       rules,
-      hasFrontend(config.frontend, ["solid", "astro"]),
+      hasFrontend(config.frontend, AI_EXAMPLE_INCOMPATIBLE_FRONTENDS),
       "example-ai-frontend-incompatible",
     );
     addRule(rules, config.backend === "none", "example-ai-requires-backend");
@@ -388,6 +425,12 @@ export function classifyMatrixError(message: string): MatrixRule | "unknown" {
     return "db-setup-supabase-requires-postgres";
   }
   if (message.includes("Turso setup requires SQLite")) return "db-setup-turso-requires-sqlite";
+  if (message.includes("Polar payments has no Foldkit checkout template yet")) {
+    return "payments-polar-frontend-incompatible";
+  }
+  if (message.includes("has no Alchemy recipe for the")) {
+    return "web-deploy-cloudflare-frontend-incompatible";
+  }
   if (message.includes("The 'ai' example is not compatible")) {
     return "example-ai-frontend-incompatible";
   }

--- a/apps/web/content/docs/cli/compatibility.mdx
+++ b/apps/web/content/docs/cli/compatibility.mdx
@@ -71,9 +71,9 @@ When using `--backend convex`, these constraints apply:
 - `--server-deploy none`
 - Auth can be `better-auth`, `clerk`, or `none` depending frontend compatibility
 
-**Note:** Convex supports Clerk authentication with compatible frontends (React frameworks, Next.js, TanStack Start, and native frameworks). Nuxt, Svelte, Solid, and Astro are not compatible with Clerk.
+**Note:** Convex supports Clerk authentication with compatible frontends (React frameworks, Next.js, TanStack Start, and native frameworks). Nuxt, Svelte, Solid, Astro, and Foldkit are not compatible with Clerk.
 
-**Better Auth with Convex:** supported frontends are `react-router`, `tanstack-router`, `tanstack-start`, `next`, `native-bare`, `native-uniwind`, and `native-unistyles`. Nuxt, Svelte, Solid, and Astro are not supported with Convex Better Auth.
+**Better Auth with Convex:** supported frontends are `react-router`, `tanstack-router`, `tanstack-start`, `next`, `native-bare`, `native-uniwind`, and `native-unistyles`. Nuxt, Svelte, Solid, Astro, and Foldkit are not supported with Convex Better Auth.
 
 #### No Backend
 
@@ -101,6 +101,7 @@ When using `--backend none`, the following options are automatically set:
 | `svelte`          | ❌           | ✅           | tRPC not supported        |
 | `solid`           | ❌           | ✅           | Solid; tRPC not supported |
 | `astro`           | ❌           | ✅           | tRPC not supported        |
+| `foldkit`         | ❌           | ✅           | tRPC not supported        |
 | Native frameworks | ✅           | ✅           | Full support              |
 
 ```bash
@@ -196,6 +197,7 @@ create-better-t-stack --addons turborepo
 
 - `--web-deploy cloudflare`, `--web-deploy docker`, and `--web-deploy vercel` require a web frontend
 - Cannot be used with native-only projects
+- `--web-deploy cloudflare` needs an Alchemy recipe for the frontend; Foldkit has none yet, so use `docker` or `vercel`
 
 ### Server Deployment
 
@@ -221,7 +223,7 @@ Clerk authentication requires:
 - Compatible frontends (React frameworks, Next.js, TanStack Start, native frameworks)
 - Supported backends: Convex, Hono, Express, Fastify, and Elysia
 - Fullstack (`--backend self`) support with Next.js or TanStack Start
-- Not compatible with Nuxt, Svelte, Solid, or Astro
+- Not compatible with Nuxt, Svelte, Solid, Astro, or Foldkit
 
 ### Payments Requirements
 
@@ -229,6 +231,7 @@ Polar payments require:
 
 - Better-Auth authentication
 - A web frontend (or no frontend selected)
+- A frontend with a checkout template; Foldkit has none yet
 
 ```bash
 # ✅ Valid - Better-Auth without database

--- a/apps/web/content/docs/cli/options.mdx
+++ b/apps/web/content/docs/cli/options.mdx
@@ -237,6 +237,7 @@ Frontend frameworks (can specify multiple):
 - `svelte`: SvelteKit
 - `solid`: Solid (SSR)
 - `astro`: Astro
+- `foldkit`: Foldkit (Effect-powered, Elm architecture, SPA)
 
 **Native Frameworks:**
 

--- a/apps/web/src/app/(home)/new/_components/utils.ts
+++ b/apps/web/src/app/(home)/new/_components/utils.ts
@@ -59,7 +59,7 @@ const clerkBackendRequirementMessage =
   "Clerk requires Convex, Hono, Express, Fastify, Elysia, or Next.js/TanStack Start fullstack backend";
 const clerkFrontendRequirementMessage =
   "Clerk requires React Router, TanStack Router, TanStack Start, Next.js, or React Native";
-const clerkIncompatibleWebFrontends = ["nuxt", "svelte", "solid", "astro"] as const;
+const clerkIncompatibleWebFrontends = ["nuxt", "svelte", "solid", "astro", "foldkit"] as const;
 const convexBetterAuthSupportedWebFrontends = [
   "react-router",
   "tanstack-router",
@@ -71,7 +71,29 @@ const convexBetterAuthSupportedNativeFrontends = [
   "native-uniwind",
   "native-unistyles",
 ] as const;
-const convexBetterAuthIncompatibleWebFrontends = ["nuxt", "svelte", "solid", "astro"] as const;
+const convexBetterAuthIncompatibleWebFrontends = [
+  "nuxt",
+  "svelte",
+  "solid",
+  "astro",
+  "foldkit",
+] as const;
+const convexIncompatibleWebFrontends = ["solid", "astro", "foldkit"] as const;
+const orpcOnlyWebFrontends = ["nuxt", "svelte", "solid", "astro", "foldkit"] as const;
+const aiIncompatibleWebFrontends = ["solid", "astro", "foldkit"] as const;
+const cloudflareIncompatibleWebFrontends = ["foldkit"] as const;
+
+const findConvexIncompatibleFrontend = (webFrontend: string[]) =>
+  webFrontend.find((f) => (convexIncompatibleWebFrontends as readonly string[]).includes(f));
+
+const findOrpcOnlyFrontend = (webFrontend: string[]) =>
+  webFrontend.find((f) => (orpcOnlyWebFrontends as readonly string[]).includes(f));
+
+const findAiIncompatibleFrontend = (webFrontend: string[]) =>
+  webFrontend.find((f) => (aiIncompatibleWebFrontends as readonly string[]).includes(f));
+
+const findCloudflareIncompatibleFrontend = (webFrontend: string[]) =>
+  webFrontend.find((f) => (cloudflareIncompatibleWebFrontends as readonly string[]).includes(f));
 const staticDesktopAddons = ["tauri", "electrobun"] as const;
 const dockerServerOutputFrontends = ["next", "svelte", "solid", "astro", "react-router"] as const;
 const prismaComputeWebFrontends = [
@@ -282,11 +304,17 @@ export const analyzeStackCompatibility = (stack: StackState): CompatibilityResul
     }
 
     // Remove incompatible frontends
-    if (nextStack.webFrontend.includes("solid") || nextStack.webFrontend.includes("astro")) {
-      nextStack.webFrontend = nextStack.webFrontend.filter((f) => f !== "solid" && f !== "astro");
+    const convexIncompatibleFrontend = findConvexIncompatibleFrontend(nextStack.webFrontend);
+    if (convexIncompatibleFrontend) {
+      nextStack.webFrontend = nextStack.webFrontend.filter(
+        (f) => !(convexIncompatibleWebFrontends as readonly string[]).includes(f),
+      );
       if (nextStack.webFrontend.length === 0) nextStack.webFrontend = ["none"];
       changed = true;
-      changes.push({ category: "backend", message: "Removed Solid (incompatible with Convex)" });
+      changes.push({
+        category: "backend",
+        message: `Removed ${convexIncompatibleFrontend} (incompatible with Convex)`,
+      });
     }
 
     // Remove AI example if incompatible frontends are selected (Convex AI only supports React-based frontends)
@@ -696,9 +724,7 @@ export const analyzeStackCompatibility = (stack: StackState): CompatibilityResul
 
   if (nextStack.backend !== "convex" && nextStack.backend !== "none") {
     // Nuxt, Svelte, Solid, Astro require oRPC (not tRPC)
-    const needsOrpc = nextStack.webFrontend.some((f) =>
-      ["nuxt", "svelte", "solid", "astro"].includes(f),
-    );
+    const needsOrpc = findOrpcOnlyFrontend(nextStack.webFrontend) !== undefined;
     if (needsOrpc && nextStack.api === "trpc") {
       nextStack.api = "orpc";
       changed = true;
@@ -741,6 +767,13 @@ export const analyzeStackCompatibility = (stack: StackState): CompatibilityResul
       changes.push({
         category: "payments",
         message: "Payments set to 'None' (Polar requires Better Auth)",
+      });
+    } else if (nextStack.webFrontend.includes("foldkit")) {
+      nextStack.payments = "none";
+      changed = true;
+      changes.push({
+        category: "payments",
+        message: "Payments set to 'None' (Polar has no Foldkit checkout template yet)",
       });
     }
   }
@@ -842,14 +875,15 @@ export const analyzeStackCompatibility = (stack: StackState): CompatibilityResul
 
   // AI example constraints
   if (nextStack.examples.includes("ai")) {
-    // Solid and Astro frontends are incompatible with the AI example
-    if (nextStack.webFrontend.includes("solid") || nextStack.webFrontend.includes("astro")) {
+    // Solid, Astro, and Foldkit frontends are incompatible with the AI example
+    const aiIncompatibleFrontend = findAiIncompatibleFrontend(nextStack.webFrontend);
+    if (aiIncompatibleFrontend) {
       nextStack.examples = nextStack.examples.filter((e) => e !== "ai");
       if (nextStack.examples.length === 0) nextStack.examples = ["none"];
       changed = true;
       changes.push({
         category: "examples",
-        message: "AI removed (not compatible with Solid or Astro frontend)",
+        message: `AI removed (not compatible with the ${aiIncompatibleFrontend} frontend)`,
       });
     }
     // Convex AI only supports React-based frontends (not Svelte/Nuxt)
@@ -920,6 +954,20 @@ export const analyzeStackCompatibility = (stack: StackState): CompatibilityResul
       changes.push({
         category: "webDeploy",
         message: `Web deploy set to 'None' (${prismaDesktopConflict.selectedDesktopAddons.join(" and ")} requires a static ${prismaDesktopConflict.affectedFrontend} build)`,
+      });
+    }
+  }
+
+  if (nextStack.webDeploy === "cloudflare") {
+    const cloudflareIncompatibleFrontend = findCloudflareIncompatibleFrontend(
+      nextStack.webFrontend,
+    );
+    if (cloudflareIncompatibleFrontend) {
+      nextStack.webDeploy = "none";
+      changed = true;
+      changes.push({
+        category: "webDeploy",
+        message: `Web deploy set to 'None' (Cloudflare has no Alchemy recipe for the ${cloudflareIncompatibleFrontend} frontend)`,
       });
     }
   }
@@ -1049,7 +1097,10 @@ export const getDisabledReason = (
         return convexBetterAuthFrontendRequirementMessage;
       }
     }
-    if (category === "webFrontend" && (optionId === "solid" || optionId === "astro")) {
+    if (
+      category === "webFrontend" &&
+      (convexIncompatibleWebFrontends as readonly string[]).includes(optionId)
+    ) {
       return `${optionId.charAt(0).toUpperCase() + optionId.slice(1)} is not compatible with Convex`;
     }
     if (category === "examples" && optionId === "ai") {
@@ -1210,12 +1261,9 @@ export const getDisabledReason = (
     if (optionId === "self-astro" && !currentStack.webFrontend.includes("astro")) {
       return "Requires Astro frontend";
     }
-    if (
-      optionId === "convex" &&
-      (currentStack.webFrontend.includes("solid") || currentStack.webFrontend.includes("astro"))
-    ) {
-      const incompatible = currentStack.webFrontend.includes("solid") ? "Solid" : "Astro";
-      return `Convex is not compatible with ${incompatible}`;
+    const convexIncompatibleFrontend = findConvexIncompatibleFrontend(currentStack.webFrontend);
+    if (optionId === "convex" && convexIncompatibleFrontend) {
+      return `Convex is not compatible with ${convexIncompatibleFrontend}`;
     }
     // Workers runtime only works with Hono backend
     if (currentStack.runtime === "workers" && optionId !== "hono" && optionId !== "none") {
@@ -1324,14 +1372,9 @@ export const getDisabledReason = (
   // API CONSTRAINTS
   // ============================================
   if (category === "api" && optionId === "trpc") {
-    const needsOrpc = currentStack.webFrontend.some((f) =>
-      ["nuxt", "svelte", "solid", "astro"].includes(f),
-    );
-    if (needsOrpc) {
-      const frontendName = currentStack.webFrontend.find((f) =>
-        ["nuxt", "svelte", "solid", "astro"].includes(f),
-      );
-      return `${frontendName} requires oRPC, not tRPC`;
+    const orpcOnlyFrontend = findOrpcOnlyFrontend(currentStack.webFrontend);
+    if (orpcOnlyFrontend) {
+      return `${orpcOnlyFrontend} requires oRPC, not tRPC`;
     }
   }
 
@@ -1357,6 +1400,9 @@ export const getDisabledReason = (
   if (category === "payments" && optionId === "polar") {
     if (currentStack.auth !== "better-auth") {
       return "Polar requires Better Auth";
+    }
+    if (currentStack.webFrontend.includes("foldkit")) {
+      return "Polar has no Foldkit checkout template yet";
     }
   }
 
@@ -1429,11 +1475,9 @@ export const getDisabledReason = (
       }
     }
     if (optionId === "ai") {
-      if (
-        currentStack.webFrontend.includes("solid") ||
-        currentStack.webFrontend.includes("astro")
-      ) {
-        return "AI example not compatible with Solid or Astro frontend";
+      const aiIncompatibleFrontend = findAiIncompatibleFrontend(currentStack.webFrontend);
+      if (aiIncompatibleFrontend) {
+        return `AI example not compatible with the ${aiIncompatibleFrontend} frontend`;
       }
       if (currentStack.backend === "convex") {
         const hasIncompatibleFrontend = currentStack.webFrontend.some((f) =>
@@ -1483,6 +1527,12 @@ export const getDisabledReason = (
       }
     }
     if (optionId === "cloudflare") {
+      const cloudflareIncompatibleFrontend = findCloudflareIncompatibleFrontend(
+        currentStack.webFrontend,
+      );
+      if (cloudflareIncompatibleFrontend) {
+        return `Cloudflare has no Alchemy recipe for the ${cloudflareIncompatibleFrontend} frontend`;
+      }
       const issue = getCloudflareNextIssue({ ...currentStack, webDeploy: "cloudflare" });
       if (issue) return issue;
     }

--- a/apps/web/src/lib/constant.ts
+++ b/apps/web/src/lib/constant.ts
@@ -93,6 +93,14 @@ export const TECH_OPTIONS = {
       default: false,
     },
     {
+      id: "foldkit",
+      name: "Foldkit",
+      description: "Effect-powered TypeScript framework architected like Elm",
+      icon: "",
+      color: "from-sky-400 to-indigo-600",
+      default: false,
+    },
+    {
       id: "none",
       name: "No Web Frontend",
       description: "No web-based frontend",

--- a/apps/web/test/stack-builder-compatibility.test.ts
+++ b/apps/web/test/stack-builder-compatibility.test.ts
@@ -300,7 +300,7 @@ describe("stack builder D1 compatibility", () => {
     });
 
     expect(getDisabledReason(stack, "examples", "ai")).toBe(
-      "AI example not compatible with Solid or Astro frontend",
+      "AI example not compatible with the astro frontend",
     );
 
     const result = analyzeStackCompatibility({
@@ -562,6 +562,40 @@ describe("stack builder Vercel deployment compatibility", () => {
     expect(result.adjustedStack).toMatchObject({
       serverDeploy: "none",
     });
+  });
+});
+
+describe("stack builder Foldkit compatibility", () => {
+  test("forces oRPC and blocks tRPC", () => {
+    const stack = createStack({ webFrontend: ["foldkit"], backend: "hono", api: "trpc" });
+
+    expect(getDisabledReason(stack, "api", "trpc")).toBe("foldkit requires oRPC, not tRPC");
+    expect(analyzeStackCompatibility(stack).adjustedStack?.api).toBe("orpc");
+  });
+
+  test("blocks Convex, Clerk, Polar, the AI example, and Cloudflare deployment", () => {
+    const stack = createStack({ webFrontend: ["foldkit"], backend: "hono", api: "orpc" });
+
+    expect(getDisabledReason(stack, "backend", "convex")).toBe(
+      "Convex is not compatible with foldkit",
+    );
+    expect(getDisabledReason(stack, "auth", "clerk")).not.toBeNull();
+    expect(getDisabledReason(stack, "payments", "polar")).toBe(
+      "Polar has no Foldkit checkout template yet",
+    );
+    expect(getDisabledReason(stack, "examples", "ai")).toBe(
+      "AI example not compatible with the foldkit frontend",
+    );
+    expect(getDisabledReason(stack, "webDeploy", "cloudflare")).toBe(
+      "Cloudflare has no Alchemy recipe for the foldkit frontend",
+    );
+  });
+
+  test("keeps Docker and Vercel web deployment available", () => {
+    const stack = createStack({ webFrontend: ["foldkit"], backend: "hono", api: "orpc" });
+
+    expect(getDisabledReason(stack, "webDeploy", "docker")).toBeNull();
+    expect(getDisabledReason(stack, "webDeploy", "vercel")).toBeNull();
   });
 });
 

--- a/packages/template-generator/src/generators/alchemy/plan.ts
+++ b/packages/template-generator/src/generators/alchemy/plan.ts
@@ -7,7 +7,9 @@ import {
   type WebFrontend,
 } from "@better-t-stack/types";
 
-export type DeployedWebFramework = Exclude<WebFrontend, "none">;
+// Foldkit ships no Alchemy recipe yet, so it is not deployable through Cloudflare
+// or Prisma Compute. `validateAlchemyWebDeploy` rejects the combination up front.
+export type DeployedWebFramework = Exclude<WebFrontend, "none" | "foldkit">;
 
 export type ManagedDatabasePlan =
   | { kind: "none" }
@@ -47,7 +49,7 @@ export type AlchemyDeploymentPlan = {
 };
 
 function isDeployedWebFramework(frontend: Frontend): frontend is DeployedWebFramework {
-  return (webFrontends as readonly Frontend[]).includes(frontend);
+  return frontend !== "foldkit" && (webFrontends as readonly Frontend[]).includes(frontend);
 }
 
 function getDeployedWebFramework(config: ProjectConfig): DeployedWebFramework {

--- a/packages/template-generator/src/post-process/vercel-config.ts
+++ b/packages/template-generator/src/post-process/vercel-config.ts
@@ -53,7 +53,9 @@ export function processVercelConfig(vfs: VirtualFileSystem, config: ProjectConfi
   const hasServer = serverDeploy === "vercel" && backend !== "self";
   const isDesktop = addons.includes("tauri") || addons.includes("electrobun");
   const isStaticSpa =
-    frontend.includes("tanstack-router") || (frontend.includes("react-router") && isDesktop);
+    frontend.includes("tanstack-router") ||
+    frontend.includes("foldkit") ||
+    (frontend.includes("react-router") && isDesktop);
   const installCommand = `cd ../.. && ${packageManager} install`;
 
   const services: Record<string, VercelService> = {};

--- a/packages/template-generator/src/processors/api-deps.ts
+++ b/packages/template-generator/src/processors/api-deps.ts
@@ -9,6 +9,7 @@ type FrontendType = {
   hasSvelteWeb: boolean;
   hasSolidWeb: boolean;
   hasAstroWeb: boolean;
+  hasFoldkitWeb: boolean;
   hasNative: boolean;
 };
 
@@ -21,6 +22,7 @@ function getFrontendType(frontend: Frontend[]): FrontendType {
     hasSvelteWeb: frontend.includes("svelte"),
     hasSolidWeb: frontend.includes("solid"),
     hasAstroWeb: frontend.includes("astro"),
+    hasFoldkitWeb: frontend.includes("foldkit"),
     hasNative: frontend.some((f) =>
       ["native-bare", "native-uniwind", "native-unistyles"].includes(f),
     ),
@@ -208,6 +210,14 @@ function addWebClientDeps(
         "@tanstack/solid-query",
       ],
       devDependencies: ["@tanstack/solid-query-devtools"],
+    });
+  } else if (api === "orpc" && frontendType.hasFoldkitWeb) {
+    // Foldkit fetches through Commands and holds server state as AsyncData in the
+    // Model, so it uses the vanilla oRPC client without a query cache
+    addPackageDependency({
+      vfs,
+      packagePath: webPath,
+      dependencies: ["@orpc/client"],
     });
   } else if (api === "orpc" && frontendType.hasAstroWeb) {
     // Astro uses vanilla oRPC client without TanStack Query

--- a/packages/template-generator/src/processors/auth-deps.ts
+++ b/packages/template-generator/src/processors/auth-deps.ts
@@ -148,6 +148,7 @@ function processStandardAuthDeps(vfs: VirtualFileSystem, config: ProjectConfig):
       "svelte",
       "solid",
       "astro",
+      "foldkit",
     ].includes(f),
   );
   const hasReactWebAuthForms = frontend.some((f) =>

--- a/packages/template-generator/src/processors/env-vars.ts
+++ b/packages/template-generator/src/processors/env-vars.ts
@@ -268,7 +268,8 @@ function buildConvexBackendVars(
     frontend.includes("nuxt") ||
     frontend.includes("solid") ||
     frontend.includes("svelte") ||
-    frontend.includes("astro");
+    frontend.includes("astro") ||
+    frontend.includes("foldkit");
   const defaultSiteUrl =
     hasNative && !hasWeb
       ? "http://localhost:8081"
@@ -379,7 +380,8 @@ function buildConvexCommentBlocks(
     frontend.includes("nuxt") ||
     frontend.includes("solid") ||
     frontend.includes("svelte") ||
-    frontend.includes("astro");
+    frontend.includes("astro") ||
+    frontend.includes("foldkit");
   const defaultSiteUrl =
     hasNative && !hasWeb
       ? "http://localhost:8081"
@@ -447,7 +449,8 @@ function buildServerVars(
     frontend.includes("tanstack-start") ||
     frontend.includes("next") ||
     frontend.includes("nuxt") ||
-    frontend.includes("solid");
+    frontend.includes("solid") ||
+    frontend.includes("foldkit");
 
   let corsOrigin = "http://localhost:3001";
   if (hasAstro) {
@@ -579,6 +582,7 @@ export function processEnvVariables(vfs: VirtualFileSystem, config: ProjectConfi
   const hasSvelte = frontend.includes("svelte");
   const hasSolid = frontend.includes("solid");
   const hasAstro = frontend.includes("astro");
+  const hasFoldkit = frontend.includes("foldkit");
   const hasWebFrontend =
     hasReactRouter ||
     hasTanStackRouter ||
@@ -587,7 +591,8 @@ export function processEnvVariables(vfs: VirtualFileSystem, config: ProjectConfi
     hasNuxt ||
     hasSolid ||
     hasSvelte ||
-    hasAstro;
+    hasAstro ||
+    hasFoldkit;
 
   // --- Client App .env ---
   if (hasWebFrontend) {

--- a/packages/template-generator/src/processors/readme-generator.ts
+++ b/packages/template-generator/src/processors/readme-generator.ts
@@ -145,6 +145,7 @@ function hasWebFrontend(frontend: ProjectConfig["frontend"]): boolean {
       "nuxt",
       "solid",
       "astro",
+      "foldkit",
     ].includes(value),
   );
 }
@@ -295,6 +296,7 @@ function generateStackDescription(
     nuxt: "Nuxt",
     solid: "Solid",
     astro: "Astro",
+    foldkit: "Foldkit",
     "native-bare": "React Native, Expo",
     "native-uniwind": "React Native, Expo",
     "native-unistyles": "React Native, Expo",
@@ -403,6 +405,7 @@ function generateProjectStructure(config: ProjectConfig): string {
       nuxt: "Nuxt",
       solid: "Solid",
       astro: "Astro",
+      foldkit: "Foldkit",
     } satisfies Record<string, string>;
     let frontendType = "";
     for (const selectedFrontend of frontend) {
@@ -495,6 +498,7 @@ function generateFeaturesList(
     nuxt: "- **Nuxt** - The Intuitive Vue Framework",
     solid: "- **Solid** - Solid application with file-based routing and SSR",
     astro: "- **Astro** - The web framework for content-driven websites",
+    foldkit: "- **Foldkit** - Effect-powered TypeScript framework architected like Elm",
   } satisfies Record<string, string>;
 
   for (const fe of frontend) {
@@ -730,6 +734,7 @@ function generateScriptsList(
       "svelte",
       "solid",
       "astro",
+      "foldkit",
     ].includes(f),
   );
   const dbSupport = getDbScriptSupport(config);

--- a/packages/template-generator/src/template-handlers/api.ts
+++ b/packages/template-generator/src/template-handlers/api.ts
@@ -20,6 +20,7 @@ export async function processApiTemplates(
   const hasSvelteWeb = config.frontend.includes("svelte");
   const hasSolidWeb = config.frontend.includes("solid");
   const hasAstroWeb = config.frontend.includes("astro");
+  const hasFoldkitWeb = config.frontend.includes("foldkit");
 
   if (hasReactWeb) {
     processTemplatesFromPrefix(
@@ -90,6 +91,8 @@ export async function processApiTemplates(
         config,
       );
     }
+  } else if (hasFoldkitWeb && config.api === "orpc") {
+    processTemplatesFromPrefix(vfs, templates, `api/${config.api}/web/foldkit`, "apps/web", config);
   } else if (hasAstroWeb && config.api === "orpc") {
     // Always include the orpc client (handles both self and external backend)
     processTemplatesFromPrefix(vfs, templates, `api/${config.api}/web/astro`, "apps/web", config);

--- a/packages/template-generator/src/template-handlers/auth.ts
+++ b/packages/template-generator/src/template-handlers/auth.ts
@@ -17,6 +17,7 @@ export async function processAuthTemplates(
   const hasSvelteWeb = config.frontend.includes("svelte");
   const hasSolidWeb = config.frontend.includes("solid");
   const hasAstroWeb = config.frontend.includes("astro");
+  const hasFoldkitWeb = config.frontend.includes("foldkit");
   const hasNativeBare = config.frontend.includes("native-bare");
   const hasUniwind = config.frontend.includes("native-uniwind");
   const hasUnistyles = config.frontend.includes("native-unistyles");
@@ -240,6 +241,14 @@ export async function processAuthTemplates(
       vfs,
       templates,
       `auth/${authProvider}/web/solid`,
+      "apps/web",
+      config,
+    );
+  } else if (hasFoldkitWeb) {
+    processTemplatesFromPrefix(
+      vfs,
+      templates,
+      `auth/${authProvider}/web/foldkit`,
       "apps/web",
       config,
     );

--- a/packages/template-generator/src/template-handlers/deploy.ts
+++ b/packages/template-generator/src/template-handlers/deploy.ts
@@ -73,6 +73,7 @@ export async function processDeployTemplates(
       nuxt: "nuxt",
       svelte: "svelte",
       astro: "astro",
+      foldkit: "foldkit",
     } satisfies Record<string, string>;
 
     for (const f of config.frontend) {

--- a/packages/template-generator/src/template-handlers/examples.ts
+++ b/packages/template-generator/src/template-handlers/examples.ts
@@ -17,6 +17,7 @@ export async function processExampleTemplates(
   const hasSvelteWeb = config.frontend.includes("svelte");
   const hasSolidWeb = config.frontend.includes("solid");
   const hasAstroWeb = config.frontend.includes("astro");
+  const hasFoldkitWeb = config.frontend.includes("foldkit");
   const hasNativeBare = config.frontend.includes("native-bare");
   const hasUniwind = config.frontend.includes("native-uniwind");
   const hasUnistyles = config.frontend.includes("native-unistyles");
@@ -126,6 +127,14 @@ export async function processExampleTemplates(
         vfs,
         templates,
         `examples/${example}/web/astro`,
+        "apps/web",
+        config,
+      );
+    } else if (hasFoldkitWeb) {
+      processTemplatesFromPrefix(
+        vfs,
+        templates,
+        `examples/${example}/web/foldkit`,
         "apps/web",
         config,
       );

--- a/packages/template-generator/src/template-handlers/frontend.ts
+++ b/packages/template-generator/src/template-handlers/frontend.ts
@@ -15,12 +15,13 @@ export async function processFrontendTemplates(
   const hasSvelteWeb = config.frontend.includes("svelte");
   const hasSolidWeb = config.frontend.includes("solid");
   const hasAstroWeb = config.frontend.includes("astro");
+  const hasFoldkitWeb = config.frontend.includes("foldkit");
   const hasNativeBare = config.frontend.includes("native-bare");
   const hasNativeUniwind = config.frontend.includes("native-uniwind");
   const hasUnistyles = config.frontend.includes("native-unistyles");
   const isConvex = config.backend === "convex";
 
-  if (hasReactWeb || hasNuxtWeb || hasSvelteWeb || hasSolidWeb || hasAstroWeb) {
+  if (hasReactWeb || hasNuxtWeb || hasSvelteWeb || hasSolidWeb || hasAstroWeb || hasFoldkitWeb) {
     if (hasReactWeb) {
       processTemplatesFromPrefix(vfs, templates, "frontend/react/web-base", "apps/web", config);
 
@@ -44,6 +45,8 @@ export async function processFrontendTemplates(
       processTemplatesFromPrefix(vfs, templates, "frontend/solid", "apps/web", config);
     } else if (hasAstroWeb) {
       processTemplatesFromPrefix(vfs, templates, "frontend/astro", "apps/web", config);
+    } else if (hasFoldkitWeb) {
+      processTemplatesFromPrefix(vfs, templates, "frontend/foldkit", "apps/web", config);
     }
   }
 

--- a/packages/template-generator/src/template-handlers/packages.ts
+++ b/packages/template-generator/src/template-handlers/packages.ts
@@ -26,6 +26,7 @@ export async function processEnvPackage(
       "svelte",
       "solid",
       "astro",
+      "foldkit",
     ].includes(f),
   );
   const hasNative = config.frontend.some((f) =>

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -1440,6 +1440,57 @@ export const link = new RPCLink({
 
 export const orpc: AppRouterClient = createORPCClient(link);
 `],
+  ["api/orpc/web/foldkit/src/api/health.ts.hbs", `import { Effect, Schema as S } from "effect";
+import { AsyncData, Command } from "foldkit";
+import { m } from "foldkit/message";
+
+import { client } from "./orpc";
+
+// MODEL
+
+export const HealthCheck = AsyncData.Schema(S.String, S.String);
+export type HealthCheck = typeof HealthCheck.schema.Type;
+
+// MESSAGE
+
+export const SucceededFetchHealthCheck = m("SucceededFetchHealthCheck", {
+  status: S.String,
+});
+export const FailedFetchHealthCheck = m("FailedFetchHealthCheck", {
+  error: S.String,
+});
+
+// COMMAND
+
+export const FetchHealthCheck = Command.define("FetchHealthCheck", {
+  messages: [SucceededFetchHealthCheck, FailedFetchHealthCheck],
+  execute: Effect.tryPromise((signal) => client.healthCheck(undefined, { signal })).pipe(
+    Effect.map((status) => SucceededFetchHealthCheck({ status })),
+    Effect.catch(() => Effect.succeed(FailedFetchHealthCheck({ error: "Disconnected" }))),
+  ),
+});
+`],
+  ["api/orpc/web/foldkit/src/api/orpc.ts.hbs", `import { createORPCClient } from "@orpc/client";
+import { RPCLink } from "@orpc/client/fetch";
+import type { AppRouterClient } from "@{{projectName}}/api/routers/index";
+import { env } from "@{{projectName}}/env/web";
+
+{{> getServerUrlSpaces}}
+
+const link = new RPCLink({
+  url: \`\${getServerUrl(env.VITE_SERVER_URL)}/rpc\`,
+{{#if (eq auth "better-auth")}}
+  fetch(url, options) {
+    return fetch(url, {
+      ...options,
+      credentials: "include",
+    });
+  },
+{{/if}}
+});
+
+export const client: AppRouterClient = createORPCClient(link);
+`],
   ["api/orpc/web/nuxt/app/plugins/orpc.ts.hbs", `import { defineNuxtPlugin } from '#app'
 import type { AppRouterClient } from "@{{projectName}}/api/routers/index";
 import { createORPCClient } from '@orpc/client'
@@ -9431,6 +9482,525 @@ import Layout from "../layouts/Layout.astro";
   </div>
 </Layout>
 `],
+  ["auth/better-auth/web/foldkit/src/auth/client.ts.hbs", `import { env } from "@{{projectName}}/env/web";
+import { createAuthClient } from "better-auth/client";
+
+{{> getServerUrlSpaces}}
+
+export const authClient = createAuthClient({
+  // better-auth derives its route-matching base from this URL's path, so the
+  // public auth path must equal the server-side mount (/api/auth everywhere)
+  baseURL: new URL("/api/auth", getServerUrl(env.VITE_SERVER_URL)).toString(),
+});
+`],
+  ["auth/better-auth/web/foldkit/src/auth/session.ts.hbs", `import { Effect, Option, Schema as S } from "effect";
+import { AsyncData, Command } from "foldkit";
+import { m } from "foldkit/message";
+
+import { authClient } from "./client";
+{{#if (eq api "orpc")}}
+import { client } from "../api/orpc";
+{{/if}}
+
+// MODEL
+
+export const Session = S.Struct({
+  user: S.Struct({
+    id: S.String,
+    name: S.String,
+    email: S.String,
+  }),
+});
+export type Session = typeof Session.Type;
+
+export const SessionState = AsyncData.Schema(S.Option(Session), S.String);
+export type SessionState = typeof SessionState.schema.Type;
+
+export const toSession = (user: Readonly<{ id: string; name: string; email: string }>): Session => ({
+  user: { id: user.id, name: user.name, email: user.email },
+});
+
+export const currentSession = (state: SessionState): Option.Option<Session> =>
+  Option.flatten(AsyncData.getData(state));
+{{#if (eq api "orpc")}}
+
+export const PrivateData = AsyncData.Schema(S.String, S.String);
+export type PrivateData = typeof PrivateData.schema.Type;
+{{/if}}
+
+// MESSAGE
+
+export const CompletedFetchSession = m("CompletedFetchSession", {
+  maybeSession: S.Option(Session),
+});
+export const CompletedSignOut = m("CompletedSignOut");
+{{#if (eq api "orpc")}}
+export const SucceededFetchPrivateData = m("SucceededFetchPrivateData", {
+  message: S.String,
+});
+export const FailedFetchPrivateData = m("FailedFetchPrivateData", {
+  error: S.String,
+});
+{{/if}}
+
+// COMMAND
+
+export const FetchSession = Command.define("FetchSession", {
+  messages: [CompletedFetchSession],
+  execute: Effect.tryPromise(() => authClient.getSession()).pipe(
+    Effect.map((result) =>
+      CompletedFetchSession({
+        maybeSession: Option.map(Option.fromNullishOr(result.data), (data) =>
+          toSession(data.user),
+        ),
+      }),
+    ),
+    Effect.catch(() => Effect.succeed(CompletedFetchSession({ maybeSession: Option.none() }))),
+  ),
+});
+
+export const SignOut = Command.define("SignOut", {
+  messages: [CompletedSignOut],
+  execute: Effect.tryPromise(() => authClient.signOut()).pipe(
+    Effect.as(CompletedSignOut()),
+    Effect.catch(() => Effect.succeed(CompletedSignOut())),
+  ),
+});
+{{#if (eq api "orpc")}}
+
+export const FetchPrivateData = Command.define("FetchPrivateData", {
+  messages: [SucceededFetchPrivateData, FailedFetchPrivateData],
+  execute: Effect.tryPromise((signal) => client.privateData(undefined, { signal })).pipe(
+    Effect.map(({ message }) => SucceededFetchPrivateData({ message })),
+    Effect.catch(() =>
+      Effect.succeed(FailedFetchPrivateData({ error: "Could not load private data" })),
+    ),
+  ),
+});
+{{/if}}
+`],
+  ["auth/better-auth/web/foldkit/src/page/login.ts.hbs", `import { Array, Effect, Match as M, Option, Schema as S } from "effect";
+import { Button, Input } from "@foldkit/ui";
+import { Command, Submodel } from "foldkit";
+import {
+  Field,
+  Invalid,
+  NotValidated,
+  Rule,
+  allValid,
+  makeRules,
+  validate,
+} from "foldkit/fieldValidation";
+import type { Html, HtmlBuilder } from "foldkit/html";
+import { m } from "foldkit/message";
+import { evo } from "foldkit/struct";
+
+import { authClient } from "../auth/client";
+import { Session, toSession } from "../auth/session";
+
+// MODEL
+
+const AuthMode = S.Literals(["SignIn", "SignUp"]);
+type AuthMode = typeof AuthMode.Type;
+
+export const Model = S.Struct({
+  mode: AuthMode,
+  name: Field(S.String),
+  email: Field(S.String),
+  password: Field(S.String),
+  isSubmitting: S.Boolean,
+  maybeError: S.Option(S.String),
+});
+
+export type Model = typeof Model.Type;
+
+export const init = (): Model => ({
+  mode: "SignIn",
+  name: NotValidated({ value: "" }),
+  email: NotValidated({ value: "" }),
+  password: NotValidated({ value: "" }),
+  isSubmitting: false,
+  maybeError: Option.none(),
+});
+
+// MESSAGE
+
+export const SelectedMode = m("SelectedMode", { mode: AuthMode });
+export const ChangedName = m("ChangedName", { value: S.String });
+export const ChangedEmail = m("ChangedEmail", { value: S.String });
+export const ChangedPassword = m("ChangedPassword", { value: S.String });
+export const SubmittedForm = m("SubmittedForm");
+export const SucceededAuthenticate = m("SucceededAuthenticate", { session: Session });
+export const FailedAuthenticate = m("FailedAuthenticate", { error: S.String });
+
+export const Message = S.Union([
+  SelectedMode,
+  ChangedName,
+  ChangedEmail,
+  ChangedPassword,
+  SubmittedForm,
+  SucceededAuthenticate,
+  FailedAuthenticate,
+]);
+export type Message = typeof Message.Type;
+
+// OUT MESSAGE
+
+export const CompletedAuthentication = m("CompletedAuthentication", { session: Session });
+
+export const OutMessage = S.Union([CompletedAuthentication]);
+export type OutMessage = typeof OutMessage.Type;
+
+// VALIDATION
+
+const nameRules = makeRules({
+  required: "Name is required",
+  rules: [Rule.minLength(2, "Name must be at least 2 characters")],
+});
+
+const emailRules = makeRules({
+  required: "Email is required",
+  rules: [Rule.email("Please enter a valid email")],
+});
+
+const passwordRules = makeRules({
+  required: "Password is required",
+  rules: [Rule.minLength(8, "Password must be at least 8 characters")],
+});
+
+const validateName = validate(nameRules);
+const validateEmail = validate(emailRules);
+const validatePassword = validate(passwordRules);
+
+const isFormValid = (model: Model): boolean =>
+  allValid(
+    model.mode === "SignUp"
+      ? [
+          [model.name, nameRules],
+          [model.email, emailRules],
+          [model.password, passwordRules],
+        ]
+      : [
+          [model.email, emailRules],
+          [model.password, passwordRules],
+        ],
+  );
+
+// COMMAND
+
+const SignIn = Command.define("SignIn", {
+  args: { email: S.String, password: S.String },
+  messages: [SucceededAuthenticate, FailedAuthenticate],
+  execute: ({ email, password }) =>
+    Effect.tryPromise(() => authClient.signIn.email({ email, password })).pipe(
+      Effect.map((result) =>
+        Option.match(Option.fromNullishOr(result.data), {
+          onNone: () =>
+            FailedAuthenticate({ error: result.error?.message ?? "Sign in failed" }),
+          onSome: (data) => SucceededAuthenticate({ session: toSession(data.user) }),
+        }),
+      ),
+      Effect.catch(() => Effect.succeed(FailedAuthenticate({ error: "Sign in failed" }))),
+    ),
+});
+
+const SignUp = Command.define("SignUp", {
+  args: { name: S.String, email: S.String, password: S.String },
+  messages: [SucceededAuthenticate, FailedAuthenticate],
+  execute: ({ name, email, password }) =>
+    Effect.tryPromise(() => authClient.signUp.email({ name, email, password })).pipe(
+      Effect.map((result) =>
+        Option.match(Option.fromNullishOr(result.data), {
+          onNone: () =>
+            FailedAuthenticate({ error: result.error?.message ?? "Sign up failed" }),
+          onSome: (data) => SucceededAuthenticate({ session: toSession(data.user) }),
+        }),
+      ),
+      Effect.catch(() => Effect.succeed(FailedAuthenticate({ error: "Sign up failed" }))),
+    ),
+});
+
+// UPDATE
+
+type UpdateReturn = readonly [
+  Model,
+  ReadonlyArray<Command.Command<Message>>,
+  Option.Option<OutMessage>,
+];
+const withUpdateReturn = M.withReturnType<UpdateReturn>();
+
+export const update = (model: Model, message: Message): UpdateReturn =>
+  M.value(message).pipe(
+    withUpdateReturn,
+    M.tagsExhaustive({
+      SelectedMode: ({ mode }) => [
+        evo(model, { mode: () => mode, maybeError: () => Option.none() }),
+        [],
+        Option.none(),
+      ],
+
+      ChangedName: ({ value }) => [
+        evo(model, { name: () => validateName(value) }),
+        [],
+        Option.none(),
+      ],
+
+      ChangedEmail: ({ value }) => [
+        evo(model, { email: () => validateEmail(value) }),
+        [],
+        Option.none(),
+      ],
+
+      ChangedPassword: ({ value }) => [
+        evo(model, { password: () => validatePassword(value) }),
+        [],
+        Option.none(),
+      ],
+
+      SubmittedForm: () => {
+        if (model.isSubmitting || !isFormValid(model)) {
+          return [model, [], Option.none()];
+        }
+
+        const command =
+          model.mode === "SignUp"
+            ? SignUp({
+                name: model.name.value,
+                email: model.email.value,
+                password: model.password.value,
+              })
+            : SignIn({ email: model.email.value, password: model.password.value });
+
+        return [
+          evo(model, { isSubmitting: () => true, maybeError: () => Option.none() }),
+          [command],
+          Option.none(),
+        ];
+      },
+
+      SucceededAuthenticate: ({ session }) => [
+        evo(model, { isSubmitting: () => false }),
+        [],
+        Option.some(CompletedAuthentication({ session })),
+      ],
+
+      FailedAuthenticate: ({ error }) => [
+        evo(model, {
+          isSubmitting: () => false,
+          maybeError: () => Option.some(error),
+          password: () => Invalid({ value: model.password.value, errors: [error] }),
+        }),
+        [],
+        Option.none(),
+      ],
+    }),
+  );
+
+// VIEW
+
+const fieldBorderClass = (field: Field<string>): string =>
+  M.value(field).pipe(
+    M.tagsExhaustive({
+      NotValidated: () => "border-neutral-700",
+      Validating: () => "border-neutral-500",
+      Valid: () => "border-green-600",
+      Invalid: () => "border-red-500",
+    }),
+  );
+
+const fieldView = (
+  id: string,
+  labelText: string,
+  type: "text" | "email" | "password",
+  field: Field<string>,
+  toMessage: (value: string) => Message,
+  h: HtmlBuilder<Message>,
+): Html =>
+  Input.view(
+    {
+      id,
+      type,
+      value: field.value,
+      onInput: toMessage,
+      isInvalid: field._tag === "Invalid",
+      toView: (attributes) =>
+        h.div(
+          [h.Class("space-y-1")],
+          [
+            h.label(
+              [...attributes.label, h.Class("block text-sm text-neutral-300")],
+              [labelText],
+            ),
+            h.input([
+              ...attributes.input,
+              h.Class(
+                \`w-full rounded border bg-neutral-900 px-3 py-2 outline-none \${fieldBorderClass(field)}\`,
+              ),
+            ]),
+            M.value(field).pipe(
+              M.tag("Invalid", ({ errors }) =>
+                h.p(
+                  [...attributes.description, h.Class("text-sm text-red-500")],
+                  [Array.headNonEmpty(errors)],
+                ),
+              ),
+              M.orElse(() => h.empty),
+            ),
+          ],
+        ),
+    },
+    h,
+  );
+
+const submitLabel = (model: Model): string => {
+  if (model.isSubmitting) {
+    return "Submitting...";
+  }
+  return model.mode === "SignIn" ? "Sign In" : "Sign Up";
+};
+
+const modeToggleView = (mode: AuthMode, h: HtmlBuilder<Message>): Html =>
+  Button.view(
+    {
+      onClick: SelectedMode({ mode: mode === "SignIn" ? "SignUp" : "SignIn" }),
+      toView: (attributes) =>
+        h.button(
+          [...attributes.button, h.Class("text-sm text-indigo-400 hover:underline")],
+          [mode === "SignIn" ? "Need an account? Sign Up" : "Already have an account? Sign In"],
+        ),
+    },
+    h,
+  );
+
+export const view = Submodel.defineView<Model, Message>((model, h) => {
+  const canSubmit = isFormValid(model) && !model.isSubmitting;
+
+  return h.div(
+    [h.Class("mx-auto mt-10 w-full max-w-md px-4")],
+    [
+      h.h1(
+        [h.Class("mb-6 text-center text-3xl font-bold")],
+        [model.mode === "SignIn" ? "Welcome Back" : "Create Account"],
+      ),
+      h.form(
+        [h.Class("space-y-4"), h.OnSubmit(SubmittedForm())],
+        [
+          model.mode === "SignUp"
+            ? fieldView("name", "Name", "text", model.name, (value) => ChangedName({ value }), h)
+            : h.empty,
+          fieldView("email", "Email", "email", model.email, (value) => ChangedEmail({ value }), h),
+          fieldView(
+            "password",
+            "Password",
+            "password",
+            model.password,
+            (value) => ChangedPassword({ value }),
+            h,
+          ),
+          Button.view(
+            {
+              type: "submit",
+              isDisabled: !canSubmit,
+              toView: (attributes) =>
+                h.button(
+                  [
+                    ...attributes.button,
+                    h.Class(
+                      "w-full rounded bg-indigo-600 py-2 font-medium text-white transition hover:bg-indigo-500 data-[disabled]:opacity-50",
+                    ),
+                  ],
+                  [submitLabel(model)],
+                ),
+            },
+            h,
+          ),
+        ],
+      ),
+      Option.match(model.maybeError, {
+        onNone: () => h.empty,
+        onSome: (error) => h.p([h.Class("mt-4 text-sm text-red-500")], [error]),
+      }),
+      h.div([h.Class("mt-4 text-center")], [modeToggleView(model.mode, h)]),
+    ],
+  );
+});
+`],
+  ["auth/better-auth/web/foldkit/src/view/dashboard.ts.hbs", `import { Option } from "effect";
+import { AsyncData } from "foldkit";
+import type { Html, HtmlBuilder } from "foldkit/html";
+
+{{#if (eq api "orpc")}}
+import type { PrivateData, Session, SessionState } from "../auth/session";
+{{else}}
+import type { Session, SessionState } from "../auth/session";
+{{/if}}
+import type { Message } from "../message";
+
+const noticeView = (text: string, h: HtmlBuilder<Message>): Html =>
+  h.p([h.Class("text-neutral-400")], [text]);
+{{#if (eq api "orpc")}}
+
+const privateDataView = (privateData: PrivateData, h: HtmlBuilder<Message>): Html =>
+  h.section(
+    [h.Class("rounded-lg border border-neutral-800 p-4")],
+    [
+      h.h2([h.Class("mb-2 font-medium")], ["Private API"]),
+      AsyncData.matchDataSplitEmpty(privateData, {
+        onIdle: () => noticeView("Not requested", h),
+        onLoading: () => noticeView("Loading...", h),
+        onFailure: (error) => h.p([h.Class("text-red-500")], [error]),
+        onData: (message) => h.p([h.Class("text-neutral-300")], [message]),
+      }),
+    ],
+  );
+{{/if}}
+
+const signedInView = (
+  session: Session,
+{{#if (eq api "orpc")}}
+  privateData: PrivateData,
+{{/if}}
+  h: HtmlBuilder<Message>,
+): Html =>
+  h.div(
+    [h.Class("grid gap-6")],
+    [
+      h.div(
+        [],
+        [
+          h.h1([h.Class("mb-2 text-3xl font-bold")], ["Dashboard"]),
+          h.p([h.Class("text-neutral-400")], [\`Signed in as \${session.user.email}\`]),
+        ],
+      ),
+{{#if (eq api "orpc")}}
+      privateDataView(privateData, h),
+{{/if}}
+    ],
+  );
+
+export const dashboardView = (
+  session: SessionState,
+{{#if (eq api "orpc")}}
+  privateData: PrivateData,
+{{/if}}
+  h: HtmlBuilder<Message>,
+): Html =>
+  h.div(
+    [h.Class("container mx-auto max-w-3xl px-4 py-8")],
+    [
+      AsyncData.matchDataSplitEmpty(session, {
+        onIdle: () => noticeView("Loading...", h),
+        onLoading: () => noticeView("Loading...", h),
+        onFailure: (error) => h.p([h.Class("text-red-500")], [error]),
+        onData: (maybeSession) =>
+          Option.match(maybeSession, {
+            onNone: () => noticeView("Redirecting to sign in...", h),
+            onSome: (session) => signedInView(session, {{#if (eq api "orpc")}}privateData, {{/if}}h),
+          }),
+      }),
+    ],
+  );
+`],
   ["auth/better-auth/web/nuxt/app/components/SignInForm.vue.hbs", `<script setup lang="ts">
 import * as z from 'zod'
 import type { FormSubmitEvent, AuthFormField } from '@nuxt/ui'
@@ -16306,7 +16876,7 @@ services:
 {{/if}}
     init: true
     ports:
-{{#if (includes frontend "tanstack-router")}}
+{{#if (or (includes frontend "tanstack-router") (includes frontend "foldkit"))}}
       - "3001:80"
 {{else}}
       - "3001:3001"
@@ -16364,7 +16934,7 @@ services:
 {{/if}}
 {{/if}}
     healthcheck:
-{{#if (includes frontend "tanstack-router")}}
+{{#if (or (includes frontend "tanstack-router") (includes frontend "foldkit"))}}
       test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:80/"]
 {{else}}
       test:
@@ -16610,6 +17180,60 @@ EXPOSE 3001
 
 WORKDIR /app/apps/web
 CMD ["node", "dist/server/entry.mjs"]
+`],
+  ["deploy/docker/web/foldkit/Dockerfile.hbs", `FROM node:24{{#unless (includes addons "vite-plus")}}-slim{{/unless}} AS builder
+{{#if (eq packageManager "bun")}}
+COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
+{{/if}}
+{{#if (eq packageManager "pnpm")}}
+RUN npm install -g pnpm@11
+{{/if}}
+WORKDIR /app
+{{#if (eq orm "prisma")}}
+# prisma generate resolves DATABASE_URL at install time; the real value comes from compose at runtime
+ENV DATABASE_URL={{#if (eq database "mysql")}}mysql://build:build@localhost:3306/build{{else if (eq database "mongodb")}}mongodb://localhost:27017/build{{else if (eq database "sqlite")}}file:./build.db{{else}}postgresql://build:build@localhost:5432/build{{/if}}
+{{/if}}
+
+COPY . .
+{{#if (eq packageManager "bun")}}
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install
+{{else if (eq packageManager "pnpm")}}
+RUN --mount=type=cache,target=/pnpm-store pnpm install --store-dir /pnpm-store
+{{else}}
+RUN --mount=type=cache,target=/root/.npm npm install
+{{/if}}
+
+{{#if (and (ne backend "none") (ne backend "convex"))}}
+ARG VITE_SERVER_URL
+ENV VITE_SERVER_URL=\${VITE_SERVER_URL}
+{{/if}}
+ENV NODE_ENV=production
+RUN cd apps/web && {{packageManager}} run build
+
+FROM nginx:alpine AS runner
+COPY --from=builder /app/apps/web/dist /usr/share/nginx/html
+COPY apps/web/nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]
+`],
+  ["deploy/docker/web/foldkit/nginx.conf", `server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript image/svg+xml;
+
+    location /assets/ {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+
+    # SPA fallback
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}
 `],
   ["deploy/docker/web/nuxt/Dockerfile.hbs", `FROM node:24-slim AS builder
 {{#if (eq packageManager "bun")}}
@@ -24197,6 +24821,354 @@ import Layout from "../layouts/Layout.astro";
   loadTodos();
 </script>
 `],
+  ["examples/todo/web/foldkit/src/page/todos.ts.hbs", `import { Array, Effect, Match as M, Option, Schema as S, String } from "effect";
+import { Button, Checkbox, Input } from "@foldkit/ui";
+import { AsyncData, Command, Submodel, Update } from "foldkit";
+import type { Html, HtmlBuilder } from "foldkit/html";
+import { m } from "foldkit/message";
+import { evo } from "foldkit/struct";
+
+import { client } from "../api/orpc";
+
+// MODEL
+
+const TodoId = {{#if (eq orm "mongoose")}}S.String{{else}}S.Number{{/if}};
+type TodoId = typeof TodoId.Type;
+
+const Todo = S.Struct({
+  id: TodoId,
+  text: S.String,
+  completed: S.Boolean,
+});
+type Todo = typeof Todo.Type;
+
+const TodoList = AsyncData.Schema(S.Array(Todo), S.String);
+
+export const Model = S.Struct({
+  todos: TodoList.schema,
+  newTodoText: S.String,
+  pendingTodoIds: S.Array(TodoId),
+  maybeError: S.Option(S.String),
+});
+
+export type Model = typeof Model.Type;
+
+// MESSAGE
+
+export const UpdatedNewTodoText = m("UpdatedNewTodoText", { text: S.String });
+export const SubmittedNewTodo = m("SubmittedNewTodo");
+export const ClickedToggleTodo = m("ClickedToggleTodo", {
+  id: TodoId,
+  completed: S.Boolean,
+});
+export const ClickedDeleteTodo = m("ClickedDeleteTodo", { id: TodoId });
+export const SucceededLoadTodos = m("SucceededLoadTodos", { todos: S.Array(Todo) });
+export const FailedLoadTodos = m("FailedLoadTodos", { error: S.String });
+export const SucceededCreateTodo = m("SucceededCreateTodo");
+export const FailedCreateTodo = m("FailedCreateTodo", { error: S.String });
+export const SucceededMutateTodo = m("SucceededMutateTodo", { id: TodoId });
+export const FailedMutateTodo = m("FailedMutateTodo", { id: TodoId, error: S.String });
+
+export const Message = S.Union([
+  UpdatedNewTodoText,
+  SubmittedNewTodo,
+  ClickedToggleTodo,
+  ClickedDeleteTodo,
+  SucceededLoadTodos,
+  FailedLoadTodos,
+  SucceededCreateTodo,
+  FailedCreateTodo,
+  SucceededMutateTodo,
+  FailedMutateTodo,
+]);
+export type Message = typeof Message.Type;
+
+// COMMAND
+
+const LoadTodos = Command.define("LoadTodos", {
+  messages: [SucceededLoadTodos, FailedLoadTodos],
+  execute: Effect.tryPromise((signal) => client.todo.getAll(undefined, { signal })).pipe(
+    Effect.map((todos) => SucceededLoadTodos({ todos })),
+    Effect.catch(() => Effect.succeed(FailedLoadTodos({ error: "Could not load todos" }))),
+  ),
+});
+
+const CreateTodo = Command.define("CreateTodo", {
+  args: { text: S.String },
+  messages: [SucceededCreateTodo, FailedCreateTodo],
+  execute: ({ text }) =>
+    Effect.tryPromise(() => client.todo.create({ text })).pipe(
+      Effect.as(SucceededCreateTodo()),
+      Effect.catch(() => Effect.succeed(FailedCreateTodo({ error: "Could not add the todo" }))),
+    ),
+});
+
+const ToggleTodo = Command.define("ToggleTodo", {
+  args: { id: TodoId, completed: S.Boolean },
+  messages: [SucceededMutateTodo, FailedMutateTodo],
+  execute: ({ id, completed }) =>
+    Effect.tryPromise(() => client.todo.toggle({ id, completed })).pipe(
+      Effect.as(SucceededMutateTodo({ id })),
+      Effect.catch(() =>
+        Effect.succeed(FailedMutateTodo({ id, error: "Could not update the todo" })),
+      ),
+    ),
+});
+
+const DeleteTodo = Command.define("DeleteTodo", {
+  args: { id: TodoId },
+  messages: [SucceededMutateTodo, FailedMutateTodo],
+  execute: ({ id }) =>
+    Effect.tryPromise(() => client.todo.delete({ id })).pipe(
+      Effect.as(SucceededMutateTodo({ id })),
+      Effect.catch(() =>
+        Effect.succeed(FailedMutateTodo({ id, error: "Could not delete the todo" })),
+      ),
+    ),
+});
+
+// INIT
+
+export const init = (): readonly [Model, ReadonlyArray<Command.Command<Message>>] => [
+  {
+    todos: TodoList.Loading(),
+    newTodoText: "",
+    pendingTodoIds: [],
+    maybeError: Option.none(),
+  },
+  [LoadTodos()],
+];
+
+// UPDATE
+
+type UpdateReturn = readonly [Model, ReadonlyArray<Command.Command<Message>>];
+const withUpdateReturn = M.withReturnType<UpdateReturn>();
+
+const refreshTodos = Update.refresh({
+  read: (model: Model) => Option.some(model.todos),
+  revalidate: AsyncData.revalidate,
+  write: (model, nextTodos) => evo(model, { todos: () => nextTodos }),
+  load: LoadTodos(),
+});
+
+const markPending =
+  (id: TodoId): Update.Step<Model, Message> =>
+  (model) => [
+    evo(model, { pendingTodoIds: Array.append(id), maybeError: () => Option.none() }),
+    [],
+  ];
+
+const clearPending =
+  (id: TodoId): Update.Step<Model, Message> =>
+  (model) => [
+    evo(model, {
+      pendingTodoIds: Array.filter((pendingId: TodoId) => pendingId !== id),
+    }),
+    [],
+  ];
+
+export const update = (model: Model, message: Message): UpdateReturn =>
+  M.value(message).pipe(
+    withUpdateReturn,
+    M.tagsExhaustive({
+      UpdatedNewTodoText: ({ text }) => [evo(model, { newTodoText: () => text }), []],
+
+      SubmittedNewTodo: () => {
+        const text = model.newTodoText.trim();
+        if (String.isEmpty(text)) {
+          return [model, []];
+        }
+        return [
+          evo(model, { newTodoText: () => "", maybeError: () => Option.none() }),
+          [CreateTodo({ text })],
+        ];
+      },
+
+      ClickedToggleTodo: ({ id, completed }) =>
+        Update.combine(model, [
+          markPending(id),
+          (nextModel) => [nextModel, [ToggleTodo({ id, completed: !completed })]],
+        ]),
+
+      ClickedDeleteTodo: ({ id }) =>
+        Update.combine(model, [
+          markPending(id),
+          (nextModel) => [nextModel, [DeleteTodo({ id })]],
+        ]),
+
+      SucceededLoadTodos: ({ todos }) => [
+        evo(model, { todos: () => TodoList.Success({ data: todos }) }),
+        [],
+      ],
+
+      FailedLoadTodos: ({ error }) => [
+        evo(model, { todos: () => TodoList.Failure({ error }) }),
+        [],
+      ],
+
+      SucceededCreateTodo: () => Update.combine(model, [refreshTodos]),
+
+      FailedCreateTodo: ({ error }) => [
+        evo(model, { maybeError: () => Option.some(error) }),
+        [],
+      ],
+
+      SucceededMutateTodo: ({ id }) => Update.combine(model, [clearPending(id), refreshTodos]),
+
+      FailedMutateTodo: ({ id, error }) =>
+        Update.combine(model, [
+          clearPending(id),
+          (nextModel) => [evo(nextModel, { maybeError: () => Option.some(error) }), []],
+        ]),
+    }),
+  );
+
+// VIEW
+
+const todoView = (
+  todo: Todo,
+  isPending: boolean,
+  h: HtmlBuilder<Message>,
+): Html =>
+  h.keyed("li")(
+    todo.id,
+    [
+      h.Class(
+        \`flex items-center justify-between gap-2 rounded border border-neutral-800 px-3 py-2 \${
+          isPending ? "opacity-50" : ""
+        }\`,
+      ),
+    ],
+    [
+      Checkbox.view(
+        {
+          id: \`todo-\${todo.id}\`,
+          isChecked: todo.completed,
+          isDisabled: isPending,
+          onToggle: () => ClickedToggleTodo({ id: todo.id, completed: todo.completed }),
+          toView: (attributes) =>
+            h.div(
+              [h.Class("flex items-center gap-2")],
+              [
+                h.div(
+                  [
+                    ...attributes.checkbox,
+                    h.Class(
+                      \`flex h-4 w-4 items-center justify-center rounded border border-neutral-600 \${
+                        todo.completed ? "bg-indigo-600" : ""
+                      }\`,
+                    ),
+                  ],
+                  todo.completed ? [h.span([h.Class("text-xs text-white")], ["✓"])] : [],
+                ),
+                h.span(
+                  [
+                    ...attributes.label,
+                    h.Class(todo.completed ? "text-neutral-500 line-through" : ""),
+                  ],
+                  [todo.text],
+                ),
+              ],
+            ),
+        },
+        h,
+      ),
+      Button.view(
+        {
+          onClick: ClickedDeleteTodo({ id: todo.id }),
+          isDisabled: isPending,
+          toView: (attributes) =>
+            h.button(
+              [
+                ...attributes.button,
+                h.AriaLabel("Delete todo"),
+                h.Class("text-red-500 transition hover:text-red-400 data-[disabled]:opacity-50"),
+              ],
+              ["✕"],
+            ),
+        },
+        h,
+      ),
+    ],
+  );
+
+const todoListView = (
+  todos: ReadonlyArray<Todo>,
+  pendingTodoIds: ReadonlyArray<TodoId>,
+  h: HtmlBuilder<Message>,
+): Html =>
+  Array.match(todos, {
+    onEmpty: () => h.p([h.Class("text-neutral-400")], ["No todos yet."]),
+    onNonEmpty: (nonEmptyTodos) =>
+      h.ul(
+        [h.Class("space-y-2")],
+        Array.map(nonEmptyTodos, (todo) =>
+          todoView(todo, Array.contains(pendingTodoIds, todo.id), h),
+        ),
+      ),
+  });
+
+export const view = Submodel.defineView<Model, Message>((model, h) =>
+  h.div(
+    [h.Class("container mx-auto max-w-3xl px-4 py-8")],
+    [
+      h.h1([h.Class("mb-4 text-2xl font-bold")], ["Todos"]),
+
+      h.form(
+        [h.Class("mb-4 flex gap-2"), h.OnSubmit(SubmittedNewTodo())],
+        [
+          Input.view(
+            {
+              id: "new-todo",
+              value: model.newTodoText,
+              placeholder: "New task...",
+              onInput: (text) => UpdatedNewTodoText({ text }),
+              toView: (attributes) =>
+                h.input([
+                  ...attributes.input,
+                  h.AriaLabel("New todo"),
+                  h.Class(
+                    "flex-grow rounded border border-neutral-800 bg-neutral-900 px-3 py-2 outline-none",
+                  ),
+                ]),
+            },
+            h,
+          ),
+          Button.view(
+            {
+              type: "submit",
+              isDisabled: String.isEmpty(model.newTodoText.trim()),
+              toView: (attributes) =>
+                h.button(
+                  [
+                    ...attributes.button,
+                    h.Class(
+                      "rounded bg-indigo-600 px-4 py-2 text-white transition hover:bg-indigo-500 data-[disabled]:opacity-50",
+                    ),
+                  ],
+                  ["Add"],
+                ),
+            },
+            h,
+          ),
+        ],
+      ),
+
+      AsyncData.matchDataSplitEmpty(model.todos, {
+        onIdle: () => h.empty,
+        onLoading: () => h.p([h.Class("text-neutral-400")], ["Loading..."]),
+        onFailure: (error) => h.p([h.Class("text-red-500")], [error]),
+        onData: (todos) => todoListView(todos, model.pendingTodoIds, h),
+      }),
+
+      Option.match(model.maybeError, {
+        onNone: () => h.empty,
+        onSome: (error) => h.p([h.Class("mt-4 text-sm text-red-500")], [error]),
+      }),
+    ],
+  ),
+);
+`],
   ["examples/todo/web/nuxt/app/pages/todos.vue.hbs", `<script setup lang="ts">
 import { ref } from 'vue'
 {{#if (eq backend "convex")}}
@@ -26259,6 +27231,776 @@ const TITLE_TEXT = \`
   "include": [".astro/types.d.ts", "**/*"],
   "exclude": ["dist"]
 }
+`],
+  ["frontend/foldkit/_gitignore", `node_modules
+.DS_Store
+dist
+.output
+.vercel
+.netlify
+*.local
+.env
+.env.*
+
+.wrangler
+.alchemy
+.dev.vars*
+`],
+  ["frontend/foldkit/index.html.hbs", `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link href="/src/styles.css" rel="stylesheet" />
+    <title>{{projectName}}</title>
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/entry.ts"></script>
+  </body>
+</html>
+`],
+  ["frontend/foldkit/package.json.hbs", `{
+  "name": "web",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "serve": "vite preview",
+    "start": "vite preview",
+    "check-types": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@foldkit/ui": "^0.145.0",
+    "effect": "4.0.0-rc.108",
+    "foldkit": "^0.145.0"
+  },
+  "devDependencies": {
+    "@foldkit/devtools": "^0.145.0",
+    "@foldkit/vite-plugin": "^0.13.1",
+    "@tailwindcss/vite": "^4.3.3",
+    "tailwindcss": "^4.3.3",
+    "vite": "^8.1.5"
+  }
+}
+`],
+  ["frontend/foldkit/src/entry.ts.hbs", `import { Runtime } from "foldkit";
+
+import { ChangedUrl, ClickedLink, Message } from "./message";
+import { Model, init, update, view } from "./main";
+
+const application = Runtime.makeApplication({
+  Model,
+  init,
+  update,
+  view,
+  container: document.getElementById("root"),
+  routing: {
+    onUrlRequest: (request) => ClickedLink({ request }),
+    onUrlChange: (url) => ChangedUrl({ url }),
+  },
+  devTools: {
+    Message,
+  },
+});
+
+Runtime.run(application);
+`],
+  ["frontend/foldkit/src/main.ts.hbs", `import { Effect, Match as M, {{#if (or (eq auth "better-auth") (includes examples "todo"))}}Option, {{/if}}Schema as S } from "effect";
+import { {{#if (or (eq api "orpc") (eq auth "better-auth"))}}AsyncData, {{/if}}Command, Runtime{{#if (or (eq auth "better-auth") (includes examples "todo"))}}, Update{{/if}} } from "foldkit";
+import type { Document, Html, HtmlBuilder } from "foldkit/html";
+import { load, pushUrl{{#if (eq auth "better-auth")}}, replaceUrl{{/if}} } from "foldkit/navigation";
+import { evo } from "foldkit/struct";
+import { toString as urlToString } from "foldkit/url";
+
+{{#if (eq api "orpc")}}
+import { FetchHealthCheck, HealthCheck } from "./api/health";
+{{/if}}
+{{#if (eq auth "better-auth")}}
+import {
+  FetchSession,
+{{#if (eq api "orpc")}}
+  FetchPrivateData,
+  PrivateData,
+{{/if}}
+  SessionState,
+  SignOut,
+  currentSession,
+} from "./auth/session";
+import * as Login from "./page/login";
+import { dashboardView } from "./view/dashboard";
+{{/if}}
+{{#if (includes examples "todo")}}
+import * as Todos from "./page/todos";
+{{/if}}
+import {
+  CompletedLoadExternal,
+  CompletedNavigateInternal,
+{{#if (eq auth "better-auth")}}
+  GotLoginMessage,
+{{/if}}
+{{#if (includes examples "todo")}}
+  GotTodosMessage,
+{{/if}}
+  type Message,
+} from "./message";
+{{#if (eq auth "better-auth")}}
+import { AppRoute, dashboardRouter, homeRouter, loginRouter, urlToAppRoute } from "./route";
+{{else}}
+import { AppRoute, urlToAppRoute } from "./route";
+{{/if}}
+import { headerView } from "./view/header";
+import { homeView } from "./view/home";
+import { notFoundView } from "./view/notFound";
+
+// MODEL
+
+export const Model = S.Struct({
+  route: AppRoute,
+{{#if (eq api "orpc")}}
+  healthCheck: HealthCheck.schema,
+{{/if}}
+{{#if (eq auth "better-auth")}}
+  session: SessionState.schema,
+  login: Login.Model,
+{{#if (eq api "orpc")}}
+  privateData: PrivateData.schema,
+{{/if}}
+{{/if}}
+{{#if (includes examples "todo")}}
+  todos: Todos.Model,
+{{/if}}
+});
+
+export type Model = typeof Model.Type;
+
+// INIT
+
+export const init: Runtime.RoutingApplicationInit<Model, Message> = (url) => {
+{{#if (includes examples "todo")}}
+  const [todos, todosCommands] = Todos.init();
+
+{{/if}}
+  const model: Model = {
+    route: urlToAppRoute(url),
+{{#if (eq api "orpc")}}
+    healthCheck: HealthCheck.Loading(),
+{{/if}}
+{{#if (eq auth "better-auth")}}
+    session: SessionState.Loading(),
+    login: Login.init(),
+{{#if (eq api "orpc")}}
+    privateData: PrivateData.Idle(),
+{{/if}}
+{{/if}}
+{{#if (includes examples "todo")}}
+    todos,
+{{/if}}
+  };
+
+  return [
+    model,
+    [
+{{#if (eq api "orpc")}}
+      FetchHealthCheck(),
+{{/if}}
+{{#if (eq auth "better-auth")}}
+      FetchSession(),
+{{/if}}
+{{#if (includes examples "todo")}}
+      ...Command.mapMessages(todosCommands, (message) => GotTodosMessage({ message })),
+{{/if}}
+    ],
+  ];
+};
+
+// COMMAND
+
+const NavigateInternal = Command.define("NavigateInternal", {
+  args: { url: S.String },
+  messages: [CompletedNavigateInternal],
+  execute: ({ url }) => pushUrl(url).pipe(Effect.as(CompletedNavigateInternal())),
+});
+
+const LoadExternal = Command.define("LoadExternal", {
+  args: { href: S.String },
+  messages: [CompletedLoadExternal],
+  execute: ({ href }) => load(href).pipe(Effect.as(CompletedLoadExternal())),
+});
+{{#if (eq auth "better-auth")}}
+
+const RedirectToLogin = Command.define("RedirectToLogin", {
+  messages: [CompletedNavigateInternal],
+  execute: replaceUrl(loginRouter()).pipe(Effect.as(CompletedNavigateInternal())),
+});
+
+const RedirectToDashboard = Command.define("RedirectToDashboard", {
+  messages: [CompletedNavigateInternal],
+  execute: replaceUrl(dashboardRouter()).pipe(Effect.as(CompletedNavigateInternal())),
+});
+
+const RedirectToHome = Command.define("RedirectToHome", {
+  messages: [CompletedNavigateInternal],
+  execute: replaceUrl(homeRouter()).pipe(Effect.as(CompletedNavigateInternal())),
+});
+{{/if}}
+
+// UPDATE
+
+type UpdateReturn = readonly [Model, ReadonlyArray<Command.Command<Message>>];
+const withUpdateReturn = M.withReturnType<UpdateReturn>();
+{{#if (eq auth "better-auth")}}
+
+// The session resolves after the first paint, so the guard waits for the fetch
+// to settle before it redirects; until then the page renders its loading state.
+const enforceRouteAccess = (model: Model): UpdateReturn =>
+  M.value(model.route).pipe(
+    withUpdateReturn,
+    M.tag("Dashboard", () => {
+      if (AsyncData.isPending(model.session)) {
+        return [model, []];
+      }
+      if (Option.isNone(currentSession(model.session))) {
+        return [model, [RedirectToLogin()]];
+      }
+{{#if (eq api "orpc")}}
+      return AsyncData.isIdle(model.privateData)
+        ? [evo(model, { privateData: () => PrivateData.Loading() }), [FetchPrivateData()]]
+        : [model, []];
+{{else}}
+      return [model, []];
+{{/if}}
+    }),
+    M.tag("Login", () =>
+      Option.isSome(currentSession(model.session))
+        ? [model, [RedirectToDashboard()]]
+        : [model, []],
+    ),
+    M.orElse(() => [model, []]),
+  );
+
+const foldLoginOutMessage: (
+  outMessage: Login.OutMessage,
+) => Update.Step<Model, Message> = M.type<Login.OutMessage>().pipe(
+  M.withReturnType<Update.Step<Model, Message>>(),
+  M.tagsExhaustive({
+    CompletedAuthentication:
+      ({ session }) =>
+      (model) => [
+        evo(model, { session: () => SessionState.Success({ data: Option.some(session) }) }),
+        [RedirectToDashboard()],
+      ],
+  }),
+);
+
+const foldLogin = Update.foldChild({
+  update: Login.update,
+  read: (model: Model) => Option.some(model.login),
+  write: (model, nextLogin) => evo(model, { login: () => nextLogin }),
+  toParentMessage: (message) => GotLoginMessage({ message }),
+  foldOutMessage: foldLoginOutMessage,
+});
+{{/if}}
+{{#if (includes examples "todo")}}
+
+const foldTodos = Update.foldChild({
+  update: Todos.update,
+  read: (model: Model) => Option.some(model.todos),
+  write: (model, nextTodos) => evo(model, { todos: () => nextTodos }),
+  toParentMessage: (message) => GotTodosMessage({ message }),
+});
+{{/if}}
+
+export const update = (model: Model, message: Message): UpdateReturn =>
+  M.value(message).pipe(
+    withUpdateReturn,
+    M.tagsExhaustive({
+      CompletedNavigateInternal: () => [model, []],
+      CompletedLoadExternal: () => [model, []],
+
+      ClickedLink: ({ request }) =>
+        M.value(request).pipe(
+          withUpdateReturn,
+          M.tagsExhaustive({
+            Internal: ({ url }) => [model, [NavigateInternal({ url: urlToString(url) })]],
+            External: ({ href }) => [model, [LoadExternal({ href })]],
+          }),
+        ),
+
+{{#if (eq auth "better-auth")}}
+      ChangedUrl: ({ url }) => enforceRouteAccess(evo(model, { route: () => urlToAppRoute(url) })),
+{{else}}
+      ChangedUrl: ({ url }) => [evo(model, { route: () => urlToAppRoute(url) }), []],
+{{/if}}
+{{#if (eq api "orpc")}}
+
+      SucceededFetchHealthCheck: ({ status }) => [
+        evo(model, { healthCheck: () => HealthCheck.Success({ data: status }) }),
+        [],
+      ],
+
+      FailedFetchHealthCheck: ({ error }) => [
+        evo(model, { healthCheck: () => HealthCheck.Failure({ error }) }),
+        [],
+      ],
+{{/if}}
+{{#if (eq auth "better-auth")}}
+
+      CompletedFetchSession: ({ maybeSession }) =>
+        enforceRouteAccess(
+          evo(model, { session: () => SessionState.Success({ data: maybeSession }) }),
+        ),
+
+      ClickedSignOut: () => [model, [SignOut()]],
+
+      CompletedSignOut: () => [
+        evo(model, {
+          session: () => SessionState.Success({ data: Option.none() }),
+{{#if (eq api "orpc")}}
+          privateData: () => PrivateData.Idle(),
+{{/if}}
+        }),
+        [RedirectToHome()],
+      ],
+
+      GotLoginMessage: ({ message }) => foldLogin(model, message),
+{{#if (eq api "orpc")}}
+
+      SucceededFetchPrivateData: ({ message }) => [
+        evo(model, { privateData: () => PrivateData.Success({ data: message }) }),
+        [],
+      ],
+
+      FailedFetchPrivateData: ({ error }) => [
+        evo(model, { privateData: () => PrivateData.Failure({ error }) }),
+        [],
+      ],
+{{/if}}
+{{/if}}
+{{#if (includes examples "todo")}}
+
+      GotTodosMessage: ({ message }) => foldTodos(model, message),
+{{/if}}
+    }),
+  );
+
+// VIEW
+
+const routeTitle = (route: AppRoute): string =>
+  M.value(route).pipe(
+    M.tag("Home", () => "{{projectName}}"),
+{{#if (includes examples "todo")}}
+    M.tag("Todos", () => "Todos | {{projectName}}"),
+{{/if}}
+{{#if (eq auth "better-auth")}}
+    M.tag("Login", () => "Sign In | {{projectName}}"),
+    M.tag("Dashboard", () => "Dashboard | {{projectName}}"),
+{{/if}}
+    M.orElse(() => "Not Found | {{projectName}}"),
+  );
+
+export const view = (model: Model, h: HtmlBuilder<Message>): Document => {
+  const content = M.value(model.route).pipe(
+    M.withReturnType<Html>(),
+    M.tagsExhaustive({
+      Home: () => homeView({{#if (eq api "orpc")}}model.healthCheck, {{/if}}h),
+{{#if (includes examples "todo")}}
+      Todos: () =>
+        h.submodel({
+          slotId: "todos",
+          model: model.todos,
+          view: Todos.view,
+          toParentMessage: (message) => GotTodosMessage({ message }),
+        }),
+{{/if}}
+{{#if (eq auth "better-auth")}}
+      Login: () =>
+        h.submodel({
+          slotId: "login",
+          model: model.login,
+          view: Login.view,
+          toParentMessage: (message) => GotLoginMessage({ message }),
+        }),
+      Dashboard: () => dashboardView(model.session, {{#if (eq api "orpc")}}model.privateData, {{/if}}h),
+{{/if}}
+      NotFound: ({ path }) => notFoundView(path, h),
+    }),
+  );
+
+  return {
+    title: routeTitle(model.route),
+    body: h.div(
+      [h.Class("grid h-svh grid-rows-[auto_1fr]")],
+      [
+        headerView(model.route, {{#if (eq auth "better-auth")}}currentSession(model.session), {{/if}}h),
+        h.main([h.Class("overflow-y-auto")], [content]),
+      ],
+    ),
+  };
+};
+`],
+  ["frontend/foldkit/src/message.ts.hbs", `import { Schema as S } from "effect";
+import { m } from "foldkit/message";
+import { UrlRequest } from "foldkit/navigation";
+import { Url } from "foldkit/url";
+
+{{#if (eq api "orpc")}}
+import { FailedFetchHealthCheck, SucceededFetchHealthCheck } from "./api/health";
+{{/if}}
+{{#if (eq auth "better-auth")}}
+import {
+  CompletedFetchSession,
+  CompletedSignOut,
+{{#if (eq api "orpc")}}
+  FailedFetchPrivateData,
+  SucceededFetchPrivateData,
+{{/if}}
+} from "./auth/session";
+import * as Login from "./page/login";
+{{/if}}
+{{#if (includes examples "todo")}}
+import * as Todos from "./page/todos";
+{{/if}}
+
+// MESSAGE
+
+export const CompletedNavigateInternal = m("CompletedNavigateInternal");
+export const CompletedLoadExternal = m("CompletedLoadExternal");
+export const ClickedLink = m("ClickedLink", { request: UrlRequest });
+export const ChangedUrl = m("ChangedUrl", { url: Url });
+{{#if (eq auth "better-auth")}}
+export const ClickedSignOut = m("ClickedSignOut");
+export const GotLoginMessage = m("GotLoginMessage", { message: Login.Message });
+{{/if}}
+{{#if (includes examples "todo")}}
+export const GotTodosMessage = m("GotTodosMessage", { message: Todos.Message });
+{{/if}}
+
+export const Message = S.Union([
+  CompletedNavigateInternal,
+  CompletedLoadExternal,
+  ClickedLink,
+  ChangedUrl,
+{{#if (eq api "orpc")}}
+  SucceededFetchHealthCheck,
+  FailedFetchHealthCheck,
+{{/if}}
+{{#if (eq auth "better-auth")}}
+  CompletedFetchSession,
+  CompletedSignOut,
+  ClickedSignOut,
+  GotLoginMessage,
+{{#if (eq api "orpc")}}
+  SucceededFetchPrivateData,
+  FailedFetchPrivateData,
+{{/if}}
+{{/if}}
+{{#if (includes examples "todo")}}
+  GotTodosMessage,
+{{/if}}
+]);
+export type Message = typeof Message.Type;
+`],
+  ["frontend/foldkit/src/route.ts.hbs", `import { Schema as S, pipe } from "effect";
+import { Route } from "foldkit";
+{{#if (or (includes examples "todo") (eq auth "better-auth"))}}
+import { literal, r } from "foldkit/route";
+{{else}}
+import { r } from "foldkit/route";
+{{/if}}
+
+export const HomeRoute = r("Home");
+{{#if (includes examples "todo")}}
+export const TodosRoute = r("Todos");
+{{/if}}
+{{#if (eq auth "better-auth")}}
+export const LoginRoute = r("Login");
+export const DashboardRoute = r("Dashboard");
+{{/if}}
+export const NotFoundRoute = r("NotFound", { path: S.String });
+
+export const AppRoute = S.Union([
+  HomeRoute,
+{{#if (includes examples "todo")}}
+  TodosRoute,
+{{/if}}
+{{#if (eq auth "better-auth")}}
+  LoginRoute,
+  DashboardRoute,
+{{/if}}
+  NotFoundRoute,
+]);
+
+export type HomeRoute = typeof HomeRoute.Type;
+{{#if (includes examples "todo")}}
+export type TodosRoute = typeof TodosRoute.Type;
+{{/if}}
+{{#if (eq auth "better-auth")}}
+export type LoginRoute = typeof LoginRoute.Type;
+export type DashboardRoute = typeof DashboardRoute.Type;
+{{/if}}
+export type NotFoundRoute = typeof NotFoundRoute.Type;
+export type AppRoute = typeof AppRoute.Type;
+
+export const homeRouter = pipe(Route.root, Route.mapTo(HomeRoute));
+{{#if (includes examples "todo")}}
+export const todosRouter = pipe(literal("todos"), Route.mapTo(TodosRoute));
+{{/if}}
+{{#if (eq auth "better-auth")}}
+export const loginRouter = pipe(literal("login"), Route.mapTo(LoginRoute));
+export const dashboardRouter = pipe(literal("dashboard"), Route.mapTo(DashboardRoute));
+{{/if}}
+
+const routeParser = Route.oneOf(
+{{#if (includes examples "todo")}}
+  todosRouter,
+{{/if}}
+{{#if (eq auth "better-auth")}}
+  loginRouter,
+  dashboardRouter,
+{{/if}}
+  homeRouter,
+);
+
+export const urlToAppRoute = Route.parseUrlWithFallback(routeParser, NotFoundRoute);
+`],
+  ["frontend/foldkit/src/styles.css", `@import "tailwindcss";
+
+body {
+  @apply bg-neutral-950 text-neutral-100;
+}
+`],
+  ["frontend/foldkit/src/view/header.ts.hbs", `import { Array{{#if (eq auth "better-auth")}}, Option{{/if}} } from "effect";
+{{#if (eq auth "better-auth")}}
+import { Button } from "@foldkit/ui";
+{{/if}}
+import type { Html, HtmlBuilder } from "foldkit/html";
+
+{{#if (eq auth "better-auth")}}
+import type { Session } from "../auth/session";
+import { ClickedSignOut, type Message } from "../message";
+{{else}}
+import type { Message } from "../message";
+{{/if}}
+{{#if (eq auth "better-auth")}}
+import { type AppRoute, dashboardRouter, homeRouter, loginRouter{{#if (includes examples "todo")}}, todosRouter{{/if}} } from "../route";
+{{else if (includes examples "todo")}}
+import { type AppRoute, homeRouter, todosRouter } from "../route";
+{{else}}
+import { type AppRoute, homeRouter } from "../route";
+{{/if}}
+
+type NavLink = Readonly<{
+  href: string;
+  label: string;
+  isActive: boolean;
+}>;
+
+const navLinksFor = (route: AppRoute): ReadonlyArray<NavLink> => [
+  { href: homeRouter(), label: "Home", isActive: route._tag === "Home" },
+{{#if (includes examples "todo")}}
+  { href: todosRouter(), label: "Todos", isActive: route._tag === "Todos" },
+{{/if}}
+{{#if (eq auth "better-auth")}}
+  { href: dashboardRouter(), label: "Dashboard", isActive: route._tag === "Dashboard" },
+{{/if}}
+];
+
+const navLinkView = (link: NavLink, h: HtmlBuilder<Message>): Html =>
+  h.keyed("a")(
+    link.href,
+    [
+      h.Href(link.href),
+      h.Class(
+        \`rounded px-3 py-1 text-sm font-medium transition hover:bg-neutral-800 \${
+          link.isActive ? "bg-neutral-800" : ""
+        }\`,
+      ),
+    ],
+    [link.label],
+  );
+{{#if (eq auth "better-auth")}}
+
+const userMenuView = (maybeSession: Option.Option<Session>, h: HtmlBuilder<Message>): Html =>
+  Option.match(maybeSession, {
+    onNone: () =>
+      h.a(
+        [
+          h.Href(loginRouter()),
+          h.Class("rounded bg-indigo-600 px-3 py-1 text-sm text-white transition hover:bg-indigo-500"),
+        ],
+        ["Sign In"],
+      ),
+    onSome: (session) =>
+      h.div(
+        [h.Class("flex items-center gap-3")],
+        [
+          h.span([h.Class("text-sm text-neutral-300")], [session.user.name]),
+          Button.view(
+            {
+              onClick: ClickedSignOut(),
+              toView: (attributes) =>
+                h.button(
+                  [
+                    ...attributes.button,
+                    h.Class(
+                      "rounded bg-neutral-800 px-3 py-1 text-sm transition hover:bg-neutral-700",
+                    ),
+                  ],
+                  ["Sign Out"],
+                ),
+            },
+            h,
+          ),
+        ],
+      ),
+  });
+{{/if}}
+
+export const headerView = (
+  route: AppRoute,
+{{#if (eq auth "better-auth")}}
+  maybeSession: Option.Option<Session>,
+{{/if}}
+  h: HtmlBuilder<Message>,
+): Html =>
+  h.header(
+    [h.Class("border-b border-neutral-800")],
+    [
+      h.div(
+        [h.Class("mx-auto flex max-w-3xl items-center justify-between px-4 py-3")],
+        [
+          h.nav([h.Class("flex gap-2")], Array.map(navLinksFor(route), (link) => navLinkView(link, h))),
+{{#if (eq auth "better-auth")}}
+          userMenuView(maybeSession, h),
+{{/if}}
+        ],
+      ),
+    ],
+  );
+`],
+  ["frontend/foldkit/src/view/home.ts.hbs", `{{#if (eq api "orpc")}}
+import { AsyncData } from "foldkit";
+{{/if}}
+import type { Html, HtmlBuilder } from "foldkit/html";
+
+{{#if (eq api "orpc")}}
+import type { HealthCheck } from "../api/health";
+{{/if}}
+import type { Message } from "../message";
+
+const TITLE_TEXT = \`
+ ██████╗ ███████╗████████╗████████╗███████╗██████╗
+ ██╔══██╗██╔════╝╚══██╔══╝╚══██╔══╝██╔════╝██╔══██╗
+ ██████╔╝█████╗     ██║      ██║   █████╗  ██████╔╝
+ ██╔══██╗██╔══╝     ██║      ██║   ██╔══╝  ██╔══██╗
+ ██████╔╝███████╗   ██║      ██║   ███████╗██║  ██║
+ ╚═════╝ ╚══════╝   ╚═╝      ╚═╝   ╚══════╝╚═╝  ╚═╝
+
+ ████████╗    ███████╗████████╗ █████╗  ██████╗██╗  ██╗
+ ╚══██╔══╝    ██╔════╝╚══██╔══╝██╔══██╗██╔════╝██║ ██╔╝
+    ██║       ███████╗   ██║   ███████║██║     █████╔╝
+    ██║       ╚════██║   ██║   ██╔══██║██║     ██╔═██╗
+    ██║       ███████║   ██║   ██║  ██║╚██████╗██║  ██╗
+    ╚═╝       ╚══════╝   ╚═╝   ╚═╝  ╚═╝ ╚═════╝╚═╝  ╚═╝
+ \`;
+{{#if (eq api "orpc")}}
+
+const statusView = (
+  dotClass: string,
+  label: string,
+  h: HtmlBuilder<Message>,
+): Html =>
+  h.div(
+    [h.Class("flex items-center gap-2")],
+    [
+      h.div([h.Class(\`h-2 w-2 rounded-full \${dotClass}\`)]),
+      h.span([h.Class("text-sm text-neutral-400")], [label]),
+    ],
+  );
+
+const apiStatusView = (healthCheck: HealthCheck, h: HtmlBuilder<Message>): Html =>
+  h.section(
+    [h.Class("rounded-lg border border-neutral-800 p-4")],
+    [
+      h.h2([h.Class("mb-2 font-medium")], ["API Status"]),
+      AsyncData.matchDataSplitEmpty(healthCheck, {
+        onIdle: () => statusView("bg-neutral-600", "Not checked", h),
+        onLoading: () => statusView("bg-orange-400", "Checking...", h),
+        onFailure: (error) => statusView("bg-red-500", error, h),
+        onData: () => statusView("bg-green-500", "Connected", h),
+      }),
+    ],
+  );
+{{/if}}
+
+export const homeView = ({{#if (eq api "orpc")}}healthCheck: HealthCheck, {{/if}}h: HtmlBuilder<Message>): Html =>
+  h.div(
+    [h.Class("container mx-auto max-w-3xl px-4 py-2")],
+    [
+      h.pre([h.Class("overflow-x-auto font-mono text-sm")], [TITLE_TEXT]),
+      h.div(
+        [h.Class("grid gap-6")],
+        [
+{{#if (eq api "orpc")}}
+          apiStatusView(healthCheck, h),
+{{else}}
+          h.p(
+            [h.Class("text-sm text-neutral-400")],
+            ["Model, Message, update, view. Edit src/main.ts to get started."],
+          ),
+{{/if}}
+        ],
+      ),
+    ],
+  );
+`],
+  ["frontend/foldkit/src/view/notFound.ts.hbs", `import type { Html, HtmlBuilder } from "foldkit/html";
+
+import type { Message } from "../message";
+import { homeRouter } from "../route";
+
+export const notFoundView = (path: string, h: HtmlBuilder<Message>): Html =>
+  h.div(
+    [h.Class("container mx-auto max-w-3xl px-4 py-10")],
+    [
+      h.h1([h.Class("mb-4 text-3xl font-bold")], ["Page not found"]),
+      h.p([h.Class("mb-6 text-neutral-400")], [\`Nothing is routed at "\${path}".\`]),
+      h.a([h.Href(homeRouter()), h.Class("text-indigo-400 hover:underline")], ["Go home"]),
+    ],
+  );
+`],
+  ["frontend/foldkit/tsconfig.json.hbs", `{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*.ts", "vite.config.ts"]
+}
+`],
+  ["frontend/foldkit/vite.config.ts.hbs", `import { foldkit } from "@foldkit/vite-plugin";
+import tailwindcss from "@tailwindcss/vite";
+import { defineConfig } from "{{#if (includes addons "vite-plus")}}vite-plus{{else}}vite{{/if}}";
+
+export default defineConfig({
+  server: {
+    port: 3001,
+  },
+  plugins: [tailwindcss(), foldkit()],
+});
 `],
   ["frontend/native/bare/_gitignore", `node_modules/
 .expo/
@@ -35680,4 +37422,4 @@ export default function Success() {
 `]
 ]);
 
-export const TEMPLATE_COUNT = 522;
+export const TEMPLATE_COUNT = 544;

--- a/packages/template-generator/src/utils/generated-ignore-patterns.ts
+++ b/packages/template-generator/src/utils/generated-ignore-patterns.ts
@@ -14,6 +14,7 @@ const FRONTEND_GENERATED_PATTERNS = {
   svelte: ["apps/web/.svelte-kit/**", "apps/web/build/**", "apps/web/.output/**"],
   solid: ["apps/web/dist/**", "apps/web/.output/**"],
   astro: ["apps/web/dist/**", "apps/web/.astro/**"],
+  foldkit: ["apps/web/dist/**"],
   "native-bare": ["apps/native/.expo/**", "apps/native/dist/**", "apps/native/web-build/**"],
   "native-uniwind": ["apps/native/.expo/**", "apps/native/dist/**", "apps/native/web-build/**"],
   "native-unistyles": [

--- a/packages/template-generator/templates/api/orpc/web/foldkit/src/api/health.ts.hbs
+++ b/packages/template-generator/templates/api/orpc/web/foldkit/src/api/health.ts.hbs
@@ -1,0 +1,29 @@
+import { Effect, Schema as S } from "effect";
+import { AsyncData, Command } from "foldkit";
+import { m } from "foldkit/message";
+
+import { client } from "./orpc";
+
+// MODEL
+
+export const HealthCheck = AsyncData.Schema(S.String, S.String);
+export type HealthCheck = typeof HealthCheck.schema.Type;
+
+// MESSAGE
+
+export const SucceededFetchHealthCheck = m("SucceededFetchHealthCheck", {
+  status: S.String,
+});
+export const FailedFetchHealthCheck = m("FailedFetchHealthCheck", {
+  error: S.String,
+});
+
+// COMMAND
+
+export const FetchHealthCheck = Command.define("FetchHealthCheck", {
+  messages: [SucceededFetchHealthCheck, FailedFetchHealthCheck],
+  execute: Effect.tryPromise((signal) => client.healthCheck(undefined, { signal })).pipe(
+    Effect.map((status) => SucceededFetchHealthCheck({ status })),
+    Effect.catch(() => Effect.succeed(FailedFetchHealthCheck({ error: "Disconnected" }))),
+  ),
+});

--- a/packages/template-generator/templates/api/orpc/web/foldkit/src/api/orpc.ts.hbs
+++ b/packages/template-generator/templates/api/orpc/web/foldkit/src/api/orpc.ts.hbs
@@ -1,0 +1,20 @@
+import { createORPCClient } from "@orpc/client";
+import { RPCLink } from "@orpc/client/fetch";
+import type { AppRouterClient } from "@{{projectName}}/api/routers/index";
+import { env } from "@{{projectName}}/env/web";
+
+{{> getServerUrlSpaces}}
+
+const link = new RPCLink({
+  url: `${getServerUrl(env.VITE_SERVER_URL)}/rpc`,
+{{#if (eq auth "better-auth")}}
+  fetch(url, options) {
+    return fetch(url, {
+      ...options,
+      credentials: "include",
+    });
+  },
+{{/if}}
+});
+
+export const client: AppRouterClient = createORPCClient(link);

--- a/packages/template-generator/templates/auth/better-auth/web/foldkit/src/auth/client.ts.hbs
+++ b/packages/template-generator/templates/auth/better-auth/web/foldkit/src/auth/client.ts.hbs
@@ -1,0 +1,10 @@
+import { env } from "@{{projectName}}/env/web";
+import { createAuthClient } from "better-auth/client";
+
+{{> getServerUrlSpaces}}
+
+export const authClient = createAuthClient({
+  // better-auth derives its route-matching base from this URL's path, so the
+  // public auth path must equal the server-side mount (/api/auth everywhere)
+  baseURL: new URL("/api/auth", getServerUrl(env.VITE_SERVER_URL)).toString(),
+});

--- a/packages/template-generator/templates/auth/better-auth/web/foldkit/src/auth/session.ts.hbs
+++ b/packages/template-generator/templates/auth/better-auth/web/foldkit/src/auth/session.ts.hbs
@@ -1,0 +1,85 @@
+import { Effect, Option, Schema as S } from "effect";
+import { AsyncData, Command } from "foldkit";
+import { m } from "foldkit/message";
+
+import { authClient } from "./client";
+{{#if (eq api "orpc")}}
+import { client } from "../api/orpc";
+{{/if}}
+
+// MODEL
+
+export const Session = S.Struct({
+  user: S.Struct({
+    id: S.String,
+    name: S.String,
+    email: S.String,
+  }),
+});
+export type Session = typeof Session.Type;
+
+export const SessionState = AsyncData.Schema(S.Option(Session), S.String);
+export type SessionState = typeof SessionState.schema.Type;
+
+export const toSession = (user: Readonly<{ id: string; name: string; email: string }>): Session => ({
+  user: { id: user.id, name: user.name, email: user.email },
+});
+
+export const currentSession = (state: SessionState): Option.Option<Session> =>
+  Option.flatten(AsyncData.getData(state));
+{{#if (eq api "orpc")}}
+
+export const PrivateData = AsyncData.Schema(S.String, S.String);
+export type PrivateData = typeof PrivateData.schema.Type;
+{{/if}}
+
+// MESSAGE
+
+export const CompletedFetchSession = m("CompletedFetchSession", {
+  maybeSession: S.Option(Session),
+});
+export const CompletedSignOut = m("CompletedSignOut");
+{{#if (eq api "orpc")}}
+export const SucceededFetchPrivateData = m("SucceededFetchPrivateData", {
+  message: S.String,
+});
+export const FailedFetchPrivateData = m("FailedFetchPrivateData", {
+  error: S.String,
+});
+{{/if}}
+
+// COMMAND
+
+export const FetchSession = Command.define("FetchSession", {
+  messages: [CompletedFetchSession],
+  execute: Effect.tryPromise(() => authClient.getSession()).pipe(
+    Effect.map((result) =>
+      CompletedFetchSession({
+        maybeSession: Option.map(Option.fromNullishOr(result.data), (data) =>
+          toSession(data.user),
+        ),
+      }),
+    ),
+    Effect.catch(() => Effect.succeed(CompletedFetchSession({ maybeSession: Option.none() }))),
+  ),
+});
+
+export const SignOut = Command.define("SignOut", {
+  messages: [CompletedSignOut],
+  execute: Effect.tryPromise(() => authClient.signOut()).pipe(
+    Effect.as(CompletedSignOut()),
+    Effect.catch(() => Effect.succeed(CompletedSignOut())),
+  ),
+});
+{{#if (eq api "orpc")}}
+
+export const FetchPrivateData = Command.define("FetchPrivateData", {
+  messages: [SucceededFetchPrivateData, FailedFetchPrivateData],
+  execute: Effect.tryPromise((signal) => client.privateData(undefined, { signal })).pipe(
+    Effect.map(({ message }) => SucceededFetchPrivateData({ message })),
+    Effect.catch(() =>
+      Effect.succeed(FailedFetchPrivateData({ error: "Could not load private data" })),
+    ),
+  ),
+});
+{{/if}}

--- a/packages/template-generator/templates/auth/better-auth/web/foldkit/src/page/login.ts.hbs
+++ b/packages/template-generator/templates/auth/better-auth/web/foldkit/src/page/login.ts.hbs
@@ -1,0 +1,345 @@
+import { Array, Effect, Match as M, Option, Schema as S } from "effect";
+import { Button, Input } from "@foldkit/ui";
+import { Command, Submodel } from "foldkit";
+import {
+  Field,
+  Invalid,
+  NotValidated,
+  Rule,
+  allValid,
+  makeRules,
+  validate,
+} from "foldkit/fieldValidation";
+import type { Html, HtmlBuilder } from "foldkit/html";
+import { m } from "foldkit/message";
+import { evo } from "foldkit/struct";
+
+import { authClient } from "../auth/client";
+import { Session, toSession } from "../auth/session";
+
+// MODEL
+
+const AuthMode = S.Literals(["SignIn", "SignUp"]);
+type AuthMode = typeof AuthMode.Type;
+
+export const Model = S.Struct({
+  mode: AuthMode,
+  name: Field(S.String),
+  email: Field(S.String),
+  password: Field(S.String),
+  isSubmitting: S.Boolean,
+  maybeError: S.Option(S.String),
+});
+
+export type Model = typeof Model.Type;
+
+export const init = (): Model => ({
+  mode: "SignIn",
+  name: NotValidated({ value: "" }),
+  email: NotValidated({ value: "" }),
+  password: NotValidated({ value: "" }),
+  isSubmitting: false,
+  maybeError: Option.none(),
+});
+
+// MESSAGE
+
+export const SelectedMode = m("SelectedMode", { mode: AuthMode });
+export const ChangedName = m("ChangedName", { value: S.String });
+export const ChangedEmail = m("ChangedEmail", { value: S.String });
+export const ChangedPassword = m("ChangedPassword", { value: S.String });
+export const SubmittedForm = m("SubmittedForm");
+export const SucceededAuthenticate = m("SucceededAuthenticate", { session: Session });
+export const FailedAuthenticate = m("FailedAuthenticate", { error: S.String });
+
+export const Message = S.Union([
+  SelectedMode,
+  ChangedName,
+  ChangedEmail,
+  ChangedPassword,
+  SubmittedForm,
+  SucceededAuthenticate,
+  FailedAuthenticate,
+]);
+export type Message = typeof Message.Type;
+
+// OUT MESSAGE
+
+export const CompletedAuthentication = m("CompletedAuthentication", { session: Session });
+
+export const OutMessage = S.Union([CompletedAuthentication]);
+export type OutMessage = typeof OutMessage.Type;
+
+// VALIDATION
+
+const nameRules = makeRules({
+  required: "Name is required",
+  rules: [Rule.minLength(2, "Name must be at least 2 characters")],
+});
+
+const emailRules = makeRules({
+  required: "Email is required",
+  rules: [Rule.email("Please enter a valid email")],
+});
+
+const passwordRules = makeRules({
+  required: "Password is required",
+  rules: [Rule.minLength(8, "Password must be at least 8 characters")],
+});
+
+const validateName = validate(nameRules);
+const validateEmail = validate(emailRules);
+const validatePassword = validate(passwordRules);
+
+const isFormValid = (model: Model): boolean =>
+  allValid(
+    model.mode === "SignUp"
+      ? [
+          [model.name, nameRules],
+          [model.email, emailRules],
+          [model.password, passwordRules],
+        ]
+      : [
+          [model.email, emailRules],
+          [model.password, passwordRules],
+        ],
+  );
+
+// COMMAND
+
+const SignIn = Command.define("SignIn", {
+  args: { email: S.String, password: S.String },
+  messages: [SucceededAuthenticate, FailedAuthenticate],
+  execute: ({ email, password }) =>
+    Effect.tryPromise(() => authClient.signIn.email({ email, password })).pipe(
+      Effect.map((result) =>
+        Option.match(Option.fromNullishOr(result.data), {
+          onNone: () =>
+            FailedAuthenticate({ error: result.error?.message ?? "Sign in failed" }),
+          onSome: (data) => SucceededAuthenticate({ session: toSession(data.user) }),
+        }),
+      ),
+      Effect.catch(() => Effect.succeed(FailedAuthenticate({ error: "Sign in failed" }))),
+    ),
+});
+
+const SignUp = Command.define("SignUp", {
+  args: { name: S.String, email: S.String, password: S.String },
+  messages: [SucceededAuthenticate, FailedAuthenticate],
+  execute: ({ name, email, password }) =>
+    Effect.tryPromise(() => authClient.signUp.email({ name, email, password })).pipe(
+      Effect.map((result) =>
+        Option.match(Option.fromNullishOr(result.data), {
+          onNone: () =>
+            FailedAuthenticate({ error: result.error?.message ?? "Sign up failed" }),
+          onSome: (data) => SucceededAuthenticate({ session: toSession(data.user) }),
+        }),
+      ),
+      Effect.catch(() => Effect.succeed(FailedAuthenticate({ error: "Sign up failed" }))),
+    ),
+});
+
+// UPDATE
+
+type UpdateReturn = readonly [
+  Model,
+  ReadonlyArray<Command.Command<Message>>,
+  Option.Option<OutMessage>,
+];
+const withUpdateReturn = M.withReturnType<UpdateReturn>();
+
+export const update = (model: Model, message: Message): UpdateReturn =>
+  M.value(message).pipe(
+    withUpdateReturn,
+    M.tagsExhaustive({
+      SelectedMode: ({ mode }) => [
+        evo(model, { mode: () => mode, maybeError: () => Option.none() }),
+        [],
+        Option.none(),
+      ],
+
+      ChangedName: ({ value }) => [
+        evo(model, { name: () => validateName(value) }),
+        [],
+        Option.none(),
+      ],
+
+      ChangedEmail: ({ value }) => [
+        evo(model, { email: () => validateEmail(value) }),
+        [],
+        Option.none(),
+      ],
+
+      ChangedPassword: ({ value }) => [
+        evo(model, { password: () => validatePassword(value) }),
+        [],
+        Option.none(),
+      ],
+
+      SubmittedForm: () => {
+        if (model.isSubmitting || !isFormValid(model)) {
+          return [model, [], Option.none()];
+        }
+
+        const command =
+          model.mode === "SignUp"
+            ? SignUp({
+                name: model.name.value,
+                email: model.email.value,
+                password: model.password.value,
+              })
+            : SignIn({ email: model.email.value, password: model.password.value });
+
+        return [
+          evo(model, { isSubmitting: () => true, maybeError: () => Option.none() }),
+          [command],
+          Option.none(),
+        ];
+      },
+
+      SucceededAuthenticate: ({ session }) => [
+        evo(model, { isSubmitting: () => false }),
+        [],
+        Option.some(CompletedAuthentication({ session })),
+      ],
+
+      FailedAuthenticate: ({ error }) => [
+        evo(model, {
+          isSubmitting: () => false,
+          maybeError: () => Option.some(error),
+          password: () => Invalid({ value: model.password.value, errors: [error] }),
+        }),
+        [],
+        Option.none(),
+      ],
+    }),
+  );
+
+// VIEW
+
+const fieldBorderClass = (field: Field<string>): string =>
+  M.value(field).pipe(
+    M.tagsExhaustive({
+      NotValidated: () => "border-neutral-700",
+      Validating: () => "border-neutral-500",
+      Valid: () => "border-green-600",
+      Invalid: () => "border-red-500",
+    }),
+  );
+
+const fieldView = (
+  id: string,
+  labelText: string,
+  type: "text" | "email" | "password",
+  field: Field<string>,
+  toMessage: (value: string) => Message,
+  h: HtmlBuilder<Message>,
+): Html =>
+  Input.view(
+    {
+      id,
+      type,
+      value: field.value,
+      onInput: toMessage,
+      isInvalid: field._tag === "Invalid",
+      toView: (attributes) =>
+        h.div(
+          [h.Class("space-y-1")],
+          [
+            h.label(
+              [...attributes.label, h.Class("block text-sm text-neutral-300")],
+              [labelText],
+            ),
+            h.input([
+              ...attributes.input,
+              h.Class(
+                `w-full rounded border bg-neutral-900 px-3 py-2 outline-none ${fieldBorderClass(field)}`,
+              ),
+            ]),
+            M.value(field).pipe(
+              M.tag("Invalid", ({ errors }) =>
+                h.p(
+                  [...attributes.description, h.Class("text-sm text-red-500")],
+                  [Array.headNonEmpty(errors)],
+                ),
+              ),
+              M.orElse(() => h.empty),
+            ),
+          ],
+        ),
+    },
+    h,
+  );
+
+const submitLabel = (model: Model): string => {
+  if (model.isSubmitting) {
+    return "Submitting...";
+  }
+  return model.mode === "SignIn" ? "Sign In" : "Sign Up";
+};
+
+const modeToggleView = (mode: AuthMode, h: HtmlBuilder<Message>): Html =>
+  Button.view(
+    {
+      onClick: SelectedMode({ mode: mode === "SignIn" ? "SignUp" : "SignIn" }),
+      toView: (attributes) =>
+        h.button(
+          [...attributes.button, h.Class("text-sm text-indigo-400 hover:underline")],
+          [mode === "SignIn" ? "Need an account? Sign Up" : "Already have an account? Sign In"],
+        ),
+    },
+    h,
+  );
+
+export const view = Submodel.defineView<Model, Message>((model, h) => {
+  const canSubmit = isFormValid(model) && !model.isSubmitting;
+
+  return h.div(
+    [h.Class("mx-auto mt-10 w-full max-w-md px-4")],
+    [
+      h.h1(
+        [h.Class("mb-6 text-center text-3xl font-bold")],
+        [model.mode === "SignIn" ? "Welcome Back" : "Create Account"],
+      ),
+      h.form(
+        [h.Class("space-y-4"), h.OnSubmit(SubmittedForm())],
+        [
+          model.mode === "SignUp"
+            ? fieldView("name", "Name", "text", model.name, (value) => ChangedName({ value }), h)
+            : h.empty,
+          fieldView("email", "Email", "email", model.email, (value) => ChangedEmail({ value }), h),
+          fieldView(
+            "password",
+            "Password",
+            "password",
+            model.password,
+            (value) => ChangedPassword({ value }),
+            h,
+          ),
+          Button.view(
+            {
+              type: "submit",
+              isDisabled: !canSubmit,
+              toView: (attributes) =>
+                h.button(
+                  [
+                    ...attributes.button,
+                    h.Class(
+                      "w-full rounded bg-indigo-600 py-2 font-medium text-white transition hover:bg-indigo-500 data-[disabled]:opacity-50",
+                    ),
+                  ],
+                  [submitLabel(model)],
+                ),
+            },
+            h,
+          ),
+        ],
+      ),
+      Option.match(model.maybeError, {
+        onNone: () => h.empty,
+        onSome: (error) => h.p([h.Class("mt-4 text-sm text-red-500")], [error]),
+      }),
+      h.div([h.Class("mt-4 text-center")], [modeToggleView(model.mode, h)]),
+    ],
+  );
+});

--- a/packages/template-generator/templates/auth/better-auth/web/foldkit/src/view/dashboard.ts.hbs
+++ b/packages/template-generator/templates/auth/better-auth/web/foldkit/src/view/dashboard.ts.hbs
@@ -1,0 +1,75 @@
+import { Option } from "effect";
+import { AsyncData } from "foldkit";
+import type { Html, HtmlBuilder } from "foldkit/html";
+
+{{#if (eq api "orpc")}}
+import type { PrivateData, Session, SessionState } from "../auth/session";
+{{else}}
+import type { Session, SessionState } from "../auth/session";
+{{/if}}
+import type { Message } from "../message";
+
+const noticeView = (text: string, h: HtmlBuilder<Message>): Html =>
+  h.p([h.Class("text-neutral-400")], [text]);
+{{#if (eq api "orpc")}}
+
+const privateDataView = (privateData: PrivateData, h: HtmlBuilder<Message>): Html =>
+  h.section(
+    [h.Class("rounded-lg border border-neutral-800 p-4")],
+    [
+      h.h2([h.Class("mb-2 font-medium")], ["Private API"]),
+      AsyncData.matchDataSplitEmpty(privateData, {
+        onIdle: () => noticeView("Not requested", h),
+        onLoading: () => noticeView("Loading...", h),
+        onFailure: (error) => h.p([h.Class("text-red-500")], [error]),
+        onData: (message) => h.p([h.Class("text-neutral-300")], [message]),
+      }),
+    ],
+  );
+{{/if}}
+
+const signedInView = (
+  session: Session,
+{{#if (eq api "orpc")}}
+  privateData: PrivateData,
+{{/if}}
+  h: HtmlBuilder<Message>,
+): Html =>
+  h.div(
+    [h.Class("grid gap-6")],
+    [
+      h.div(
+        [],
+        [
+          h.h1([h.Class("mb-2 text-3xl font-bold")], ["Dashboard"]),
+          h.p([h.Class("text-neutral-400")], [`Signed in as ${session.user.email}`]),
+        ],
+      ),
+{{#if (eq api "orpc")}}
+      privateDataView(privateData, h),
+{{/if}}
+    ],
+  );
+
+export const dashboardView = (
+  session: SessionState,
+{{#if (eq api "orpc")}}
+  privateData: PrivateData,
+{{/if}}
+  h: HtmlBuilder<Message>,
+): Html =>
+  h.div(
+    [h.Class("container mx-auto max-w-3xl px-4 py-8")],
+    [
+      AsyncData.matchDataSplitEmpty(session, {
+        onIdle: () => noticeView("Loading...", h),
+        onLoading: () => noticeView("Loading...", h),
+        onFailure: (error) => h.p([h.Class("text-red-500")], [error]),
+        onData: (maybeSession) =>
+          Option.match(maybeSession, {
+            onNone: () => noticeView("Redirecting to sign in...", h),
+            onSome: (session) => signedInView(session, {{#if (eq api "orpc")}}privateData, {{/if}}h),
+          }),
+      }),
+    ],
+  );

--- a/packages/template-generator/templates/deploy/docker/compose/docker-compose.yml.hbs
+++ b/packages/template-generator/templates/deploy/docker/compose/docker-compose.yml.hbs
@@ -20,7 +20,7 @@ services:
 {{/if}}
     init: true
     ports:
-{{#if (includes frontend "tanstack-router")}}
+{{#if (or (includes frontend "tanstack-router") (includes frontend "foldkit"))}}
       - "3001:80"
 {{else}}
       - "3001:3001"
@@ -78,7 +78,7 @@ services:
 {{/if}}
 {{/if}}
     healthcheck:
-{{#if (includes frontend "tanstack-router")}}
+{{#if (or (includes frontend "tanstack-router") (includes frontend "foldkit"))}}
       test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:80/"]
 {{else}}
       test:

--- a/packages/template-generator/templates/deploy/docker/web/foldkit/Dockerfile.hbs
+++ b/packages/template-generator/templates/deploy/docker/web/foldkit/Dockerfile.hbs
@@ -1,0 +1,34 @@
+FROM node:24{{#unless (includes addons "vite-plus")}}-slim{{/unless}} AS builder
+{{#if (eq packageManager "bun")}}
+COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
+{{/if}}
+{{#if (eq packageManager "pnpm")}}
+RUN npm install -g pnpm@11
+{{/if}}
+WORKDIR /app
+{{#if (eq orm "prisma")}}
+# prisma generate resolves DATABASE_URL at install time; the real value comes from compose at runtime
+ENV DATABASE_URL={{#if (eq database "mysql")}}mysql://build:build@localhost:3306/build{{else if (eq database "mongodb")}}mongodb://localhost:27017/build{{else if (eq database "sqlite")}}file:./build.db{{else}}postgresql://build:build@localhost:5432/build{{/if}}
+{{/if}}
+
+COPY . .
+{{#if (eq packageManager "bun")}}
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install
+{{else if (eq packageManager "pnpm")}}
+RUN --mount=type=cache,target=/pnpm-store pnpm install --store-dir /pnpm-store
+{{else}}
+RUN --mount=type=cache,target=/root/.npm npm install
+{{/if}}
+
+{{#if (and (ne backend "none") (ne backend "convex"))}}
+ARG VITE_SERVER_URL
+ENV VITE_SERVER_URL=${VITE_SERVER_URL}
+{{/if}}
+ENV NODE_ENV=production
+RUN cd apps/web && {{packageManager}} run build
+
+FROM nginx:alpine AS runner
+COPY --from=builder /app/apps/web/dist /usr/share/nginx/html
+COPY apps/web/nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/packages/template-generator/templates/deploy/docker/web/foldkit/nginx.conf
+++ b/packages/template-generator/templates/deploy/docker/web/foldkit/nginx.conf
@@ -1,0 +1,18 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript image/svg+xml;
+
+    location /assets/ {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+
+    # SPA fallback
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/packages/template-generator/templates/examples/todo/web/foldkit/src/page/todos.ts.hbs
+++ b/packages/template-generator/templates/examples/todo/web/foldkit/src/page/todos.ts.hbs
@@ -1,0 +1,347 @@
+import { Array, Effect, Match as M, Option, Schema as S, String } from "effect";
+import { Button, Checkbox, Input } from "@foldkit/ui";
+import { AsyncData, Command, Submodel, Update } from "foldkit";
+import type { Html, HtmlBuilder } from "foldkit/html";
+import { m } from "foldkit/message";
+import { evo } from "foldkit/struct";
+
+import { client } from "../api/orpc";
+
+// MODEL
+
+const TodoId = {{#if (eq orm "mongoose")}}S.String{{else}}S.Number{{/if}};
+type TodoId = typeof TodoId.Type;
+
+const Todo = S.Struct({
+  id: TodoId,
+  text: S.String,
+  completed: S.Boolean,
+});
+type Todo = typeof Todo.Type;
+
+const TodoList = AsyncData.Schema(S.Array(Todo), S.String);
+
+export const Model = S.Struct({
+  todos: TodoList.schema,
+  newTodoText: S.String,
+  pendingTodoIds: S.Array(TodoId),
+  maybeError: S.Option(S.String),
+});
+
+export type Model = typeof Model.Type;
+
+// MESSAGE
+
+export const UpdatedNewTodoText = m("UpdatedNewTodoText", { text: S.String });
+export const SubmittedNewTodo = m("SubmittedNewTodo");
+export const ClickedToggleTodo = m("ClickedToggleTodo", {
+  id: TodoId,
+  completed: S.Boolean,
+});
+export const ClickedDeleteTodo = m("ClickedDeleteTodo", { id: TodoId });
+export const SucceededLoadTodos = m("SucceededLoadTodos", { todos: S.Array(Todo) });
+export const FailedLoadTodos = m("FailedLoadTodos", { error: S.String });
+export const SucceededCreateTodo = m("SucceededCreateTodo");
+export const FailedCreateTodo = m("FailedCreateTodo", { error: S.String });
+export const SucceededMutateTodo = m("SucceededMutateTodo", { id: TodoId });
+export const FailedMutateTodo = m("FailedMutateTodo", { id: TodoId, error: S.String });
+
+export const Message = S.Union([
+  UpdatedNewTodoText,
+  SubmittedNewTodo,
+  ClickedToggleTodo,
+  ClickedDeleteTodo,
+  SucceededLoadTodos,
+  FailedLoadTodos,
+  SucceededCreateTodo,
+  FailedCreateTodo,
+  SucceededMutateTodo,
+  FailedMutateTodo,
+]);
+export type Message = typeof Message.Type;
+
+// COMMAND
+
+const LoadTodos = Command.define("LoadTodos", {
+  messages: [SucceededLoadTodos, FailedLoadTodos],
+  execute: Effect.tryPromise((signal) => client.todo.getAll(undefined, { signal })).pipe(
+    Effect.map((todos) => SucceededLoadTodos({ todos })),
+    Effect.catch(() => Effect.succeed(FailedLoadTodos({ error: "Could not load todos" }))),
+  ),
+});
+
+const CreateTodo = Command.define("CreateTodo", {
+  args: { text: S.String },
+  messages: [SucceededCreateTodo, FailedCreateTodo],
+  execute: ({ text }) =>
+    Effect.tryPromise(() => client.todo.create({ text })).pipe(
+      Effect.as(SucceededCreateTodo()),
+      Effect.catch(() => Effect.succeed(FailedCreateTodo({ error: "Could not add the todo" }))),
+    ),
+});
+
+const ToggleTodo = Command.define("ToggleTodo", {
+  args: { id: TodoId, completed: S.Boolean },
+  messages: [SucceededMutateTodo, FailedMutateTodo],
+  execute: ({ id, completed }) =>
+    Effect.tryPromise(() => client.todo.toggle({ id, completed })).pipe(
+      Effect.as(SucceededMutateTodo({ id })),
+      Effect.catch(() =>
+        Effect.succeed(FailedMutateTodo({ id, error: "Could not update the todo" })),
+      ),
+    ),
+});
+
+const DeleteTodo = Command.define("DeleteTodo", {
+  args: { id: TodoId },
+  messages: [SucceededMutateTodo, FailedMutateTodo],
+  execute: ({ id }) =>
+    Effect.tryPromise(() => client.todo.delete({ id })).pipe(
+      Effect.as(SucceededMutateTodo({ id })),
+      Effect.catch(() =>
+        Effect.succeed(FailedMutateTodo({ id, error: "Could not delete the todo" })),
+      ),
+    ),
+});
+
+// INIT
+
+export const init = (): readonly [Model, ReadonlyArray<Command.Command<Message>>] => [
+  {
+    todos: TodoList.Loading(),
+    newTodoText: "",
+    pendingTodoIds: [],
+    maybeError: Option.none(),
+  },
+  [LoadTodos()],
+];
+
+// UPDATE
+
+type UpdateReturn = readonly [Model, ReadonlyArray<Command.Command<Message>>];
+const withUpdateReturn = M.withReturnType<UpdateReturn>();
+
+const refreshTodos = Update.refresh({
+  read: (model: Model) => Option.some(model.todos),
+  revalidate: AsyncData.revalidate,
+  write: (model, nextTodos) => evo(model, { todos: () => nextTodos }),
+  load: LoadTodos(),
+});
+
+const markPending =
+  (id: TodoId): Update.Step<Model, Message> =>
+  (model) => [
+    evo(model, { pendingTodoIds: Array.append(id), maybeError: () => Option.none() }),
+    [],
+  ];
+
+const clearPending =
+  (id: TodoId): Update.Step<Model, Message> =>
+  (model) => [
+    evo(model, {
+      pendingTodoIds: Array.filter((pendingId: TodoId) => pendingId !== id),
+    }),
+    [],
+  ];
+
+export const update = (model: Model, message: Message): UpdateReturn =>
+  M.value(message).pipe(
+    withUpdateReturn,
+    M.tagsExhaustive({
+      UpdatedNewTodoText: ({ text }) => [evo(model, { newTodoText: () => text }), []],
+
+      SubmittedNewTodo: () => {
+        const text = model.newTodoText.trim();
+        if (String.isEmpty(text)) {
+          return [model, []];
+        }
+        return [
+          evo(model, { newTodoText: () => "", maybeError: () => Option.none() }),
+          [CreateTodo({ text })],
+        ];
+      },
+
+      ClickedToggleTodo: ({ id, completed }) =>
+        Update.combine(model, [
+          markPending(id),
+          (nextModel) => [nextModel, [ToggleTodo({ id, completed: !completed })]],
+        ]),
+
+      ClickedDeleteTodo: ({ id }) =>
+        Update.combine(model, [
+          markPending(id),
+          (nextModel) => [nextModel, [DeleteTodo({ id })]],
+        ]),
+
+      SucceededLoadTodos: ({ todos }) => [
+        evo(model, { todos: () => TodoList.Success({ data: todos }) }),
+        [],
+      ],
+
+      FailedLoadTodos: ({ error }) => [
+        evo(model, { todos: () => TodoList.Failure({ error }) }),
+        [],
+      ],
+
+      SucceededCreateTodo: () => Update.combine(model, [refreshTodos]),
+
+      FailedCreateTodo: ({ error }) => [
+        evo(model, { maybeError: () => Option.some(error) }),
+        [],
+      ],
+
+      SucceededMutateTodo: ({ id }) => Update.combine(model, [clearPending(id), refreshTodos]),
+
+      FailedMutateTodo: ({ id, error }) =>
+        Update.combine(model, [
+          clearPending(id),
+          (nextModel) => [evo(nextModel, { maybeError: () => Option.some(error) }), []],
+        ]),
+    }),
+  );
+
+// VIEW
+
+const todoView = (
+  todo: Todo,
+  isPending: boolean,
+  h: HtmlBuilder<Message>,
+): Html =>
+  h.keyed("li")(
+    todo.id,
+    [
+      h.Class(
+        `flex items-center justify-between gap-2 rounded border border-neutral-800 px-3 py-2 ${
+          isPending ? "opacity-50" : ""
+        }`,
+      ),
+    ],
+    [
+      Checkbox.view(
+        {
+          id: `todo-${todo.id}`,
+          isChecked: todo.completed,
+          isDisabled: isPending,
+          onToggle: () => ClickedToggleTodo({ id: todo.id, completed: todo.completed }),
+          toView: (attributes) =>
+            h.div(
+              [h.Class("flex items-center gap-2")],
+              [
+                h.div(
+                  [
+                    ...attributes.checkbox,
+                    h.Class(
+                      `flex h-4 w-4 items-center justify-center rounded border border-neutral-600 ${
+                        todo.completed ? "bg-indigo-600" : ""
+                      }`,
+                    ),
+                  ],
+                  todo.completed ? [h.span([h.Class("text-xs text-white")], ["✓"])] : [],
+                ),
+                h.span(
+                  [
+                    ...attributes.label,
+                    h.Class(todo.completed ? "text-neutral-500 line-through" : ""),
+                  ],
+                  [todo.text],
+                ),
+              ],
+            ),
+        },
+        h,
+      ),
+      Button.view(
+        {
+          onClick: ClickedDeleteTodo({ id: todo.id }),
+          isDisabled: isPending,
+          toView: (attributes) =>
+            h.button(
+              [
+                ...attributes.button,
+                h.AriaLabel("Delete todo"),
+                h.Class("text-red-500 transition hover:text-red-400 data-[disabled]:opacity-50"),
+              ],
+              ["✕"],
+            ),
+        },
+        h,
+      ),
+    ],
+  );
+
+const todoListView = (
+  todos: ReadonlyArray<Todo>,
+  pendingTodoIds: ReadonlyArray<TodoId>,
+  h: HtmlBuilder<Message>,
+): Html =>
+  Array.match(todos, {
+    onEmpty: () => h.p([h.Class("text-neutral-400")], ["No todos yet."]),
+    onNonEmpty: (nonEmptyTodos) =>
+      h.ul(
+        [h.Class("space-y-2")],
+        Array.map(nonEmptyTodos, (todo) =>
+          todoView(todo, Array.contains(pendingTodoIds, todo.id), h),
+        ),
+      ),
+  });
+
+export const view = Submodel.defineView<Model, Message>((model, h) =>
+  h.div(
+    [h.Class("container mx-auto max-w-3xl px-4 py-8")],
+    [
+      h.h1([h.Class("mb-4 text-2xl font-bold")], ["Todos"]),
+
+      h.form(
+        [h.Class("mb-4 flex gap-2"), h.OnSubmit(SubmittedNewTodo())],
+        [
+          Input.view(
+            {
+              id: "new-todo",
+              value: model.newTodoText,
+              placeholder: "New task...",
+              onInput: (text) => UpdatedNewTodoText({ text }),
+              toView: (attributes) =>
+                h.input([
+                  ...attributes.input,
+                  h.AriaLabel("New todo"),
+                  h.Class(
+                    "flex-grow rounded border border-neutral-800 bg-neutral-900 px-3 py-2 outline-none",
+                  ),
+                ]),
+            },
+            h,
+          ),
+          Button.view(
+            {
+              type: "submit",
+              isDisabled: String.isEmpty(model.newTodoText.trim()),
+              toView: (attributes) =>
+                h.button(
+                  [
+                    ...attributes.button,
+                    h.Class(
+                      "rounded bg-indigo-600 px-4 py-2 text-white transition hover:bg-indigo-500 data-[disabled]:opacity-50",
+                    ),
+                  ],
+                  ["Add"],
+                ),
+            },
+            h,
+          ),
+        ],
+      ),
+
+      AsyncData.matchDataSplitEmpty(model.todos, {
+        onIdle: () => h.empty,
+        onLoading: () => h.p([h.Class("text-neutral-400")], ["Loading..."]),
+        onFailure: (error) => h.p([h.Class("text-red-500")], [error]),
+        onData: (todos) => todoListView(todos, model.pendingTodoIds, h),
+      }),
+
+      Option.match(model.maybeError, {
+        onNone: () => h.empty,
+        onSome: (error) => h.p([h.Class("mt-4 text-sm text-red-500")], [error]),
+      }),
+    ],
+  ),
+);

--- a/packages/template-generator/templates/frontend/foldkit/_gitignore
+++ b/packages/template-generator/templates/frontend/foldkit/_gitignore
@@ -1,0 +1,13 @@
+node_modules
+.DS_Store
+dist
+.output
+.vercel
+.netlify
+*.local
+.env
+.env.*
+
+.wrangler
+.alchemy
+.dev.vars*

--- a/packages/template-generator/templates/frontend/foldkit/index.html.hbs
+++ b/packages/template-generator/templates/frontend/foldkit/index.html.hbs
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link href="/src/styles.css" rel="stylesheet" />
+    <title>{{projectName}}</title>
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/entry.ts"></script>
+  </body>
+</html>

--- a/packages/template-generator/templates/frontend/foldkit/package.json.hbs
+++ b/packages/template-generator/templates/frontend/foldkit/package.json.hbs
@@ -1,0 +1,25 @@
+{
+  "name": "web",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "serve": "vite preview",
+    "start": "vite preview",
+    "check-types": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@foldkit/ui": "^0.145.0",
+    "effect": "4.0.0-rc.108",
+    "foldkit": "^0.145.0"
+  },
+  "devDependencies": {
+    "@foldkit/devtools": "^0.145.0",
+    "@foldkit/vite-plugin": "^0.13.1",
+    "@tailwindcss/vite": "^4.3.3",
+    "tailwindcss": "^4.3.3",
+    "vite": "^8.1.5"
+  }
+}

--- a/packages/template-generator/templates/frontend/foldkit/src/entry.ts.hbs
+++ b/packages/template-generator/templates/frontend/foldkit/src/entry.ts.hbs
@@ -1,0 +1,21 @@
+import { Runtime } from "foldkit";
+
+import { ChangedUrl, ClickedLink, Message } from "./message";
+import { Model, init, update, view } from "./main";
+
+const application = Runtime.makeApplication({
+  Model,
+  init,
+  update,
+  view,
+  container: document.getElementById("root"),
+  routing: {
+    onUrlRequest: (request) => ClickedLink({ request }),
+    onUrlChange: (url) => ChangedUrl({ url }),
+  },
+  devTools: {
+    Message,
+  },
+});
+
+Runtime.run(application);

--- a/packages/template-generator/templates/frontend/foldkit/src/main.ts.hbs
+++ b/packages/template-generator/templates/frontend/foldkit/src/main.ts.hbs
@@ -1,0 +1,332 @@
+import { Effect, Match as M, {{#if (or (eq auth "better-auth") (includes examples "todo"))}}Option, {{/if}}Schema as S } from "effect";
+import { {{#if (or (eq api "orpc") (eq auth "better-auth"))}}AsyncData, {{/if}}Command, Runtime{{#if (or (eq auth "better-auth") (includes examples "todo"))}}, Update{{/if}} } from "foldkit";
+import type { Document, Html, HtmlBuilder } from "foldkit/html";
+import { load, pushUrl{{#if (eq auth "better-auth")}}, replaceUrl{{/if}} } from "foldkit/navigation";
+import { evo } from "foldkit/struct";
+import { toString as urlToString } from "foldkit/url";
+
+{{#if (eq api "orpc")}}
+import { FetchHealthCheck, HealthCheck } from "./api/health";
+{{/if}}
+{{#if (eq auth "better-auth")}}
+import {
+  FetchSession,
+{{#if (eq api "orpc")}}
+  FetchPrivateData,
+  PrivateData,
+{{/if}}
+  SessionState,
+  SignOut,
+  currentSession,
+} from "./auth/session";
+import * as Login from "./page/login";
+import { dashboardView } from "./view/dashboard";
+{{/if}}
+{{#if (includes examples "todo")}}
+import * as Todos from "./page/todos";
+{{/if}}
+import {
+  CompletedLoadExternal,
+  CompletedNavigateInternal,
+{{#if (eq auth "better-auth")}}
+  GotLoginMessage,
+{{/if}}
+{{#if (includes examples "todo")}}
+  GotTodosMessage,
+{{/if}}
+  type Message,
+} from "./message";
+{{#if (eq auth "better-auth")}}
+import { AppRoute, dashboardRouter, homeRouter, loginRouter, urlToAppRoute } from "./route";
+{{else}}
+import { AppRoute, urlToAppRoute } from "./route";
+{{/if}}
+import { headerView } from "./view/header";
+import { homeView } from "./view/home";
+import { notFoundView } from "./view/notFound";
+
+// MODEL
+
+export const Model = S.Struct({
+  route: AppRoute,
+{{#if (eq api "orpc")}}
+  healthCheck: HealthCheck.schema,
+{{/if}}
+{{#if (eq auth "better-auth")}}
+  session: SessionState.schema,
+  login: Login.Model,
+{{#if (eq api "orpc")}}
+  privateData: PrivateData.schema,
+{{/if}}
+{{/if}}
+{{#if (includes examples "todo")}}
+  todos: Todos.Model,
+{{/if}}
+});
+
+export type Model = typeof Model.Type;
+
+// INIT
+
+export const init: Runtime.RoutingApplicationInit<Model, Message> = (url) => {
+{{#if (includes examples "todo")}}
+  const [todos, todosCommands] = Todos.init();
+
+{{/if}}
+  const model: Model = {
+    route: urlToAppRoute(url),
+{{#if (eq api "orpc")}}
+    healthCheck: HealthCheck.Loading(),
+{{/if}}
+{{#if (eq auth "better-auth")}}
+    session: SessionState.Loading(),
+    login: Login.init(),
+{{#if (eq api "orpc")}}
+    privateData: PrivateData.Idle(),
+{{/if}}
+{{/if}}
+{{#if (includes examples "todo")}}
+    todos,
+{{/if}}
+  };
+
+  return [
+    model,
+    [
+{{#if (eq api "orpc")}}
+      FetchHealthCheck(),
+{{/if}}
+{{#if (eq auth "better-auth")}}
+      FetchSession(),
+{{/if}}
+{{#if (includes examples "todo")}}
+      ...Command.mapMessages(todosCommands, (message) => GotTodosMessage({ message })),
+{{/if}}
+    ],
+  ];
+};
+
+// COMMAND
+
+const NavigateInternal = Command.define("NavigateInternal", {
+  args: { url: S.String },
+  messages: [CompletedNavigateInternal],
+  execute: ({ url }) => pushUrl(url).pipe(Effect.as(CompletedNavigateInternal())),
+});
+
+const LoadExternal = Command.define("LoadExternal", {
+  args: { href: S.String },
+  messages: [CompletedLoadExternal],
+  execute: ({ href }) => load(href).pipe(Effect.as(CompletedLoadExternal())),
+});
+{{#if (eq auth "better-auth")}}
+
+const RedirectToLogin = Command.define("RedirectToLogin", {
+  messages: [CompletedNavigateInternal],
+  execute: replaceUrl(loginRouter()).pipe(Effect.as(CompletedNavigateInternal())),
+});
+
+const RedirectToDashboard = Command.define("RedirectToDashboard", {
+  messages: [CompletedNavigateInternal],
+  execute: replaceUrl(dashboardRouter()).pipe(Effect.as(CompletedNavigateInternal())),
+});
+
+const RedirectToHome = Command.define("RedirectToHome", {
+  messages: [CompletedNavigateInternal],
+  execute: replaceUrl(homeRouter()).pipe(Effect.as(CompletedNavigateInternal())),
+});
+{{/if}}
+
+// UPDATE
+
+type UpdateReturn = readonly [Model, ReadonlyArray<Command.Command<Message>>];
+const withUpdateReturn = M.withReturnType<UpdateReturn>();
+{{#if (eq auth "better-auth")}}
+
+// The session resolves after the first paint, so the guard waits for the fetch
+// to settle before it redirects; until then the page renders its loading state.
+const enforceRouteAccess = (model: Model): UpdateReturn =>
+  M.value(model.route).pipe(
+    withUpdateReturn,
+    M.tag("Dashboard", () => {
+      if (AsyncData.isPending(model.session)) {
+        return [model, []];
+      }
+      if (Option.isNone(currentSession(model.session))) {
+        return [model, [RedirectToLogin()]];
+      }
+{{#if (eq api "orpc")}}
+      return AsyncData.isIdle(model.privateData)
+        ? [evo(model, { privateData: () => PrivateData.Loading() }), [FetchPrivateData()]]
+        : [model, []];
+{{else}}
+      return [model, []];
+{{/if}}
+    }),
+    M.tag("Login", () =>
+      Option.isSome(currentSession(model.session))
+        ? [model, [RedirectToDashboard()]]
+        : [model, []],
+    ),
+    M.orElse(() => [model, []]),
+  );
+
+const foldLoginOutMessage: (
+  outMessage: Login.OutMessage,
+) => Update.Step<Model, Message> = M.type<Login.OutMessage>().pipe(
+  M.withReturnType<Update.Step<Model, Message>>(),
+  M.tagsExhaustive({
+    CompletedAuthentication:
+      ({ session }) =>
+      (model) => [
+        evo(model, { session: () => SessionState.Success({ data: Option.some(session) }) }),
+        [RedirectToDashboard()],
+      ],
+  }),
+);
+
+const foldLogin = Update.foldChild({
+  update: Login.update,
+  read: (model: Model) => Option.some(model.login),
+  write: (model, nextLogin) => evo(model, { login: () => nextLogin }),
+  toParentMessage: (message) => GotLoginMessage({ message }),
+  foldOutMessage: foldLoginOutMessage,
+});
+{{/if}}
+{{#if (includes examples "todo")}}
+
+const foldTodos = Update.foldChild({
+  update: Todos.update,
+  read: (model: Model) => Option.some(model.todos),
+  write: (model, nextTodos) => evo(model, { todos: () => nextTodos }),
+  toParentMessage: (message) => GotTodosMessage({ message }),
+});
+{{/if}}
+
+export const update = (model: Model, message: Message): UpdateReturn =>
+  M.value(message).pipe(
+    withUpdateReturn,
+    M.tagsExhaustive({
+      CompletedNavigateInternal: () => [model, []],
+      CompletedLoadExternal: () => [model, []],
+
+      ClickedLink: ({ request }) =>
+        M.value(request).pipe(
+          withUpdateReturn,
+          M.tagsExhaustive({
+            Internal: ({ url }) => [model, [NavigateInternal({ url: urlToString(url) })]],
+            External: ({ href }) => [model, [LoadExternal({ href })]],
+          }),
+        ),
+
+{{#if (eq auth "better-auth")}}
+      ChangedUrl: ({ url }) => enforceRouteAccess(evo(model, { route: () => urlToAppRoute(url) })),
+{{else}}
+      ChangedUrl: ({ url }) => [evo(model, { route: () => urlToAppRoute(url) }), []],
+{{/if}}
+{{#if (eq api "orpc")}}
+
+      SucceededFetchHealthCheck: ({ status }) => [
+        evo(model, { healthCheck: () => HealthCheck.Success({ data: status }) }),
+        [],
+      ],
+
+      FailedFetchHealthCheck: ({ error }) => [
+        evo(model, { healthCheck: () => HealthCheck.Failure({ error }) }),
+        [],
+      ],
+{{/if}}
+{{#if (eq auth "better-auth")}}
+
+      CompletedFetchSession: ({ maybeSession }) =>
+        enforceRouteAccess(
+          evo(model, { session: () => SessionState.Success({ data: maybeSession }) }),
+        ),
+
+      ClickedSignOut: () => [model, [SignOut()]],
+
+      CompletedSignOut: () => [
+        evo(model, {
+          session: () => SessionState.Success({ data: Option.none() }),
+{{#if (eq api "orpc")}}
+          privateData: () => PrivateData.Idle(),
+{{/if}}
+        }),
+        [RedirectToHome()],
+      ],
+
+      GotLoginMessage: ({ message }) => foldLogin(model, message),
+{{#if (eq api "orpc")}}
+
+      SucceededFetchPrivateData: ({ message }) => [
+        evo(model, { privateData: () => PrivateData.Success({ data: message }) }),
+        [],
+      ],
+
+      FailedFetchPrivateData: ({ error }) => [
+        evo(model, { privateData: () => PrivateData.Failure({ error }) }),
+        [],
+      ],
+{{/if}}
+{{/if}}
+{{#if (includes examples "todo")}}
+
+      GotTodosMessage: ({ message }) => foldTodos(model, message),
+{{/if}}
+    }),
+  );
+
+// VIEW
+
+const routeTitle = (route: AppRoute): string =>
+  M.value(route).pipe(
+    M.tag("Home", () => "{{projectName}}"),
+{{#if (includes examples "todo")}}
+    M.tag("Todos", () => "Todos | {{projectName}}"),
+{{/if}}
+{{#if (eq auth "better-auth")}}
+    M.tag("Login", () => "Sign In | {{projectName}}"),
+    M.tag("Dashboard", () => "Dashboard | {{projectName}}"),
+{{/if}}
+    M.orElse(() => "Not Found | {{projectName}}"),
+  );
+
+export const view = (model: Model, h: HtmlBuilder<Message>): Document => {
+  const content = M.value(model.route).pipe(
+    M.withReturnType<Html>(),
+    M.tagsExhaustive({
+      Home: () => homeView({{#if (eq api "orpc")}}model.healthCheck, {{/if}}h),
+{{#if (includes examples "todo")}}
+      Todos: () =>
+        h.submodel({
+          slotId: "todos",
+          model: model.todos,
+          view: Todos.view,
+          toParentMessage: (message) => GotTodosMessage({ message }),
+        }),
+{{/if}}
+{{#if (eq auth "better-auth")}}
+      Login: () =>
+        h.submodel({
+          slotId: "login",
+          model: model.login,
+          view: Login.view,
+          toParentMessage: (message) => GotLoginMessage({ message }),
+        }),
+      Dashboard: () => dashboardView(model.session, {{#if (eq api "orpc")}}model.privateData, {{/if}}h),
+{{/if}}
+      NotFound: ({ path }) => notFoundView(path, h),
+    }),
+  );
+
+  return {
+    title: routeTitle(model.route),
+    body: h.div(
+      [h.Class("grid h-svh grid-rows-[auto_1fr]")],
+      [
+        headerView(model.route, {{#if (eq auth "better-auth")}}currentSession(model.session), {{/if}}h),
+        h.main([h.Class("overflow-y-auto")], [content]),
+      ],
+    ),
+  };
+};

--- a/packages/template-generator/templates/frontend/foldkit/src/message.ts.hbs
+++ b/packages/template-generator/templates/frontend/foldkit/src/message.ts.hbs
@@ -1,0 +1,61 @@
+import { Schema as S } from "effect";
+import { m } from "foldkit/message";
+import { UrlRequest } from "foldkit/navigation";
+import { Url } from "foldkit/url";
+
+{{#if (eq api "orpc")}}
+import { FailedFetchHealthCheck, SucceededFetchHealthCheck } from "./api/health";
+{{/if}}
+{{#if (eq auth "better-auth")}}
+import {
+  CompletedFetchSession,
+  CompletedSignOut,
+{{#if (eq api "orpc")}}
+  FailedFetchPrivateData,
+  SucceededFetchPrivateData,
+{{/if}}
+} from "./auth/session";
+import * as Login from "./page/login";
+{{/if}}
+{{#if (includes examples "todo")}}
+import * as Todos from "./page/todos";
+{{/if}}
+
+// MESSAGE
+
+export const CompletedNavigateInternal = m("CompletedNavigateInternal");
+export const CompletedLoadExternal = m("CompletedLoadExternal");
+export const ClickedLink = m("ClickedLink", { request: UrlRequest });
+export const ChangedUrl = m("ChangedUrl", { url: Url });
+{{#if (eq auth "better-auth")}}
+export const ClickedSignOut = m("ClickedSignOut");
+export const GotLoginMessage = m("GotLoginMessage", { message: Login.Message });
+{{/if}}
+{{#if (includes examples "todo")}}
+export const GotTodosMessage = m("GotTodosMessage", { message: Todos.Message });
+{{/if}}
+
+export const Message = S.Union([
+  CompletedNavigateInternal,
+  CompletedLoadExternal,
+  ClickedLink,
+  ChangedUrl,
+{{#if (eq api "orpc")}}
+  SucceededFetchHealthCheck,
+  FailedFetchHealthCheck,
+{{/if}}
+{{#if (eq auth "better-auth")}}
+  CompletedFetchSession,
+  CompletedSignOut,
+  ClickedSignOut,
+  GotLoginMessage,
+{{#if (eq api "orpc")}}
+  SucceededFetchPrivateData,
+  FailedFetchPrivateData,
+{{/if}}
+{{/if}}
+{{#if (includes examples "todo")}}
+  GotTodosMessage,
+{{/if}}
+]);
+export type Message = typeof Message.Type;

--- a/packages/template-generator/templates/frontend/foldkit/src/route.ts.hbs
+++ b/packages/template-generator/templates/frontend/foldkit/src/route.ts.hbs
@@ -1,0 +1,62 @@
+import { Schema as S, pipe } from "effect";
+import { Route } from "foldkit";
+{{#if (or (includes examples "todo") (eq auth "better-auth"))}}
+import { literal, r } from "foldkit/route";
+{{else}}
+import { r } from "foldkit/route";
+{{/if}}
+
+export const HomeRoute = r("Home");
+{{#if (includes examples "todo")}}
+export const TodosRoute = r("Todos");
+{{/if}}
+{{#if (eq auth "better-auth")}}
+export const LoginRoute = r("Login");
+export const DashboardRoute = r("Dashboard");
+{{/if}}
+export const NotFoundRoute = r("NotFound", { path: S.String });
+
+export const AppRoute = S.Union([
+  HomeRoute,
+{{#if (includes examples "todo")}}
+  TodosRoute,
+{{/if}}
+{{#if (eq auth "better-auth")}}
+  LoginRoute,
+  DashboardRoute,
+{{/if}}
+  NotFoundRoute,
+]);
+
+export type HomeRoute = typeof HomeRoute.Type;
+{{#if (includes examples "todo")}}
+export type TodosRoute = typeof TodosRoute.Type;
+{{/if}}
+{{#if (eq auth "better-auth")}}
+export type LoginRoute = typeof LoginRoute.Type;
+export type DashboardRoute = typeof DashboardRoute.Type;
+{{/if}}
+export type NotFoundRoute = typeof NotFoundRoute.Type;
+export type AppRoute = typeof AppRoute.Type;
+
+export const homeRouter = pipe(Route.root, Route.mapTo(HomeRoute));
+{{#if (includes examples "todo")}}
+export const todosRouter = pipe(literal("todos"), Route.mapTo(TodosRoute));
+{{/if}}
+{{#if (eq auth "better-auth")}}
+export const loginRouter = pipe(literal("login"), Route.mapTo(LoginRoute));
+export const dashboardRouter = pipe(literal("dashboard"), Route.mapTo(DashboardRoute));
+{{/if}}
+
+const routeParser = Route.oneOf(
+{{#if (includes examples "todo")}}
+  todosRouter,
+{{/if}}
+{{#if (eq auth "better-auth")}}
+  loginRouter,
+  dashboardRouter,
+{{/if}}
+  homeRouter,
+);
+
+export const urlToAppRoute = Route.parseUrlWithFallback(routeParser, NotFoundRoute);

--- a/packages/template-generator/templates/frontend/foldkit/src/styles.css
+++ b/packages/template-generator/templates/frontend/foldkit/src/styles.css
@@ -1,0 +1,5 @@
+@import "tailwindcss";
+
+body {
+  @apply bg-neutral-950 text-neutral-100;
+}

--- a/packages/template-generator/templates/frontend/foldkit/src/view/header.ts.hbs
+++ b/packages/template-generator/templates/frontend/foldkit/src/view/header.ts.hbs
@@ -1,0 +1,108 @@
+import { Array{{#if (eq auth "better-auth")}}, Option{{/if}} } from "effect";
+{{#if (eq auth "better-auth")}}
+import { Button } from "@foldkit/ui";
+{{/if}}
+import type { Html, HtmlBuilder } from "foldkit/html";
+
+{{#if (eq auth "better-auth")}}
+import type { Session } from "../auth/session";
+import { ClickedSignOut, type Message } from "../message";
+{{else}}
+import type { Message } from "../message";
+{{/if}}
+{{#if (eq auth "better-auth")}}
+import { type AppRoute, dashboardRouter, homeRouter, loginRouter{{#if (includes examples "todo")}}, todosRouter{{/if}} } from "../route";
+{{else if (includes examples "todo")}}
+import { type AppRoute, homeRouter, todosRouter } from "../route";
+{{else}}
+import { type AppRoute, homeRouter } from "../route";
+{{/if}}
+
+type NavLink = Readonly<{
+  href: string;
+  label: string;
+  isActive: boolean;
+}>;
+
+const navLinksFor = (route: AppRoute): ReadonlyArray<NavLink> => [
+  { href: homeRouter(), label: "Home", isActive: route._tag === "Home" },
+{{#if (includes examples "todo")}}
+  { href: todosRouter(), label: "Todos", isActive: route._tag === "Todos" },
+{{/if}}
+{{#if (eq auth "better-auth")}}
+  { href: dashboardRouter(), label: "Dashboard", isActive: route._tag === "Dashboard" },
+{{/if}}
+];
+
+const navLinkView = (link: NavLink, h: HtmlBuilder<Message>): Html =>
+  h.keyed("a")(
+    link.href,
+    [
+      h.Href(link.href),
+      h.Class(
+        `rounded px-3 py-1 text-sm font-medium transition hover:bg-neutral-800 ${
+          link.isActive ? "bg-neutral-800" : ""
+        }`,
+      ),
+    ],
+    [link.label],
+  );
+{{#if (eq auth "better-auth")}}
+
+const userMenuView = (maybeSession: Option.Option<Session>, h: HtmlBuilder<Message>): Html =>
+  Option.match(maybeSession, {
+    onNone: () =>
+      h.a(
+        [
+          h.Href(loginRouter()),
+          h.Class("rounded bg-indigo-600 px-3 py-1 text-sm text-white transition hover:bg-indigo-500"),
+        ],
+        ["Sign In"],
+      ),
+    onSome: (session) =>
+      h.div(
+        [h.Class("flex items-center gap-3")],
+        [
+          h.span([h.Class("text-sm text-neutral-300")], [session.user.name]),
+          Button.view(
+            {
+              onClick: ClickedSignOut(),
+              toView: (attributes) =>
+                h.button(
+                  [
+                    ...attributes.button,
+                    h.Class(
+                      "rounded bg-neutral-800 px-3 py-1 text-sm transition hover:bg-neutral-700",
+                    ),
+                  ],
+                  ["Sign Out"],
+                ),
+            },
+            h,
+          ),
+        ],
+      ),
+  });
+{{/if}}
+
+export const headerView = (
+  route: AppRoute,
+{{#if (eq auth "better-auth")}}
+  maybeSession: Option.Option<Session>,
+{{/if}}
+  h: HtmlBuilder<Message>,
+): Html =>
+  h.header(
+    [h.Class("border-b border-neutral-800")],
+    [
+      h.div(
+        [h.Class("mx-auto flex max-w-3xl items-center justify-between px-4 py-3")],
+        [
+          h.nav([h.Class("flex gap-2")], Array.map(navLinksFor(route), (link) => navLinkView(link, h))),
+{{#if (eq auth "better-auth")}}
+          userMenuView(maybeSession, h),
+{{/if}}
+        ],
+      ),
+    ],
+  );

--- a/packages/template-generator/templates/frontend/foldkit/src/view/home.ts.hbs
+++ b/packages/template-generator/templates/frontend/foldkit/src/view/home.ts.hbs
@@ -1,0 +1,75 @@
+{{#if (eq api "orpc")}}
+import { AsyncData } from "foldkit";
+{{/if}}
+import type { Html, HtmlBuilder } from "foldkit/html";
+
+{{#if (eq api "orpc")}}
+import type { HealthCheck } from "../api/health";
+{{/if}}
+import type { Message } from "../message";
+
+const TITLE_TEXT = `
+ ██████╗ ███████╗████████╗████████╗███████╗██████╗
+ ██╔══██╗██╔════╝╚══██╔══╝╚══██╔══╝██╔════╝██╔══██╗
+ ██████╔╝█████╗     ██║      ██║   █████╗  ██████╔╝
+ ██╔══██╗██╔══╝     ██║      ██║   ██╔══╝  ██╔══██╗
+ ██████╔╝███████╗   ██║      ██║   ███████╗██║  ██║
+ ╚═════╝ ╚══════╝   ╚═╝      ╚═╝   ╚══════╝╚═╝  ╚═╝
+
+ ████████╗    ███████╗████████╗ █████╗  ██████╗██╗  ██╗
+ ╚══██╔══╝    ██╔════╝╚══██╔══╝██╔══██╗██╔════╝██║ ██╔╝
+    ██║       ███████╗   ██║   ███████║██║     █████╔╝
+    ██║       ╚════██║   ██║   ██╔══██║██║     ██╔═██╗
+    ██║       ███████║   ██║   ██║  ██║╚██████╗██║  ██╗
+    ╚═╝       ╚══════╝   ╚═╝   ╚═╝  ╚═╝ ╚═════╝╚═╝  ╚═╝
+ `;
+{{#if (eq api "orpc")}}
+
+const statusView = (
+  dotClass: string,
+  label: string,
+  h: HtmlBuilder<Message>,
+): Html =>
+  h.div(
+    [h.Class("flex items-center gap-2")],
+    [
+      h.div([h.Class(`h-2 w-2 rounded-full ${dotClass}`)]),
+      h.span([h.Class("text-sm text-neutral-400")], [label]),
+    ],
+  );
+
+const apiStatusView = (healthCheck: HealthCheck, h: HtmlBuilder<Message>): Html =>
+  h.section(
+    [h.Class("rounded-lg border border-neutral-800 p-4")],
+    [
+      h.h2([h.Class("mb-2 font-medium")], ["API Status"]),
+      AsyncData.matchDataSplitEmpty(healthCheck, {
+        onIdle: () => statusView("bg-neutral-600", "Not checked", h),
+        onLoading: () => statusView("bg-orange-400", "Checking...", h),
+        onFailure: (error) => statusView("bg-red-500", error, h),
+        onData: () => statusView("bg-green-500", "Connected", h),
+      }),
+    ],
+  );
+{{/if}}
+
+export const homeView = ({{#if (eq api "orpc")}}healthCheck: HealthCheck, {{/if}}h: HtmlBuilder<Message>): Html =>
+  h.div(
+    [h.Class("container mx-auto max-w-3xl px-4 py-2")],
+    [
+      h.pre([h.Class("overflow-x-auto font-mono text-sm")], [TITLE_TEXT]),
+      h.div(
+        [h.Class("grid gap-6")],
+        [
+{{#if (eq api "orpc")}}
+          apiStatusView(healthCheck, h),
+{{else}}
+          h.p(
+            [h.Class("text-sm text-neutral-400")],
+            ["Model, Message, update, view. Edit src/main.ts to get started."],
+          ),
+{{/if}}
+        ],
+      ),
+    ],
+  );

--- a/packages/template-generator/templates/frontend/foldkit/src/view/notFound.ts.hbs
+++ b/packages/template-generator/templates/frontend/foldkit/src/view/notFound.ts.hbs
@@ -1,0 +1,14 @@
+import type { Html, HtmlBuilder } from "foldkit/html";
+
+import type { Message } from "../message";
+import { homeRouter } from "../route";
+
+export const notFoundView = (path: string, h: HtmlBuilder<Message>): Html =>
+  h.div(
+    [h.Class("container mx-auto max-w-3xl px-4 py-10")],
+    [
+      h.h1([h.Class("mb-4 text-3xl font-bold")], ["Page not found"]),
+      h.p([h.Class("mb-6 text-neutral-400")], [`Nothing is routed at "${path}".`]),
+      h.a([h.Href(homeRouter()), h.Class("text-indigo-400 hover:underline")], ["Go home"]),
+    ],
+  );

--- a/packages/template-generator/templates/frontend/foldkit/tsconfig.json.hbs
+++ b/packages/template-generator/templates/frontend/foldkit/tsconfig.json.hbs
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*.ts", "vite.config.ts"]
+}

--- a/packages/template-generator/templates/frontend/foldkit/vite.config.ts.hbs
+++ b/packages/template-generator/templates/frontend/foldkit/vite.config.ts.hbs
@@ -1,0 +1,10 @@
+import { foldkit } from "@foldkit/vite-plugin";
+import tailwindcss from "@tailwindcss/vite";
+import { defineConfig } from "{{#if (includes addons "vite-plus")}}vite-plus{{else}}vite{{/if}}";
+
+export default defineConfig({
+  server: {
+    port: 3001,
+  },
+  plugins: [tailwindcss(), foldkit()],
+});

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -9,6 +9,7 @@ export const webFrontends = [
   "svelte",
   "solid",
   "astro",
+  "foldkit",
 ] as const satisfies readonly Exclude<WebFrontend, "none">[];
 
 export const desktopWebFrontends = [

--- a/packages/types/src/schemas.ts
+++ b/packages/types/src/schemas.ts
@@ -27,6 +27,7 @@ export const FrontendSchema = z
     "svelte",
     "solid",
     "astro",
+    "foldkit",
     "none",
   ])
   .describe("Frontend framework");

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -66,10 +66,11 @@ export type WebFrontend = Extract<
   | "svelte"
   | "solid"
   | "astro"
+  | "foldkit"
   | "none"
 >;
 
-export type DesktopWebFrontend = Exclude<WebFrontend, "none" | "solid">;
+export type DesktopWebFrontend = Exclude<WebFrontend, "none" | "solid" | "foldkit">;
 
 export type NativeFrontend = Extract<
   Frontend,


### PR DESCRIPTION
Closes #1175.

Adds [Foldkit](https://github.com/foldkit/foldkit) as a ninth web frontend (`--frontend foldkit`). Foldkit is a TypeScript frontend framework built on Effect and architected like Elm: Model, Message, update, view, and side effects confined to Commands. It ships its own router, virtual DOM, and Vite plugin, and uses Effect Schema for every type.

## The one design difference worth reviewing first

Every current web frontend gets a TanStack Query binding through `api-deps.ts`. Foldkit gets none, on purpose: server state lives in the Model as `AsyncData` and is fetched by Commands. So the Foldkit branch adds the vanilla `@orpc/client` only, and better-auth uses its vanilla client. Both calls are wrapped in an Effect inside a Command. A query cache next to the Model would fight the architecture rather than help it.

## What the templates generate

`packages/template-generator/templates/frontend/foldkit` is a Vite SPA on port 3001 with `@foldkit/vite-plugin` and Tailwind v4. The cross-cutting templates follow the existing layout:

| Path | Contents |
| --- | --- |
| `frontend/foldkit` | app shell, routes, Messages, header, home, 404 |
| `api/orpc/web/foldkit` | oRPC client and the health-check Command |
| `auth/better-auth/web/foldkit` | auth client, session state, sign-in/sign-up page, dashboard |
| `examples/todo/web/foldkit` | the todo example as a Submodel |
| `deploy/docker/web/foldkit` | multi-stage build serving `dist` through nginx |

## What it rejects, and where

Everything without a Foldkit template fails during configuration rather than after generation, which is the rule `openspec/config.yaml` asks for:

- tRPC. Foldkit joins `TRPC_UNSUPPORTED_FRONTENDS`, which also replaces the four-way `includesNuxt ? ... : includesSvelte ? ...` chains in `validateApiFrontendCompatibility` and `allowedApisForFrontends`.
- Convex, Clerk, Polar, the AI example, `--backend self`, Tauri and Electrobun.
- `--web-deploy cloudflare` and `--web-deploy prisma`. There is no Alchemy recipe, so `DeployedWebFramework` excludes Foldkit and a new `validateCloudflareWebDeploy` reports it. The prompt hides the option instead of offering a dead end.

Docker and Vercel web deployment both work. Vercel gets the SPA `index.html` rewrite; Docker maps `3001:80` and health-checks nginx, matching what TanStack Router already does.

## Verification

- `bun run check`, `packages/template-generator` typecheck, and `apps/cli` typecheck are clean. The one remaining `apps/cli` error, in `prompts/database-setup.ts`, and the `apps/web` Next.js prerender failure both reproduce on `main` untouched.
- `cd apps/cli && bun test`: 685 pass, 30 skip, 0 fail.
- `cd apps/web && bun test`: 46 pass, 0 fail. Includes a new Foldkit suite in `stack-builder-compatibility.test.ts`.
- `BTS_MATRIX_MODE=smoke`: 307 pass, 0 fail.
- Full matrix: I sampled 14,479 Foldkit configurations and compared the oracle against production validation. Zero mismatches. Shard 1/6000 has 11 failures, 7 of which reproduce on `main`; the rest share the same pre-existing `next` + `planetscale` + `cloudflare` signature and none involve Foldkit.
- New `Foldkit Frontend` suite in `apps/cli/test/frontend.test.ts` covers the generated layout, the absence of a query cache, the Docker output, and each rejected combination.

I also ran a generated project end to end (Hono + oRPC + better-auth + SQLite/Drizzle + todo). `tsc --noEmit` and `vite build` pass, and in a headless browser:

- the home page renders and the API status card reaches Connected,
- sign-up redirects to `/dashboard`, which shows the session and the `privateData` response,
- creating, toggling, and deleting a todo all round-trip through oRPC,
- `/dashboard` while signed out redirects to `/login`, `/login` while signed in redirects to `/dashboard`, sign-out returns to `/`,
- no console or page errors.

Typecheck also passes for the minimal config (`--api none --auth none`), for oRPC with the todo example and no auth, for Prisma/Postgres with better-auth, and for Mongoose, whose string todo ids the template handles.

## Notes

- App source follows this repo's template style, double quotes and semicolons, not Foldkit's own scaffolder style. Say the word if you would rather the generated app match Foldkit's formatting.
- Versions are pinned to `foldkit@^0.145.0`, `@foldkit/ui@^0.145.0`, `@foldkit/vite-plugin@^0.13.1`, and `effect@4.0.0-rc.108`, which is the version Foldkit 0.145 requires.
- I maintain Foldkit, so I can keep this branch current with the framework.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Foldkit as a supported web frontend option.
  - Added project generation for Foldkit apps, including routing, authentication, oRPC, todo examples, and Docker deployment.
  - Added generated Vercel static SPA support and required Node.js version guidance.

- **Bug Fixes**
  - Improved compatibility checks for unsupported authentication, backend, payment, AI, and deployment combinations.
  - Cloudflare deployment is now offered only for compatible frontends.

- **Documentation**
  - Updated frontend options and compatibility guidance to include Foldkit and its supported configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->