### PR TITLE
feat(cli): add Nitro backend

### DIFF
--- a/apps/cli/src/prompts/backend.ts
+++ b/apps/cli/src/prompts/backend.ts
@@ -58,6 +58,11 @@ export async function getBackendFrameworkChoice(
       label: "Elysia",
       hint: "Ergonomic web framework for building backend servers",
     },
+    {
+      value: "nitro" as const,
+      label: "Nitro (experimental)",
+      hint: "Portable, file-routed server framework powered by H3",
+    },
   );
 
   if (!hasIncompatibleFrontend) {

--- a/apps/cli/src/prompts/database-setup.ts
+++ b/apps/cli/src/prompts/database-setup.ts
@@ -129,6 +129,10 @@ const providerLabels = {
   "prisma-postgres": "Prisma Postgres",
 } as const satisfies Partial<Record<DatabaseSetup, string>>;
 
+function hasProviderLabel(dbSetup: DatabaseSetup): dbSetup is keyof typeof providerLabels {
+  return Object.hasOwn(providerLabels, dbSetup);
+}
+
 export async function getDbProvisioningChoice(
   mode: DbSetupMode | undefined,
   dbSetup: DatabaseSetup | undefined,
@@ -152,8 +156,8 @@ export async function getDbProvisioningChoice(
 
   if (mode !== undefined) return mode;
 
+  if (!hasProviderLabel(dbSetup)) return undefined;
   const provider = providerLabels[dbSetup];
-  if (!provider) return undefined;
 
   const options: Array<{ value: DbSetupMode; label: string; hint: string }> = [
     {

--- a/apps/cli/src/prompts/runtime.ts
+++ b/apps/cli/src/prompts/runtime.ts
@@ -31,7 +31,7 @@ export async function getRuntimeChoice(
     },
   ];
 
-  if (backend === "hono") {
+  if (backend === "hono" || backend === "nitro") {
     runtimeOptions.push({
       value: "workers",
       label: "Cloudflare Workers",

--- a/apps/cli/src/prompts/server-deploy.ts
+++ b/apps/cli/src/prompts/server-deploy.ts
@@ -3,7 +3,7 @@ import type { Backend, Runtime, ServerDeploy, WebDeploy } from "../types";
 import { UserCancelledError } from "../utils/errors";
 import { isCancel, navigableSelect, preferValidInitial } from "./navigable";
 
-const SERVER_APP_BACKENDS: Backend[] = ["hono", "express", "fastify", "elysia"];
+const SERVER_APP_BACKENDS: Backend[] = ["hono", "express", "fastify", "elysia", "nitro"];
 
 type DeploymentOption = {
   value: ServerDeploy;

--- a/apps/cli/src/utils/compatibility-rules.ts
+++ b/apps/cli/src/utils/compatibility-rules.ts
@@ -164,21 +164,21 @@ export function validateWorkersCompatibility(
     providedFlags.has("runtime") &&
     options.runtime === "workers" &&
     config.backend &&
-    config.backend !== "hono"
+    !["hono", "nitro"].includes(config.backend)
   ) {
     return validationErr(
-      `Cloudflare Workers runtime (--runtime workers) is only supported with Hono backend (--backend hono). Current backend: ${config.backend}. Please use '--backend hono' or choose a different runtime.`,
+      `Cloudflare Workers runtime (--runtime workers) is only supported with Hono or Nitro backend. Current backend: ${config.backend}. Please use '--backend hono', '--backend nitro', or choose a different runtime.`,
     );
   }
 
   if (
     providedFlags.has("backend") &&
     config.backend &&
-    config.backend !== "hono" &&
+    !["hono", "nitro"].includes(config.backend) &&
     config.runtime === "workers"
   ) {
     return validationErr(
-      `Backend '${config.backend}' is not compatible with Cloudflare Workers runtime. Cloudflare Workers runtime is only supported with Hono backend. Please use '--backend hono' or choose a different runtime.`,
+      `Backend '${config.backend}' is not compatible with Cloudflare Workers runtime. Cloudflare Workers runtime is only supported with Hono or Nitro backend. Please use '--backend hono', '--backend nitro', or choose a different runtime.`,
     );
   }
 
@@ -317,19 +317,6 @@ export function validateServerDeployRequiresBackend(
       "'--server-deploy' requires a backend. Please select a backend or set '--server-deploy none'.",
     );
   }
-  return Result.ok(undefined);
-}
-
-export function validateNitroCloudflareServerDeploy(
-  serverDeploy: ServerDeploy | undefined,
-  backend: Backend | undefined,
-): ValidationResult {
-  if (serverDeploy === "cloudflare" && backend === "nitro") {
-    return validationErr(
-      "Nitro server deployment to Cloudflare is not available yet because Alchemy does not expose a standalone Nitro adapter. Choose Prisma, Docker, Vercel, or no server deployment.",
-    );
-  }
-
   return Result.ok(undefined);
 }
 

--- a/apps/cli/src/utils/compatibility-rules.ts
+++ b/apps/cli/src/utils/compatibility-rules.ts
@@ -320,6 +320,19 @@ export function validateServerDeployRequiresBackend(
   return Result.ok(undefined);
 }
 
+export function validateNitroCloudflareServerDeploy(
+  serverDeploy: ServerDeploy | undefined,
+  backend: Backend | undefined,
+): ValidationResult {
+  if (serverDeploy === "cloudflare" && backend === "nitro") {
+    return validationErr(
+      "Nitro server deployment to Cloudflare is not available yet because Alchemy does not expose a standalone Nitro adapter. Choose Prisma, Docker, Vercel, or no server deployment.",
+    );
+  }
+
+  return Result.ok(undefined);
+}
+
 export function validateDockerServerDeploy(
   serverDeploy: ServerDeploy | undefined,
   backend: Backend | undefined,
@@ -329,7 +342,7 @@ export function validateDockerServerDeploy(
 
   if (backend === "convex" || backend === "self") {
     return validationErr(
-      "'--server-deploy docker' requires a separate server backend (hono, express, fastify, elysia). For a fullstack 'self' backend, use '--web-deploy docker' instead.",
+      "'--server-deploy docker' requires a separate server backend (hono, express, fastify, elysia, nitro). For a fullstack 'self' backend, use '--web-deploy docker' instead.",
     );
   }
 
@@ -351,7 +364,7 @@ export function validateVercelServerDeploy(
 
   if (backend === "convex" || backend === "self") {
     return validationErr(
-      "'--server-deploy vercel' requires a separate server backend (hono, express, fastify, elysia). For a fullstack 'self' backend, use '--web-deploy vercel' instead.",
+      "'--server-deploy vercel' requires a separate server backend (hono, express, fastify, elysia, nitro). For a fullstack 'self' backend, use '--web-deploy vercel' instead.",
     );
   }
 
@@ -373,7 +386,7 @@ export function validatePrismaServerDeploy(
 
   if (backend === "convex" || backend === "self") {
     return validationErr(
-      "'--server-deploy prisma' requires a separate server backend (hono, express, fastify, elysia). For a fullstack 'self' backend, use '--web-deploy prisma' instead.",
+      "'--server-deploy prisma' requires a separate server backend (hono, express, fastify, elysia, nitro). For a fullstack 'self' backend, use '--web-deploy prisma' instead.",
     );
   }
 

--- a/apps/cli/src/utils/config-validation.ts
+++ b/apps/cli/src/utils/config-validation.ts
@@ -22,6 +22,7 @@ import {
   validateDockerServerDeploy,
   validateDockerWebDeployDesktopAddons,
   validateServerDeployRequiresBackend,
+  validateNitroCloudflareServerDeploy,
   validateVercelServerDeploy,
   validatePrismaServerDeploy,
   validatePrismaWebDeploy,
@@ -543,6 +544,7 @@ export function validateFullConfig(
     yield* validateApiConstraints(config, options);
 
     yield* validateServerDeployRequiresBackend(config.serverDeploy, config.backend);
+    yield* validateNitroCloudflareServerDeploy(config.serverDeploy, config.backend);
     yield* validateDockerServerDeploy(config.serverDeploy, config.backend, config.runtime);
     yield* validateVercelServerDeploy(config.serverDeploy, config.backend, config.runtime);
     yield* validatePrismaServerDeploy(config.serverDeploy, config.backend, config.runtime);

--- a/apps/cli/src/utils/config-validation.ts
+++ b/apps/cli/src/utils/config-validation.ts
@@ -22,7 +22,6 @@ import {
   validateDockerServerDeploy,
   validateDockerWebDeployDesktopAddons,
   validateServerDeployRequiresBackend,
-  validateNitroCloudflareServerDeploy,
   validateVercelServerDeploy,
   validatePrismaServerDeploy,
   validatePrismaWebDeploy,
@@ -41,7 +40,7 @@ function validationErr(message: string): ValidationResult {
 
 function hasResolvedWorkersD1Target(config: Partial<ProjectConfig>) {
   return (
-    config.backend === "hono" &&
+    (config.backend === "hono" || config.backend === "nitro") &&
     config.runtime === "workers" &&
     config.serverDeploy === "cloudflare"
   );
@@ -55,7 +54,7 @@ function hasResolvedSelfCloudflareD1Target(config: Partial<ProjectConfig>) {
 
 function canResolveWorkersD1Target(config: Partial<ProjectConfig>) {
   return (
-    (config.backend === undefined || config.backend === "hono") &&
+    (config.backend === undefined || config.backend === "hono" || config.backend === "nitro") &&
     (config.runtime === undefined || config.runtime === "workers") &&
     (config.serverDeploy === undefined || config.serverDeploy === "cloudflare")
   );
@@ -544,7 +543,6 @@ export function validateFullConfig(
     yield* validateApiConstraints(config, options);
 
     yield* validateServerDeployRequiresBackend(config.serverDeploy, config.backend);
-    yield* validateNitroCloudflareServerDeploy(config.serverDeploy, config.backend);
     yield* validateDockerServerDeploy(config.serverDeploy, config.backend, config.runtime);
     yield* validateVercelServerDeploy(config.serverDeploy, config.backend, config.runtime);
     yield* validatePrismaServerDeploy(config.serverDeploy, config.backend, config.runtime);

--- a/apps/cli/src/utils/display-config.ts
+++ b/apps/cli/src/utils/display-config.ts
@@ -37,6 +37,7 @@ const VALUE_LABELS = {
   express: "Express",
   fastify: "Fastify",
   elysia: "Elysia",
+  nitro: "Nitro",
   convex: "Convex",
   self: "Fullstack framework",
   bun: "Bun",

--- a/apps/cli/src/utils/requirements.ts
+++ b/apps/cli/src/utils/requirements.ts
@@ -106,7 +106,9 @@ function getNodeToolingRequirements(config: RequirementConfig): VersionRequireme
     }
   }
 
-  if (!["none", "self", "convex"].includes(config.backend)) {
+  if (config.backend === "nitro") {
+    addNodeRequirement(requirements, "^20.19.0 || >=22.12.0", "Nitro 3");
+  } else if (!["none", "self", "convex"].includes(config.backend)) {
     addNodeRequirement(
       requirements,
       "^22.18.0 || >=24.11.0",

--- a/apps/cli/test/addons.test.ts
+++ b/apps/cli/test/addons.test.ts
@@ -1053,6 +1053,7 @@ describe("Addon Configurations", () => {
       express: 'import { evlog } from "evlog/express";',
       fastify: 'import { evlog } from "evlog/fastify";',
       elysia: 'import { evlog } from "evlog/elysia";',
+      nitro: "",
       convex: "",
       self: "",
       none: "",

--- a/apps/cli/test/api.test.ts
+++ b/apps/cli/test/api.test.ts
@@ -57,7 +57,7 @@ describe("API Configurations", () => {
       });
     }
 
-    const backends = ["hono", "express", "fastify", "elysia"];
+    const backends = ["hono", "express", "fastify", "elysia", "nitro"];
 
     for (const backend of backends) {
       it(`should work with tRPC + ${backend}`, async () => {
@@ -184,7 +184,7 @@ describe("API Configurations", () => {
       });
     }
 
-    const backends = ["hono", "express", "fastify", "elysia"];
+    const backends = ["hono", "express", "fastify", "elysia", "nitro"];
 
     for (const backend of backends) {
       it(`should work with oRPC + ${backend}`, async () => {

--- a/apps/cli/test/auth.test.ts
+++ b/apps/cli/test/auth.test.ts
@@ -1155,7 +1155,7 @@ describe("Authentication Configurations", () => {
   });
 
   describe("Authentication with Different Backends", () => {
-    const backends = ["hono", "express", "fastify", "elysia", "self"];
+    const backends = ["hono", "express", "fastify", "elysia", "nitro", "self"];
 
     for (const backend of backends) {
       it(`should work with better-auth + ${backend}`, async () => {

--- a/apps/cli/test/backend-runtime.test.ts
+++ b/apps/cli/test/backend-runtime.test.ts
@@ -19,6 +19,9 @@ describe("Backend and Runtime Combinations", () => {
 
       { backend: "elysia" as const, runtime: "bun" as const },
 
+      { backend: "nitro" as const, runtime: "bun" as const },
+      { backend: "nitro" as const, runtime: "node" as const },
+
       // Special cases
       { backend: "convex" as const, runtime: "none" as const },
       { backend: "none" as const, runtime: "none" as const },
@@ -93,6 +96,11 @@ describe("Backend and Runtime Combinations", () => {
         runtime: "workers",
         error: "Cloudflare Workers runtime (--runtime workers) is only supported with Hono backend",
       },
+      {
+        backend: "nitro",
+        runtime: "workers",
+        error: "Cloudflare Workers runtime (--runtime workers) is only supported with Hono backend",
+      },
 
       // Convex backend requires runtime none
       {
@@ -157,6 +165,12 @@ describe("Backend and Runtime Combinations", () => {
       },
       {
         backend: "express",
+        runtime: "none",
+        error:
+          "'--runtime none' is only supported with '--backend convex', '--backend none', or '--backend self'",
+      },
+      {
+        backend: "nitro",
         runtime: "none",
         error:
           "'--runtime none' is only supported with '--backend convex', '--backend none', or '--backend self'",

--- a/apps/cli/test/backend-runtime.test.ts
+++ b/apps/cli/test/backend-runtime.test.ts
@@ -21,6 +21,7 @@ describe("Backend and Runtime Combinations", () => {
 
       { backend: "nitro" as const, runtime: "bun" as const },
       { backend: "nitro" as const, runtime: "node" as const },
+      { backend: "nitro" as const, runtime: "workers" as const },
 
       // Special cases
       { backend: "convex" as const, runtime: "none" as const },
@@ -80,26 +81,24 @@ describe("Backend and Runtime Combinations", () => {
 
   describe("Invalid Backend-Runtime Combinations", () => {
     const invalidCombinations = [
-      // Workers runtime only works with Hono
+      // Workers runtime only works with Hono or Nitro
       {
         backend: "express" as const,
         runtime: "workers" as const,
-        error: "Cloudflare Workers runtime (--runtime workers) is only supported with Hono backend",
+        error:
+          "Cloudflare Workers runtime (--runtime workers) is only supported with Hono or Nitro backend",
       },
       {
         backend: "fastify",
         runtime: "workers",
-        error: "Cloudflare Workers runtime (--runtime workers) is only supported with Hono backend",
+        error:
+          "Cloudflare Workers runtime (--runtime workers) is only supported with Hono or Nitro backend",
       },
       {
         backend: "elysia",
         runtime: "workers",
-        error: "Cloudflare Workers runtime (--runtime workers) is only supported with Hono backend",
-      },
-      {
-        backend: "nitro",
-        runtime: "workers",
-        error: "Cloudflare Workers runtime (--runtime workers) is only supported with Hono backend",
+        error:
+          "Cloudflare Workers runtime (--runtime workers) is only supported with Hono or Nitro backend",
       },
 
       // Convex backend requires runtime none

--- a/apps/cli/test/deployment.test.ts
+++ b/apps/cli/test/deployment.test.ts
@@ -219,7 +219,7 @@ describe("Deployment Configurations", () => {
     });
 
     it("should work with server deploy + all compatible backends", async () => {
-      const backends = ["hono", "express", "fastify", "elysia"] as const;
+      const backends = ["hono", "express", "fastify", "elysia", "nitro"] as const;
 
       for (const backend of backends) {
         const config: TestConfig = {

--- a/apps/cli/test/generated-builds.test.ts
+++ b/apps/cli/test/generated-builds.test.ts
@@ -82,6 +82,91 @@ const buildSamples: BuildSample[] = [
     },
   },
   {
+    name: "nitro-orpc-drizzle-auth-todo",
+    packageManagers: ["bun", "npm", "pnpm"],
+    config: {
+      ...baseConfig,
+      frontend: ["tanstack-router"],
+      backend: "nitro",
+      runtime: "node",
+      database: "sqlite",
+      orm: "drizzle",
+      api: "orpc",
+      auth: "better-auth",
+      payments: "none",
+      addons: ["turborepo"],
+      examples: ["todo"],
+    },
+  },
+  {
+    name: "nitro-trpc-clerk-bun",
+    packageManagers: ["bun"],
+    config: {
+      ...baseConfig,
+      frontend: ["tanstack-router"],
+      backend: "nitro",
+      runtime: "bun",
+      database: "none",
+      orm: "none",
+      api: "trpc",
+      auth: "clerk",
+      payments: "none",
+      addons: ["nx"],
+      examples: ["none"],
+    },
+  },
+  {
+    name: "nitro-prisma-better-auth",
+    packageManagers: ["bun"],
+    config: {
+      ...baseConfig,
+      frontend: ["react-router"],
+      backend: "nitro",
+      runtime: "bun",
+      database: "sqlite",
+      orm: "prisma",
+      api: "trpc",
+      auth: "better-auth",
+      payments: "polar",
+      addons: ["turborepo"],
+      examples: ["none"],
+    },
+  },
+  {
+    name: "nitro-solid-mongoose",
+    packageManagers: ["bun"],
+    config: {
+      ...baseConfig,
+      frontend: ["solid"],
+      backend: "nitro",
+      runtime: "node",
+      database: "mongodb",
+      orm: "mongoose",
+      api: "orpc",
+      auth: "none",
+      payments: "none",
+      addons: ["turborepo"],
+      examples: ["none"],
+    },
+  },
+  {
+    name: "nitro-ai-bun",
+    packageManagers: ["bun"],
+    config: {
+      ...baseConfig,
+      frontend: ["tanstack-router"],
+      backend: "nitro",
+      runtime: "bun",
+      database: "none",
+      orm: "none",
+      api: "orpc",
+      auth: "none",
+      payments: "none",
+      addons: ["turborepo"],
+      examples: ["ai"],
+    },
+  },
+  {
     name: "next-self-prisma",
     config: {
       ...baseConfig,
@@ -956,6 +1041,92 @@ async function bootAndValidateSolidDevRuntime(sample: SelectedBuildSample, proje
   }
 }
 
+async function bootAndValidateNitroRuntime(sample: SelectedBuildSample, projectDir: string) {
+  if (sample.config.backend !== "nitro") return;
+
+  const serverDir = path.join(projectDir, "apps/server");
+  const port = await getAvailablePort();
+  const runtime = execa(
+    sample.config.runtime === "bun" ? "bun" : "node",
+    [".output/server/index.mjs"],
+    {
+      cwd: serverDir,
+      all: true,
+      reject: false,
+      env: {
+        ...process.env,
+        BETTER_AUTH_SECRET: "generated-build-test-secret-at-least-32-characters",
+        BETTER_AUTH_URL: `http://127.0.0.1:${port}`,
+        CLERK_PUBLISHABLE_KEY: "pk_test_generated-build-test",
+        CLERK_SECRET_KEY: "sk_test_generated-build-test",
+        CORS_ORIGIN: "https://web.example.test",
+        DATABASE_URL: "file:./local.db",
+        GOOGLE_GENERATIVE_AI_API_KEY: "generated-build-test-key",
+        HOST: "127.0.0.1",
+        NODE_ENV: "production",
+        POLAR_ACCESS_TOKEN: "polar_generated-build-test",
+        POLAR_SUCCESS_URL: `http://127.0.0.1:${port}/success`,
+        PORT: String(port),
+      },
+    },
+  );
+
+  let failure: unknown;
+  try {
+    const root = await fetchWhenReady(`http://127.0.0.1:${port}/`);
+    expect(root?.status).toBe(200);
+    expect(await root?.text()).toBe("OK");
+
+    const preflight = await fetchWhenReady(`http://127.0.0.1:${port}/rpc/healthCheck`, {
+      method: "OPTIONS",
+      headers: {
+        origin: "https://web.example.test",
+        "access-control-request-method": "POST",
+      },
+    });
+    expect(preflight?.status).toBe(204);
+    expect(preflight?.headers.get("access-control-allow-origin")).toBe("https://web.example.test");
+
+    if (sample.config.api === "orpc") {
+      const health = await fetchWhenReady(`http://127.0.0.1:${port}/rpc/healthCheck`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ json: null }),
+      });
+      expect(health?.status).toBe(200);
+      expect(await health?.json()).toEqual({ json: "OK" });
+    }
+
+    if (sample.config.api === "trpc" && sample.config.auth !== "clerk") {
+      const input = encodeURIComponent(JSON.stringify({ json: null }));
+      const health = await fetchWhenReady(
+        `http://127.0.0.1:${port}/trpc/healthCheck?input=${input}`,
+      );
+      expect(health?.status).toBe(200);
+      expect(await health?.json()).toEqual({ result: { data: "OK" } });
+    }
+
+    if (sample.config.auth === "better-auth") {
+      const session = await fetchWhenReady(`http://127.0.0.1:${port}/api/auth/get-session`);
+      expect(session?.status).toBe(200);
+      expect(await session?.json()).toBeNull();
+    }
+  } catch (error) {
+    failure = error;
+  } finally {
+    runtime.kill("SIGTERM");
+  }
+
+  const result = await runtime;
+  if (failure) {
+    throw new Error(
+      [`Generated Nitro runtime probe failed: ${String(failure)}`, formatOutput(result.all)]
+        .filter(Boolean)
+        .join("\n\n"),
+    );
+  }
+}
+
 describe.skipIf(!shouldRunBuildSamples)("Generated project install/build samples", () => {
   for (const sample of getSelectedBuildSamples()) {
     it(
@@ -976,6 +1147,7 @@ describe.skipIf(!shouldRunBuildSamples)("Generated project install/build samples
         await bootAndValidatePrismaWebArtifact(sample, projectDir);
         await bootAndValidateSolidDevRuntime(sample, projectDir);
         await bootAndValidateSolidRuntime(sample, projectDir);
+        await bootAndValidateNitroRuntime(sample, projectDir);
         await validateSolidBuildArtifacts(sample, projectDir);
         await runWorkspaceTypeChecks(sample.name, projectDir, sample.packageManager);
       },

--- a/apps/cli/test/generated-builds.test.ts
+++ b/apps/cli/test/generated-builds.test.ts
@@ -116,6 +116,25 @@ const buildSamples: BuildSample[] = [
     },
   },
   {
+    name: "nitro-cloudflare-d1-auth-todo",
+    packageManagers: ["bun"],
+    config: {
+      ...baseConfig,
+      frontend: ["tanstack-router"],
+      backend: "nitro",
+      runtime: "workers",
+      database: "sqlite",
+      orm: "drizzle",
+      dbSetup: "d1",
+      api: "orpc",
+      auth: "better-auth",
+      payments: "none",
+      addons: ["turborepo"],
+      examples: ["todo"],
+      serverDeploy: "cloudflare",
+    },
+  },
+  {
     name: "nitro-prisma-better-auth",
     packageManagers: ["bun"],
     config: {
@@ -1042,7 +1061,7 @@ async function bootAndValidateSolidDevRuntime(sample: SelectedBuildSample, proje
 }
 
 async function bootAndValidateNitroRuntime(sample: SelectedBuildSample, projectDir: string) {
-  if (sample.config.backend !== "nitro") return;
+  if (sample.config.backend !== "nitro" || sample.config.runtime === "workers") return;
 
   const serverDir = path.join(projectDir, "apps/server");
   const port = await getAvailablePort();

--- a/apps/cli/test/matrix/oracle.ts
+++ b/apps/cli/test/matrix/oracle.ts
@@ -35,7 +35,7 @@ export type MatrixRule =
   | "server-deploy-requires-backend"
   | "server-deploy-requires-workers-runtime"
   | "web-deploy-requires-web-frontend"
-  | "workers-requires-hono"
+  | "workers-requires-compatible-backend"
   | "workers-requires-server-deploy"
   | "workers-rejects-mongodb";
 
@@ -258,8 +258,8 @@ function validateBackend(config: ProjectConfig, rules: Set<MatrixRule>) {
 function validateRuntimeAndDeploy(config: ProjectConfig, rules: Set<MatrixRule>) {
   addRule(
     rules,
-    config.runtime === "workers" && config.backend !== "hono",
-    "workers-requires-hono",
+    config.runtime === "workers" && !["hono", "nitro"].includes(config.backend),
+    "workers-requires-compatible-backend",
   );
   addRule(
     rules,
@@ -429,7 +429,7 @@ export function classifyMatrixError(message: string): MatrixRule | "unknown" {
     return "web-deploy-requires-web-frontend";
   }
   if (message.includes("Workers runtime") && message.includes("only supported with Hono")) {
-    return "workers-requires-hono";
+    return "workers-requires-compatible-backend";
   }
   if (message.includes("Workers runtime") && message.includes("not compatible with MongoDB")) {
     return "workers-rejects-mongodb";

--- a/apps/cli/test/nitro.test.ts
+++ b/apps/cli/test/nitro.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from "bun:test";
+
+import { createVirtual } from "../src/index";
+import { collectFiles } from "./setup";
+
+type CreateOptions = Parameters<typeof createVirtual>[0];
+
+const baseConfig = {
+  projectName: "nitro-test",
+  frontend: ["tanstack-router"],
+  backend: "nitro",
+  runtime: "node",
+  api: "orpc",
+  database: "sqlite",
+  orm: "drizzle",
+  dbSetup: "none",
+  auth: "better-auth",
+  payments: "none",
+  addons: ["turborepo"],
+  examples: ["todo"],
+  webDeploy: "none",
+  serverDeploy: "none",
+  packageManager: "bun",
+  install: false,
+  git: false,
+} satisfies CreateOptions;
+
+async function generate(overrides: Partial<CreateOptions> = {}) {
+  const result = await createVirtual({ ...baseConfig, ...overrides } as CreateOptions);
+  if (result.isErr()) throw result.error;
+  return collectFiles(result.value.root, result.value.root.path);
+}
+
+describe("Nitro backend", () => {
+  it("generates the native Nitro 3 standalone structure", async () => {
+    const files = await generate({
+      projectName: "nitro-standalone",
+      runtime: "node",
+      api: "none",
+      database: "none",
+      orm: "none",
+      auth: "none",
+      examples: ["none"],
+    });
+
+    expect(files.get("apps/server/nitro.config.ts")).toContain('defaultPreset: "node"');
+    expect(files.get("apps/server/nitro.config.ts")).toContain('serverDir: "./server"');
+    expect(files.get("apps/server/server/routes/index.get.ts")).toContain(
+      'defineHandler(() => "OK")',
+    );
+    expect(files.has("apps/server/src/index.ts")).toBe(false);
+    expect(files.has("apps/server/server/routes/rpc/[...].ts")).toBe(false);
+    expect(files.has("apps/server/server/routes/api/auth/[...all].ts")).toBe(false);
+
+    const packageJson = files.get("apps/server/package.json") ?? "";
+    expect(packageJson).toContain('"build": "nitro build"');
+    expect(packageJson).toContain('"dev": "nitro dev --port 3000"');
+    expect(packageJson).toContain('"start": "node .output/server/index.mjs"');
+    expect(packageJson).toContain('"nitro": "^3.0.260610-beta"');
+    expect(packageJson).not.toContain("tsdown");
+    expect(packageJson).not.toContain("hono");
+  });
+
+  it("uses Web Request adapters for oRPC and Better Auth", async () => {
+    const files = await generate({ projectName: "nitro-orpc-auth" });
+
+    expect(files.get("apps/server/server/routes/rpc/[...].ts")).toContain(
+      "handler.handle(event.req",
+    );
+    expect(files.get("apps/server/server/routes/api-reference/[...].ts")).toContain(
+      'prefix: "/api-reference"',
+    );
+    expect(files.get("apps/server/server/routes/api/auth/[...all].ts")).toContain(
+      "auth.handler(event.req)",
+    );
+    expect(files.get("packages/api/src/context.ts")).toContain("request: Request;");
+    expect(files.get("packages/api/src/context.ts")).toContain(
+      "auth.api.getSession({ headers: request.headers })",
+    );
+  });
+
+  it("uses the tRPC fetch adapter and Clerk request authentication", async () => {
+    const files = await generate({
+      projectName: "nitro-trpc-clerk",
+      runtime: "bun",
+      api: "trpc",
+      auth: "clerk",
+      examples: ["none"],
+    });
+
+    expect(files.get("apps/server/nitro.config.ts")).toContain('defaultPreset: "bun"');
+    expect(files.get("apps/server/server/routes/trpc/[...].ts")).toContain("fetchRequestHandler({");
+    expect(files.get("packages/api/src/context.ts")).toContain(
+      "clerkClient.authenticateRequest(request",
+    );
+    expect(files.get("packages/env/src/server.ts")).toContain(
+      "CLERK_PUBLISHABLE_KEY: z.string().min(1)",
+    );
+
+    const serverPackage = files.get("apps/server/package.json") ?? "";
+    const apiPackage = files.get("packages/api/package.json") ?? "";
+    expect(serverPackage).toContain('"@trpc/server"');
+    expect(serverPackage).not.toContain("@hono/trpc-server");
+    expect(apiPackage).toContain('"@clerk/backend"');
+  });
+
+  it("generates the native redirect and AI routes when selected", async () => {
+    const files = await generate({
+      projectName: "nitro-native-ai",
+      frontend: ["tanstack-router", "native-bare"],
+      payments: "polar",
+      examples: ["todo", "ai"],
+    });
+
+    expect(files.get("apps/server/server/routes/polar/success.get.ts")).toContain(
+      "Response.redirect(redirectUrl, 302)",
+    );
+    expect(files.get("apps/server/server/routes/ai.post.ts")).toContain("await event.req.json()");
+  });
+
+  it("generates first-class Docker, Prisma, and Vercel deployment contracts", async () => {
+    const dockerFiles = await generate({
+      projectName: "nitro-docker",
+      serverDeploy: "docker",
+    });
+    const dockerfile = dockerFiles.get("apps/server/Dockerfile") ?? "";
+    expect(dockerfile).toContain("COPY --from=builder /app/apps/server/.output ./");
+    expect(dockerfile).toContain('CMD ["node", "server/index.mjs"]');
+    expect(dockerfile).not.toContain("dist/index.mjs");
+
+    const prismaFiles = await generate({
+      projectName: "nitro-prisma",
+      serverDeploy: "prisma",
+    });
+    const infra = prismaFiles.get("packages/infra/alchemy.run.ts") ?? "";
+    expect(infra).toContain('command: "bun run build"');
+    expect(infra).toContain('outdir: ".output"');
+    expect(infra).toContain('entrypoint: "server/index.mjs"');
+    expect(infra).not.toContain('framework: "bun"');
+    expect(infra).not.toContain('entrypoint: "src/index.ts"');
+
+    const vercelFiles = await generate({
+      projectName: "nitro-vercel",
+      serverDeploy: "vercel",
+    });
+    const vercel = JSON.parse(vercelFiles.get("vercel.json") ?? "{}") as {
+      services?: {
+        server?: { root?: string; framework?: string; entrypoint?: string };
+      };
+    };
+    expect(vercel.services?.server).toMatchObject({
+      root: "apps/server",
+      framework: "nitro",
+    });
+    expect(vercel.services?.server).not.toHaveProperty("entrypoint");
+  });
+
+  it("rejects unsupported Cloudflare and evlog configurations before generation", async () => {
+    const cloudflare = await createVirtual({
+      ...baseConfig,
+      projectName: "nitro-cloudflare-rejected",
+      runtime: "workers",
+      serverDeploy: "cloudflare",
+    });
+    expect(cloudflare.isErr()).toBe(true);
+    expect(cloudflare.isErr() && cloudflare.error.message).toContain(
+      "Alchemy does not expose a standalone Nitro adapter",
+    );
+
+    const evlog = await createVirtual({
+      ...baseConfig,
+      projectName: "nitro-evlog-rejected",
+      addons: ["evlog"],
+    });
+    expect(evlog.isErr()).toBe(true);
+    expect(evlog.isErr() && evlog.error.message).toContain("evlog addon supports");
+  });
+
+  it("tracks Nitro output in task-runner configuration", async () => {
+    const files = await generate({ projectName: "nitro-turbo", frontend: ["solid"] });
+    const turbo = JSON.parse(files.get("turbo.json") ?? "{}") as {
+      tasks?: { build?: { outputs?: string[] } };
+    };
+    expect(turbo.tasks?.build?.outputs).toContain(".output/**");
+    expect(turbo.tasks?.build?.outputs?.filter((output) => output === ".output/**")).toHaveLength(
+      1,
+    );
+
+    const nxFiles = await generate({
+      projectName: "nitro-nx",
+      addons: ["nx"],
+    });
+    expect(nxFiles.get("nx.json")).toContain("!{workspaceRoot}/apps/server/.output/**");
+  });
+
+  it.each([
+    ["sqlite", "drizzle"],
+    ["sqlite", "prisma"],
+    ["postgres", "drizzle"],
+    ["postgres", "prisma"],
+    ["mysql", "drizzle"],
+    ["mysql", "prisma"],
+    ["mongodb", "mongoose"],
+    ["mongodb", "prisma"],
+  ] as const)("composes the %s and %s database packages", async (database, orm) => {
+    const files = await generate({
+      projectName: `nitro-${database}-${orm}`,
+      database,
+      orm,
+      auth: "none",
+      examples: ["none"],
+    });
+
+    expect(files.has("apps/server/nitro.config.ts")).toBe(true);
+    expect(files.has("packages/db/package.json")).toBe(true);
+    expect(files.get("apps/server/package.json")).toContain(`@nitro-${database}-${orm}/db`);
+  });
+
+  it.each([
+    ["tanstack-router", "trpc"],
+    ["react-router", "trpc"],
+    ["tanstack-start", "orpc"],
+    ["next", "orpc"],
+    ["nuxt", "orpc"],
+    ["svelte", "orpc"],
+    ["solid", "orpc"],
+    ["astro", "orpc"],
+    ["native-bare", "orpc"],
+    ["native-uniwind", "orpc"],
+    ["native-unistyles", "orpc"],
+  ] as const)("composes the %s frontend with %s", async (frontend, api) => {
+    const files = await generate({
+      projectName: `nitro-${frontend}`,
+      frontend: [frontend],
+      api,
+      auth: "none",
+      examples: ["none"],
+    });
+
+    expect(files.has("apps/server/nitro.config.ts")).toBe(true);
+    expect(
+      files.has(
+        frontend.startsWith("native-") ? "apps/native/package.json" : "apps/web/package.json",
+      ),
+    ).toBe(true);
+  });
+});

--- a/apps/cli/test/nitro.test.ts
+++ b/apps/cli/test/nitro.test.ts
@@ -118,7 +118,7 @@ describe("Nitro backend", () => {
     expect(files.get("apps/server/server/routes/ai.post.ts")).toContain("await event.req.json()");
   });
 
-  it("generates first-class Docker, Prisma, and Vercel deployment contracts", async () => {
+  it("generates first-class Docker, Prisma, Vercel, and Cloudflare contracts", async () => {
     const dockerFiles = await generate({
       projectName: "nitro-docker",
       serverDeploy: "docker",
@@ -153,20 +153,36 @@ describe("Nitro backend", () => {
       framework: "nitro",
     });
     expect(vercel.services?.server).not.toHaveProperty("entrypoint");
-  });
 
-  it("rejects unsupported Cloudflare and evlog configurations before generation", async () => {
-    const cloudflare = await createVirtual({
-      ...baseConfig,
-      projectName: "nitro-cloudflare-rejected",
+    const cloudflareFiles = await generate({
+      projectName: "nitro-cloudflare",
       runtime: "workers",
       serverDeploy: "cloudflare",
     });
-    expect(cloudflare.isErr()).toBe(true);
-    expect(cloudflare.isErr() && cloudflare.error.message).toContain(
-      "Alchemy does not expose a standalone Nitro adapter",
+    const cloudflareInfra = cloudflareFiles.get("packages/infra/alchemy.run.ts") ?? "";
+    expect(cloudflareFiles.get("apps/server/nitro.config.ts")).toContain(
+      'defaultPreset: "cloudflare_module"',
     );
+    expect(cloudflareFiles.get("apps/server/nitro.config.ts")).toContain("nodeCompat: true");
+    expect(cloudflareFiles.get("apps/server/package.json")).toContain('"start": "nitro preview"');
+    expect(cloudflareInfra).toContain('Command.Build("server-build", {');
+    expect(cloudflareInfra).toContain('cwd: "../../apps/server"');
+    expect(cloudflareInfra).toContain('outdir: ".output"');
+    expect(cloudflareInfra).toContain("`${outdir}/server/index.mjs`");
+    expect(cloudflareInfra).toContain('directory: "../../apps/server/.output/public"');
+    expect(cloudflareInfra).toContain("bundle: false");
+    expect(cloudflareInfra).toContain('flags: ["nodejs_compat"]');
+    expect(cloudflareInfra).toContain("port: 3000");
+    expect(cloudflareInfra).not.toContain('main: "../../apps/server/src/index.ts"');
+    expect(cloudflareFiles.get("apps/server/server/routes/api/auth/[...all].ts")).toContain(
+      "createAuth().handler(event.req)",
+    );
+    expect(cloudflareFiles.get("packages/api/src/context.ts")).toContain(
+      "createAuth().api.getSession",
+    );
+  });
 
+  it("rejects evlog before generation", async () => {
     const evlog = await createVirtual({
       ...baseConfig,
       projectName: "nitro-evlog-rejected",

--- a/apps/cli/test/requirements.test.ts
+++ b/apps/cli/test/requirements.test.ts
@@ -158,6 +158,20 @@ describe("local tool requirements", () => {
     ).toBe(true);
   });
 
+  it("uses Nitro's own Node requirement instead of the tsdown requirement", () => {
+    const requirements = getLocalVersionRequirements(
+      config({ backend: "nitro", frontend: [], packageManager: "npm", runtime: "node" }),
+      "node",
+    );
+
+    expect(requirements).toContainEqual({
+      tool: "node",
+      range: "^20.19.0 || >=22.12.0",
+      reason: "Nitro 3",
+    });
+    expect(requirements.some(({ reason }) => reason.includes("tsdown"))).toBe(false);
+  });
+
   it.each([
     [{ examples: ["ai"] }, "21.7.0", "22.0.0", "AI SDK 7"],
     [{ orm: "mongoose" }, "20.18.0", "20.19.0", "Mongoose 9 and MongoDB 7"],

--- a/apps/web/content/docs/cli/compatibility.mdx
+++ b/apps/web/content/docs/cli/compatibility.mdx
@@ -199,9 +199,9 @@ create-better-t-stack --addons turborepo
 
 ### Server Deployment
 
-- `--server-deploy cloudflare` requires `--runtime workers` with `--backend hono`
+- `--server-deploy cloudflare` requires `--runtime workers` with `--backend hono` or `--backend nitro`
 - `--server-deploy docker`, `--server-deploy prisma`, and `--server-deploy vercel` require `--runtime bun` or `--runtime node`
-- Nitro supports Docker, Prisma, Vercel, or no deployment. Cloudflare requires a first-class standalone Nitro adapter in Alchemy and is rejected before generation.
+- Nitro supports Cloudflare, Docker, Prisma, Vercel, or no deployment. Cloudflare uses Nitro's official module output with Alchemy's prebuilt Worker contract.
 - `--server-deploy` is not used for `--backend self`, because fullstack backends deploy with the web app
 
 ## Authentication Requirements
@@ -271,11 +271,12 @@ create-better-t-stack --auth clerk --backend self --frontend astro
 create-better-t-stack --database mongodb --orm mongoose
 ```
 
-### "Cloudflare Workers runtime is only supported with Hono backend"
+### "Cloudflare Workers runtime is only supported with Hono or Nitro backend"
 
 ```bash
-# Fix by using Hono
+# Fix by using Hono or Nitro
 create-better-t-stack --runtime workers --backend hono
+create-better-t-stack --runtime workers --backend nitro
 ```
 
 ### "Cannot select multiple web frameworks"

--- a/apps/web/content/docs/cli/compatibility.mdx
+++ b/apps/web/content/docs/cli/compatibility.mdx
@@ -200,7 +200,8 @@ create-better-t-stack --addons turborepo
 ### Server Deployment
 
 - `--server-deploy cloudflare` requires `--runtime workers` with `--backend hono`
-- `--server-deploy docker` and `--server-deploy vercel` require `--runtime bun` or `--runtime node`
+- `--server-deploy docker`, `--server-deploy prisma`, and `--server-deploy vercel` require `--runtime bun` or `--runtime node`
+- Nitro supports Docker, Prisma, Vercel, or no deployment. Cloudflare requires a first-class standalone Nitro adapter in Alchemy and is rejected before generation.
 - `--server-deploy` is not used for `--backend self`, because fullstack backends deploy with the web app
 
 ## Authentication Requirements
@@ -219,7 +220,7 @@ Better-Auth authentication requires:
 Clerk authentication requires:
 
 - Compatible frontends (React frameworks, Next.js, TanStack Start, native frameworks)
-- Supported backends: Convex, Hono, Express, Fastify, and Elysia
+- Supported backends: Convex, Hono, Express, Fastify, Elysia, and Nitro
 - Fullstack (`--backend self`) support with Next.js or TanStack Start
 - Not compatible with Nuxt, Svelte, Solid, or Astro
 

--- a/apps/web/content/docs/cli/index.mdx
+++ b/apps/web/content/docs/cli/index.mdx
@@ -29,7 +29,7 @@ create-better-t-stack [project-directory] [options]
 - `--install / --no-install`: Install dependencies after creation
 - `--git / --no-git`: Initialize Git repository
 - `--frontend <types...>`: Web and/or native frameworks (see [Options](/docs/cli/options#frontend))
-- `--backend <framework>`: `hono`, `express`, `fastify`, `elysia`, `convex`, `self`, `none`
+- `--backend <framework>`: `hono`, `express`, `fastify`, `elysia`, `nitro`, `convex`, `self`, `none`
 - `--runtime <runtime>`: `bun`, `node`, `workers` (`none` only with `--backend convex`, `--backend none`, or `--backend self`)
 - `--database <type>`: `none`, `sqlite`, `postgres`, `mysql`, `mongodb`
 - `--orm <type>`: `none`, `drizzle`, `prisma`, `mongoose`
@@ -38,8 +38,8 @@ create-better-t-stack [project-directory] [options]
 - `--payments <provider>`: `polar`, `none`
 - `--db-setup <setup>`: `none`, `turso`, `d1`, `neon`, `supabase`, `prisma-postgres`, `planetscale`, `mongodb-atlas`, `docker`
 - `--examples <types...>`: `none`, `todo`, `ai`
-- `--web-deploy <setup>`: `none`, `cloudflare`
-- `--server-deploy <setup>`: `none`, `cloudflare`
+- `--web-deploy <setup>`: `none`, `cloudflare`, `prisma`, `docker`, `vercel`
+- `--server-deploy <setup>`: `none`, `cloudflare`, `prisma`, `docker`, `vercel`
 - `--template <type>`: `none`, `mern`, `pern`, `t3`, `uniwind`
 - `--directory-conflict <strategy>`: `merge`, `overwrite`, `increment`, `error`
 - `--render-title / --no-render-title`: Show/hide ASCII art title

--- a/apps/web/content/docs/cli/options.mdx
+++ b/apps/web/content/docs/cli/options.mdx
@@ -189,6 +189,7 @@ Backend framework to use:
 - `express`: Express.js (popular, mature)
 - `fastify`: Fastify (fast, plugin-based)
 - `elysia`: Elysia (Bun-native)
+- `nitro`: Nitro 3 (experimental, portable, file-routed, H3-based)
 - `convex`: Convex backend
 - `self`: Self-hosted/custom backend
 
@@ -281,7 +282,7 @@ create-better-t-stack --auth none
 - if you choose a database, you should also choose an ORM
 - with `--backend convex`, `better-auth` supports `react-router`, `tanstack-router`, `tanstack-start`, `next`, and native Expo frontends
 - `clerk` requires a compatible frontend
-- Supported Clerk backends: `convex`, `hono`, `express`, `fastify`, `elysia`, and `self` with Next.js or TanStack Start
+- Supported Clerk backends: `convex`, `hono`, `express`, `fastify`, `elysia`, `nitro`, and `self` with Next.js or TanStack Start
 - Authentication is automatically set to `none` when using `--backend none`
 
 ## Payments

--- a/apps/web/content/docs/guides/cloudflare-alchemy.mdx
+++ b/apps/web/content/docs/guides/cloudflare-alchemy.mdx
@@ -15,7 +15,7 @@ The CLI calls the deployment choice **Prisma**. In the generated TypeScript, tha
 
 ## Supported deployment shapes
 
-Cloudflare supports a separate Hono server on the Workers runtime and supported web frameworks. Full-stack `backend: self` projects deploy as one web application.
+Cloudflare supports separate Hono and Nitro servers on the Workers runtime and supported web frameworks. Full-stack `backend: self` projects deploy as one web application.
 
 Prisma supports:
 
@@ -25,7 +25,7 @@ Prisma supports:
 
 The CLI rejects unsupported framework/runtime combinations before writing files.
 
-Nitro servers use Nitro's native command build for Prisma Compute: Alchemy runs the generated build script and deploys `.output/server/index.mjs`. Cloudflare is intentionally unavailable until Alchemy exposes a first-class standalone Nitro adapter.
+Nitro servers use native provider output. Prisma Compute deploys `.output/server/index.mjs` from Nitro's command build. Cloudflare builds the official `cloudflare_module` preset, deploys the same prebuilt ESM entrypoint without rebundling it, and uploads `.output/public` as Worker assets.
 
 Alchemy's automatic framework builds handle Next.js, Nuxt, Astro, and TanStack Start. The generated
 stack supplies explicit production artifacts for the remaining frameworks: Solid's Nitro

--- a/apps/web/content/docs/guides/cloudflare-alchemy.mdx
+++ b/apps/web/content/docs/guides/cloudflare-alchemy.mdx
@@ -8,7 +8,7 @@ description: Deploy Better-T-Stack projects to Cloudflare or Prisma and manage h
 [Alchemy](https://alchemy.run) is the infrastructure-as-code layer generated when you choose **Cloudflare** or **Prisma** as a deployment target. The CLI writes a `packages/infra` workspace containing:
 
 - one `alchemy.run.ts` for applications, managed databases, and migrations
-- exact selected Alchemy and latest Effect beta versions
+- exact compatible Alchemy and Effect versions
 - root `dev`, `deploy`, and `destroy` commands
 
 The CLI calls the deployment choice **Prisma**. In the generated TypeScript, that target uses Alchemy's `Prisma.Compute` resource.
@@ -20,10 +20,12 @@ Cloudflare supports a separate Hono server on the Workers runtime and supported 
 Prisma supports:
 
 - web: Next.js, Nuxt, Astro, React Router, TanStack Start, SvelteKit, and Solid
-- server: Hono, Express, Fastify, and Elysia on Bun or Node
+- server: Hono, Express, Fastify, Elysia, and Nitro on Bun or Node
 - mixed stacks, such as Cloudflare web + Prisma server or Prisma web + Cloudflare server
 
 The CLI rejects unsupported framework/runtime combinations before writing files.
+
+Nitro servers use Nitro's native command build for Prisma Compute: Alchemy runs the generated build script and deploys `.output/server/index.mjs`. Cloudflare is intentionally unavailable until Alchemy exposes a first-class standalone Nitro adapter.
 
 Alchemy's automatic framework builds handle Next.js, Nuxt, Astro, and TanStack Start. The generated
 stack supplies explicit production artifacts for the remaining frameworks: Solid's Nitro

--- a/apps/web/content/docs/guides/docker.mdx
+++ b/apps/web/content/docs/guides/docker.mdx
@@ -38,7 +38,7 @@ Choosing `docker` as a deploy target generates:
 </Files>
 
 - **`docker-compose.yml`** at the repo root defines the `web`, `server`, and (optionally) database services with health checks and startup ordering.
-- **`apps/*/Dockerfile`** are multi-stage builds that install the whole monorepo workspace, build one app, and ship a minimal runtime image.
+- **`apps/*/Dockerfile`** are multi-stage builds that install the whole monorepo workspace, build one app, and ship a minimal runtime image. Nitro server images copy its native `.output` artifact and start `.output/server/index.mjs` directly.
 - **`nginx.conf`** is generated for the static TanStack Router SPA, which is served by nginx. Solid runs as a Node SSR server from its Nitro `.output` build.
 
 ## Enabling Docker Deployment

--- a/apps/web/content/docs/guides/vercel.mdx
+++ b/apps/web/content/docs/guides/vercel.mdx
@@ -21,7 +21,7 @@ This guide explains how Better-T-Stack deploys your applications to [Vercel](htt
 
 **Vercel Services** let you run multiple apps — a frontend and one or more backends — as services inside a single Vercel project. Each service gets its own build and its own [Fluid Compute](https://vercel.com/docs/fluid-compute) functions, while sharing one domain, one set of environment variables, and one deployment lifecycle.
 
-Better-T-Stack uses this to deploy your monorepo's `apps/web` and `apps/server` together: the web service serves your frontend, the server service runs your Hono/Express/Fastify/Elysia backend, and rewrites route `/api/*` requests between them on the same domain. No CORS configuration, no separate projects to keep in sync.
+Better-T-Stack uses this to deploy your monorepo's `apps/web` and `apps/server` together: the web service serves your frontend, the server service runs your Hono/Express/Fastify/Elysia/Nitro backend, and rewrites route `/api/*` requests between them on the same domain. No CORS configuration, no separate projects to keep in sync.
 
 ## Enabling Vercel Deployment
 
@@ -57,7 +57,7 @@ npm create better-t-stack@latest my-app \
   --server-deploy vercel
 ```
 
-Server deployment requires the `bun` or `node` runtime and a separate backend (hono, express, fastify, elysia). For the Cloudflare `workers` runtime, use `--server-deploy cloudflare` instead.
+Server deployment requires the `bun` or `node` runtime and a separate backend (hono, express, fastify, elysia, nitro). For the Cloudflare `workers` runtime, use `--server-deploy cloudflare` instead.
 
 ## Understanding vercel.json
 
@@ -116,6 +116,8 @@ How the pieces fit together:
 | Solid           | `nitro`           |         | SSR via Nitro's Vercel preset            |
 
 Astro projects automatically use the [`@astrojs/vercel`](https://docs.astro.build/en/guides/integrations-guide/vercel/) adapter instead of the Node standalone adapter.
+
+Standalone Nitro backends use the `nitro` service framework and omit a source entrypoint. Nitro emits Vercel's Build Output API directly from its file-based server routes.
 
 ### Choosing a region
 

--- a/apps/web/content/docs/index.mdx
+++ b/apps/web/content/docs/index.mdx
@@ -100,7 +100,7 @@ npm create better-t-stack@latest my-workspace \
 See the full list in the [CLI Reference](/docs/cli). Key flags:
 
 - `--frontend`: tanstack-router, react-router, tanstack-start, next, nuxt, svelte, solid, astro, native-bare, native-uniwind, native-unistyles, none
-- `--backend`: hono, express, fastify, elysia, convex, self, none
+- `--backend`: hono, express, fastify, elysia, nitro, convex, self, none
 - `--runtime`: bun, node, workers, none
 - `--database`: sqlite, postgres, mysql, mongodb, none
 - `--orm`: drizzle, prisma, mongoose, none

--- a/apps/web/content/docs/project-structure.mdx
+++ b/apps/web/content/docs/project-structure.mdx
@@ -320,7 +320,7 @@ Nitro uses its native file-based server layout rather than a generated framework
   </Folder>
 </Files>
 
-The selected features control which route files are present. Production builds are emitted to `apps/server/.output` and run from `.output/server/index.mjs`.
+The selected features control which route files are present. Node/Bun production builds are emitted to `apps/server/.output` and run from `.output/server/index.mjs`. Vercel deployments use Nitro's detected Vercel output.
 
 ### Workers runtime (optional)
 

--- a/apps/web/content/docs/project-structure.mdx
+++ b/apps/web/content/docs/project-structure.mdx
@@ -40,7 +40,7 @@ Notes:
 
 ## Monorepo structure by backend
 
-### Server backends (hono, express, fastify, elysia)
+### Server backends (hono, express, fastify, elysia, nitro)
 
 <Files>
   <Folder name="my-app" defaultOpen>
@@ -292,6 +292,36 @@ The server structure depends on your backend choice:
   </Folder>
 </Files>
 
+### Nitro
+
+Nitro uses its native file-based server layout rather than a generated framework wrapper:
+
+<Files>
+  <Folder name="apps/server" defaultOpen>
+    <Folder name="server" defaultOpen>
+      <Folder name="middleware">
+        <File name="cors.ts" />
+      </Folder>
+      <Folder name="routes" defaultOpen>
+        <File name="index.get.ts" />
+        <Folder name="rpc">
+          <File name="[...].ts" />
+        </Folder>
+        <Folder name="api">
+          <Folder name="auth">
+            <File name="[...all].ts" />
+          </Folder>
+        </Folder>
+      </Folder>
+    </Folder>
+    <File name="nitro.config.ts" />
+    <File name="package.json" />
+    <File name="tsconfig.json" />
+  </Folder>
+</Files>
+
+The selected features control which route files are present. Production builds are emitted to `apps/server/.output` and run from `.output/server/index.mjs`.
+
 ### Workers runtime (optional)
 
 When `runtime=workers`, the server targets Cloudflare Workers. If you also choose Cloudflare deployment, you'll get `packages/infra/alchemy.run.ts` and related infra files.
@@ -433,7 +463,7 @@ Electrobun adds an `apps/desktop` workspace with its own `package.json`, `electr
   "createdAt": "<timestamp>",
   "database": "<none|sqlite|postgres|mysql|mongodb>",
   "orm": "<none|drizzle|prisma|mongoose>",
-  "backend": "<none|hono|express|fastify|elysia|convex|self>",
+  "backend": "<none|hono|express|fastify|elysia|nitro|convex|self>",
   "runtime": "<bun|node|workers|none>",
   "frontend": ["<tanstack-router|react-router|tanstack-start|next|nuxt|svelte|solid|astro|native-bare|native-uniwind|native-unistyles|none>"] ,
   "addons": ["<pwa|tauri|electrobun|starlight|fumadocs|biome|lefthook|husky|mcp|turborepo|nx|vite-plus|ultracite|oxlint|opentui|wxt|skills|evlog|none>"] ,
@@ -442,8 +472,8 @@ Electrobun adds an `apps/desktop` workspace with its own `package.json`, `electr
   "packageManager": "<bun|pnpm|npm>",
   "dbSetup": "<turso|neon|prisma-postgres|planetscale|mongodb-atlas|supabase|d1|docker|none>",
   "api": "<none|trpc|orpc>",
-  "webDeploy": "<cloudflare|docker|vercel|none>",
-  "serverDeploy": "<cloudflare|docker|vercel|none>"
+  "webDeploy": "<cloudflare|prisma|docker|vercel|none>",
+  "serverDeploy": "<cloudflare|prisma|docker|vercel|none>"
 }
 ```
 

--- a/apps/web/src/app/(home)/new/_components/utils.ts
+++ b/apps/web/src/app/(home)/new/_components/utils.ts
@@ -34,6 +34,7 @@ const clerkSupportedBackends = [
   "express",
   "fastify",
   "elysia",
+  "nitro",
   "self-next",
   "self-tanstack-start",
 ] as const;
@@ -56,7 +57,7 @@ const evlogSupportedFullstackBackends = [
 ] as const;
 
 const clerkBackendRequirementMessage =
-  "Clerk requires Convex, Hono, Express, Fastify, Elysia, or Next.js/TanStack Start fullstack backend";
+  "Clerk requires Convex, Hono, Express, Fastify, Elysia, Nitro, or Next.js/TanStack Start fullstack backend";
 const clerkFrontendRequirementMessage =
   "Clerk requires React Router, TanStack Router, TanStack Start, Next.js, or React Native";
 const clerkIncompatibleWebFrontends = ["nuxt", "svelte", "solid", "astro"] as const;
@@ -1499,6 +1500,9 @@ export const getDisabledReason = (
 
   if (category === "serverDeploy") {
     if (optionId === "cloudflare") {
+      if (currentStack.backend === "nitro") {
+        return "Cloudflare support requires a standalone Alchemy Nitro adapter";
+      }
       if (currentStack.runtime !== "workers") return "Cloudflare requires Workers runtime";
       if (currentStack.backend !== "hono") return "Cloudflare requires Hono backend";
     }

--- a/apps/web/src/app/(home)/new/_components/utils.ts
+++ b/apps/web/src/app/(home)/new/_components/utils.ts
@@ -449,8 +449,8 @@ export const analyzeStackCompatibility = (stack: StackState): CompatibilityResul
   // RUNTIME CONSTRAINTS
   // ============================================
 
-  // Workers runtime requires Hono backend
-  if (nextStack.runtime === "workers" && nextStack.backend !== "hono") {
+  // Workers runtime requires a Workers-compatible backend
+  if (nextStack.runtime === "workers" && !["hono", "nitro"].includes(nextStack.backend)) {
     nextStack.backend = "hono";
     changed = true;
     changes.push({ category: "runtime", message: "Backend set to 'Hono' (required for Workers)" });
@@ -605,13 +605,20 @@ export const analyzeStackCompatibility = (stack: StackState): CompatibilityResul
           });
         }
       } else {
-        if (nextStack.runtime !== "workers" || nextStack.backend !== "hono") {
+        if (nextStack.runtime !== "workers") {
           nextStack.runtime = "workers";
+          changed = true;
+          changes.push({
+            category: "dbSetup",
+            message: "Runtime set to 'Workers' (required for D1)",
+          });
+        }
+        if (!["hono", "nitro"].includes(nextStack.backend)) {
           nextStack.backend = "hono";
           changed = true;
           changes.push({
             category: "dbSetup",
-            message: "Runtime set to 'Workers' with 'Hono' (required for D1)",
+            message: "Backend set to 'Hono' (required for D1)",
           });
         }
         if (nextStack.serverDeploy !== "cloudflare") {
@@ -937,12 +944,12 @@ export const analyzeStackCompatibility = (stack: StackState): CompatibilityResul
 
   // Server deploy constraints
   if (nextStack.serverDeploy === "cloudflare") {
-    if (nextStack.runtime !== "workers" || nextStack.backend !== "hono") {
+    if (nextStack.runtime !== "workers" || !["hono", "nitro"].includes(nextStack.backend)) {
       nextStack.serverDeploy = "none";
       changed = true;
       changes.push({
         category: "serverDeploy",
-        message: "Server deploy set to 'None' (Cloudflare requires Workers + Hono)",
+        message: "Server deploy set to 'None' (Cloudflare requires Workers + Hono or Nitro)",
       });
     }
   }
@@ -1218,9 +1225,14 @@ export const getDisabledReason = (
       const incompatible = currentStack.webFrontend.includes("solid") ? "Solid" : "Astro";
       return `Convex is not compatible with ${incompatible}`;
     }
-    // Workers runtime only works with Hono backend
-    if (currentStack.runtime === "workers" && optionId !== "hono" && optionId !== "none") {
-      return "Workers runtime only works with Hono";
+    // Workers runtime only works with Workers-compatible backends
+    if (
+      currentStack.runtime === "workers" &&
+      optionId !== "hono" &&
+      optionId !== "nitro" &&
+      optionId !== "none"
+    ) {
+      return "Workers runtime only works with Hono or Nitro";
     }
   }
 
@@ -1228,8 +1240,8 @@ export const getDisabledReason = (
   // RUNTIME CONSTRAINTS
   // ============================================
   if (category === "runtime") {
-    if (optionId === "workers" && currentStack.backend !== "hono") {
-      return "Workers requires Hono backend";
+    if (optionId === "workers" && !["hono", "nitro"].includes(currentStack.backend)) {
+      return "Workers requires Hono or Nitro backend";
     }
     if (optionId === "none") {
       if (
@@ -1500,11 +1512,10 @@ export const getDisabledReason = (
 
   if (category === "serverDeploy") {
     if (optionId === "cloudflare") {
-      if (currentStack.backend === "nitro") {
-        return "Cloudflare support requires a standalone Alchemy Nitro adapter";
-      }
       if (currentStack.runtime !== "workers") return "Cloudflare requires Workers runtime";
-      if (currentStack.backend !== "hono") return "Cloudflare requires Hono backend";
+      if (!["hono", "nitro"].includes(currentStack.backend)) {
+        return "Cloudflare requires Hono or Nitro backend";
+      }
     }
     if (optionId === "docker" && currentStack.runtime === "workers") {
       return "Docker server deployment requires the Bun or Node runtime";

--- a/apps/web/src/lib/constant.ts
+++ b/apps/web/src/lib/constant.ts
@@ -200,6 +200,14 @@ export const TECH_OPTIONS = {
       color: "from-gray-500 to-gray-700",
     },
     {
+      id: "nitro",
+      name: "Nitro",
+      description: "Portable, file-routed server framework",
+      icon: "",
+      color: "from-violet-500 to-indigo-700",
+      experimental: true,
+    },
+    {
       id: "convex",
       name: "Convex",
       description: "Reactive backend-as-a-service",

--- a/apps/web/test/stack-builder-compatibility.test.ts
+++ b/apps/web/test/stack-builder-compatibility.test.ts
@@ -31,7 +31,7 @@ function createStack(overrides: Partial<StackState> = {}): StackState {
 }
 
 describe("stack builder D1 compatibility", () => {
-  test("offers Nitro with only its supported server deployment targets", () => {
+  test("offers Nitro with all supported server deployment targets", () => {
     expect(TECH_OPTIONS.backend.find((option) => option.id === "nitro")).toMatchObject({
       name: "Nitro",
       experimental: true,
@@ -47,8 +47,15 @@ describe("stack builder D1 compatibility", () => {
     expect(getDisabledReason(stack, "serverDeploy", "prisma")).toBeNull();
     expect(getDisabledReason(stack, "serverDeploy", "vercel")).toBeNull();
     expect(getDisabledReason(stack, "serverDeploy", "cloudflare")).toBe(
-      "Cloudflare support requires a standalone Alchemy Nitro adapter",
+      "Cloudflare requires Workers runtime",
     );
+    expect(
+      getDisabledReason(
+        createStack({ backend: "nitro", runtime: "workers", serverDeploy: "cloudflare" }),
+        "serverDeploy",
+        "cloudflare",
+      ),
+    ).toBeNull();
     expect(getDisabledReason(stack, "addons", "evlog")).toBe(
       "evlog requires Hono, Express, Fastify, Elysia, or a fullstack backend",
     );
@@ -118,6 +125,26 @@ describe("stack builder D1 compatibility", () => {
       backend: "hono",
       runtime: "workers",
       database: "sqlite",
+      dbSetup: "d1",
+      serverDeploy: "cloudflare",
+    });
+  });
+
+  test("keeps Nitro when D1 selects the Workers deployment path", () => {
+    const result = analyzeStackCompatibility(
+      createStack({
+        backend: "nitro",
+        runtime: "node",
+        database: "sqlite",
+        orm: "drizzle",
+        dbSetup: "d1",
+        serverDeploy: "none",
+      }),
+    );
+
+    expect(result.adjustedStack).toMatchObject({
+      backend: "nitro",
+      runtime: "workers",
       dbSetup: "d1",
       serverDeploy: "cloudflare",
     });

--- a/apps/web/test/stack-builder-compatibility.test.ts
+++ b/apps/web/test/stack-builder-compatibility.test.ts
@@ -31,6 +31,30 @@ function createStack(overrides: Partial<StackState> = {}): StackState {
 }
 
 describe("stack builder D1 compatibility", () => {
+  test("offers Nitro with only its supported server deployment targets", () => {
+    expect(TECH_OPTIONS.backend.find((option) => option.id === "nitro")).toMatchObject({
+      name: "Nitro",
+      experimental: true,
+    });
+
+    const stack = createStack({
+      backend: "nitro",
+      runtime: "node",
+      serverDeploy: "none",
+    });
+
+    expect(getDisabledReason(stack, "serverDeploy", "docker")).toBeNull();
+    expect(getDisabledReason(stack, "serverDeploy", "prisma")).toBeNull();
+    expect(getDisabledReason(stack, "serverDeploy", "vercel")).toBeNull();
+    expect(getDisabledReason(stack, "serverDeploy", "cloudflare")).toBe(
+      "Cloudflare support requires a standalone Alchemy Nitro adapter",
+    );
+    expect(getDisabledReason(stack, "addons", "evlog")).toBe(
+      "evlog requires Hono, Express, Fastify, Elysia, or a fullstack backend",
+    );
+    expect(generateStackCommand(stack)).toContain("--backend nitro");
+  });
+
   test("supports Solid 2 as a self-hosted fullstack backend", () => {
     const stack = createStack({
       webFrontend: ["solid"],

--- a/openspec/changes/add-nitro-backend/.openspec.yaml
+++ b/openspec/changes/add-nitro-backend/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-15

--- a/openspec/changes/add-nitro-backend/design.md
+++ b/openspec/changes/add-nitro-backend/design.md
@@ -1,0 +1,97 @@
+## Context
+
+Better T Stack currently generates framework-owned server entrypoints for Hono, Express, Fastify, and Elysia. Nitro 3 provides a different first-class model: a `nitro.config.ts`, a `server/` source directory with file-based routes, and provider-selected production output. Its current `latest` npm release is still prerelease software, but the repository already generates applications that depend on the same Nitro version through Solid and TanStack Start.
+
+The documented Nitro behavior is:
+
+- `nitro dev` runs the development server and `nitro build` writes the production artifact.
+- `server/routes` is scanned for routes and each route exports a Web API-compatible handler through H3/Nitro.
+- the runtime selects a local default preset, while detected deployment providers take precedence over `defaultPreset`.
+- Node and Bun builds expose `.output/server/index.mjs`; Vercel builds use the Vercel Build Output API.
+
+Inspected Alchemy behavior adds two boundaries:
+
+- Prisma `Compute` has a released command-build contract consisting of a build command, output directory, and output-relative entrypoint. This can package Nitro without teaching Alchemy a Nitro-specific build strategy.
+- Alchemy's Cloudflare website adapters own framework preset injection, local binding proxies, output discovery, assets, and Worker entrypoints. There is no released standalone Nitro adapter, so a generic Worker call would not be equivalent.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Generate a native Nitro 3 backend with official configuration, file routing, imports, scripts, and output conventions.
+- Preserve the existing stack experience for oRPC, tRPC, Better Auth, Clerk, databases, ORMs, payments, examples, web/native clients, and task runners wherever those features have portable Web API integrations.
+- Make every provider choice truthful at prompt/validation time.
+- Verify source generation, dependency installation, typechecking, production builds, runtime routes, container output, and live provider behavior.
+
+**Non-Goals:**
+
+- Embedding another backend framework inside Nitro.
+- Creating a bespoke server wrapper around Nitro output.
+- Claiming standalone Cloudflare support before Alchemy publishes the adapter required for correct dev bindings and deployment assets.
+- Enabling evlog until it has a Nitro integration.
+- Depending on unreleased provider code.
+
+## Decisions
+
+### Generate Nitro's standalone CLI layout
+
+The server package will own `nitro.config.ts`, extend `nitro/tsconfig`, and place handlers under `server/routes`. Shared application logic remains in the existing workspace packages.
+
+Alternative considered: keep `src/index.ts` and mount H3/Hono manually through Nitro's custom server entry. Rejected because it discards the file-routing DX the backend selection is meant to provide and creates another integration surface.
+
+### Support Node and Bun as runtime defaults
+
+Nitro will receive `defaultPreset: "node"` for the Node runtime and `defaultPreset: "bun"` for Bun. `defaultPreset` is used instead of `preset` so provider auto-detection, especially Vercel, can override it as documented. Development uses `nitro dev` in both cases.
+
+### Use Web Request adapters for integrations
+
+Better Auth receives the route event's `Request`. oRPC uses its fetch handlers, and tRPC uses its fetch adapter. Context creation will accept a `Request`, keeping auth/session logic independent of H3 internals. CORS and native redirect handlers use H3's documented response APIs.
+
+### Use provider-native build contracts
+
+| Deployment | Runtime            | Contract                                                              | Status                                              |
+| ---------- | ------------------ | --------------------------------------------------------------------- | --------------------------------------------------- |
+| None       | Node/Bun           | Nitro dev/build                                                       | Supported                                           |
+| Docker     | Node               | `.output/server/index.mjs` in a Node image                            | Supported                                           |
+| Docker     | Bun                | `.output/server/index.mjs` in a Bun image                             | Supported                                           |
+| Prisma     | Node/Bun           | `Prisma.Compute` command build of `.output`, entry `server/index.mjs` | Supported                                           |
+| Vercel     | Node/Bun selection | Vercel Services `nitro` framework and Nitro's detected Vercel preset  | Supported, experimental with existing Vercel option |
+| Cloudflare | Any                | Requires standalone Alchemy Nitro adapter                             | Unavailable                                         |
+
+The generated Nitro config will not hard-code a provider preset. Provider-specific environment variables or platform detection remain able to select the final output.
+
+### Retain existing cross-product rules
+
+- tRPC remains limited to frontends that already have generated tRPC clients; oRPC and no API retain their current frontend matrix.
+- Existing ORM/database compatibility remains unchanged for Node and Bun.
+- Better Auth and Clerk retain their existing frontend compatibility. Nitro implements the server request boundary for both.
+- Todo requires a database and API. AI requires a backend and a frontend with an existing AI client template.
+- evlog is excluded because its current setup rewrites framework-specific server entrypoints.
+
+### Mark Nitro experimental at selection points
+
+The CLI and web builder will label Nitro as experimental while npm's current Nitro 3 release is a prerelease. Generated source uses the repository's centralized Nitro version and documented public APIs only.
+
+## Risks / Trade-offs
+
+- [Nitro 3 public APIs can still change] → Keep its version centralized, label the choice experimental, and cover official project shape plus builds in the generated matrix.
+- [A build may work locally but package incorrectly for a provider] → Inspect provider source and run disposable live deployments with route probes and teardown.
+- [Global middleware can accidentally consume request bodies before RPC handlers] → Implement CORS without parsing bodies and test POST and preflight requests.
+- [Provider detection can be blocked by a hard-coded preset] → Use `defaultPreset`, then assert Vercel and local outputs separately.
+- [A new backend value can drift across CLI and builder] → Drive both from the shared schema where possible and add CLI, JSON schema, builder, and preview assertions.
+- [Cloudflare users may expect Nitro's own Cloudflare preset to be enough] → Reject the unsupported Alchemy combination during configuration and state the adapter boundary in generated/docs-facing messaging.
+
+## Migration Plan
+
+1. Add the schema value and compatibility rules without changing existing defaults.
+2. Add generation and integration templates behind `backend === "nitro"`.
+3. Add deployment generation for Docker, Prisma, and Vercel.
+4. Regenerate derived builder/template assets.
+5. Run repository tests and generated application verification.
+6. Live-deploy disposable targets, probe routes, and destroy them.
+
+Rollback consists of reverting the Nitro schema option and its isolated templates/processors. Existing generated stacks are unaffected because Nitro is opt-in.
+
+## Open Questions
+
+None for the initial release. Cloudflare becomes eligible only after a released Alchemy standalone Nitro adapter is available and independently verified.

--- a/openspec/changes/add-nitro-backend/design.md
+++ b/openspec/changes/add-nitro-backend/design.md
@@ -9,10 +9,10 @@ The documented Nitro behavior is:
 - the runtime selects a local default preset, while detected deployment providers take precedence over `defaultPreset`.
 - Node and Bun builds expose `.output/server/index.mjs`; Vercel builds use the Vercel Build Output API.
 
-Inspected Alchemy behavior adds two boundaries:
+Inspected Alchemy behavior provides two relevant build contracts:
 
 - Prisma `Compute` has a released command-build contract consisting of a build command, output directory, and output-relative entrypoint. This can package Nitro without teaching Alchemy a Nitro-specific build strategy.
-- Alchemy's Cloudflare website adapters own framework preset injection, local binding proxies, output discovery, assets, and Worker entrypoints. There is no released standalone Nitro adapter, so a generic Worker call would not be equivalent.
+- Alchemy `Command.Build` can own an arbitrary framework build, and `Cloudflare.Worker` can deploy a prebuilt ESM entrypoint byte-for-byte with sibling modules, static assets, runtime bindings, and the normal local workerd lifecycle. Nitro's documented `cloudflare_module` preset emits exactly that shape.
 
 ## Goals / Non-Goals
 
@@ -27,7 +27,7 @@ Inspected Alchemy behavior adds two boundaries:
 
 - Embedding another backend framework inside Nitro.
 - Creating a bespoke server wrapper around Nitro output.
-- Claiming standalone Cloudflare support before Alchemy publishes the adapter required for correct dev bindings and deployment assets.
+- Adding a generated compatibility server or modifying Nitro's provider output.
 - Enabling evlog until it has a Nitro integration.
 - Depending on unreleased provider code.
 
@@ -56,9 +56,11 @@ Better Auth receives the route event's `Request`. oRPC uses its fetch handlers, 
 | Docker     | Bun                | `.output/server/index.mjs` in a Bun image                             | Supported                                           |
 | Prisma     | Node/Bun           | `Prisma.Compute` command build of `.output`, entry `server/index.mjs` | Supported                                           |
 | Vercel     | Node/Bun selection | Vercel Services `nitro` framework and Nitro's detected Vercel preset  | Supported, experimental with existing Vercel option |
-| Cloudflare | Any                | Requires standalone Alchemy Nitro adapter                             | Unavailable                                         |
+| Cloudflare | Workers            | Nitro `cloudflare_module` build + Alchemy prebuilt Worker and assets  | Supported                                           |
 
-The generated Nitro config will not hard-code a provider preset. Provider-specific environment variables or platform detection remain able to select the final output.
+The generated Nitro config uses the selected runtime as its default preset. Workers selects `cloudflare_module`; Node and Bun retain their native defaults. Vercel provider detection can still override Node and Bun defaults.
+
+For Cloudflare, Alchemy runs the generated Nitro build from `apps/server`, tracks `.output`, deploys `.output/server/index.mjs` with `bundle: false`, uploads `.output/public` as Worker assets, enables `nodejs_compat`, and keeps the normal workerd dev server on port 3000. This is direct composition of two released provider contracts, not a framework wrapper.
 
 ### Retain existing cross-product rules
 
@@ -79,7 +81,8 @@ The CLI and web builder will label Nitro as experimental while npm's current Nit
 - [Global middleware can accidentally consume request bodies before RPC handlers] → Implement CORS without parsing bodies and test POST and preflight requests.
 - [Provider detection can be blocked by a hard-coded preset] → Use `defaultPreset`, then assert Vercel and local outputs separately.
 - [A new backend value can drift across CLI and builder] → Drive both from the shared schema where possible and add CLI, JSON schema, builder, and preview assertions.
-- [Cloudflare users may expect Nitro's own Cloudflare preset to be enough] → Reject the unsupported Alchemy combination during configuration and state the adapter boundary in generated/docs-facing messaging.
+- [Prebuilt Cloudflare output may contain sibling ESM chunks] → Deploy it with `bundle: false`; Alchemy recursively uploads the default `.mjs` and `.js` module rules from the entrypoint directory.
+- [A framework-owned dev server would not receive real Cloudflare bindings] → Keep Alchemy's local workerd runtime instead of configuring an external Nitro dev process.
 
 ## Migration Plan
 
@@ -88,10 +91,10 @@ The CLI and web builder will label Nitro as experimental while npm's current Nit
 3. Add deployment generation for Docker, Prisma, and Vercel.
 4. Regenerate derived builder/template assets.
 5. Run repository tests and generated application verification.
-6. Live-deploy disposable targets, probe routes, and destroy them.
+6. Live-deploy disposable targets, including Cloudflare, probe routes, and destroy them.
 
 Rollback consists of reverting the Nitro schema option and its isolated templates/processors. Existing generated stacks are unaffected because Nitro is opt-in.
 
 ## Open Questions
 
-None for the initial release. Cloudflare becomes eligible only after a released Alchemy standalone Nitro adapter is available and independently verified.
+None.

--- a/openspec/changes/add-nitro-backend/proposal.md
+++ b/openspec/changes/add-nitro-backend/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Better T Stack should offer Nitro as a native backend for users who want its file-based routing, portable Web API runtime, and deployment presets without coupling their server to a frontend framework. Nitro 3 is now the version published under npm's `latest` tag and already underpins generated Solid and TanStack Start applications, so exposing its backend model directly makes the stack matrix more coherent.
+
+## What Changes
+
+- Add Nitro as an experimental backend choice throughout the CLI, saved configuration, generated README, and web stack builder.
+- Generate the official Nitro 3 standalone project structure and native Nitro scripts instead of wrapping another HTTP framework.
+- Integrate supported API layers, authentication, databases, ORMs, examples, and environment handling with Nitro's Web Request and file-route APIs.
+- Support deployment only through documented provider paths: Nitro output for Docker, Nitro's Vercel preset through Vercel Services, and Prisma Compute's supported custom-build contract.
+- Add deterministic generation/build/runtime coverage across package managers and representative stack combinations, plus disposable live deployment verification where provider credentials are available.
+- Keep Cloudflare server deployment unavailable until Alchemy exposes a first-class standalone Nitro adapter; do not emulate one with a generic Worker or custom proxy.
+- Treat Nitro as experimental while Nitro 3 remains a prerelease package, without pinning undocumented internals.
+
+Non-goals:
+
+- Do not add a second framework selection within Nitro or run Hono, Express, Fastify, or Elysia inside it.
+- Do not add provider-specific shims, generated compatibility servers, or unreleased Alchemy APIs.
+- Do not change existing backend output unless needed for shared validation or display logic.
+
+## Capabilities
+
+### New Capabilities
+
+- `nitro-backend`: Native Nitro backend selection, generation, integration compatibility, deployment behavior, and verification requirements.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+The change affects backend schemas and validation in `packages/types`, CLI prompts and summaries in `apps/cli`, backend and deployment generation in `packages/template-generator`, stack-builder options in `apps/web`, generated documentation, and compatibility/matrix tests. It adds Nitro's CLI/runtime packages to generated Nitro servers but does not add a new root runtime dependency. Cloudflare support is release-gated on a public first-class Alchemy adapter; other provider support must use released documented contracts.

--- a/openspec/changes/add-nitro-backend/proposal.md
+++ b/openspec/changes/add-nitro-backend/proposal.md
@@ -7,9 +7,9 @@ Better T Stack should offer Nitro as a native backend for users who want its fil
 - Add Nitro as an experimental backend choice throughout the CLI, saved configuration, generated README, and web stack builder.
 - Generate the official Nitro 3 standalone project structure and native Nitro scripts instead of wrapping another HTTP framework.
 - Integrate supported API layers, authentication, databases, ORMs, examples, and environment handling with Nitro's Web Request and file-route APIs.
-- Support deployment only through documented provider paths: Nitro output for Docker, Nitro's Vercel preset through Vercel Services, and Prisma Compute's supported custom-build contract.
+- Support deployment only through documented provider paths: Nitro output for Docker, Nitro's Vercel preset through Vercel Services, Prisma Compute's supported custom-build contract, and Nitro's Cloudflare module output through Alchemy's prebuilt Worker contract.
 - Add deterministic generation/build/runtime coverage across package managers and representative stack combinations, plus disposable live deployment verification where provider credentials are available.
-- Keep Cloudflare server deployment unavailable until Alchemy exposes a first-class standalone Nitro adapter; do not emulate one with a generic Worker or custom proxy.
+- Support Cloudflare without a framework adapter by composing Nitro's documented `cloudflare_module` output with Alchemy's documented `Command.Build` and prebuilt `Cloudflare.Worker` APIs.
 - Treat Nitro as experimental while Nitro 3 remains a prerelease package, without pinning undocumented internals.
 
 Non-goals:
@@ -30,4 +30,4 @@ None.
 
 ## Impact
 
-The change affects backend schemas and validation in `packages/types`, CLI prompts and summaries in `apps/cli`, backend and deployment generation in `packages/template-generator`, stack-builder options in `apps/web`, generated documentation, and compatibility/matrix tests. It adds Nitro's CLI/runtime packages to generated Nitro servers but does not add a new root runtime dependency. Cloudflare support is release-gated on a public first-class Alchemy adapter; other provider support must use released documented contracts.
+The change affects backend schemas and validation in `packages/types`, CLI prompts and summaries in `apps/cli`, backend and deployment generation in `packages/template-generator`, stack-builder options in `apps/web`, generated documentation, and compatibility/matrix tests. It adds Nitro's CLI/runtime packages to generated Nitro servers but does not add a new root runtime dependency. Every provider integration uses released documented contracts.

--- a/openspec/changes/add-nitro-backend/specs/nitro-backend/spec.md
+++ b/openspec/changes/add-nitro-backend/specs/nitro-backend/spec.md
@@ -95,10 +95,10 @@ The system SHALL only offer Nitro deployment targets backed by released provider
 - **WHEN** Nitro is selected with Vercel deployment
 - **THEN** generated Vercel Services configuration identifies Nitro and allows Nitro's provider detection to create Vercel output
 
-#### Scenario: Cloudflare deployment unavailable
+#### Scenario: Cloudflare deployment
 
-- **WHEN** a user attempts to configure Nitro with Cloudflare server deployment before a first-class Alchemy adapter is released
-- **THEN** validation rejects the combination before generation and explains the missing adapter boundary
+- **WHEN** Nitro is selected with the Workers runtime and Cloudflare server deployment
+- **THEN** generated Alchemy builds Nitro's `cloudflare_module` output, deploys `.output/server/index.mjs` as a prebuilt Worker, uploads `.output/public` as assets, and preserves runtime bindings in local and live environments
 
 ### Requirement: Nitro verification matrix
 

--- a/openspec/changes/add-nitro-backend/specs/nitro-backend/spec.md
+++ b/openspec/changes/add-nitro-backend/specs/nitro-backend/spec.md
@@ -1,0 +1,115 @@
+## ADDED Requirements
+
+### Requirement: Nitro backend selection
+
+The system SHALL expose Nitro as an experimental separate-server backend through the interactive CLI, programmatic configuration, JSON schema, generated summaries, and web stack builder.
+
+#### Scenario: Interactive selection
+
+- **WHEN** a user opens the backend prompt for a web or native project
+- **THEN** Nitro is available with an experimental label and a description of its native file-routed server model
+
+#### Scenario: Programmatic selection
+
+- **WHEN** a user supplies `backend: "nitro"` through a supported non-interactive interface
+- **THEN** validation accepts the value and generated summaries identify the backend as Nitro
+
+### Requirement: Native Nitro project structure
+
+The generator SHALL create a Nitro 3 server using documented standalone project structure and public APIs, without nesting another server framework or adding a compatibility wrapper.
+
+#### Scenario: Generated source layout
+
+- **WHEN** a Nitro project is generated
+- **THEN** `apps/server` contains a Nitro config, Nitro TypeScript configuration, native Nitro scripts, and file-based handlers under `server/routes`
+
+#### Scenario: Runtime defaults
+
+- **WHEN** Node or Bun is selected for Nitro
+- **THEN** the generated Nitro configuration uses that runtime as its default preset while allowing provider auto-detection to override it
+
+### Requirement: Nitro API and authentication integrations
+
+The generator SHALL implement selected API and authentication integrations at Nitro's Web Request boundary using released public adapters.
+
+#### Scenario: oRPC routes
+
+- **WHEN** Nitro and oRPC are selected
+- **THEN** generated RPC and OpenAPI reference routes handle requests through oRPC fetch handlers and receive the shared request context
+
+#### Scenario: tRPC routes
+
+- **WHEN** Nitro and tRPC are selected with a compatible frontend
+- **THEN** generated tRPC routes handle requests through the official tRPC fetch adapter and receive the shared request context
+
+#### Scenario: Better Auth route
+
+- **WHEN** Nitro and Better Auth are selected
+- **THEN** generated GET and POST requests under `/api/auth` are passed to Better Auth as standard Web Requests
+
+#### Scenario: Clerk context
+
+- **WHEN** Nitro and Clerk are selected
+- **THEN** generated API context authenticates the incoming standard Web Request through Clerk's backend client
+
+### Requirement: Existing stack feature compatibility
+
+The system SHALL apply existing frontend, database, ORM, auth, payments, example, and addon compatibility rules to Nitro and SHALL generate the selected supported integrations without backend-specific omissions.
+
+#### Scenario: Database and ORM
+
+- **WHEN** a valid Nitro database and ORM combination is selected
+- **THEN** the server can import the generated database package and the generated project installs, typechecks, and builds
+
+#### Scenario: Todo example
+
+- **WHEN** Nitro, an API, a database, and the Todo example are selected
+- **THEN** the generated Todo procedures and client calls work through the Nitro API routes
+
+#### Scenario: AI example
+
+- **WHEN** Nitro and a frontend that supports the AI example are selected
+- **THEN** Nitro exposes the generated streaming AI route using a standard Web Request and Response
+
+#### Scenario: Unsupported addon
+
+- **WHEN** Nitro is selected with an addon that rewrites only supported framework entrypoints
+- **THEN** configuration rejects the addon before files are generated with an actionable reason
+
+### Requirement: Truthful Nitro deployment choices
+
+The system SHALL only offer Nitro deployment targets backed by released provider contracts and SHALL reject unsupported targets during configuration.
+
+#### Scenario: Docker deployment
+
+- **WHEN** Nitro is selected with Node or Bun and Docker deployment
+- **THEN** the generated image builds Nitro output and starts `.output/server/index.mjs` with the selected runtime
+
+#### Scenario: Prisma deployment
+
+- **WHEN** Nitro is selected with Prisma deployment
+- **THEN** generated Alchemy uses Prisma Compute's documented command-build output and `server/index.mjs` entrypoint
+
+#### Scenario: Vercel deployment
+
+- **WHEN** Nitro is selected with Vercel deployment
+- **THEN** generated Vercel Services configuration identifies Nitro and allows Nitro's provider detection to create Vercel output
+
+#### Scenario: Cloudflare deployment unavailable
+
+- **WHEN** a user attempts to configure Nitro with Cloudflare server deployment before a first-class Alchemy adapter is released
+- **THEN** validation rejects the combination before generation and explains the missing adapter boundary
+
+### Requirement: Nitro verification matrix
+
+The change SHALL include deterministic generated-project verification across package managers and representative feature boundaries, plus live deployment probes where credentials are available.
+
+#### Scenario: Package-manager builds
+
+- **WHEN** verification runs for Bun, npm, and pnpm Nitro fixtures
+- **THEN** each fixture installs dependencies, typechecks, builds, starts, and responds successfully on its generated health/API routes
+
+#### Scenario: Provider lifecycle
+
+- **WHEN** a disposable Nitro deployment is created for an authenticated supported provider
+- **THEN** verification probes health, API, auth or database routes as applicable and destroys all created resources afterward

--- a/openspec/changes/add-nitro-backend/tasks.md
+++ b/openspec/changes/add-nitro-backend/tasks.md
@@ -1,0 +1,39 @@
+## 1. Shared Configuration and DX
+
+- [x] 1.1 Add Nitro to shared backend schemas, serialized configuration, analytics-safe values, and display names
+- [x] 1.2 Add the experimental Nitro choice to CLI prompts, runtime selection, summaries, and programmatic validation
+- [x] 1.3 Add Nitro to the web stack builder, compatibility logic, and generated preview path
+- [x] 1.4 Reject unsupported Nitro combinations, including Workers/Cloudflare and evlog, before generation
+
+## 2. Native Nitro Generation
+
+- [x] 2.1 Add the official Nitro config, TypeScript config, package scripts, ignores, and route directory structure
+- [x] 2.2 Add health, CORS, Better Auth, Clerk context, oRPC, tRPC, payments, and AI handlers using Web Request APIs
+- [x] 2.3 Wire Nitro dependencies and generated shared package imports without duplicating framework dependencies
+- [x] 2.4 Verify database, ORM, auth, frontend, native, payments, and examples template composition
+
+## 3. Deployment Integrations
+
+- [x] 3.1 Generate Node and Bun Docker images from native Nitro output and update compose behavior
+- [x] 3.2 Generate Prisma Compute command-build configuration for Nitro output
+- [x] 3.3 Generate Vercel Services configuration using Nitro framework detection
+- [x] 3.4 Update generated deployment instructions, requirements, ignores, and task-runner configuration
+
+## 4. Automated Verification
+
+- [x] 4.1 Add focused schema, prompt, validation, dependency, output, and stack-builder tests
+- [x] 4.2 Add representative generated Nitro matrix cases across Bun, npm, and pnpm
+- [x] 4.3 Install, typecheck, build, start, and HTTP-probe generated Nitro fixtures including API, auth, database, and example boundaries
+- [x] 4.4 Run repository formatting, linting, typechecking, build, CLI tests, web tests, and derived-template regeneration checks
+
+## 5. Live Provider Verification
+
+- [x] 5.1 Build and run disposable Node and Bun Docker images, probe routes, and remove owned containers/images
+- [x] 5.2 Create a uniquely marked Prisma stage, deploy, probe routes, destroy from retained state, and reconcile only marker-owned resources
+- [x] 5.3 Create a uniquely marked Vercel deployment, probe routes, remove only owned resources, and reconcile by marker
+- [x] 5.4 Confirm unsupported Cloudflare configuration fails before generation and record the first-class adapter release gate
+
+## 6. Delivery
+
+- [x] 6.1 Regenerate committed builder/template artifacts and review the complete diff for duplication or provider workarounds
+- [x] 6.2 Commit with a conventional message, push the feature branch, and open a concise pull request with the supported matrix

--- a/openspec/changes/add-nitro-backend/tasks.md
+++ b/openspec/changes/add-nitro-backend/tasks.md
@@ -3,7 +3,7 @@
 - [x] 1.1 Add Nitro to shared backend schemas, serialized configuration, analytics-safe values, and display names
 - [x] 1.2 Add the experimental Nitro choice to CLI prompts, runtime selection, summaries, and programmatic validation
 - [x] 1.3 Add Nitro to the web stack builder, compatibility logic, and generated preview path
-- [x] 1.4 Reject unsupported Nitro combinations, including Workers/Cloudflare and evlog, before generation
+- [x] 1.4 Reject unsupported Nitro combinations such as evlog before generation
 
 ## 2. Native Nitro Generation
 
@@ -18,6 +18,7 @@
 - [x] 3.2 Generate Prisma Compute command-build configuration for Nitro output
 - [x] 3.3 Generate Vercel Services configuration using Nitro framework detection
 - [x] 3.4 Update generated deployment instructions, requirements, ignores, and task-runner configuration
+- [x] 3.5 Generate Nitro's official Cloudflare module build and deploy it through Alchemy's prebuilt Worker contract
 
 ## 4. Automated Verification
 
@@ -25,15 +26,17 @@
 - [x] 4.2 Add representative generated Nitro matrix cases across Bun, npm, and pnpm
 - [x] 4.3 Install, typecheck, build, start, and HTTP-probe generated Nitro fixtures including API, auth, database, and example boundaries
 - [x] 4.4 Run repository formatting, linting, typechecking, build, CLI tests, web tests, and derived-template regeneration checks
+- [x] 4.5 Add Cloudflare runtime, generation, auth, database, and stack-builder coverage for Nitro
 
 ## 5. Live Provider Verification
 
 - [x] 5.1 Build and run disposable Node and Bun Docker images, probe routes, and remove owned containers/images
 - [x] 5.2 Create a uniquely marked Prisma stage, deploy, probe routes, destroy from retained state, and reconcile only marker-owned resources
 - [x] 5.3 Create a uniquely marked Vercel deployment, probe routes, remove only owned resources, and reconcile by marker
-- [x] 5.4 Confirm unsupported Cloudflare configuration fails before generation and record the first-class adapter release gate
+- [x] 5.4 Create a uniquely marked Cloudflare Nitro deployment, probe routes and bindings, destroy it from retained state, and reconcile only marker-owned resources
 
 ## 6. Delivery
 
 - [x] 6.1 Regenerate committed builder/template artifacts and review the complete diff for duplication or provider workarounds
 - [x] 6.2 Commit with a conventional message, push the feature branch, and open a concise pull request with the supported matrix
+- [x] 6.3 Regenerate examples and update the existing pull request with verified Cloudflare support

--- a/packages/template-generator/src/generators/alchemy/env.ts
+++ b/packages/template-generator/src/generators/alchemy/env.ts
@@ -64,7 +64,7 @@ export function cloudflareServerEnvEntries(plan: AlchemyDeploymentPlan): string[
       (entry) => entry.startsWith("GOOGLE_") || entry.startsWith("POLAR_"),
     );
     const clerkEntries = ['CLERK_SECRET_KEY: Config.redacted("CLERK_SECRET_KEY"),'];
-    if (api !== "none" && ["self", "hono", "elysia"].includes(backend)) {
+    if (api !== "none" && ["self", "hono", "elysia", "nitro"].includes(backend)) {
       clerkEntries.push('CLERK_PUBLISHABLE_KEY: Config.string("CLERK_PUBLISHABLE_KEY"),');
     }
     entries.splice(insertAt === -1 ? entries.length : insertAt, 0, ...clerkEntries);
@@ -87,7 +87,7 @@ export function prismaServerEnvEntries(plan: AlchemyDeploymentPlan): string[] {
     entries.push('CLERK_SECRET_KEY: Config.redacted("CLERK_SECRET_KEY"),');
     if (
       ["express", "fastify"].includes(backend) ||
-      (api !== "none" && ["hono", "elysia"].includes(backend))
+      (api !== "none" && ["hono", "elysia", "nitro"].includes(backend))
     ) {
       entries.push('CLERK_PUBLISHABLE_KEY: Config.string("CLERK_PUBLISHABLE_KEY"),');
     }

--- a/packages/template-generator/src/generators/alchemy/render.ts
+++ b/packages/template-generator/src/generators/alchemy/render.ts
@@ -9,6 +9,7 @@ import { createAlchemyWriter, writeObject, type AlchemyWriter } from "./writer";
 
 function usesCommand(plan: AlchemyDeploymentPlan): boolean {
   return (
+    (plan.server.target === "cloudflare" && plan.config.backend === "nitro") ||
     plan.managedDatabase.kind === "prisma-postgres" ||
     (plan.managedDatabase.kind !== "none" && plan.managedDatabase.orm === "prisma")
   );
@@ -17,6 +18,7 @@ function usesCommand(plan: AlchemyDeploymentPlan): boolean {
 function usesOutput(plan: AlchemyDeploymentPlan): boolean {
   const database = plan.managedDatabase;
   return (
+    (plan.server.target === "cloudflare" && plan.config.backend === "nitro") ||
     database.kind === "neon" ||
     database.kind === "prisma-postgres" ||
     (database.kind === "planetscale-mysql" && database.orm === "prisma")

--- a/packages/template-generator/src/generators/alchemy/server.ts
+++ b/packages/template-generator/src/generators/alchemy/server.ts
@@ -53,12 +53,20 @@ function writePrismaServer(writer: AlchemyWriter, plan: AlchemyDeploymentPlan): 
         writer,
         "build: {",
         () => {
+          if (plan.config.backend === "nitro") {
+            writer.writeLine(`command: "${plan.config.packageManager} run build",`);
+            writer.writeLine('outdir: ".output",');
+            writer.writeLine('entrypoint: "server/index.mjs",');
+            return;
+          }
           writer.writeLine('type: "auto" as const,');
           writer.writeLine('framework: "bun" as const,');
         },
         "},",
       );
-      writer.writeLine('entrypoint: "src/index.ts",');
+      if (plan.config.backend !== "nitro") {
+        writer.writeLine('entrypoint: "src/index.ts",');
+      }
       writer.writeLine("port: 3000,");
       writeObject(
         writer,

--- a/packages/template-generator/src/generators/alchemy/server.ts
+++ b/packages/template-generator/src/generators/alchemy/server.ts
@@ -3,6 +3,70 @@ import type { AlchemyDeploymentPlan } from "./plan";
 import { writeLines, writeObject, type AlchemyWriter } from "./writer";
 
 function writeCloudflareServer(writer: AlchemyWriter, plan: AlchemyDeploymentPlan): void {
+  if (plan.config.backend === "nitro") {
+    writer.writeLine("export const server = Effect.gen(function* () {");
+    writer.indent(() => {
+      writeObject(
+        writer,
+        'const build = yield* Command.Build("server-build", {',
+        () => {
+          writer.writeLine(`command: "${plan.config.packageManager} run build",`);
+          writer.writeLine('cwd: "../../apps/server",');
+          writer.writeLine('outdir: ".output",');
+        },
+        "});",
+      );
+      writer.blankLine();
+      writeObject(
+        writer,
+        'return yield* Cloudflare.Worker("server", {',
+        () => {
+          writer.writeLine(
+            "main: Output.map(build.outdir, (outdir) => `${outdir}/server/index.mjs`),",
+          );
+          writer.writeLine("bundle: false,");
+          writeObject(
+            writer,
+            "assets: {",
+            () => {
+              writer.writeLine('directory: "../../apps/server/.output/public",');
+            },
+            "},",
+          );
+          writeObject(
+            writer,
+            "compatibility: {",
+            () => {
+              writer.writeLine('flags: ["nodejs_compat"],');
+            },
+            "},",
+          );
+          writeObject(
+            writer,
+            "env: {",
+            () => {
+              writeLines(writer, cloudflareServerEnvEntries(plan));
+            },
+            "},",
+          );
+          writeObject(
+            writer,
+            "dev: {",
+            () => {
+              writer.writeLine("port: 3000,");
+            },
+            "},",
+          );
+        },
+        "});",
+      );
+    });
+    writer.writeLine("});");
+    writer.blankLine();
+    writer.writeLine("export type ServerEnv = Cloudflare.InferEnv<typeof server>;");
+    return;
+  }
+
   writeObject(
     writer,
     'export const server = Cloudflare.Worker("server", {',

--- a/packages/template-generator/src/post-process/vercel-config.ts
+++ b/packages/template-generator/src/post-process/vercel-config.ts
@@ -81,7 +81,7 @@ export function processVercelConfig(vfs: VirtualFileSystem, config: ProjectConfi
     const server: VercelService = {
       root: "apps/server",
       framework: backend,
-      entrypoint: "src/index.ts",
+      entrypoint: backend === "nitro" ? undefined : "src/index.ts",
       installCommand,
     };
     if (hasWeb) {

--- a/packages/template-generator/src/processors/api-deps.ts
+++ b/packages/template-generator/src/processors/api-deps.ts
@@ -103,10 +103,12 @@ function addServerDeps(vfs: VirtualFileSystem, api: API, backend: Backend): void
   if (backend === "convex") return;
 
   if (api === "trpc") {
+    const dependencies: AvailableDependencies[] = ["@trpc/server"];
+    if (backend === "hono") dependencies.push("@hono/trpc-server");
     addPackageDependency({
       vfs,
       packagePath: serverPath,
-      dependencies: ["@trpc/server", "@hono/trpc-server"],
+      dependencies,
     });
   } else if (api === "orpc") {
     addPackageDependency({

--- a/packages/template-generator/src/processors/auth-deps.ts
+++ b/packages/template-generator/src/processors/auth-deps.ts
@@ -182,7 +182,7 @@ function processStandardAuthDeps(vfs: VirtualFileSystem, config: ProjectConfig):
     }
 
     if (apiExists) {
-      if (backend === "self" || backend === "hono" || backend === "elysia") {
+      if (backend === "self" || backend === "hono" || backend === "elysia" || backend === "nitro") {
         addPackageDependency({ vfs, packagePath: apiPath, dependencies: ["@clerk/backend"] });
       } else if (backend === "express") {
         addPackageDependency({ vfs, packagePath: apiPath, dependencies: ["@clerk/express"] });

--- a/packages/template-generator/src/processors/backend-deps.ts
+++ b/packages/template-generator/src/processors/backend-deps.ts
@@ -31,6 +31,8 @@ export function processBackendDeps(vfs: VirtualFileSystem, config: ProjectConfig
     devDeps.push("@types/express", "@types/cors");
   } else if (backend === "fastify") {
     deps.push("fastify", "@fastify/cors");
+  } else if (backend === "nitro") {
+    devDeps.push("nitro");
   }
 
   if (api === "trpc") {
@@ -43,8 +45,10 @@ export function processBackendDeps(vfs: VirtualFileSystem, config: ProjectConfig
 
   if (auth === "better-auth") deps.push("better-auth");
 
-  if (runtime === "node") devDeps.push("tsx", "@types/node");
-  else if (runtime === "bun") devDeps.push("@types/bun");
+  if (runtime === "node") {
+    if (backend !== "nitro") devDeps.push("tsx");
+    devDeps.push("@types/node");
+  } else if (runtime === "bun") devDeps.push("@types/bun");
 
   if (deps.length > 0 || devDeps.length > 0) {
     addPackageDependency({

--- a/packages/template-generator/src/processors/env-vars.ts
+++ b/packages/template-generator/src/processors/env-vars.ts
@@ -504,7 +504,7 @@ function buildServerVars(
   const needsClerkPublishableKey =
     hasClerk &&
     (["express", "fastify"].includes(backend) ||
-      (api !== "none" && ["self", "hono", "elysia"].includes(backend)));
+      (api !== "none" && ["self", "hono", "elysia", "nitro"].includes(backend)));
 
   return [
     {

--- a/packages/template-generator/src/processors/readme-generator.ts
+++ b/packages/template-generator/src/processors/readme-generator.ts
@@ -525,6 +525,7 @@ function generateFeaturesList(
     express: "- **Express** - Fast, unopinionated web framework",
     fastify: "- **Fastify** - Fast, low-overhead web framework",
     elysia: "- **Elysia** - Type-safe, high-performance framework",
+    nitro: "- **Nitro** - Portable, file-routed server framework",
   } satisfies Record<string, string>;
 
   if (hasOwnKey(backendFeatures, backend)) {

--- a/packages/template-generator/src/processors/runtime-deps.ts
+++ b/packages/template-generator/src/processors/runtime-deps.ts
@@ -22,6 +22,19 @@ export function processRuntimeDeps(vfs: VirtualFileSystem, config: ProjectConfig
 
   pkgJson.scripts = pkgJson.scripts || {};
 
+  if (backend === "nitro") {
+    pkgJson.scripts.dev = "nitro dev --port 3000";
+    pkgJson.scripts.start = `${runtime} .output/server/index.mjs`;
+
+    addPackageDependency({
+      vfs,
+      packagePath: serverPath,
+      devDependencies: [runtime === "bun" ? "@types/bun" : "@types/node"],
+    });
+    vfs.writeJson(serverPath, pkgJson);
+    return;
+  }
+
   if (runtime === "bun") {
     pkgJson.scripts.dev = "bun run --hot src/index.ts";
     pkgJson.scripts.start = "bun run dist/index.mjs";

--- a/packages/template-generator/src/processors/runtime-deps.ts
+++ b/packages/template-generator/src/processors/runtime-deps.ts
@@ -24,7 +24,8 @@ export function processRuntimeDeps(vfs: VirtualFileSystem, config: ProjectConfig
 
   if (backend === "nitro") {
     pkgJson.scripts.dev = "nitro dev --port 3000";
-    pkgJson.scripts.start = `${runtime} .output/server/index.mjs`;
+    pkgJson.scripts.start =
+      runtime === "workers" ? "nitro preview" : `${runtime} .output/server/index.mjs`;
 
     addPackageDependency({
       vfs,

--- a/packages/template-generator/src/processors/turbo-generator.ts
+++ b/packages/template-generator/src/processors/turbo-generator.ts
@@ -43,7 +43,7 @@ export function generateTurboConfig(config: ProjectConfig): TurboConfig {
   const hasAlchemy = isAlchemyDeployTarget(webDeploy) || isAlchemyDeployTarget(serverDeploy);
   const hasLocalD1 = getLocalD1Owner(config) === "wrangler";
 
-  const tasks: TurboTasks = getBaseTasks(frontend, config.addons);
+  const tasks: TurboTasks = getBaseTasks(frontend, config.addons, backend);
 
   if (config.addons.includes("electrobun")) Object.assign(tasks, getElectrobunTasks());
   if (isConvex) Object.assign(tasks, getConvexTasks());
@@ -60,7 +60,11 @@ export function generateTurboConfig(config: ProjectConfig): TurboConfig {
   };
 }
 
-function getBaseTasks(frontend: string[], addons: string[]): TurboTasks {
+function getBaseTasks(
+  frontend: string[],
+  addons: string[],
+  backend: ProjectConfig["backend"],
+): TurboTasks {
   // Build outputs per framework:
   // - Vite-based client apps: dist/**
   // - Next.js: .next/** excluding .next/cache/**
@@ -76,6 +80,10 @@ function getBaseTasks(frontend: string[], addons: string[]): TurboTasks {
   }
 
   if (frontend.includes("solid")) {
+    buildOutputs.push(".output/**");
+  }
+
+  if (backend === "nitro" && !buildOutputs.includes(".output/**")) {
     buildOutputs.push(".output/**");
   }
 

--- a/packages/template-generator/src/processors/workspace-deps.ts
+++ b/packages/template-generator/src/processors/workspace-deps.ts
@@ -134,7 +134,8 @@ export function processWorkspaceDeps(vfs: VirtualFileSystem, config: ProjectConf
   }
 
   if (packages.server) {
-    const serverDevDependencies: AvailableDependencies[] = ["typescript", "tsdown"];
+    const serverDevDependencies: AvailableDependencies[] =
+      backend === "nitro" ? ["typescript"] : ["typescript", "tsdown"];
     if (runtime === "workers" && orm === "prisma") {
       serverDevDependencies.push("unwasm");
     }

--- a/packages/template-generator/src/template-handlers/backend.ts
+++ b/packages/template-generator/src/template-handlers/backend.ts
@@ -23,6 +23,47 @@ export async function processBackendTemplates(
 
   if (config.backend === "self") return;
 
+  if (config.backend === "nitro") {
+    processTemplatesFromPrefix(vfs, templates, "backend/server/nitro/base", "apps/server", config);
+    if (config.auth === "better-auth") {
+      processTemplatesFromPrefix(
+        vfs,
+        templates,
+        "backend/server/nitro/better-auth",
+        "apps/server",
+        config,
+      );
+    }
+    if (config.api !== "none") {
+      processTemplatesFromPrefix(
+        vfs,
+        templates,
+        `backend/server/nitro/${config.api}`,
+        "apps/server",
+        config,
+      );
+    }
+    if (
+      config.auth === "better-auth" &&
+      config.payments === "polar" &&
+      config.frontend.some((frontend) =>
+        ["native-bare", "native-uniwind", "native-unistyles"].includes(frontend),
+      )
+    ) {
+      processTemplatesFromPrefix(
+        vfs,
+        templates,
+        "backend/server/nitro/native-polar",
+        "apps/server",
+        config,
+      );
+    }
+    if (config.examples.includes("ai")) {
+      processTemplatesFromPrefix(vfs, templates, "backend/server/nitro/ai", "apps/server", config);
+    }
+    return;
+  }
+
   processTemplatesFromPrefix(vfs, templates, "backend/server/base", "apps/server", config);
   processTemplatesFromPrefix(
     vfs,

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -1157,7 +1157,11 @@ export async function createContext({{#if (eq auth "none")}}_options{{else}}{ he
 
 {{else if (eq backend 'nitro')}}
 {{#if (eq auth "better-auth")}}
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare"))}}
+import { createAuth } from "@{{projectName}}/auth";
+{{else}}
 import { auth } from "@{{projectName}}/auth";
+{{/if}}
 {{/if}}
 
 export type CreateContextOptions = {
@@ -1166,7 +1170,7 @@ export type CreateContextOptions = {
 
 export async function createContext({{#if (eq auth "none")}}_options{{else}}{ request }{{/if}}: CreateContextOptions){{#if (eq auth "clerk")}}: Promise<ClerkRequestContext>{{/if}} {
 {{#if (eq auth "better-auth")}}
-	const session = await auth.api.getSession({ headers: request.headers });
+	const session = await {{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare"))}}createAuth(){{else}}auth{{/if}}.api.getSession({ headers: request.headers });
 	return {
 		auth: null,
 		session,
@@ -2092,7 +2096,11 @@ export async function createContext({{#if (eq auth "none")}}_options{{else}}{ re
 
 {{else if (eq backend 'nitro')}}
 {{#if (eq auth "better-auth")}}
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare"))}}
+import { createAuth } from "@{{projectName}}/auth";
+{{else}}
 import { auth } from "@{{projectName}}/auth";
+{{/if}}
 {{/if}}
 
 export type CreateContextOptions = {
@@ -2101,7 +2109,7 @@ export type CreateContextOptions = {
 
 export async function createContext({{#if (eq auth "none")}}_options{{else}}{ request }{{/if}}: CreateContextOptions){{#if (eq auth "clerk")}}: Promise<ClerkRequestContext>{{/if}} {
 {{#if (eq auth "better-auth")}}
-	const session = await auth.api.getSession({ headers: request.headers });
+	const session = await {{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare"))}}createAuth(){{else}}auth{{/if}}.api.getSession({ headers: request.headers });
 	return {
 		auth: null,
 		session,
@@ -15290,12 +15298,22 @@ export default defineHandler(async (event) => {
 .nitro
 .cache
 .output
+.wrangler
 `],
   ["backend/server/nitro/base/nitro.config.ts.hbs", `import { defineConfig } from "nitro";
 
 export default defineConfig({
+{{#if (eq runtime "workers")}}
+  defaultPreset: "cloudflare_module",
+{{else}}
   defaultPreset: "{{runtime}}",
+{{/if}}
   serverDir: "./server",
+{{#if (eq runtime "workers")}}
+  cloudflare: {
+    nodeCompat: true,
+  },
+{{/if}}
 });
 `],
   ["backend/server/nitro/base/package.json.hbs", `{
@@ -15342,14 +15360,21 @@ export default defineHandler(() => "OK");
   "extends": ["@{{projectName}}/config/tsconfig.base.json", "nitro/tsconfig"],
   "compilerOptions": {
     "composite": true,
-    "noEmit": true
+    "noEmit": true{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare"))}},
+    "types": ["node"]{{/if}}
   }
 }
 `],
-  ["backend/server/nitro/better-auth/server/routes/api/auth/[...all].ts.hbs", `import { auth } from "@{{projectName}}/auth";
+  ["backend/server/nitro/better-auth/server/routes/api/auth/[...all].ts.hbs", `{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare"))}}
+import { createAuth } from "@{{projectName}}/auth";
+{{else}}
+import { auth } from "@{{projectName}}/auth";
+{{/if}}
 import { defineHandler } from "nitro";
 
-export default defineHandler((event) => auth.handler(event.req));
+export default defineHandler((event) =>
+  {{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare"))}}createAuth(){{else}}auth{{/if}}.handler(event.req),
+);
 `],
   ["backend/server/nitro/native-polar/server/routes/polar/success.get.ts.hbs", `import { defineHandler } from "nitro";
 
@@ -26162,7 +26187,19 @@ export default function Todos() {
 shamefully-hoist=true
 strict-peer-dependencies=false
 {{/if}}`],
-  ["extras/env.d.ts.hbs", `{{#if (eq serverDeploy "cloudflare")}}
+  ["extras/env.d.ts.hbs", `{{#if (and (eq backend "nitro") (eq serverDeploy "cloudflare"))}}
+type CloudflareEnv = import("@{{projectName}}/infra/alchemy.run").ServerEnv;
+type Env = CloudflareEnv;
+
+declare module "cloudflare:workers" {
+  export const env: CloudflareEnv;
+
+  namespace Cloudflare {
+    export interface Env extends CloudflareEnv {}
+  }
+}
+{{else}}
+{{#if (eq serverDeploy "cloudflare")}}
 import type { ServerEnv } from "@{{projectName}}/infra/alchemy.run";
 {{else}}
 import type { WebEnv as ServerEnv } from "@{{projectName}}/infra/alchemy.run";
@@ -26182,6 +26219,7 @@ declare module "cloudflare:workers" {
     export interface Env extends CloudflareEnv {}
   }
 }
+{{/if}}
 `],
   ["extras/pnpm-workspace.yaml.hbs", `packages:
   - "apps/*"
@@ -33605,11 +33643,19 @@ export const env = createEnv({
 });
 `],
   ["packages/env/src/server.ts.hbs", `{{#if (and (eq serverDeploy "cloudflare") (or (ne backend "self") (ne webDeploy "cloudflare")))}}
+{{#if (eq backend "nitro")}}
+/// <reference path="../env.d.ts" />
+import type { ServerEnv } from "@{{projectName}}/infra/alchemy.run";
+
+export type CloudflareEnv = ServerEnv;
+export { env } from "cloudflare:workers";
+{{else}}
 /// <reference types="@cloudflare/workers-types" />
 /// <reference path="../env.d.ts" />
 // For Cloudflare Workers, env is accessed via cloudflare:workers module
 // Types are defined in env.d.ts based on your alchemy.run.ts bindings
 export { env } from "cloudflare:workers";
+{{/if}}
 {{else if (and (eq backend "self") (eq webDeploy "cloudflare") (includes frontend "next"))}}
 /// <reference path="../env.d.ts" />
 import { getCloudflareContext } from "@opennextjs/cloudflare";

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -934,7 +934,7 @@ function toClerkContextAuth(auth: { userId: string | null } | null): ClerkContex
 }
 {{/if}}
 
-{{#if (and (eq auth "clerk") (or (eq backend 'self') (eq backend 'hono') (eq backend 'elysia')))}}
+{{#if (and (eq auth "clerk") (or (eq backend 'self') (eq backend 'hono') (eq backend 'elysia') (eq backend 'nitro')))}}
 {{#if (usesRequestScopedCloudflareEnv backend webDeploy frontend)}}
 {{else}}
 import { createClerkClient } from "@clerk/backend";
@@ -1146,6 +1146,36 @@ export async function createContext({{#if (eq auth "none")}}_options{{else}}{ he
 	return {
 		auth: null,
 		session,
+	};
+{{else}}
+	return {
+		auth: null,
+		session: null,
+	};
+{{/if}}
+}
+
+{{else if (eq backend 'nitro')}}
+{{#if (eq auth "better-auth")}}
+import { auth } from "@{{projectName}}/auth";
+{{/if}}
+
+export type CreateContextOptions = {
+	request: Request;
+};
+
+export async function createContext({{#if (eq auth "none")}}_options{{else}}{ request }{{/if}}: CreateContextOptions){{#if (eq auth "clerk")}}: Promise<ClerkRequestContext>{{/if}} {
+{{#if (eq auth "better-auth")}}
+	const session = await auth.api.getSession({ headers: request.headers });
+	return {
+		auth: null,
+		session,
+	};
+{{else if (eq auth "clerk")}}
+	const clerkAuth = await authenticateClerkRequest(request);
+	return {
+		auth: clerkAuth,
+		session: null,
 	};
 {{else}}
 	return {
@@ -1978,7 +2008,7 @@ function toClerkContextAuth(auth: { userId: string | null } | null): ClerkContex
 }
 {{/if}}
 
-{{#if (and (eq auth "clerk") (or (eq backend 'self') (eq backend 'hono') (eq backend 'elysia')))}}
+{{#if (and (eq auth "clerk") (or (eq backend 'self') (eq backend 'hono') (eq backend 'elysia') (eq backend 'nitro')))}}
 import { createClerkClient } from "@clerk/backend";
 import { env } from "@{{projectName}}/env/server";
 
@@ -2048,6 +2078,36 @@ export async function createContext({{#if (eq auth "none")}}_options{{else}}{ re
 	};
 {{else if (eq auth "clerk")}}
 	const clerkAuth = await authenticateClerkRequest(req);
+	return {
+		auth: clerkAuth,
+		session: null,
+	};
+{{else}}
+	return {
+		auth: null,
+		session: null,
+	};
+{{/if}}
+}
+
+{{else if (eq backend 'nitro')}}
+{{#if (eq auth "better-auth")}}
+import { auth } from "@{{projectName}}/auth";
+{{/if}}
+
+export type CreateContextOptions = {
+	request: Request;
+};
+
+export async function createContext({{#if (eq auth "none")}}_options{{else}}{ request }{{/if}}: CreateContextOptions){{#if (eq auth "clerk")}}: Promise<ClerkRequestContext>{{/if}} {
+{{#if (eq auth "better-auth")}}
+	const session = await auth.api.getSession({ headers: request.headers });
+	return {
+		auth: null,
+		session,
+	};
+{{else if (eq auth "clerk")}}
+	const clerkAuth = await authenticateClerkRequest(request);
 	return {
 		auth: clerkAuth,
 		session: null,
@@ -15198,6 +15258,189 @@ export default app;
 {{/if}}
 {{/if}}
 `],
+  ["backend/server/nitro/ai/server/routes/ai.post.ts.hbs", `import { devToolsMiddleware } from "@ai-sdk/devtools";
+import { google } from "@ai-sdk/google";
+import {
+  convertToModelMessages,
+  createUIMessageStreamResponse,
+  streamText,
+  toUIMessageStream,
+  type UIMessage,
+  wrapLanguageModel,
+} from "ai";
+import { defineHandler } from "nitro";
+
+export default defineHandler(async (event) => {
+  const { messages = [] } = (await event.req.json()) as { messages?: UIMessage[] };
+  const model = wrapLanguageModel({
+    model: google("gemini-2.5-flash"),
+    middleware: devToolsMiddleware(),
+  });
+  const result = streamText({
+    model,
+    messages: await convertToModelMessages(messages),
+  });
+
+  return createUIMessageStreamResponse({
+    stream: toUIMessageStream({ stream: result.stream }),
+  });
+});
+`],
+  ["backend/server/nitro/base/_gitignore", `.data
+.nitro
+.cache
+.output
+`],
+  ["backend/server/nitro/base/nitro.config.ts.hbs", `import { defineConfig } from "nitro";
+
+export default defineConfig({
+  defaultPreset: "{{runtime}}",
+  serverDir: "./server",
+});
+`],
+  ["backend/server/nitro/base/package.json.hbs", `{
+  "name": "server",
+  "type": "module",
+  "scripts": {
+    "build": "nitro build",
+    "check-types": "tsc --noEmit"
+  },
+  "dependencies": {},
+  {{#if (eq dbSetup 'supabase')}}
+  "trustedDependencies": [
+    "supabase"
+  ],
+  {{/if}}
+  "devDependencies": {}
+}
+`],
+  ["backend/server/nitro/base/server/middleware/cors.ts.hbs", `import { env } from "@{{projectName}}/env/server";
+import { defineHandler } from "nitro";
+import { handleCors } from "nitro/h3";
+
+export default defineHandler((event) => {
+  const response = handleCors(event, {
+    origin: [env.CORS_ORIGIN],
+    methods: ["GET", "POST", "OPTIONS"],
+{{#if (or (eq auth "better-auth") (eq auth "clerk"))}}
+    allowHeaders: ["Content-Type", "Authorization"],
+{{/if}}
+{{#if (eq auth "better-auth")}}
+    credentials: true,
+{{/if}}
+  });
+
+  if (response !== false) return response;
+  return undefined;
+});
+`],
+  ["backend/server/nitro/base/server/routes/index.get.ts.hbs", `import { defineHandler } from "nitro";
+
+export default defineHandler(() => "OK");
+`],
+  ["backend/server/nitro/base/tsconfig.json.hbs", `{
+  "extends": ["@{{projectName}}/config/tsconfig.base.json", "nitro/tsconfig"],
+  "compilerOptions": {
+    "composite": true,
+    "noEmit": true
+  }
+}
+`],
+  ["backend/server/nitro/better-auth/server/routes/api/auth/[...all].ts.hbs", `import { auth } from "@{{projectName}}/auth";
+import { defineHandler } from "nitro";
+
+export default defineHandler((event) => auth.handler(event.req));
+`],
+  ["backend/server/nitro/native-polar/server/routes/polar/success.get.ts.hbs", `import { defineHandler } from "nitro";
+
+const nativeAppUrl = "{{projectName}}://";
+const allowedNativeProtocols = new Set(["exp:", new URL(nativeAppUrl).protocol]);
+
+export default defineHandler((event) => {
+  const requestUrl = new URL(event.req.url);
+  const returnUrl = requestUrl.searchParams.get("returnUrl") || nativeAppUrl;
+
+  let redirectUrl: URL;
+  try {
+    redirectUrl = new URL(returnUrl);
+  } catch {
+    return new Response("Invalid return URL", { status: 400 });
+  }
+
+  if (!allowedNativeProtocols.has(redirectUrl.protocol)) {
+    return new Response("Invalid return URL", { status: 400 });
+  }
+
+  return Response.redirect(redirectUrl, 302);
+});
+`],
+  ["backend/server/nitro/orpc/server/routes/api-reference/[...].ts.hbs", `import { createContext } from "@{{projectName}}/api/context";
+import { appRouter } from "@{{projectName}}/api/routers/index";
+import { OpenAPIHandler } from "@orpc/openapi/fetch";
+import { OpenAPIReferencePlugin } from "@orpc/openapi/plugins";
+import { onError } from "@orpc/server";
+import { ZodToJsonSchemaConverter } from "@orpc/zod/zod4";
+import { defineHandler } from "nitro";
+
+const handler = new OpenAPIHandler(appRouter, {
+  plugins: [
+    new OpenAPIReferencePlugin({
+      schemaConverters: [new ZodToJsonSchemaConverter()],
+    }),
+  ],
+  interceptors: [
+    onError((error) => {
+      console.error(error);
+    }),
+  ],
+});
+
+export default defineHandler(async (event) => {
+  const result = await handler.handle(event.req, {
+    prefix: "/api-reference",
+    context: await createContext({ request: event.req }),
+  });
+
+  return result.response ?? new Response("Not Found", { status: 404 });
+});
+`],
+  ["backend/server/nitro/orpc/server/routes/rpc/[...].ts.hbs", `import { createContext } from "@{{projectName}}/api/context";
+import { appRouter } from "@{{projectName}}/api/routers/index";
+import { onError } from "@orpc/server";
+import { RPCHandler } from "@orpc/server/fetch";
+import { defineHandler } from "nitro";
+
+const handler = new RPCHandler(appRouter, {
+  interceptors: [
+    onError((error) => {
+      console.error(error);
+    }),
+  ],
+});
+
+export default defineHandler(async (event) => {
+  const result = await handler.handle(event.req, {
+    prefix: "/rpc",
+    context: await createContext({ request: event.req }),
+  });
+
+  return result.response ?? new Response("Not Found", { status: 404 });
+});
+`],
+  ["backend/server/nitro/trpc/server/routes/trpc/[...].ts.hbs", `import { createContext } from "@{{projectName}}/api/context";
+import { appRouter } from "@{{projectName}}/api/routers/index";
+import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
+import { defineHandler } from "nitro";
+
+export default defineHandler((event) =>
+  fetchRequestHandler({
+    endpoint: "/trpc",
+    req: event.req,
+    router: appRouter,
+    createContext: () => createContext({ request: event.req }),
+  }),
+);
+`],
   ["base/_gitignore", `# Dependencies
 node_modules
 .pnp
@@ -16544,15 +16787,27 @@ FROM node:24-slim AS runner
 {{/if}}
 WORKDIR /app
 ENV NODE_ENV=production
+{{#if (eq backend "nitro")}}
+COPY --from=builder /app/apps/server/.output ./
+{{else}}
 COPY --from=builder /app /app
+{{/if}}
 
 EXPOSE 3000
 
+{{#if (eq backend "nitro")}}
+{{#if (eq runtime "bun")}}
+CMD ["bun", "server/index.mjs"]
+{{else}}
+CMD ["node", "server/index.mjs"]
+{{/if}}
+{{else}}
 WORKDIR /app/apps/server
 {{#if (eq runtime "bun")}}
 CMD ["bun", "dist/index.mjs"]
 {{else}}
 CMD ["node", "dist/index.mjs"]
+{{/if}}
 {{/if}}
 `],
   ["deploy/docker/web/astro/Dockerfile.hbs", `FROM node:24-slim AS base
@@ -33502,7 +33757,7 @@ export const env = createEnv({
 {{/if}}
 {{#if (eq auth "clerk")}}
 		CLERK_SECRET_KEY: z.string().min(1),
-{{#if (or (eq backend "express") (eq backend "fastify") (and (ne api "none") (or (eq backend "self") (eq backend "hono") (eq backend "elysia"))))}}
+{{#if (or (eq backend "express") (eq backend "fastify") (and (ne api "none") (or (eq backend "self") (eq backend "hono") (eq backend "elysia") (eq backend "nitro"))))}}
 		CLERK_PUBLISHABLE_KEY: z.string().min(1),
 {{/if}}
 {{/if}}
@@ -35680,4 +35935,4 @@ export default function Success() {
 `]
 ]);
 
-export const TEMPLATE_COUNT = 522;
+export const TEMPLATE_COUNT = 534;

--- a/packages/template-generator/src/utils/generated-ignore-patterns.ts
+++ b/packages/template-generator/src/utils/generated-ignore-patterns.ts
@@ -26,7 +26,7 @@ const FRONTEND_GENERATED_PATTERNS = {
   none: [],
 } as const satisfies Partial<Record<ProjectConfig["frontend"][number], readonly string[]>>;
 
-const SERVER_BUILD_BACKENDS = ["hono", "express", "fastify", "elysia"] as const;
+const SERVER_BUILD_BACKENDS = ["hono", "express", "fastify", "elysia", "nitro"] as const;
 
 export function getStackGeneratedIgnorePatterns(config: ProjectConfig): string[] {
   const patterns = new Set<string>();
@@ -40,7 +40,7 @@ export function getStackGeneratedIgnorePatterns(config: ProjectConfig): string[]
   }
 
   if ((SERVER_BUILD_BACKENDS as readonly string[]).includes(config.backend)) {
-    patterns.add("apps/server/dist/**");
+    patterns.add(config.backend === "nitro" ? "apps/server/.output/**" : "apps/server/dist/**");
   }
 
   if (config.database !== "none" && config.orm !== "none") {

--- a/packages/template-generator/templates/api/orpc/server/src/context.ts.hbs
+++ b/packages/template-generator/templates/api/orpc/server/src/context.ts.hbs
@@ -236,7 +236,11 @@ export async function createContext({{#if (eq auth "none")}}_options{{else}}{ he
 
 {{else if (eq backend 'nitro')}}
 {{#if (eq auth "better-auth")}}
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare"))}}
+import { createAuth } from "@{{projectName}}/auth";
+{{else}}
 import { auth } from "@{{projectName}}/auth";
+{{/if}}
 {{/if}}
 
 export type CreateContextOptions = {
@@ -245,7 +249,7 @@ export type CreateContextOptions = {
 
 export async function createContext({{#if (eq auth "none")}}_options{{else}}{ request }{{/if}}: CreateContextOptions){{#if (eq auth "clerk")}}: Promise<ClerkRequestContext>{{/if}} {
 {{#if (eq auth "better-auth")}}
-	const session = await auth.api.getSession({ headers: request.headers });
+	const session = await {{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare"))}}createAuth(){{else}}auth{{/if}}.api.getSession({ headers: request.headers });
 	return {
 		auth: null,
 		session,

--- a/packages/template-generator/templates/api/orpc/server/src/context.ts.hbs
+++ b/packages/template-generator/templates/api/orpc/server/src/context.ts.hbs
@@ -13,7 +13,7 @@ function toClerkContextAuth(auth: { userId: string | null } | null): ClerkContex
 }
 {{/if}}
 
-{{#if (and (eq auth "clerk") (or (eq backend 'self') (eq backend 'hono') (eq backend 'elysia')))}}
+{{#if (and (eq auth "clerk") (or (eq backend 'self') (eq backend 'hono') (eq backend 'elysia') (eq backend 'nitro')))}}
 {{#if (usesRequestScopedCloudflareEnv backend webDeploy frontend)}}
 {{else}}
 import { createClerkClient } from "@clerk/backend";
@@ -225,6 +225,36 @@ export async function createContext({{#if (eq auth "none")}}_options{{else}}{ he
 	return {
 		auth: null,
 		session,
+	};
+{{else}}
+	return {
+		auth: null,
+		session: null,
+	};
+{{/if}}
+}
+
+{{else if (eq backend 'nitro')}}
+{{#if (eq auth "better-auth")}}
+import { auth } from "@{{projectName}}/auth";
+{{/if}}
+
+export type CreateContextOptions = {
+	request: Request;
+};
+
+export async function createContext({{#if (eq auth "none")}}_options{{else}}{ request }{{/if}}: CreateContextOptions){{#if (eq auth "clerk")}}: Promise<ClerkRequestContext>{{/if}} {
+{{#if (eq auth "better-auth")}}
+	const session = await auth.api.getSession({ headers: request.headers });
+	return {
+		auth: null,
+		session,
+	};
+{{else if (eq auth "clerk")}}
+	const clerkAuth = await authenticateClerkRequest(request);
+	return {
+		auth: clerkAuth,
+		session: null,
 	};
 {{else}}
 	return {

--- a/packages/template-generator/templates/api/trpc/server/src/context.ts.hbs
+++ b/packages/template-generator/templates/api/trpc/server/src/context.ts.hbs
@@ -97,7 +97,11 @@ export async function createContext({{#if (eq auth "none")}}_options{{else}}{ re
 
 {{else if (eq backend 'nitro')}}
 {{#if (eq auth "better-auth")}}
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare"))}}
+import { createAuth } from "@{{projectName}}/auth";
+{{else}}
 import { auth } from "@{{projectName}}/auth";
+{{/if}}
 {{/if}}
 
 export type CreateContextOptions = {
@@ -106,7 +110,7 @@ export type CreateContextOptions = {
 
 export async function createContext({{#if (eq auth "none")}}_options{{else}}{ request }{{/if}}: CreateContextOptions){{#if (eq auth "clerk")}}: Promise<ClerkRequestContext>{{/if}} {
 {{#if (eq auth "better-auth")}}
-	const session = await auth.api.getSession({ headers: request.headers });
+	const session = await {{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare"))}}createAuth(){{else}}auth{{/if}}.api.getSession({ headers: request.headers });
 	return {
 		auth: null,
 		session,

--- a/packages/template-generator/templates/api/trpc/server/src/context.ts.hbs
+++ b/packages/template-generator/templates/api/trpc/server/src/context.ts.hbs
@@ -13,7 +13,7 @@ function toClerkContextAuth(auth: { userId: string | null } | null): ClerkContex
 }
 {{/if}}
 
-{{#if (and (eq auth "clerk") (or (eq backend 'self') (eq backend 'hono') (eq backend 'elysia')))}}
+{{#if (and (eq auth "clerk") (or (eq backend 'self') (eq backend 'hono') (eq backend 'elysia') (eq backend 'nitro')))}}
 import { createClerkClient } from "@clerk/backend";
 import { env } from "@{{projectName}}/env/server";
 
@@ -83,6 +83,36 @@ export async function createContext({{#if (eq auth "none")}}_options{{else}}{ re
 	};
 {{else if (eq auth "clerk")}}
 	const clerkAuth = await authenticateClerkRequest(req);
+	return {
+		auth: clerkAuth,
+		session: null,
+	};
+{{else}}
+	return {
+		auth: null,
+		session: null,
+	};
+{{/if}}
+}
+
+{{else if (eq backend 'nitro')}}
+{{#if (eq auth "better-auth")}}
+import { auth } from "@{{projectName}}/auth";
+{{/if}}
+
+export type CreateContextOptions = {
+	request: Request;
+};
+
+export async function createContext({{#if (eq auth "none")}}_options{{else}}{ request }{{/if}}: CreateContextOptions){{#if (eq auth "clerk")}}: Promise<ClerkRequestContext>{{/if}} {
+{{#if (eq auth "better-auth")}}
+	const session = await auth.api.getSession({ headers: request.headers });
+	return {
+		auth: null,
+		session,
+	};
+{{else if (eq auth "clerk")}}
+	const clerkAuth = await authenticateClerkRequest(request);
 	return {
 		auth: clerkAuth,
 		session: null,

--- a/packages/template-generator/templates/backend/server/nitro/ai/server/routes/ai.post.ts.hbs
+++ b/packages/template-generator/templates/backend/server/nitro/ai/server/routes/ai.post.ts.hbs
@@ -1,0 +1,27 @@
+import { devToolsMiddleware } from "@ai-sdk/devtools";
+import { google } from "@ai-sdk/google";
+import {
+  convertToModelMessages,
+  createUIMessageStreamResponse,
+  streamText,
+  toUIMessageStream,
+  type UIMessage,
+  wrapLanguageModel,
+} from "ai";
+import { defineHandler } from "nitro";
+
+export default defineHandler(async (event) => {
+  const { messages = [] } = (await event.req.json()) as { messages?: UIMessage[] };
+  const model = wrapLanguageModel({
+    model: google("gemini-2.5-flash"),
+    middleware: devToolsMiddleware(),
+  });
+  const result = streamText({
+    model,
+    messages: await convertToModelMessages(messages),
+  });
+
+  return createUIMessageStreamResponse({
+    stream: toUIMessageStream({ stream: result.stream }),
+  });
+});

--- a/packages/template-generator/templates/backend/server/nitro/base/_gitignore
+++ b/packages/template-generator/templates/backend/server/nitro/base/_gitignore
@@ -1,0 +1,4 @@
+.data
+.nitro
+.cache
+.output

--- a/packages/template-generator/templates/backend/server/nitro/base/_gitignore
+++ b/packages/template-generator/templates/backend/server/nitro/base/_gitignore
@@ -2,3 +2,4 @@
 .nitro
 .cache
 .output
+.wrangler

--- a/packages/template-generator/templates/backend/server/nitro/base/nitro.config.ts.hbs
+++ b/packages/template-generator/templates/backend/server/nitro/base/nitro.config.ts.hbs
@@ -1,6 +1,15 @@
 import { defineConfig } from "nitro";
 
 export default defineConfig({
+{{#if (eq runtime "workers")}}
+  defaultPreset: "cloudflare_module",
+{{else}}
   defaultPreset: "{{runtime}}",
+{{/if}}
   serverDir: "./server",
+{{#if (eq runtime "workers")}}
+  cloudflare: {
+    nodeCompat: true,
+  },
+{{/if}}
 });

--- a/packages/template-generator/templates/backend/server/nitro/base/nitro.config.ts.hbs
+++ b/packages/template-generator/templates/backend/server/nitro/base/nitro.config.ts.hbs
@@ -1,0 +1,6 @@
+import { defineConfig } from "nitro";
+
+export default defineConfig({
+  defaultPreset: "{{runtime}}",
+  serverDir: "./server",
+});

--- a/packages/template-generator/templates/backend/server/nitro/base/package.json.hbs
+++ b/packages/template-generator/templates/backend/server/nitro/base/package.json.hbs
@@ -1,0 +1,15 @@
+{
+  "name": "server",
+  "type": "module",
+  "scripts": {
+    "build": "nitro build",
+    "check-types": "tsc --noEmit"
+  },
+  "dependencies": {},
+  {{#if (eq dbSetup 'supabase')}}
+  "trustedDependencies": [
+    "supabase"
+  ],
+  {{/if}}
+  "devDependencies": {}
+}

--- a/packages/template-generator/templates/backend/server/nitro/base/server/middleware/cors.ts.hbs
+++ b/packages/template-generator/templates/backend/server/nitro/base/server/middleware/cors.ts.hbs
@@ -1,0 +1,19 @@
+import { env } from "@{{projectName}}/env/server";
+import { defineHandler } from "nitro";
+import { handleCors } from "nitro/h3";
+
+export default defineHandler((event) => {
+  const response = handleCors(event, {
+    origin: [env.CORS_ORIGIN],
+    methods: ["GET", "POST", "OPTIONS"],
+{{#if (or (eq auth "better-auth") (eq auth "clerk"))}}
+    allowHeaders: ["Content-Type", "Authorization"],
+{{/if}}
+{{#if (eq auth "better-auth")}}
+    credentials: true,
+{{/if}}
+  });
+
+  if (response !== false) return response;
+  return undefined;
+});

--- a/packages/template-generator/templates/backend/server/nitro/base/server/routes/index.get.ts.hbs
+++ b/packages/template-generator/templates/backend/server/nitro/base/server/routes/index.get.ts.hbs
@@ -1,0 +1,3 @@
+import { defineHandler } from "nitro";
+
+export default defineHandler(() => "OK");

--- a/packages/template-generator/templates/backend/server/nitro/base/tsconfig.json.hbs
+++ b/packages/template-generator/templates/backend/server/nitro/base/tsconfig.json.hbs
@@ -1,0 +1,7 @@
+{
+  "extends": ["@{{projectName}}/config/tsconfig.base.json", "nitro/tsconfig"],
+  "compilerOptions": {
+    "composite": true,
+    "noEmit": true
+  }
+}

--- a/packages/template-generator/templates/backend/server/nitro/base/tsconfig.json.hbs
+++ b/packages/template-generator/templates/backend/server/nitro/base/tsconfig.json.hbs
@@ -2,6 +2,7 @@
   "extends": ["@{{projectName}}/config/tsconfig.base.json", "nitro/tsconfig"],
   "compilerOptions": {
     "composite": true,
-    "noEmit": true
+    "noEmit": true{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare"))}},
+    "types": ["node"]{{/if}}
   }
 }

--- a/packages/template-generator/templates/backend/server/nitro/better-auth/server/routes/api/auth/[...all].ts.hbs
+++ b/packages/template-generator/templates/backend/server/nitro/better-auth/server/routes/api/auth/[...all].ts.hbs
@@ -1,4 +1,10 @@
+{{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare"))}}
+import { createAuth } from "@{{projectName}}/auth";
+{{else}}
 import { auth } from "@{{projectName}}/auth";
+{{/if}}
 import { defineHandler } from "nitro";
 
-export default defineHandler((event) => auth.handler(event.req));
+export default defineHandler((event) =>
+  {{#if (or (eq runtime "workers") (eq serverDeploy "cloudflare"))}}createAuth(){{else}}auth{{/if}}.handler(event.req),
+);

--- a/packages/template-generator/templates/backend/server/nitro/better-auth/server/routes/api/auth/[...all].ts.hbs
+++ b/packages/template-generator/templates/backend/server/nitro/better-auth/server/routes/api/auth/[...all].ts.hbs
@@ -1,0 +1,4 @@
+import { auth } from "@{{projectName}}/auth";
+import { defineHandler } from "nitro";
+
+export default defineHandler((event) => auth.handler(event.req));

--- a/packages/template-generator/templates/backend/server/nitro/native-polar/server/routes/polar/success.get.ts.hbs
+++ b/packages/template-generator/templates/backend/server/nitro/native-polar/server/routes/polar/success.get.ts.hbs
@@ -1,0 +1,22 @@
+import { defineHandler } from "nitro";
+
+const nativeAppUrl = "{{projectName}}://";
+const allowedNativeProtocols = new Set(["exp:", new URL(nativeAppUrl).protocol]);
+
+export default defineHandler((event) => {
+  const requestUrl = new URL(event.req.url);
+  const returnUrl = requestUrl.searchParams.get("returnUrl") || nativeAppUrl;
+
+  let redirectUrl: URL;
+  try {
+    redirectUrl = new URL(returnUrl);
+  } catch {
+    return new Response("Invalid return URL", { status: 400 });
+  }
+
+  if (!allowedNativeProtocols.has(redirectUrl.protocol)) {
+    return new Response("Invalid return URL", { status: 400 });
+  }
+
+  return Response.redirect(redirectUrl, 302);
+});

--- a/packages/template-generator/templates/backend/server/nitro/orpc/server/routes/api-reference/[...].ts.hbs
+++ b/packages/template-generator/templates/backend/server/nitro/orpc/server/routes/api-reference/[...].ts.hbs
@@ -1,0 +1,29 @@
+import { createContext } from "@{{projectName}}/api/context";
+import { appRouter } from "@{{projectName}}/api/routers/index";
+import { OpenAPIHandler } from "@orpc/openapi/fetch";
+import { OpenAPIReferencePlugin } from "@orpc/openapi/plugins";
+import { onError } from "@orpc/server";
+import { ZodToJsonSchemaConverter } from "@orpc/zod/zod4";
+import { defineHandler } from "nitro";
+
+const handler = new OpenAPIHandler(appRouter, {
+  plugins: [
+    new OpenAPIReferencePlugin({
+      schemaConverters: [new ZodToJsonSchemaConverter()],
+    }),
+  ],
+  interceptors: [
+    onError((error) => {
+      console.error(error);
+    }),
+  ],
+});
+
+export default defineHandler(async (event) => {
+  const result = await handler.handle(event.req, {
+    prefix: "/api-reference",
+    context: await createContext({ request: event.req }),
+  });
+
+  return result.response ?? new Response("Not Found", { status: 404 });
+});

--- a/packages/template-generator/templates/backend/server/nitro/orpc/server/routes/rpc/[...].ts.hbs
+++ b/packages/template-generator/templates/backend/server/nitro/orpc/server/routes/rpc/[...].ts.hbs
@@ -1,0 +1,22 @@
+import { createContext } from "@{{projectName}}/api/context";
+import { appRouter } from "@{{projectName}}/api/routers/index";
+import { onError } from "@orpc/server";
+import { RPCHandler } from "@orpc/server/fetch";
+import { defineHandler } from "nitro";
+
+const handler = new RPCHandler(appRouter, {
+  interceptors: [
+    onError((error) => {
+      console.error(error);
+    }),
+  ],
+});
+
+export default defineHandler(async (event) => {
+  const result = await handler.handle(event.req, {
+    prefix: "/rpc",
+    context: await createContext({ request: event.req }),
+  });
+
+  return result.response ?? new Response("Not Found", { status: 404 });
+});

--- a/packages/template-generator/templates/backend/server/nitro/trpc/server/routes/trpc/[...].ts.hbs
+++ b/packages/template-generator/templates/backend/server/nitro/trpc/server/routes/trpc/[...].ts.hbs
@@ -1,0 +1,13 @@
+import { createContext } from "@{{projectName}}/api/context";
+import { appRouter } from "@{{projectName}}/api/routers/index";
+import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
+import { defineHandler } from "nitro";
+
+export default defineHandler((event) =>
+  fetchRequestHandler({
+    endpoint: "/trpc",
+    req: event.req,
+    router: appRouter,
+    createContext: () => createContext({ request: event.req }),
+  }),
+);

--- a/packages/template-generator/templates/deploy/docker/server/Dockerfile.hbs
+++ b/packages/template-generator/templates/deploy/docker/server/Dockerfile.hbs
@@ -32,13 +32,25 @@ FROM node:24-slim AS runner
 {{/if}}
 WORKDIR /app
 ENV NODE_ENV=production
+{{#if (eq backend "nitro")}}
+COPY --from=builder /app/apps/server/.output ./
+{{else}}
 COPY --from=builder /app /app
+{{/if}}
 
 EXPOSE 3000
 
+{{#if (eq backend "nitro")}}
+{{#if (eq runtime "bun")}}
+CMD ["bun", "server/index.mjs"]
+{{else}}
+CMD ["node", "server/index.mjs"]
+{{/if}}
+{{else}}
 WORKDIR /app/apps/server
 {{#if (eq runtime "bun")}}
 CMD ["bun", "dist/index.mjs"]
 {{else}}
 CMD ["node", "dist/index.mjs"]
+{{/if}}
 {{/if}}

--- a/packages/template-generator/templates/extras/env.d.ts.hbs
+++ b/packages/template-generator/templates/extras/env.d.ts.hbs
@@ -1,3 +1,15 @@
+{{#if (and (eq backend "nitro") (eq serverDeploy "cloudflare"))}}
+type CloudflareEnv = import("@{{projectName}}/infra/alchemy.run").ServerEnv;
+type Env = CloudflareEnv;
+
+declare module "cloudflare:workers" {
+  export const env: CloudflareEnv;
+
+  namespace Cloudflare {
+    export interface Env extends CloudflareEnv {}
+  }
+}
+{{else}}
 {{#if (eq serverDeploy "cloudflare")}}
 import type { ServerEnv } from "@{{projectName}}/infra/alchemy.run";
 {{else}}
@@ -18,3 +30,4 @@ declare module "cloudflare:workers" {
     export interface Env extends CloudflareEnv {}
   }
 }
+{{/if}}

--- a/packages/template-generator/templates/packages/env/src/server.ts.hbs
+++ b/packages/template-generator/templates/packages/env/src/server.ts.hbs
@@ -1,9 +1,17 @@
 {{#if (and (eq serverDeploy "cloudflare") (or (ne backend "self") (ne webDeploy "cloudflare")))}}
+{{#if (eq backend "nitro")}}
+/// <reference path="../env.d.ts" />
+import type { ServerEnv } from "@{{projectName}}/infra/alchemy.run";
+
+export type CloudflareEnv = ServerEnv;
+export { env } from "cloudflare:workers";
+{{else}}
 /// <reference types="@cloudflare/workers-types" />
 /// <reference path="../env.d.ts" />
 // For Cloudflare Workers, env is accessed via cloudflare:workers module
 // Types are defined in env.d.ts based on your alchemy.run.ts bindings
 export { env } from "cloudflare:workers";
+{{/if}}
 {{else if (and (eq backend "self") (eq webDeploy "cloudflare") (includes frontend "next"))}}
 /// <reference path="../env.d.ts" />
 import { getCloudflareContext } from "@opennextjs/cloudflare";

--- a/packages/template-generator/templates/packages/env/src/server.ts.hbs
+++ b/packages/template-generator/templates/packages/env/src/server.ts.hbs
@@ -151,7 +151,7 @@ export const env = createEnv({
 {{/if}}
 {{#if (eq auth "clerk")}}
 		CLERK_SECRET_KEY: z.string().min(1),
-{{#if (or (eq backend "express") (eq backend "fastify") (and (ne api "none") (or (eq backend "self") (eq backend "hono") (eq backend "elysia"))))}}
+{{#if (or (eq backend "express") (eq backend "fastify") (and (ne api "none") (or (eq backend "self") (eq backend "hono") (eq backend "elysia") (eq backend "nitro"))))}}
 		CLERK_PUBLISHABLE_KEY: z.string().min(1),
 {{/if}}
 {{/if}}

--- a/packages/types/src/schemas.ts
+++ b/packages/types/src/schemas.ts
@@ -7,7 +7,7 @@ export const DatabaseSchema = z
 export const ORMSchema = z.enum(["drizzle", "prisma", "mongoose", "none"]).describe("ORM type");
 
 export const BackendSchema = z
-  .enum(["hono", "express", "fastify", "elysia", "convex", "self", "none"])
+  .enum(["hono", "express", "fastify", "elysia", "nitro", "convex", "self", "none"])
   .describe("Backend framework");
 
 export const RuntimeSchema = z


### PR DESCRIPTION
## Summary

- add Nitro 3 as an experimental backend using its native file routes and `.output` artifacts
- support oRPC, tRPC, Better Auth, Clerk, databases, ORMs, Polar, AI, web/native clients, and the stack builder
- support Docker, Prisma Compute, Vercel Services, and Cloudflare Workers
- build Cloudflare deployments with Nitro's official `cloudflare_module` preset and Alchemy's public `Command.Build` + prebuilt `Cloudflare.Worker` APIs
- document the generated structure and deployment behavior

## Verification

- `bun run check`
- `bun run build`
- CLI: 709 passed, 38 skipped, 0 failed
- generated Bun, npm, and pnpm projects installed, built, typechecked, and served
- live Docker, Prisma, Vercel, and Cloudflare deployments passed route probes
- Cloudflare D1, Better Auth, oRPC, CORS, web-to-server URL wiring, and destroy were verified


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added experimental Nitro 3 as a backend option with file-based routing and native runtime support.
  - Added compatibility with tRPC, oRPC, Better Auth, Clerk, AI features, databases, and payment routes.
  - Added Docker, Prisma, Vercel, and Cloudflare deployment support.

- **Bug Fixes**
  - Improved validation for unsupported database provider selections and runtime combinations.

- **Documentation**
  - Updated CLI and deployment guides with Nitro setup, routing, runtime, and deployment details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->