### PR TITLE
fix: restore broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,10 @@ Please read the Contribution Guide first and open an issue before starting new f
 
 ## Star History
 
-<a href="https://www.star-history.com/#AmanVarshney01/create-better-t-stack&Date">
+<a href="https://star-history.dera.page/#AmanVarshney01/create-better-t-stack&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=AmanVarshney01/create-better-t-stack&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=AmanVarshney01/create-better-t-stack&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=AmanVarshney01/create-better-t-stack&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=AmanVarshney01/create-better-t-stack&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=AmanVarshney01/create-better-t-stack&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=AmanVarshney01/create-better-t-stack&type=Date" />
  </picture>
 </a>


### PR DESCRIPTION
The star history chart at the bottom of the README is currently broken, which means visitors can no longer see the repository's growth. This change points the chart to a working source so it renders correctly again. No other changes are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Star History embed to use the new Star History page address.
  * Existing Star History visualizations will now load from the updated service location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->