### PR TITLE
feat(cli): add T3 Code and Orca launchers

### DIFF
--- a/apps/cli/src/utils/project-launcher.ts
+++ b/apps/cli/src/utils/project-launcher.ts
@@ -21,6 +21,7 @@ export const ProjectLauncherSchema = z
     "neovim",
     "codex-app",
     "codex",
+    "t3-code",
     "claude-code",
     "opencode",
     "pi",
@@ -36,6 +37,7 @@ export const ProjectLauncherSchema = z
     "qwen-code",
     "crush",
     "cursor-agent",
+    "orca",
     "none",
   ])
   .describe("Editor, IDE, or coding agent to open after creating the project");
@@ -48,9 +50,17 @@ interface ProjectLauncherDefinition {
   label: string;
   kind: ProjectLauncherKind;
   commands: readonly string[];
+  commandsByPlatform?: Partial<Record<NodeJS.Platform, readonly string[]>>;
   args?: (projectDir: string) => string[];
   cwd?: (projectDir: string) => string;
+  launchSequence?: (command: string, projectDir: string) => ProjectLaunchCommand[];
   platforms?: readonly NodeJS.Platform[];
+}
+
+interface ProjectLaunchCommand {
+  command: string;
+  args: string[];
+  cwd?: string;
 }
 
 export interface AvailableProjectLauncher {
@@ -60,6 +70,7 @@ export interface AvailableProjectLauncher {
   command: string;
   args: string[];
   cwd?: string;
+  launchSequence?: ProjectLaunchCommand[];
 }
 
 export const PROJECT_LAUNCHERS = [
@@ -147,6 +158,13 @@ export const PROJECT_LAUNCHERS = [
     label: "Codex CLI",
     kind: "agent",
     commands: ["codex"],
+    cwd: (projectDir) => projectDir,
+  },
+  {
+    id: "t3-code",
+    label: "T3 Code",
+    kind: "agent",
+    commands: ["t3"],
     cwd: (projectDir) => projectDir,
   },
   {
@@ -256,6 +274,17 @@ export const PROJECT_LAUNCHERS = [
     commands: ["cursor-agent"],
     cwd: (projectDir) => projectDir,
   },
+  {
+    id: "orca",
+    label: "Orca",
+    kind: "agent",
+    commands: ["orca"],
+    commandsByPlatform: { linux: ["orca-ide"] },
+    launchSequence: (command, projectDir) => [
+      { command, args: ["open", "--json"] },
+      { command, args: ["repo", "add", "--path", projectDir, "--json"] },
+    ],
+  },
 ] as const satisfies readonly ProjectLauncherDefinition[];
 
 type CommandDetector = (command: string) => Promise<boolean>;
@@ -269,7 +298,9 @@ export async function detectProjectLaunchers(
   const supportedDefinitions = definitions.filter(
     ({ platforms }) => platforms === undefined || platforms.includes(platform),
   );
-  const commands = [...new Set(supportedDefinitions.flatMap(({ commands }) => commands))];
+  const commandsFor = (launcher: ProjectLauncherDefinition) =>
+    launcher.commandsByPlatform?.[platform] ?? launcher.commands;
+  const commands = [...new Set(supportedDefinitions.flatMap(commandsFor))];
   const detectedCommands = new Map(
     await Promise.all(
       commands.map(async (command) => [command, await detectCommand(command)] as const),
@@ -277,19 +308,21 @@ export async function detectProjectLaunchers(
   );
 
   return supportedDefinitions.flatMap((launcher) => {
-    const command = launcher.commands.find((candidate) => detectedCommands.get(candidate));
+    const command = commandsFor(launcher).find((candidate) => detectedCommands.get(candidate));
     if (!command) return [];
 
-    return [
-      {
-        id: launcher.id,
-        label: launcher.label,
-        kind: launcher.kind,
-        command,
-        args: launcher.args?.(projectDir) ?? [],
-        cwd: launcher.cwd?.(projectDir),
-      },
-    ];
+    const availableLauncher: AvailableProjectLauncher = {
+      id: launcher.id,
+      label: launcher.label,
+      kind: launcher.kind,
+      command,
+      args: launcher.args?.(projectDir) ?? [],
+      cwd: launcher.cwd?.(projectDir),
+    };
+    if (launcher.launchSequence) {
+      availableLauncher.launchSequence = launcher.launchSequence(command, projectDir);
+    }
+    return [availableLauncher];
   });
 }
 
@@ -372,11 +405,15 @@ export async function launchProject(
   }
 
   return Result.tryPromise({
-    try: () =>
-      (options.runner ?? runCommand)(launcher.command, launcher.args, {
-        cwd: launcher.cwd,
-        stdio: launcher.cwd ? "inherit" : "ignore",
-      }),
+    try: async () => {
+      const commands = launcher.launchSequence ?? [launcher];
+      for (const command of commands) {
+        await (options.runner ?? runCommand)(command.command, command.args, {
+          cwd: command.cwd,
+          stdio: command.cwd ? "inherit" : "ignore",
+        });
+      }
+    },
     catch: (cause: unknown) =>
       new CLIError({
         message: `Could not open the project with ${launcher.label}.`,

--- a/apps/cli/test/project-launcher.test.ts
+++ b/apps/cli/test/project-launcher.test.ts
@@ -116,6 +116,52 @@ describe("project launcher", () => {
     });
   });
 
+  it("uses the documented T3 Code and Orca project-opening commands", async () => {
+    const installed = new Set(["t3", "orca"]);
+    const launchers = await detectProjectLaunchers(
+      "/tmp/my-app",
+      async (command) => installed.has(command),
+      "darwin",
+    );
+
+    expect(launchers.map(({ id }) => id)).toEqual(["t3-code", "orca"]);
+    expect(launchers.find(({ id }) => id === "t3-code")).toMatchObject({
+      command: "t3",
+      args: [],
+      cwd: "/tmp/my-app",
+    });
+    expect(launchers.find(({ id }) => id === "orca")).toMatchObject({
+      command: "orca",
+      launchSequence: [
+        { command: "orca", args: ["open", "--json"] },
+        {
+          command: "orca",
+          args: ["repo", "add", "--path", "/tmp/my-app", "--json"],
+        },
+      ],
+    });
+  });
+
+  it("uses Orca's Linux-specific CLI name", async () => {
+    const launchers = await detectProjectLaunchers(
+      "/tmp/my-app",
+      async (command) => command === "orca-ide",
+      "linux",
+    );
+
+    expect(launchers.map(({ id }) => id)).toEqual(["orca"]);
+    expect(launchers[0]).toMatchObject({
+      command: "orca-ide",
+      launchSequence: [
+        { command: "orca-ide", args: ["open", "--json"] },
+        {
+          command: "orca-ide",
+          args: ["repo", "add", "--path", "/tmp/my-app", "--json"],
+        },
+      ],
+    });
+  });
+
   it("returns a useful error for an explicitly requested missing launcher", async () => {
     const result = await getProjectLauncherChoice("opencode", "/tmp/my-app", {
       detectCommand: async () => false,
@@ -216,6 +262,41 @@ describe("project launcher", () => {
     if (result.isErr()) {
       expect(result.error.message).toBe("Could not open the project with Visual Studio Code.");
     }
+  });
+
+  it("runs multi-command launchers in order", async () => {
+    const calls: Array<{ command: string; args: string[] }> = [];
+    const result = await launchProject(
+      {
+        id: "orca",
+        label: "Orca",
+        kind: "agent",
+        command: "orca",
+        args: [],
+        launchSequence: [
+          { command: "orca", args: ["open", "--json"] },
+          {
+            command: "orca",
+            args: ["repo", "add", "--path", "/tmp/my-app", "--json"],
+          },
+        ],
+      },
+      {
+        runner: async (command, args) => {
+          calls.push({ command, args });
+        },
+        skipExternalCommands: false,
+      },
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(calls).toEqual([
+      { command: "orca", args: ["open", "--json"] },
+      {
+        command: "orca",
+        args: ["repo", "add", "--path", "/tmp/my-app", "--json"],
+      },
+    ]);
   });
 
   it("honors external-command guards", async () => {

--- a/apps/web/content/docs/cli/options.mdx
+++ b/apps/web/content/docs/cli/options.mdx
@@ -72,7 +72,7 @@ create-better-t-stack my-app --yes --open codex
 Supported targets include Cursor, VS Code, VS Code Insiders, Zed, Windsurf, VSCodium, WebStorm,
 IntelliJ IDEA, Sublime Text, Neovim, the Codex app (macOS only), Codex CLI, Claude Code, OpenCode,
 Pi, Gemini CLI, GitHub Copilot CLI, Kiro CLI, Factory Droid, goose, Cline CLI, Continue CLI, Amp,
-Aider, Qwen Code, Crush, and Cursor Agent.
+Aider, Qwen Code, Crush, Cursor Agent, T3 Code, and Orca.
 
 The picker is skipped for `--yes`, CI, and non-interactive terminals. An explicit `--open` value
 still works in those modes. JSON and programmatic creation never launch external applications.


### PR DESCRIPTION
## Summary

- add T3 Code and Orca to the post-create project launcher
- run T3 Code from the generated project directory
- open Orca before registering the generated repository, using `orca-ide` on Linux
- document both supported launcher targets

## Why

Developers can open a newly scaffolded project in more of the tools they already use. The launcher follows each tool's documented CLI behavior and only offers commands detected on the user's `PATH`.

## Verification

- `bun run check`
- `bun test apps/cli/test/project-launcher.test.ts`
- `cd apps/cli && bun run test`
- `bun run build:cli`
