### PR TITLE
feat(web): surface website analytics link

### DIFF
--- a/apps/web/src/app/(home)/analytics/_components/analytics-header.tsx
+++ b/apps/web/src/app/(home)/analytics/_components/analytics-header.tsx
@@ -1,4 +1,4 @@
-import { Activity, DatabaseZap, Terminal } from "lucide-react";
+import { Activity, ArrowUpRight, DatabaseZap, Terminal } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
@@ -85,11 +85,22 @@ export function AnalyticsHeader({
         title="ANALYTICS.SH"
         description="Aggregate CLI telemetry for create-better-t-stack."
         actions={
-          <span className="flex shrink-0 items-center gap-2 font-mono text-[10px] uppercase tracking-[0.10em]">
-            <Activity className={cn("h-3 w-3", statusMeta.textClass)} />
-            <span aria-hidden="true" className={cn("h-1.5 w-1.5", statusMeta.dotClass)} />
-            <span className={statusMeta.textClass}>{statusMeta.label}</span>
-          </span>
+          <div className="flex flex-wrap items-center gap-3">
+            <span className="flex shrink-0 items-center gap-2 font-mono text-[10px] uppercase tracking-[0.10em]">
+              <Activity className={cn("h-3 w-3", statusMeta.textClass)} />
+              <span aria-hidden="true" className={cn("h-1.5 w-1.5", statusMeta.dotClass)} />
+              <span className={statusMeta.textClass}>{statusMeta.label}</span>
+            </span>
+            <a
+              href="https://umami.amanv.cloud/share/pHvqHleyOl9PBfaK"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="builder-focus-ring flex min-h-8 items-center gap-2 rounded-[4px] border px-3 py-1.5 font-mono text-[10px] text-primary uppercase tracking-[0.10em] transition-colors duration-150 hover:text-fd-foreground"
+            >
+              <span>Website analytics</span>
+              <ArrowUpRight aria-hidden="true" className="h-3 w-3" />
+            </a>
+          </div>
         }
       />
 

--- a/apps/web/src/app/(home)/analytics/_components/analytics-sources.tsx
+++ b/apps/web/src/app/(home)/analytics/_components/analytics-sources.tsx
@@ -45,23 +45,6 @@ export function AnalyticsSources() {
           </span>
           <ArrowUpRight className="h-3.5 w-3.5 shrink-0 text-fd-muted-foreground transition-colors duration-150 group-hover:text-primary" />
         </Link>
-
-        <Link
-          href="https://umami.amanv.cloud/share/pHvqHleyOl9PBfaK"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="builder-focus-ring group flex items-center justify-between gap-3 py-2.5"
-        >
-          <span className="min-w-0">
-            <span className="block text-[10px] text-fd-muted-foreground uppercase tracking-[0.10em]">
-              Website analytics
-            </span>
-            <span className="block break-words text-[13px] leading-[1.55] transition-colors duration-150 group-hover:text-primary">
-              Umami dashboard
-            </span>
-          </span>
-          <ArrowUpRight className="h-3.5 w-3.5 shrink-0 text-fd-muted-foreground transition-colors duration-150 group-hover:text-primary" />
-        </Link>
       </div>
 
       <p className="mt-4 text-[11px] text-fd-muted-foreground leading-[1.5]">


### PR DESCRIPTION
## Summary

- promote the public Umami website analytics link into the analytics page header
- keep the live Convex streaming status visible beside the new action
- remove the duplicate Umami entry from the bottom source map

## Why

Website traffic and CLI telemetry are separate datasets. Keeping Umami as a prominent external dashboard avoids introducing API credentials and duplicate charting while making the existing public analytics easier to discover.

## Verification

- targeted Oxlint and Oxfmt checks
- full `bun run build:web`
- desktop visual verification
- 390px mobile viewport verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Website analytics” link to the analytics header for quick access to the Umami dashboard.
  - Improved responsive layout for the analytics header actions.

- **Improvements**
  - Removed the duplicate website analytics link from the analytics sources section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->