### PR TITLE
feat(cli): open generated projects in editors and agents

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -78,6 +78,7 @@ Options:
   --package-manager <pm>          Package manager (npm, pnpm, bun)
   --install                       Install dependencies
   --no-install                    Skip installing dependencies
+  --open <target>                 Open in an editor, IDE, or coding agent after creation
   --db-setup <setup>              Database setup (turso, d1, neon, supabase, prisma-postgres, planetscale, mongodb-atlas, docker, none)
   --web-deploy <setup>            Web deployment (cloudflare, docker, vercel, none)
   --server-deploy <setup>         Server deployment (cloudflare, docker, vercel, none)

--- a/apps/cli/src/helpers/core/command-handlers.ts
+++ b/apps/cli/src/helpers/core/command-handlers.ts
@@ -31,6 +31,12 @@ import {
   validateSafeProjectDirectoryPath,
 } from "../../utils/project-directory";
 import { addToHistory } from "../../utils/project-history";
+import {
+  type AvailableProjectLauncher,
+  type ProjectLauncher,
+  getProjectLauncherChoice,
+  launchProject,
+} from "../../utils/project-launcher";
 import { validateProjectName } from "../../utils/project-name-validation";
 import { renderTitle } from "../../utils/render-title";
 import { checkLocalRequirements } from "../../utils/requirements";
@@ -48,6 +54,11 @@ import { resolveProjectDbSetupOptions } from "./db-setup-options";
 export interface CreateHandlerOptions {
   silent?: boolean;
 }
+
+type CreateCommandInput = CreateInput & {
+  projectName?: string;
+  open?: ProjectLauncher;
+};
 
 /**
  * Result type for project creation
@@ -117,7 +128,7 @@ interface CreateHandlerExecution {
 }
 
 async function executeCreateProjectHandler(
-  input: CreateInput & { projectName?: string },
+  input: CreateCommandInput,
   options: CreateHandlerOptions,
 ): Promise<CreateHandlerExecution> {
   const { silent = false } = options;
@@ -132,7 +143,7 @@ async function executeCreateProjectHandler(
 }
 
 export async function createProjectHandlerResult(
-  input: CreateInput & { projectName?: string },
+  input: CreateCommandInput,
   options: CreateHandlerOptions = {},
 ): Promise<Result<CreateProjectResult, CreateHandlerError>> {
   const execution = await executeCreateProjectHandler(input, options);
@@ -140,7 +151,7 @@ export async function createProjectHandlerResult(
 }
 
 export async function createProjectHandler(
-  input: CreateInput & { projectName?: string },
+  input: CreateCommandInput,
   options: CreateHandlerOptions = {},
 ): Promise<CreateProjectResult | undefined> {
   const { silent = false } = options;
@@ -175,7 +186,7 @@ export async function createProjectHandler(
 }
 
 async function createProjectHandlerInternal(
-  input: CreateInput & { projectName?: string },
+  input: CreateCommandInput,
   startTime: number,
   timeScaffolded: string,
 ): Promise<Result<CreateProjectResult, CreateHandlerError>> {
@@ -438,10 +449,34 @@ async function createProjectHandlerInternal(
       log.message(`${pc.dim("Setup saved to history")}\n${pc.cyan(historyCommand)}`);
     }
 
+    let projectLauncher: AvailableProjectLauncher | undefined;
+    if (!isSilent()) {
+      const launcherResult = await getProjectLauncherChoice(input.open, config.projectDir, {
+        prompt:
+          !input.yes &&
+          process.env.CI === undefined &&
+          process.stdin.isTTY === true &&
+          process.stdout.isTTY === true,
+      });
+
+      if (launcherResult.isErr()) {
+        log.warn(pc.yellow(launcherResult.error.message));
+      } else {
+        projectLauncher = launcherResult.value;
+      }
+    }
+
     const elapsedTimeMs = Date.now() - startTime;
     if (!isSilent()) {
       const elapsedTimeInSeconds = (elapsedTimeMs / 1000).toFixed(1);
       outro(pc.magenta(`Project ready in ${pc.bold(`${elapsedTimeInSeconds}s`)}`));
+
+      if (projectLauncher) {
+        const launchResult = await launchProject(projectLauncher);
+        if (launchResult.isErr()) {
+          log.warn(pc.yellow(launchResult.error.message));
+        }
+      }
     }
 
     return Result.ok({

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -61,6 +61,7 @@ import {
   UserCancelledError,
 } from "./utils/errors";
 import { getLatestCLIVersion } from "./utils/get-latest-cli-version";
+import { type ProjectLauncher, ProjectLauncherSchema } from "./utils/project-launcher";
 import { validateResolvedConfigCompatibility } from "./validation";
 
 export const SchemaNameSchema = z
@@ -165,6 +166,7 @@ export const router = t.router({
           git: z.boolean().optional(),
           packageManager: PackageManagerSchema.optional(),
           install: z.boolean().optional(),
+          open: ProjectLauncherSchema.optional(),
           dbSetup: DatabaseSetupSchema.optional(),
           backend: BackendSchema.optional(),
           runtime: RuntimeSchema.optional(),
@@ -523,7 +525,10 @@ export type {
   ServerDeploy,
   Template,
   DirectoryConflict,
+  ProjectLauncher,
 };
+
+export { ProjectLauncherSchema };
 
 export type { AddResult };
 

--- a/apps/cli/src/utils/project-launcher.ts
+++ b/apps/cli/src/utils/project-launcher.ts
@@ -109,14 +109,14 @@ export const PROJECT_LAUNCHERS = [
     id: "webstorm",
     label: "JetBrains WebStorm",
     kind: "editor",
-    commands: ["webstorm", "webstorm64.exe", "webstorm.sh"],
+    commands: ["webstorm", "webstorm64.exe", "webstorm.bat", "webstorm.sh"],
     args: (projectDir) => [projectDir],
   },
   {
     id: "intellij-idea",
     label: "JetBrains IntelliJ IDEA",
     kind: "editor",
-    commands: ["idea", "idea64.exe", "idea.sh"],
+    commands: ["idea", "intellij-idea", "idea64.exe", "idea.bat", "idea.sh"],
     args: (projectDir) => [projectDir],
   },
   {

--- a/apps/cli/src/utils/project-launcher.ts
+++ b/apps/cli/src/utils/project-launcher.ts
@@ -1,0 +1,385 @@
+import { Result } from "better-result";
+import { execa } from "execa";
+import z from "zod";
+
+import { isCancel, navigableSelect, setIsFirstPrompt } from "../prompts/navigable";
+import { commandExists } from "./command-exists";
+import { CLIError } from "./errors";
+import { shouldSkipExternalCommands } from "./external-commands";
+
+export const ProjectLauncherSchema = z
+  .enum([
+    "cursor",
+    "vscode",
+    "vscode-insiders",
+    "zed",
+    "windsurf",
+    "vscodium",
+    "webstorm",
+    "intellij-idea",
+    "sublime-text",
+    "neovim",
+    "codex-app",
+    "codex",
+    "claude-code",
+    "opencode",
+    "pi",
+    "gemini-cli",
+    "github-copilot",
+    "kiro-cli",
+    "droid",
+    "goose",
+    "cline",
+    "continue",
+    "amp",
+    "aider",
+    "qwen-code",
+    "crush",
+    "cursor-agent",
+    "none",
+  ])
+  .describe("Editor, IDE, or coding agent to open after creating the project");
+
+export type ProjectLauncher = z.infer<typeof ProjectLauncherSchema>;
+export type ProjectLauncherKind = "editor" | "agent";
+
+interface ProjectLauncherDefinition {
+  id: Exclude<ProjectLauncher, "none">;
+  label: string;
+  kind: ProjectLauncherKind;
+  commands: readonly string[];
+  args?: (projectDir: string) => string[];
+  cwd?: (projectDir: string) => string;
+  platforms?: readonly NodeJS.Platform[];
+}
+
+export interface AvailableProjectLauncher {
+  id: Exclude<ProjectLauncher, "none">;
+  label: string;
+  kind: ProjectLauncherKind;
+  command: string;
+  args: string[];
+  cwd?: string;
+}
+
+export const PROJECT_LAUNCHERS = [
+  {
+    id: "cursor",
+    label: "Cursor",
+    kind: "editor",
+    commands: ["cursor"],
+    args: (projectDir) => [projectDir],
+  },
+  {
+    id: "vscode",
+    label: "Visual Studio Code",
+    kind: "editor",
+    commands: ["code"],
+    args: (projectDir) => [projectDir],
+  },
+  {
+    id: "vscode-insiders",
+    label: "Visual Studio Code Insiders",
+    kind: "editor",
+    commands: ["code-insiders"],
+    args: (projectDir) => [projectDir],
+  },
+  {
+    id: "zed",
+    label: "Zed",
+    kind: "editor",
+    commands: ["zed", "zeditor"],
+    args: (projectDir) => [projectDir],
+  },
+  {
+    id: "windsurf",
+    label: "Windsurf",
+    kind: "editor",
+    commands: ["windsurf"],
+    args: (projectDir) => [projectDir],
+  },
+  {
+    id: "vscodium",
+    label: "VSCodium",
+    kind: "editor",
+    commands: ["codium"],
+    args: (projectDir) => [projectDir],
+  },
+  {
+    id: "webstorm",
+    label: "JetBrains WebStorm",
+    kind: "editor",
+    commands: ["webstorm", "webstorm64.exe", "webstorm.sh"],
+    args: (projectDir) => [projectDir],
+  },
+  {
+    id: "intellij-idea",
+    label: "JetBrains IntelliJ IDEA",
+    kind: "editor",
+    commands: ["idea", "idea64.exe", "idea.sh"],
+    args: (projectDir) => [projectDir],
+  },
+  {
+    id: "sublime-text",
+    label: "Sublime Text",
+    kind: "editor",
+    commands: ["subl"],
+    args: (projectDir) => [projectDir],
+  },
+  {
+    id: "neovim",
+    label: "Neovim",
+    kind: "editor",
+    commands: ["nvim"],
+    cwd: (projectDir) => projectDir,
+  },
+  {
+    id: "codex-app",
+    label: "Codex app",
+    kind: "agent",
+    commands: ["codex"],
+    args: (projectDir) => ["app", projectDir],
+    platforms: ["darwin"],
+  },
+  {
+    id: "codex",
+    label: "Codex CLI",
+    kind: "agent",
+    commands: ["codex"],
+    cwd: (projectDir) => projectDir,
+  },
+  {
+    id: "claude-code",
+    label: "Claude Code",
+    kind: "agent",
+    commands: ["claude"],
+    cwd: (projectDir) => projectDir,
+  },
+  {
+    id: "opencode",
+    label: "OpenCode",
+    kind: "agent",
+    commands: ["opencode"],
+    cwd: (projectDir) => projectDir,
+  },
+  {
+    id: "pi",
+    label: "Pi",
+    kind: "agent",
+    commands: ["pi"],
+    cwd: (projectDir) => projectDir,
+  },
+  {
+    id: "gemini-cli",
+    label: "Gemini CLI",
+    kind: "agent",
+    commands: ["gemini"],
+    cwd: (projectDir) => projectDir,
+  },
+  {
+    id: "github-copilot",
+    label: "GitHub Copilot CLI",
+    kind: "agent",
+    commands: ["copilot"],
+    cwd: (projectDir) => projectDir,
+  },
+  {
+    id: "kiro-cli",
+    label: "Kiro CLI",
+    kind: "agent",
+    commands: ["kiro-cli"],
+    cwd: (projectDir) => projectDir,
+  },
+  {
+    id: "droid",
+    label: "Factory Droid",
+    kind: "agent",
+    commands: ["droid"],
+    cwd: (projectDir) => projectDir,
+  },
+  {
+    id: "goose",
+    label: "goose",
+    kind: "agent",
+    commands: ["goose"],
+    args: () => ["session"],
+    cwd: (projectDir) => projectDir,
+  },
+  {
+    id: "cline",
+    label: "Cline CLI",
+    kind: "agent",
+    commands: ["cline"],
+    cwd: (projectDir) => projectDir,
+    platforms: ["darwin", "linux"],
+  },
+  {
+    id: "continue",
+    label: "Continue CLI",
+    kind: "agent",
+    commands: ["cn"],
+    cwd: (projectDir) => projectDir,
+  },
+  {
+    id: "amp",
+    label: "Amp",
+    kind: "agent",
+    commands: ["amp"],
+    cwd: (projectDir) => projectDir,
+  },
+  {
+    id: "aider",
+    label: "Aider",
+    kind: "agent",
+    commands: ["aider"],
+    cwd: (projectDir) => projectDir,
+  },
+  {
+    id: "qwen-code",
+    label: "Qwen Code",
+    kind: "agent",
+    commands: ["qwen"],
+    cwd: (projectDir) => projectDir,
+  },
+  {
+    id: "crush",
+    label: "Crush",
+    kind: "agent",
+    commands: ["crush"],
+    cwd: (projectDir) => projectDir,
+  },
+  {
+    id: "cursor-agent",
+    label: "Cursor Agent",
+    kind: "agent",
+    commands: ["cursor-agent"],
+    cwd: (projectDir) => projectDir,
+  },
+] as const satisfies readonly ProjectLauncherDefinition[];
+
+type CommandDetector = (command: string) => Promise<boolean>;
+
+export async function detectProjectLaunchers(
+  projectDir: string,
+  detectCommand: CommandDetector = commandExists,
+  platform: NodeJS.Platform = process.platform,
+): Promise<AvailableProjectLauncher[]> {
+  const definitions: readonly ProjectLauncherDefinition[] = PROJECT_LAUNCHERS;
+  const supportedDefinitions = definitions.filter(
+    ({ platforms }) => platforms === undefined || platforms.includes(platform),
+  );
+  const commands = [...new Set(supportedDefinitions.flatMap(({ commands }) => commands))];
+  const detectedCommands = new Map(
+    await Promise.all(
+      commands.map(async (command) => [command, await detectCommand(command)] as const),
+    ),
+  );
+
+  return supportedDefinitions.flatMap((launcher) => {
+    const command = launcher.commands.find((candidate) => detectedCommands.get(candidate));
+    if (!command) return [];
+
+    return [
+      {
+        id: launcher.id,
+        label: launcher.label,
+        kind: launcher.kind,
+        command,
+        args: launcher.args?.(projectDir) ?? [],
+        cwd: launcher.cwd?.(projectDir),
+      },
+    ];
+  });
+}
+
+export async function getProjectLauncherChoice(
+  requestedLauncher: ProjectLauncher | undefined,
+  projectDir: string,
+  options: {
+    detectCommand?: CommandDetector;
+    platform?: NodeJS.Platform;
+    prompt?: boolean;
+  } = {},
+): Promise<Result<AvailableProjectLauncher | undefined, CLIError>> {
+  if (requestedLauncher === "none") return Result.ok(undefined);
+  if (!requestedLauncher && options.prompt === false) return Result.ok(undefined);
+
+  const availableLaunchers = await detectProjectLaunchers(
+    projectDir,
+    options.detectCommand,
+    options.platform,
+  );
+
+  if (requestedLauncher) {
+    const launcher = availableLaunchers.find(({ id }) => id === requestedLauncher);
+    if (launcher) return Result.ok(launcher);
+
+    const definition = PROJECT_LAUNCHERS.find(({ id }) => id === requestedLauncher);
+    return Result.err(
+      new CLIError({
+        message: `${definition?.label ?? requestedLauncher} is not installed or its command is not available in PATH.`,
+      }),
+    );
+  }
+
+  if (availableLaunchers.length === 0) {
+    return Result.ok(undefined);
+  }
+
+  setIsFirstPrompt(true);
+  try {
+    const selected = await navigableSelect<ProjectLauncher>({
+      message: "Open project with?",
+      options: [
+        ...availableLaunchers.map(({ id, label, kind }) => ({
+          value: id,
+          label,
+          hint: kind === "editor" ? "editor / IDE" : "coding agent",
+        })),
+        { value: "none" as const, label: "Not now" },
+      ],
+      initialValue: "none",
+      maxItems: 12,
+    });
+
+    if (isCancel(selected) || selected === "none") return Result.ok(undefined);
+    return Result.ok(availableLaunchers.find(({ id }) => id === selected));
+  } finally {
+    setIsFirstPrompt(false);
+  }
+}
+
+type CommandRunner = (
+  command: string,
+  args: string[],
+  options: { cwd?: string; stdio: "inherit" | "ignore" },
+) => Promise<void>;
+
+const runCommand: CommandRunner = async (command, args, options) => {
+  await execa(command, args, options);
+};
+
+export async function launchProject(
+  launcher: AvailableProjectLauncher,
+  options: {
+    runner?: CommandRunner;
+    skipExternalCommands?: boolean;
+  } = {},
+): Promise<Result<void, CLIError>> {
+  if (options.skipExternalCommands ?? shouldSkipExternalCommands()) {
+    return Result.ok(undefined);
+  }
+
+  return Result.tryPromise({
+    try: () =>
+      (options.runner ?? runCommand)(launcher.command, launcher.args, {
+        cwd: launcher.cwd,
+        stdio: launcher.cwd ? "inherit" : "ignore",
+      }),
+    catch: (cause: unknown) =>
+      new CLIError({
+        message: `Could not open the project with ${launcher.label}.`,
+        cause,
+      }),
+  });
+}

--- a/apps/cli/src/utils/project-launcher.ts
+++ b/apps/cli/src/utils/project-launcher.ts
@@ -131,6 +131,7 @@ export const PROJECT_LAUNCHERS = [
     label: "Neovim",
     kind: "editor",
     commands: ["nvim"],
+    args: () => ["."],
     cwd: (projectDir) => projectDir,
   },
   {

--- a/apps/cli/test/project-launcher.test.ts
+++ b/apps/cli/test/project-launcher.test.ts
@@ -47,6 +47,25 @@ describe("project launcher", () => {
     });
   });
 
+  it("opens Neovim on the generated project directory", async () => {
+    const launchers = await detectProjectLaunchers(
+      "/tmp/my-app",
+      async (command) => command === "nvim",
+      "linux",
+    );
+
+    expect(launchers).toEqual([
+      {
+        id: "neovim",
+        label: "Neovim",
+        kind: "editor",
+        command: "nvim",
+        args: ["."],
+        cwd: "/tmp/my-app",
+      },
+    ]);
+  });
+
   it("only offers the Codex app launcher on supported platforms", async () => {
     const detectCommand = async (command: string) => command === "codex";
     const macLaunchers = await detectProjectLaunchers("/tmp/my-app", detectCommand, "darwin");

--- a/apps/cli/test/project-launcher.test.ts
+++ b/apps/cli/test/project-launcher.test.ts
@@ -20,7 +20,15 @@ describe("project launcher", () => {
   });
 
   it("detects installed editors and agents and resolves command aliases", async () => {
-    const installed = new Set(["code", "zeditor", "webstorm", "codex", "claude", "pi"]);
+    const installed = new Set([
+      "code",
+      "zeditor",
+      "webstorm",
+      "intellij-idea",
+      "codex",
+      "claude",
+      "pi",
+    ]);
     const launchers = await detectProjectLaunchers(
       "/tmp/my-app",
       async (command) => installed.has(command),
@@ -31,6 +39,7 @@ describe("project launcher", () => {
       "vscode",
       "zed",
       "webstorm",
+      "intellij-idea",
       "codex-app",
       "codex",
       "claude-code",
@@ -38,6 +47,10 @@ describe("project launcher", () => {
     ]);
     expect(launchers.find(({ id }) => id === "zed")).toMatchObject({
       command: "zeditor",
+      args: ["/tmp/my-app"],
+    });
+    expect(launchers.find(({ id }) => id === "intellij-idea")).toMatchObject({
+      command: "intellij-idea",
       args: ["/tmp/my-app"],
     });
     expect(launchers.find(({ id }) => id === "claude-code")).toMatchObject({

--- a/apps/cli/test/project-launcher.test.ts
+++ b/apps/cli/test/project-launcher.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  PROJECT_LAUNCHERS,
+  ProjectLauncherSchema,
+  detectProjectLaunchers,
+  getProjectLauncherChoice,
+  launchProject,
+} from "../src/utils/project-launcher";
+
+describe("project launcher", () => {
+  it("defines unique launcher ids accepted by the CLI schema", () => {
+    const ids = PROJECT_LAUNCHERS.map(({ id }) => id);
+
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const id of ids) {
+      expect(ProjectLauncherSchema.safeParse(id).success).toBe(true);
+    }
+    expect(ProjectLauncherSchema.safeParse("none").success).toBe(true);
+  });
+
+  it("detects installed editors and agents and resolves command aliases", async () => {
+    const installed = new Set(["code", "zeditor", "webstorm", "codex", "claude", "pi"]);
+    const launchers = await detectProjectLaunchers(
+      "/tmp/my-app",
+      async (command) => installed.has(command),
+      "darwin",
+    );
+
+    expect(launchers.map(({ id }) => id)).toEqual([
+      "vscode",
+      "zed",
+      "webstorm",
+      "codex-app",
+      "codex",
+      "claude-code",
+      "pi",
+    ]);
+    expect(launchers.find(({ id }) => id === "zed")).toMatchObject({
+      command: "zeditor",
+      args: ["/tmp/my-app"],
+    });
+    expect(launchers.find(({ id }) => id === "claude-code")).toMatchObject({
+      command: "claude",
+      args: [],
+      cwd: "/tmp/my-app",
+    });
+  });
+
+  it("only offers the Codex app launcher on supported platforms", async () => {
+    const detectCommand = async (command: string) => command === "codex";
+    const macLaunchers = await detectProjectLaunchers("/tmp/my-app", detectCommand, "darwin");
+    const linuxLaunchers = await detectProjectLaunchers("/tmp/my-app", detectCommand, "linux");
+
+    expect(macLaunchers.map(({ id }) => id)).toEqual(["codex-app", "codex"]);
+    expect(linuxLaunchers.map(({ id }) => id)).toEqual(["codex"]);
+  });
+
+  it("uses the documented entry commands for additional coding agents", async () => {
+    const installed = new Set(["kiro-cli", "droid", "goose", "cline", "cn", "crush"]);
+    const launchers = await detectProjectLaunchers(
+      "/tmp/my-app",
+      async (command) => installed.has(command),
+      "darwin",
+    );
+
+    expect(launchers.map(({ id }) => id)).toEqual([
+      "kiro-cli",
+      "droid",
+      "goose",
+      "cline",
+      "continue",
+      "crush",
+    ]);
+    expect(launchers.find(({ id }) => id === "goose")).toMatchObject({
+      command: "goose",
+      args: ["session"],
+      cwd: "/tmp/my-app",
+    });
+    expect(launchers.find(({ id }) => id === "continue")).toMatchObject({
+      command: "cn",
+      args: [],
+      cwd: "/tmp/my-app",
+    });
+  });
+
+  it("returns a useful error for an explicitly requested missing launcher", async () => {
+    const result = await getProjectLauncherChoice("opencode", "/tmp/my-app", {
+      detectCommand: async () => false,
+      prompt: false,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("OpenCode");
+      expect(result.error.message).toContain("PATH");
+    }
+  });
+
+  it("does not scan PATH when the interactive picker is disabled", async () => {
+    let detectionCount = 0;
+    const result = await getProjectLauncherChoice(undefined, "/tmp/my-app", {
+      detectCommand: async () => {
+        detectionCount += 1;
+        return true;
+      },
+      prompt: false,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(detectionCount).toBe(0);
+  });
+
+  it("opens GUI launchers with a path and terminal agents from the project directory", async () => {
+    const calls: Array<{
+      command: string;
+      args: string[];
+      options: { cwd?: string; stdio: "inherit" | "ignore" };
+    }> = [];
+    const runner = async (
+      command: string,
+      args: string[],
+      options: { cwd?: string; stdio: "inherit" | "ignore" },
+    ) => {
+      calls.push({ command, args, options });
+    };
+
+    const editorResult = await launchProject(
+      {
+        id: "vscode",
+        label: "Visual Studio Code",
+        kind: "editor",
+        command: "code",
+        args: ["/tmp/my-app"],
+      },
+      { runner, skipExternalCommands: false },
+    );
+    const agentResult = await launchProject(
+      {
+        id: "opencode",
+        label: "OpenCode",
+        kind: "agent",
+        command: "opencode",
+        args: [],
+        cwd: "/tmp/my-app",
+      },
+      { runner, skipExternalCommands: false },
+    );
+
+    expect(editorResult.isOk()).toBe(true);
+    expect(agentResult.isOk()).toBe(true);
+    expect(calls).toEqual([
+      {
+        command: "code",
+        args: ["/tmp/my-app"],
+        options: { cwd: undefined, stdio: "ignore" },
+      },
+      {
+        command: "opencode",
+        args: [],
+        options: { cwd: "/tmp/my-app", stdio: "inherit" },
+      },
+    ]);
+  });
+
+  it("keeps launcher failures non-throwing", async () => {
+    const result = await launchProject(
+      {
+        id: "vscode",
+        label: "Visual Studio Code",
+        kind: "editor",
+        command: "code",
+        args: ["/tmp/my-app"],
+      },
+      {
+        runner: async () => {
+          throw new Error("launch failed");
+        },
+        skipExternalCommands: false,
+      },
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toBe("Could not open the project with Visual Studio Code.");
+    }
+  });
+
+  it("honors external-command guards", async () => {
+    let launched = false;
+    const result = await launchProject(
+      {
+        id: "codex",
+        label: "Codex CLI",
+        kind: "agent",
+        command: "codex",
+        args: [],
+        cwd: "/tmp/my-app",
+      },
+      {
+        runner: async () => {
+          launched = true;
+        },
+        skipExternalCommands: true,
+      },
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(launched).toBe(false);
+  });
+});

--- a/apps/cli/test/schema-command.test.ts
+++ b/apps/cli/test/schema-command.test.ts
@@ -34,4 +34,18 @@ describe("Schema command", () => {
     expect(commandNames).toContain("add-json");
     expect(commandNames).toContain("schema");
   });
+
+  it("describes the post-create launcher option", async () => {
+    const result = await caller.schema({ name: "cli" });
+    const createCommand = result.commands.find((command) => command.name === "create");
+    const openOption = createCommand?.options.find((option) => option.name === "open");
+
+    expect(openOption?.choices).toContain("vscode");
+    expect(openOption?.choices).toContain("codex");
+    expect(openOption?.choices).toContain("claude-code");
+    expect(openOption?.choices).toContain("opencode");
+    expect(openOption?.choices).toContain("pi");
+    expect(openOption?.choices).toContain("goose");
+    expect(openOption?.choices).toContain("continue");
+  });
 });

--- a/apps/web/content/docs/cli/index.mdx
+++ b/apps/web/content/docs/cli/index.mdx
@@ -27,6 +27,7 @@ create-better-t-stack [project-directory] [options]
 - `--yolo`: Bypass validations and compatibility checks
 - `--package-manager <pm>`: `npm`, `pnpm`, `bun`
 - `--install / --no-install`: Install dependencies after creation
+- `--open <target>`: Open the project in an installed editor, IDE, or coding agent
 - `--git / --no-git`: Initialize Git repository
 - `--frontend <types...>`: Web and/or native frameworks (see [Options](/docs/cli/options#frontend))
 - `--backend <framework>`: `hono`, `express`, `fastify`, `elysia`, `convex`, `self`, `none`

--- a/apps/web/content/docs/cli/options.mdx
+++ b/apps/web/content/docs/cli/options.mdx
@@ -69,10 +69,10 @@ create-better-t-stack my-app --yes --open zed
 create-better-t-stack my-app --yes --open codex
 ```
 
-Supported targets include Cursor, VS Code, Zed, Windsurf, VSCodium, WebStorm, IntelliJ IDEA,
-Sublime Text, Neovim, the Codex app and CLI, Claude Code, OpenCode, Pi, Gemini CLI, GitHub Copilot
-CLI, Kiro CLI, Factory Droid, goose, Cline CLI, Continue CLI, Amp, Aider, Qwen Code, Crush, and
-Cursor Agent.
+Supported targets include Cursor, VS Code, VS Code Insiders, Zed, Windsurf, VSCodium, WebStorm,
+IntelliJ IDEA, Sublime Text, Neovim, the Codex app (macOS only), Codex CLI, Claude Code, OpenCode,
+Pi, Gemini CLI, GitHub Copilot CLI, Kiro CLI, Factory Droid, goose, Cline CLI, Continue CLI, Amp,
+Aider, Qwen Code, Crush, and Cursor Agent.
 
 The picker is skipped for `--yes`, CI, and non-interactive terminals. An explicit `--open` value
 still works in those modes. JSON and programmatic creation never launch external applications.

--- a/apps/web/content/docs/cli/options.mdx
+++ b/apps/web/content/docs/cli/options.mdx
@@ -59,6 +59,24 @@ Control dependency installation after project creation.
 create-better-t-stack --no-install
 ```
 
+### `--open <target>`
+
+Open the generated project in an installed editor, IDE, or coding agent. Interactive runs show an
+installed-tools-only picker after scaffolding. Use `none` to skip it explicitly.
+
+```bash
+create-better-t-stack my-app --yes --open zed
+create-better-t-stack my-app --yes --open codex
+```
+
+Supported targets include Cursor, VS Code, Zed, Windsurf, VSCodium, WebStorm, IntelliJ IDEA,
+Sublime Text, Neovim, the Codex app and CLI, Claude Code, OpenCode, Pi, Gemini CLI, GitHub Copilot
+CLI, Kiro CLI, Factory Droid, goose, Cline CLI, Continue CLI, Amp, Aider, Qwen Code, Crush, and
+Cursor Agent.
+
+The picker is skipped for `--yes`, CI, and non-interactive terminals. An explicit `--open` value
+still works in those modes. JSON and programmatic creation never launch external applications.
+
 ### `--git / --no-git`
 
 Control Git repository initialization.


### PR DESCRIPTION
## Summary

- offer an installed-tools-only launcher after project creation
- support popular editors, JetBrains IDEs, and terminal coding agents
- add `--open <target>` for explicit scripted use while keeping `--yes`, CI, JSON, and programmatic creation non-interactive

## DX

```text
◇ Open project with?
│  Cursor
│  Zed
│  Codex app
│  Claude Code
│  OpenCode
│  Not now
```

```bash
create-better-t-stack my-app --yes --open zed
create-better-t-stack my-app --yes --open codex
```

Only available commands are shown. Editors receive the generated project path, while terminal agents start inside the project directory.

## Verification

- `bun run check`
- `bun run test:ci` — 685 passed, 30 skipped
- interactive terminal smoke test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional `--open <target>` option to launch generated projects in a supported editor, IDE, or coding agent.
  - Added interactive launcher selection after project creation, including a “Not now” option.
  - Added platform-aware detection of available launchers with clear warnings for unavailable or failed launches.

- **Documentation**
  - Updated CLI help and documentation with supported launcher targets, interactive behavior, and usage restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->