### PR TITLE
feat(cli): add add-app command for additional frontend apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Then ask: _"create a fullstack app with Next, Hono, Postgres and Better Auth"_, 
 ## Features
 
 - Frontend: React (TanStack Router, React Router, TanStack Start), Next.js, Nuxt, Svelte, Solid, Astro, React Native (Bare, NativeWind, Unistyles), or none
+- Extra apps: additional frontend apps (admin panel, landing page, ...) sharing one backend, via `--apps` at create time or the `add-app` command later
 - Backend: Hono, Express, Fastify, Elysia, Self (fullstack web app), Convex, or none
 - API: tRPC or oRPC (or none)
 - Runtime: Bun, Node.js, or Cloudflare Workers

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -53,6 +53,7 @@ generated commands.
 | **Authentication**       | • Better Auth<br>• Clerk                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | **Styling**              | Tailwind CSS with a shared shadcn/ui package for React web apps                                                                                                                                                                                                                                                                                                                                                                           |
 | **Addons**               | • PWA support<br>• Tauri (desktop applications)<br>• Electrobun (lightweight desktop shell)<br>• Starlight and Fumadocs (documentation sites)<br>• Biome, Oxlint, Ultracite, or Vite+ (linting and formatting)<br>• Lefthook, Husky (Git hooks)<br>• evlog (request logging for server/fullstack backends)<br>• MCP, Skills (agent tooling)<br>• OpenTUI, WXT (platform extensions)<br>• Turborepo, Nx, or Vite+ (monorepo orchestration) |
+| **Extra Apps**           | Additional frontend apps (admin panel, landing page, ...) sharing one backend — `--apps admin:next` at create time, or `add-app` on an existing project                                                                                                                                                                                                                                                                                   |
 | **Examples**             | • Todo app<br>• AI Chat interface (using Vercel AI SDK)                                                                                                                                                                                                                                                                                                                                                                                   |
 | **Developer Experience** | • Automatic Git initialization<br>• Package manager choice (npm, pnpm, bun)<br>• Automatic dependency installation                                                                                                                                                                                                                                                                                                                        |
 
@@ -71,6 +72,7 @@ Options:
   --auth <provider>               Authentication (better-auth, clerk, none)
   --payments <provider>           Payments provider (polar, none)
   --frontend <types...>           Frontend types (tanstack-router, react-router, tanstack-start, next, nuxt, svelte, solid, astro, native-bare, native-uniwind, native-unistyles, none)
+  --apps <specs...>               Extra frontend apps as name:framework (e.g. admin:next landing:astro)
   --addons <types...>             Additional addons (pwa, tauri, electrobun, starlight, biome, lefthook, husky, mcp, turborepo, nx, vite-plus, fumadocs, ultracite, oxlint, opentui, wxt, skills, evlog, none)
   --examples <types...>           Examples to include (todo, ai, none)
   --git                           Initialize git repository
@@ -96,6 +98,7 @@ Options:
 # Raw JSON payload input (agent-friendly)
 create-better-t-stack create-json --input '{"projectName":"my-app","yes":true,"dryRun":true}'
 create-better-t-stack add-json --input '{"projectDir":"./my-app","addons":["wxt"],"addonOptions":{"wxt":{"template":"react"}}}'
+create-better-t-stack add-app-json --input '{"projectDir":"./my-app","name":"admin","frontend":"next"}'
 create-better-t-stack create-json --input '{"projectName":"db-app","database":"postgres","orm":"drizzle","dbSetup":"neon","dbSetupOptions":{"mode":"manual"}}'
 
 # Runtime schema/introspection output

--- a/apps/cli/src/helpers/core/add-app-handler.ts
+++ b/apps/cli/src/helpers/core/add-app-handler.ts
@@ -1,0 +1,995 @@
+import path from "node:path";
+
+import {
+  collectTreeFiles,
+  EMBEDDED_TEMPLATES,
+  generate,
+  getWorkspaceScriptCommand,
+  VirtualFileSystem,
+  type JsonObject,
+  type VirtualFile,
+} from "@better-t-stack/template-generator";
+import { writeTree } from "@better-t-stack/template-generator/fs-writer";
+import { intro, log, outro } from "@clack/prompts";
+import { Result } from "better-result";
+import fs from "fs-extra";
+import pc from "picocolors";
+import YAML from "yaml";
+
+import { getAppFrontend, getAppName, validateAppName } from "../../prompts/add-app";
+import type { AddAppInput, AddedApp, Addons, ProjectConfig } from "../../types";
+import { updateBtsConfig } from "../../utils/bts-config";
+import {
+  isExampleAIAllowed,
+  isExampleTodoAllowed,
+  validateAddAppFrontendCompatibility,
+} from "../../utils/compatibility-rules";
+import { isSilent, runWithContextAsync } from "../../utils/context";
+import { CLIError, displayError, UserCancelledError } from "../../utils/errors";
+import { formatCode } from "../../utils/file-formatter";
+import { getLatestCLIVersion } from "../../utils/get-latest-cli-version";
+import { validateAgentSafePathInput } from "../../utils/input-hardening";
+import { inspectProjectPath } from "../../utils/project-directory";
+import { renderTitle } from "../../utils/render-title";
+import { detectProjectConfig } from "./detect-project-config";
+import { installDependencies } from "./install-dependencies";
+
+export interface AddAppHandlerOptions {
+  silent?: boolean;
+}
+
+export interface AddAppResult {
+  success: boolean;
+  appName?: string;
+  frontend?: AddedApp["frontend"];
+  port?: number;
+  projectDir: string;
+  dryRun?: boolean;
+  plannedFileCount?: number;
+  warning?: string;
+  error?: string;
+}
+
+type ExistingProjectConfig = NonNullable<Awaited<ReturnType<typeof detectProjectConfig>>>;
+
+const BINARY_MARKER = "[Binary file]";
+const TASK_RUNNER_ADDONS = ["turborepo", "nx", "vite-plus"] as const satisfies readonly Addons[];
+const REACT_FAMILY_FRONTENDS: readonly AddedApp["frontend"][] = [
+  "tanstack-router",
+  "react-router",
+  "tanstack-start",
+  "next",
+];
+
+interface WorkspacePackagesConfig extends JsonObject {
+  packages?: string[];
+  catalog?: Record<string, string>;
+}
+
+interface RootPackageJson extends JsonObject {
+  scripts?: Record<string, string>;
+  workspaces?: string[] | WorkspacePackagesConfig;
+  allowScripts?: Record<string, boolean>;
+  overrides?: Record<string, string>;
+}
+
+interface EnvPackageJson extends JsonObject {
+  exports?: Record<string, string>;
+  dependencies?: Record<string, string>;
+}
+
+interface PnpmWorkspaceConfig extends JsonObject {
+  catalog?: Record<string, string>;
+  allowBuilds?: Record<string, boolean>;
+  minimumReleaseAgeExclude?: string[];
+}
+
+interface AppPackageJson extends JsonObject {
+  name?: string;
+  scripts?: Record<string, string>;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+}
+
+/**
+ * Adds another frontend app to an existing Better-T-Stack project.
+ * In silent mode returns a structured failure instead of exiting; interactive
+ * cancellation returns undefined.
+ */
+export async function addAppHandler(
+  input: AddAppInput,
+  options: AddAppHandlerOptions = {},
+): Promise<AddAppResult | undefined> {
+  return runWithContextAsync({ silent: options.silent ?? false }, async () => {
+    const result = await addAppHandlerInternal(input);
+
+    if (result.isOk()) {
+      return result.value;
+    }
+
+    const error = result.error;
+
+    if (UserCancelledError.is(error)) {
+      if (isSilent()) {
+        return {
+          success: false,
+          projectDir: input.projectDir ?? process.cwd(),
+          error: error.message,
+        };
+      }
+      return undefined;
+    }
+
+    if (isSilent()) {
+      return {
+        success: false,
+        projectDir: input.projectDir ?? process.cwd(),
+        error: error.message,
+      };
+    }
+
+    displayError(error);
+    process.exit(1);
+  });
+}
+
+/**
+ * The full add-app flow: detect the project, resolve name/frontend/port,
+ * scratch-generate a single-frontend project in memory, relocate its web app
+ * into apps/<name>, patch workspace files, and write the result.
+ */
+async function addAppHandlerInternal(
+  input: AddAppInput,
+): Promise<Result<AddAppResult, UserCancelledError | CLIError>> {
+  const projectDir = input.projectDir || process.cwd();
+
+  const pathValidation = validateAgentSafePathInput(projectDir, "projectDir");
+  if (pathValidation.isErr()) {
+    return Result.err(new CLIError({ message: pathValidation.error.message }));
+  }
+
+  if (!isSilent()) {
+    renderTitle();
+    intro(pc.magenta("Add an app to your project"));
+  }
+
+  const existingConfig = await detectProjectConfig(projectDir);
+  if (!existingConfig) {
+    return Result.err(
+      new CLIError({
+        message: `No Better-T-Stack project found in ${projectDir}. Make sure bts.jsonc exists.`,
+      }),
+    );
+  }
+
+  const cliVersion = getLatestCLIVersion();
+  if (!isSilent() && existingConfig.version && existingConfig.version !== cliVersion) {
+    log.warn(
+      pc.yellow(
+        `This project was created with CLI ${existingConfig.version}; you are running ${cliVersion}. Generated app files may not match older shared packages.`,
+      ),
+    );
+  }
+
+  // Guard before any prompt: a fullstack (self) backend rejects every
+  // framework, so the interactive selector would otherwise open with no options.
+  if (existingConfig.backend === "self") {
+    const selfResult = validateAddAppFrontendCompatibility("next", existingConfig);
+    if (selfResult.isErr()) {
+      return Result.err(new CLIError({ message: selfResult.error.message }));
+    }
+  }
+
+  const existingApps = existingConfig.apps ?? [];
+  const takenNames = new Set(existingApps.map((app) => app.name));
+
+  // Resolve app name
+  let appName: string;
+  if (input.name !== undefined) {
+    const nameError = validateAppName(input.name, takenNames);
+    if (nameError) {
+      return Result.err(new CLIError({ message: `Invalid app name: ${nameError}` }));
+    }
+    appName = input.name;
+  } else if (isSilent()) {
+    return Result.err(
+      new CLIError({
+        message:
+          "App name and frontend are required in silent mode. Provide 'name' and 'frontend'.",
+      }),
+    );
+  } else {
+    const nameResult = await Result.tryPromise({
+      try: () => getAppName(takenNames),
+      catch: (e) =>
+        UserCancelledError.is(e)
+          ? e
+          : new CLIError({
+              message: `Failed to get app name: ${e instanceof Error ? e.message : String(e)}`,
+              cause: e,
+            }),
+    });
+    if (nameResult.isErr()) return Result.err(nameResult.error);
+    appName = nameResult.value;
+  }
+
+  // Resolve frontend
+  let frontend: AddedApp["frontend"];
+  if (input.frontend !== undefined) {
+    frontend = input.frontend;
+  } else if (isSilent()) {
+    return Result.err(
+      new CLIError({
+        message:
+          "App name and frontend are required in silent mode. Provide 'name' and 'frontend'.",
+      }),
+    );
+  } else {
+    const frontendResult = await Result.tryPromise({
+      try: () => getAppFrontend(existingConfig),
+      catch: (e) =>
+        UserCancelledError.is(e)
+          ? e
+          : new CLIError({
+              message: `Failed to select a framework: ${e instanceof Error ? e.message : String(e)}`,
+              cause: e,
+            }),
+    });
+    if (frontendResult.isErr()) return Result.err(frontendResult.error);
+    frontend = frontendResult.value;
+  }
+
+  const compatResult = validateAddAppFrontendCompatibility(frontend, existingConfig);
+  if (compatResult.isErr()) {
+    return Result.err(new CLIError({ message: compatResult.error.message }));
+  }
+
+  // Directory conflict check
+  const appDir = `apps/${appName}`;
+  const pathStateResult = await inspectProjectPath(path.join(projectDir, "apps", appName));
+  if (pathStateResult.isErr()) {
+    return Result.err(pathStateResult.error);
+  }
+  if (pathStateResult.value !== "missing" && pathStateResult.value !== "empty-directory") {
+    return Result.err(
+      new CLIError({
+        message: `Cannot add app '${appName}': ${appDir} already exists in this project.`,
+      }),
+    );
+  }
+
+  // Port allocation
+  const usedPorts = new Set([3000, 3001, ...existingApps.map((app) => app.port)]);
+  let port: number;
+  if (input.port !== undefined) {
+    if (usedPorts.has(input.port)) {
+      return Result.err(
+        new CLIError({
+          message: `Port ${input.port} is already used in this project. Choose a different --port.`,
+        }),
+      );
+    }
+    port = input.port;
+  } else {
+    port = 3002;
+    while (usedPorts.has(port)) port++;
+  }
+
+  // Examples that remain compatible with the new app's framework
+  const keptExamples = (existingConfig.examples ?? []).filter((example) => {
+    if (example === "todo") {
+      return isExampleTodoAllowed(
+        existingConfig.backend,
+        existingConfig.database,
+        existingConfig.api,
+      );
+    }
+    if (example === "ai") {
+      return isExampleAIAllowed(existingConfig.backend, [frontend]);
+    }
+    return false;
+  });
+  const droppedExamples = (existingConfig.examples ?? []).filter(
+    (example) => example !== "none" && !keptExamples.includes(example),
+  );
+  if (!isSilent() && droppedExamples.length > 0) {
+    log.info(
+      pc.dim(
+        `Skipping example${droppedExamples.length > 1 ? "s" : ""} not supported by this stack: ${droppedExamples.join(", ")}`,
+      ),
+    );
+  }
+
+  const packageManager = input.packageManager || existingConfig.packageManager;
+  const projectAddons = existingConfig.addons ?? [];
+
+  // Synthetic config: render the new app exactly like a fresh single-frontend
+  // project, minus deploy wiring and app-targeting addons.
+  const syntheticConfig: ProjectConfig = {
+    projectName: existingConfig.projectName,
+    projectDir,
+    relativePath: ".",
+    addonOptions: undefined,
+    dbSetupOptions: existingConfig.dbSetupOptions,
+    database: existingConfig.database,
+    orm: existingConfig.orm,
+    backend: existingConfig.backend,
+    runtime: existingConfig.runtime,
+    frontend: [frontend],
+    addons: projectAddons.filter((addon) =>
+      (TASK_RUNNER_ADDONS as readonly string[]).includes(addon),
+    ),
+    examples: keptExamples,
+    auth: existingConfig.auth,
+    payments: existingConfig.payments,
+    git: false,
+    packageManager,
+    install: false,
+    dbSetup: existingConfig.dbSetup,
+    api: existingConfig.api,
+    webDeploy: "none",
+    serverDeploy: "none",
+  };
+
+  if (!isSilent()) {
+    log.info(pc.dim(`Preparing ${appDir} (${frontend}, port ${port})…`));
+  }
+
+  const generateResult = await generate({
+    config: syntheticConfig,
+    templates: EMBEDDED_TEMPLATES,
+  });
+  if (generateResult.isErr()) {
+    return Result.err(
+      new CLIError({
+        message: `Failed to generate app files: ${generateResult.error.message}`,
+        cause: generateResult.error,
+      }),
+    );
+  }
+
+  const scratchFiles = collectTreeFiles(generateResult.value.root);
+  const scratchCatalog = readScratchCatalog(scratchFiles, packageManager);
+
+  const vfs = new VirtualFileSystem();
+  const projectName = existingConfig.projectName;
+
+  // Relocate apps/web/** -> apps/<name>/**
+  const scratchWebPrefix = "apps/web/";
+  for (const [filePath, file] of scratchFiles) {
+    if (!filePath.startsWith(scratchWebPrefix)) continue;
+    const destPath = `${appDir}/${filePath.slice(scratchWebPrefix.length)}`;
+    let content = file.content;
+    if (content !== BINARY_MARKER) {
+      content = content.replaceAll(`@${projectName}/env/web`, `@${projectName}/env/${appName}`);
+    }
+    vfs.writeFile(destPath, content, file.sourcePath);
+  }
+
+  if (vfs.getFileCount() === 0) {
+    return Result.err(
+      new CLIError({ message: `No app files were generated for frontend '${frontend}'.` }),
+    );
+  }
+
+  // Per-app env module
+  const scratchEnvWeb = scratchFiles.get("packages/env/src/web.ts");
+  const envModuleWritten = scratchEnvWeb !== undefined;
+  if (scratchEnvWeb) {
+    vfs.writeFile(`packages/env/src/${appName}.ts`, scratchEnvWeb.content);
+  }
+
+  // packages/ui for a react app added to a non-react project
+  const isReactFamily = REACT_FAMILY_FRONTENDS.includes(frontend);
+  const uiExistsOnDisk = await fs.pathExists(path.join(projectDir, "packages/ui/package.json"));
+  if (isReactFamily && !uiExistsOnDisk) {
+    for (const [filePath, file] of scratchFiles) {
+      if (filePath.startsWith("packages/ui/")) {
+        vfs.writeFile(filePath, file.content, file.sourcePath);
+      }
+    }
+  }
+
+  // App identity: package name, catalog resolution, dev port
+  patchAppPackageJson(vfs, appDir, appName, frontend, port, scratchCatalog);
+  pinDevPortInConfigFiles(vfs, appDir, frontend, port);
+  resolveCatalogVersions(vfs, `packages/ui/package.json`, scratchCatalog);
+
+  if (frontend === "tanstack-router" || frontend === "tanstack-start") {
+    appendAppGitignore(vfs, appDir, "src/routeTree.gen.ts");
+  }
+
+  // Patch root package.json (dev:<name> script, npm allowScripts/overrides, workspaces)
+  const rootPatchResult = await patchRootPackageJson(
+    vfs,
+    projectDir,
+    scratchFiles,
+    appName,
+    packageManager,
+    projectAddons,
+  );
+  if (rootPatchResult.isErr()) return Result.err(rootPatchResult.error);
+
+  // Patch packages/env/package.json exports — only when the per-app env module
+  // was actually written, so the exports map never points at a missing file.
+  if (envModuleWritten) {
+    const envPatchResult = await patchEnvPackageJson(
+      vfs,
+      projectDir,
+      scratchFiles,
+      appName,
+      scratchCatalog,
+    );
+    if (envPatchResult.isErr()) return Result.err(envPatchResult.error);
+  }
+
+  // pnpm: union framework-conditional allowBuilds / minimumReleaseAgeExclude entries
+  if (packageManager === "pnpm") {
+    await mergePnpmWorkspaceEntries(vfs, projectDir, scratchFiles);
+  }
+
+  await formatVfsFiles(vfs);
+
+  const tree = {
+    root: vfs.toTree(""),
+    fileCount: vfs.getFileCount(),
+    directoryCount: vfs.getDirectoryCount(),
+    config: syntheticConfig,
+  };
+
+  if (input.dryRun) {
+    if (!isSilent()) {
+      log.info(
+        `Dry run passed · ${pc.bold(String(tree.fileCount))} file(s) would be written for ${appDir}`,
+      );
+      outro(pc.green("Dry run complete. No files were written."));
+    }
+    return Result.ok({
+      success: true,
+      appName,
+      frontend,
+      port,
+      projectDir,
+      dryRun: true,
+      plannedFileCount: tree.fileCount,
+    });
+  }
+
+  const writeResult = await writeTree(tree, projectDir);
+  if (writeResult.isErr()) {
+    return Result.err(
+      new CLIError({
+        message: `Failed to write app files: ${writeResult.error.message}`,
+        cause: writeResult.error,
+      }),
+    );
+  }
+
+  const warnings: string[] = [];
+
+  const configUpdated = await updateBtsConfig(projectDir, {
+    apps: [...existingApps, { name: appName, frontend, port }],
+  });
+  if (!configUpdated) {
+    warnings.push(
+      `Could not update bts.jsonc. Add { "name": "${appName}", "frontend": "${frontend}", "port": ${port} } to its 'apps' array manually so future commands see it.`,
+    );
+  }
+
+  if (input.install) {
+    const installResult = await installDependencies({ projectDir, packageManager });
+    if (installResult.isErr()) {
+      warnings.push(
+        `App files were written, but dependency installation failed: ${installResult.error.message}`,
+      );
+    }
+  }
+
+  if (!isSilent()) {
+    for (const warning of warnings) {
+      log.warn(pc.yellow(warning));
+    }
+  }
+
+  if (!isSilent()) {
+    log.success(pc.green(`Added ${appDir} (${frontend}, port ${port})`));
+    log.message(
+      buildAddAppNextSteps({
+        appName,
+        port,
+        packageManager,
+        install: input.install ?? false,
+        existingConfig,
+      }),
+    );
+    outro(pc.green("App added successfully!"));
+  }
+
+  return Result.ok({
+    success: true,
+    appName,
+    frontend,
+    port,
+    projectDir,
+    plannedFileCount: tree.fileCount,
+    warning: warnings.length > 0 ? warnings.join(" ") : undefined,
+  });
+}
+
+/**
+ * Reads the dependency catalog the scratch generation produced (bun root
+ * package.json or pnpm-workspace.yaml), used to resolve "catalog:" versions.
+ */
+function readScratchCatalog(
+  scratchFiles: Map<string, VirtualFile>,
+  packageManager: ProjectConfig["packageManager"],
+): Map<string, string> {
+  const catalog = new Map<string, string>();
+
+  if (packageManager === "bun") {
+    const rootPkg = scratchFiles.get("package.json");
+    if (!rootPkg) return catalog;
+    const parsed = Result.try({
+      try: () => JSON.parse(rootPkg.content) as RootPackageJson,
+      catch: () => null,
+    });
+    if (parsed.isErr() || !parsed.value) return catalog;
+    const workspaces = parsed.value.workspaces;
+    if (workspaces && !Array.isArray(workspaces)) {
+      for (const [dep, version] of Object.entries(workspaces.catalog ?? {})) {
+        catalog.set(dep, version);
+      }
+    }
+    return catalog;
+  }
+
+  if (packageManager === "pnpm") {
+    const workspaceYaml = scratchFiles.get("pnpm-workspace.yaml");
+    if (!workspaceYaml) return catalog;
+    const parsed = Result.try({
+      try: () => YAML.parse(workspaceYaml.content) as PnpmWorkspaceConfig,
+      catch: () => null,
+    });
+    if (parsed.isErr() || !parsed.value) return catalog;
+    for (const [dep, version] of Object.entries(parsed.value.catalog ?? {})) {
+      catalog.set(dep, version);
+    }
+  }
+
+  return catalog;
+}
+
+/**
+ * Rewrites "catalog:" dependency versions back to concrete versions — the
+ * project's real catalog does not know the new app's dependencies.
+ */
+function resolveCatalogVersions(
+  vfs: VirtualFileSystem,
+  packageJsonPath: string,
+  catalog: Map<string, string>,
+): void {
+  const pkgJson = vfs.readJson<AppPackageJson>(packageJsonPath);
+  if (!pkgJson) return;
+
+  for (const section of [pkgJson.dependencies, pkgJson.devDependencies]) {
+    if (!section) continue;
+    for (const [dep, version] of Object.entries(section)) {
+      const resolved = catalog.get(dep);
+      if (version === "catalog:" && resolved) {
+        section[dep] = resolved;
+      }
+    }
+  }
+
+  vfs.writeJson(packageJsonPath, pkgJson);
+}
+
+/**
+ * Sets the app's package name, pins its dev port in the dev script, and
+ * resolves catalog versions in its package.json.
+ */
+function patchAppPackageJson(
+  vfs: VirtualFileSystem,
+  appDir: string,
+  appName: string,
+  frontend: AddedApp["frontend"],
+  port: number,
+  catalog: Map<string, string>,
+): void {
+  const pkgPath = `${appDir}/package.json`;
+  const pkgJson = vfs.readJson<AppPackageJson>(pkgPath);
+  if (!pkgJson) return;
+
+  pkgJson.name = appName;
+
+  if (pkgJson.scripts?.dev) {
+    if (frontend === "next") {
+      // Replace the template's port when present; append otherwise so the
+      // pin never silently no-ops if the template's dev script changes.
+      pkgJson.scripts.dev = /--port \d+/.test(pkgJson.scripts.dev)
+        ? pkgJson.scripts.dev.replace(/--port \d+/, `--port ${port}`)
+        : `${pkgJson.scripts.dev} --port ${port}`;
+    } else if (frontend === "react-router" || frontend === "svelte" || frontend === "astro") {
+      // These frameworks rely on default ports (5173/4321); pin explicitly so the
+      // new app never collides with the primary web app.
+      pkgJson.scripts.dev = `${pkgJson.scripts.dev} --port ${port}`;
+    }
+  }
+
+  vfs.writeJson(pkgPath, pkgJson);
+  resolveCatalogVersions(vfs, pkgPath, catalog);
+}
+
+/** Config file that carries the dev port for frameworks that pin it there. */
+function getPortConfigPath(appDir: string, frontend: AddedApp["frontend"]): string | undefined {
+  switch (frontend) {
+    case "tanstack-router":
+    case "tanstack-start":
+    case "solid":
+      return `${appDir}/vite.config.ts`;
+    case "nuxt":
+      return `${appDir}/nuxt.config.ts`;
+    default:
+      return undefined;
+  }
+}
+
+/** Pins the allocated dev port in the app's vite/nuxt config, warning on a no-op. */
+function pinDevPortInConfigFiles(
+  vfs: VirtualFileSystem,
+  appDir: string,
+  frontend: AddedApp["frontend"],
+  port: number,
+): void {
+  const configPath = getPortConfigPath(appDir, frontend);
+  if (!configPath) return;
+
+  const content = vfs.readFile(configPath);
+  if (!content) return;
+
+  const updated = content.replaceAll("port: 3001", `port: ${port}`);
+  if (updated === content) {
+    // The template no longer matches the expected literal — don't record a
+    // port that was never applied without telling the user.
+    if (!isSilent()) {
+      log.warn(
+        pc.yellow(`Could not pin the dev port in ${configPath}. Set port ${port} manually.`),
+      );
+    }
+    return;
+  }
+
+  vfs.writeFile(configPath, updated);
+}
+
+/** Appends a generated-file entry to the app's .gitignore, creating it if needed. */
+function appendAppGitignore(vfs: VirtualFileSystem, appDir: string, entry: string): void {
+  const gitignorePath = `${appDir}/.gitignore`;
+  const existing = vfs.readFile(gitignorePath);
+  if (existing) {
+    if (!existing.split("\n").includes(entry)) {
+      vfs.writeFile(gitignorePath, `${existing.trimEnd()}\n${entry}\n`);
+    }
+  } else {
+    vfs.writeFile(gitignorePath, `${entry}\n`);
+  }
+}
+
+/**
+ * Adds the root dev:<name> script (task-runner aware), ensures the apps/*
+ * workspace glob, and on npm unions framework-conditional allowScripts/overrides.
+ */
+async function patchRootPackageJson(
+  vfs: VirtualFileSystem,
+  projectDir: string,
+  scratchFiles: Map<string, VirtualFile>,
+  appName: string,
+  packageManager: ProjectConfig["packageManager"],
+  projectAddons: Addons[],
+): Promise<Result<void, CLIError>> {
+  const rootPkgDiskPath = path.join(projectDir, "package.json");
+
+  return Result.tryPromise({
+    try: async () => {
+      const content = await fs.readFile(rootPkgDiskPath, "utf-8");
+      const pkgJson = JSON.parse(content) as RootPackageJson;
+
+      pkgJson.scripts = pkgJson.scripts ?? {};
+      pkgJson.scripts[`dev:${appName}`] = getWorkspaceScriptCommand(
+        packageManager,
+        projectAddons,
+        appName,
+        "dev",
+      );
+
+      // Make sure the new app is covered by the workspace globs.
+      if (Array.isArray(pkgJson.workspaces)) {
+        if (!pkgJson.workspaces.includes("apps/*")) pkgJson.workspaces.push("apps/*");
+      } else if (pkgJson.workspaces?.packages) {
+        if (!pkgJson.workspaces.packages.includes("apps/*")) {
+          pkgJson.workspaces.packages.push("apps/*");
+        }
+      }
+
+      // npm: framework-conditional install-script allowances and overrides.
+      if (packageManager === "npm") {
+        const scratchRootPkg = scratchFiles.get("package.json");
+        if (scratchRootPkg) {
+          const scratchJson = JSON.parse(scratchRootPkg.content) as RootPackageJson;
+          if (scratchJson.allowScripts) {
+            pkgJson.allowScripts = { ...scratchJson.allowScripts, ...pkgJson.allowScripts };
+          }
+          if (scratchJson.overrides) {
+            pkgJson.overrides = { ...scratchJson.overrides, ...pkgJson.overrides };
+          }
+        }
+      }
+
+      vfs.writeJson("package.json", pkgJson);
+    },
+    catch: (e) =>
+      new CLIError({
+        message: `Failed to update root package.json: ${e instanceof Error ? e.message : String(e)}`,
+        cause: e,
+      }),
+  });
+}
+
+/**
+ * Registers the per-app env module in packages/env exports and adds any
+ * framework-specific env dependencies the project does not have yet.
+ */
+async function patchEnvPackageJson(
+  vfs: VirtualFileSystem,
+  projectDir: string,
+  scratchFiles: Map<string, VirtualFile>,
+  appName: string,
+  scratchCatalog: Map<string, string>,
+): Promise<Result<void, CLIError>> {
+  const envPkgRelPath = "packages/env/package.json";
+  const envPkgDiskPath = path.join(projectDir, envPkgRelPath);
+
+  return Result.tryPromise({
+    try: async () => {
+      let pkgJson: EnvPackageJson;
+
+      if (await fs.pathExists(envPkgDiskPath)) {
+        pkgJson = JSON.parse(await fs.readFile(envPkgDiskPath, "utf-8")) as EnvPackageJson;
+
+        // A different-framework app may need env deps the project doesn't have
+        // yet (e.g. @t3-oss/env-nextjs); add missing ones from the scratch run.
+        const scratchEnvPkg = scratchFiles.get(envPkgRelPath);
+        if (scratchEnvPkg) {
+          const scratchJson = JSON.parse(scratchEnvPkg.content) as EnvPackageJson;
+          for (const [dep, version] of Object.entries(scratchJson.dependencies ?? {})) {
+            const resolved = version === "catalog:" ? scratchCatalog.get(dep) : version;
+            if (!resolved) continue;
+            pkgJson.dependencies = pkgJson.dependencies ?? {};
+            if (!pkgJson.dependencies[dep]) {
+              pkgJson.dependencies[dep] = resolved;
+            }
+          }
+        }
+      } else {
+        // Project without an env package (e.g. created without a web frontend):
+        // bring in the scratch-generated one, exposing only the new app's module.
+        const scratchEnvPkg = scratchFiles.get(envPkgRelPath);
+        if (!scratchEnvPkg) return;
+        pkgJson = JSON.parse(scratchEnvPkg.content) as EnvPackageJson;
+        pkgJson.exports = {};
+      }
+
+      const exports = { ...pkgJson.exports };
+      exports[`./${appName}`] = `./src/${appName}.ts`;
+      pkgJson.exports = exports;
+
+      vfs.writeJson(envPkgRelPath, pkgJson);
+    },
+    catch: (e) =>
+      new CLIError({
+        message: `Failed to update packages/env/package.json: ${e instanceof Error ? e.message : String(e)}. Add "./${appName}": "./src/${appName}.ts" to its exports manually.`,
+        cause: e,
+      }),
+  });
+}
+
+/**
+ * Unions framework-conditional pnpm-workspace.yaml entries (allowBuilds map,
+ * minimumReleaseAgeExclude list) from the scratch run into the real file.
+ */
+async function mergePnpmWorkspaceEntries(
+  vfs: VirtualFileSystem,
+  projectDir: string,
+  scratchFiles: Map<string, VirtualFile>,
+): Promise<void> {
+  const workspaceRelPath = "pnpm-workspace.yaml";
+  const workspaceDiskPath = path.join(projectDir, workspaceRelPath);
+  const scratchWorkspace = scratchFiles.get(workspaceRelPath);
+  if (!scratchWorkspace) return;
+  if (!(await fs.pathExists(workspaceDiskPath))) return;
+
+  const merged = Result.try({
+    try: () => {
+      const scratchParsed = YAML.parse(scratchWorkspace.content) as PnpmWorkspaceConfig;
+      const realContent = fs.readFileSync(workspaceDiskPath, "utf-8");
+      const doc = YAML.parseDocument(realContent);
+
+      let changed = false;
+
+      // allowBuilds is a map of "package: true" entries; setIn creates the
+      // map when the key is absent.
+      for (const [pkg, allowed] of Object.entries(scratchParsed.allowBuilds ?? {})) {
+        if (doc.getIn(["allowBuilds", pkg]) === undefined) {
+          doc.setIn(["allowBuilds", pkg], allowed);
+          changed = true;
+        }
+      }
+
+      // minimumReleaseAgeExclude is a sequence of strings. Rebuild it as a
+      // proper node — doc.set with a plain array does not create a sequence
+      // node, so appending entry-by-entry would silently no-op.
+      const scratchExcludes = scratchParsed.minimumReleaseAgeExclude;
+      if (Array.isArray(scratchExcludes) && scratchExcludes.length > 0) {
+        const realList = doc.get("minimumReleaseAgeExclude");
+        const existing = YAML.isSeq(realList) ? realList.items.map((item) => String(item)) : [];
+        const additions = scratchExcludes.filter((entry) => !existing.includes(String(entry)));
+        if (additions.length > 0) {
+          doc.set("minimumReleaseAgeExclude", doc.createNode([...existing, ...additions]));
+          changed = true;
+        }
+      }
+
+      return changed ? doc.toString() : null;
+    },
+    catch: () => null,
+  });
+
+  if (merged.isOk() && merged.value) {
+    vfs.writeFile(workspaceRelPath, merged.value);
+  }
+}
+
+/** Formats every text file in the VFS with oxfmt before it is written to disk. */
+async function formatVfsFiles(vfs: VirtualFileSystem): Promise<void> {
+  for (const filePath of vfs.getAllFiles()) {
+    const content = vfs.readFile(filePath);
+    if (!content || content === BINARY_MARKER) continue;
+    const formatted = await formatCode(filePath, content);
+    if (formatted && formatted !== content) {
+      vfs.writeFile(filePath, formatted);
+    }
+  }
+}
+
+/**
+ * Condensed summary + manual wiring steps for extra apps scaffolded during
+ * `create --apps`. Single-app interactive runs use buildAddAppNextSteps.
+ */
+export function buildExtraAppsWiringNote(options: {
+  apps: AddedApp[];
+  backend: ProjectConfig["backend"];
+  auth: ProjectConfig["auth"];
+  webDeploy: ProjectConfig["webDeploy"];
+  serverDeploy: ProjectConfig["serverDeploy"];
+  packageManager: ProjectConfig["packageManager"];
+}): string {
+  const { apps, backend, auth, webDeploy, serverDeploy, packageManager } = options;
+  const lines: string[] = [];
+
+  lines.push(pc.bold("Extra apps:"));
+  for (const app of apps) {
+    lines.push(
+      `  apps/${app.name} — ${app.frontend}, port ${app.port} (${packageManager} run dev:${app.name})`,
+    );
+  }
+
+  const origins = apps.map((app) => `http://localhost:${app.port}`).join(",");
+  const isConvex = backend === "convex";
+  const hasServer = backend !== "none" && !isConvex;
+  const manualSteps: string[] = [];
+
+  if (hasServer) {
+    manualSteps.push(
+      `Allow the new origin${apps.length > 1 ? "s" : ""} in CORS: append ${origins} to CORS_ORIGIN in apps/server/.env, and split it in apps/server/src/index.ts (e.g. origin: env.CORS_ORIGIN.split(",")).`,
+    );
+  }
+  if (auth === "better-auth" && !isConvex) {
+    manualSteps.push(
+      `Add the new origin${apps.length > 1 ? "s" : ""} to the trustedOrigins array in packages/auth/src/index.ts.`,
+    );
+  }
+  if (auth === "clerk") {
+    manualSteps.push("Add the new origins to the allowed origins in your Clerk dashboard.");
+  }
+  if (isConvex) {
+    manualSteps.push(
+      `Copy the *_CONVEX_URL value from apps/web/.env into each new app's .env file.`,
+    );
+  }
+
+  if (manualSteps.length > 0) {
+    lines.push("");
+    lines.push(pc.bold("Manual wiring (your server code is never edited):"));
+    for (const [index, step] of manualSteps.entries()) {
+      lines.push(`  ${index + 1}. ${step}`);
+    }
+  }
+
+  if (webDeploy !== "none" || serverDeploy !== "none") {
+    lines.push("");
+    lines.push(
+      `  Note: extra apps are scaffolded without deploy wiring; deploying them is manual for now.`,
+    );
+  }
+
+  return lines.join("\n");
+}
+
+/** Next steps + manual CORS/auth wiring instructions for a single added app. */
+function buildAddAppNextSteps(options: {
+  appName: string;
+  port: number;
+  packageManager: ProjectConfig["packageManager"];
+  install: boolean;
+  existingConfig: ExistingProjectConfig;
+}): string {
+  const { appName, port, packageManager, install, existingConfig } = options;
+  const origin = `http://localhost:${port}`;
+  const lines: string[] = [];
+
+  lines.push(pc.bold("Next steps:"));
+  if (!install) {
+    lines.push(`  ${packageManager} install`);
+  }
+  lines.push(`  ${packageManager} run dev:${appName}`);
+
+  const manualSteps: string[] = [];
+  const isConvex = existingConfig.backend === "convex";
+  const hasServer = existingConfig.backend !== "none" && !isConvex;
+
+  if (hasServer) {
+    manualSteps.push(
+      `Allow the new origin in CORS: append ${origin} to CORS_ORIGIN in apps/server/.env, and split it in apps/server/src/index.ts (e.g. origin: env.CORS_ORIGIN.split(",")).`,
+    );
+  }
+  if (existingConfig.auth === "better-auth" && !isConvex) {
+    manualSteps.push(`Add "${origin}" to the trustedOrigins array in packages/auth/src/index.ts.`);
+  }
+  if (existingConfig.auth === "clerk") {
+    manualSteps.push(`Add ${origin} to the allowed origins in your Clerk dashboard.`);
+  }
+  if (isConvex) {
+    manualSteps.push(`Copy the *_CONVEX_URL value from apps/web/.env into apps/${appName}/.env.`);
+  }
+
+  if (manualSteps.length > 0) {
+    lines.push("");
+    lines.push(pc.bold("Manual wiring (your server code is never edited):"));
+    for (const [index, step] of manualSteps.entries()) {
+      lines.push(`  ${index + 1}. ${step}`);
+    }
+  }
+
+  const notes: string[] = [];
+  if (existingConfig.webDeploy !== "none" || existingConfig.serverDeploy !== "none") {
+    notes.push(
+      `apps/${appName} was scaffolded without deploy wiring; deploying extra apps is manual for now.`,
+    );
+  }
+  if (existingConfig.addons?.some((addon) => addon === "vite-plus" || addon === "nx")) {
+    notes.push(
+      `Add apps/${appName} build-output globs to your root vite.config ignorePatterns / nx namedInputs if you want them excluded from lint and cache inputs.`,
+    );
+  }
+  notes.push("The project README was not updated.");
+
+  if (notes.length > 0) {
+    lines.push("");
+    lines.push(pc.bold("Notes:"));
+    for (const note of notes) {
+      lines.push(`  - ${note}`);
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/apps/cli/src/helpers/core/add-handler.ts
+++ b/apps/cli/src/helpers/core/add-handler.ts
@@ -338,7 +338,12 @@ async function addHandlerInternal(
   const vfs = new VirtualFileSystem();
 
   // Pre-load existing files into VFS so addon processors can modify them.
-  for (const pkgPath of ADD_PACKAGE_JSON_PATHS) {
+  // Apps created with `add-app` are included so whole-workspace processors see them.
+  const packageJsonPaths = [
+    ...ADD_PACKAGE_JSON_PATHS,
+    ...(existingConfig.apps ?? []).map((app) => `apps/${app.name}/package.json`),
+  ];
+  for (const pkgPath of packageJsonPaths) {
     const fullPath = path.join(projectDir, pkgPath);
     if (await fs.pathExists(fullPath)) {
       const content = await fs.readFile(fullPath, "utf-8");

--- a/apps/cli/src/helpers/core/command-handlers.ts
+++ b/apps/cli/src/helpers/core/command-handlers.ts
@@ -8,9 +8,10 @@ import pc from "picocolors";
 import { getDefaultConfig } from "../../constants";
 import { gatherConfig } from "../../prompts/config-prompts";
 import { getProjectName } from "../../prompts/project-name";
-import type { CreateInput, DirectoryConflict, ProjectConfig } from "../../types";
+import type { AddedApp, CreateInput, DirectoryConflict, ProjectConfig } from "../../types";
 import { trackProjectCreation } from "../../utils/analytics";
 import { getCliSubcommandCommand } from "../../utils/cli-invocation";
+import { validateAddAppFrontendCompatibility } from "../../utils/compatibility-rules";
 import { isSilent, runWithContextAsync } from "../../utils/context";
 import { displayConfig } from "../../utils/display-config";
 import {
@@ -371,6 +372,30 @@ async function createProjectHandlerInternal(
       }
     }
 
+    // Extra frontend apps (--apps): validate names and framework compatibility
+    // against the resolved stack before anything is written.
+    const extraApps: { name: string; frontend: AddedApp["frontend"] }[] = [];
+    const seenAppNames = new Set<string>();
+    for (const spec of input.apps ?? []) {
+      const separatorIndex = spec.indexOf(":");
+      const name = spec.slice(0, separatorIndex);
+      const frontend = spec.slice(separatorIndex + 1) as AddedApp["frontend"];
+
+      if (seenAppNames.has(name)) {
+        yield* new CLIError({ message: `Duplicate app name in --apps: '${name}'.` });
+      }
+      seenAppNames.add(name);
+
+      const appCompatResult = validateAddAppFrontendCompatibility(frontend, config);
+      if (appCompatResult.isErr()) {
+        yield* new CLIError({
+          message: `Invalid --apps entry '${spec}': ${appCompatResult.error.message}`,
+        });
+      }
+
+      extraApps.push({ name, frontend });
+    }
+
     const localRequirements = yield* Result.await(checkLocalRequirements(config));
     if (!isSilent()) {
       for (const warning of localRequirements.warnings) {
@@ -398,7 +423,12 @@ async function createProjectHandlerInternal(
       log.message(displayConfig(config));
     }
 
-    const reproducibleCommand = generateReproducibleCommand(config);
+    const reproducibleCommand =
+      extraApps.length > 0
+        ? `${generateReproducibleCommand(config)} --apps ${extraApps
+            .map((app) => `${app.name}:${app.frontend}`)
+            .join(" ")}`
+        : generateReproducibleCommand(config);
 
     if (input.dryRun) {
       const elapsedTimeMs = Date.now() - startTime;
@@ -434,6 +464,7 @@ async function createProjectHandlerInternal(
         manualDb: cliInput.manualDb ?? input.manualDb,
         dbSetupOptions: effectiveDbSetupOptions,
         packageManagerVersion: localRequirements.packageManagerVersion,
+        extraApps,
       }),
     );
 

--- a/apps/cli/src/helpers/core/create-project.ts
+++ b/apps/cli/src/helpers/core/create-project.ts
@@ -6,13 +6,15 @@ import { log } from "@clack/prompts";
 import { Result } from "better-result";
 import fs from "fs-extra";
 
-import type { DbSetupOptions, ProjectConfig } from "../../types";
+import type { AddedApp, DbSetupOptions, ProjectConfig } from "../../types";
+import { readBtsConfig, updateBtsConfig } from "../../utils/bts-config";
 import { isSilent } from "../../utils/context";
 import { ProjectCreationError } from "../../utils/errors";
 import { formatProject } from "../../utils/file-formatter";
 import { getLatestCLIVersion } from "../../utils/get-latest-cli-version";
 import { setupAddons } from "../addons/addons-setup";
 import { setupDatabase } from "../core/db-setup";
+import { addAppHandler, buildExtraAppsWiringNote } from "./add-app-handler";
 import { initializeGit } from "./git";
 import { installDependencies } from "./install-dependencies";
 import { displayPostInstallInstructions } from "./post-installation";
@@ -21,6 +23,7 @@ export interface CreateProjectOptions {
   manualDb?: boolean;
   dbSetupOptions?: DbSetupOptions;
   packageManagerVersion: string;
+  extraApps?: { name: string; frontend: AddedApp["frontend"] }[];
 }
 
 /**
@@ -119,6 +122,52 @@ export async function createProject(
     yield* Result.await(formatProject(projectDir));
 
     if (!isSilent()) log.success("Project scaffolded");
+
+    // Scaffold extra frontend apps (--apps) before install and git so the
+    // single install and the initial commit include them.
+    const extraApps = cliInput.extraApps ?? [];
+    if (extraApps.length > 0) {
+      const addedApps: AddedApp[] = [];
+
+      for (const app of extraApps) {
+        const appResult = await addAppHandler(
+          { projectDir, name: app.name, frontend: app.frontend, install: false },
+          { silent: true },
+        );
+        const appPort = appResult?.success ? appResult.port : undefined;
+        if (appPort === undefined) {
+          yield* new ProjectCreationError({
+            phase: "extra-apps",
+            message: appResult?.error ?? `Failed to add app '${app.name}'.`,
+          });
+        } else {
+          addedApps.push({ name: app.name, frontend: app.frontend, port: appPort });
+        }
+      }
+
+      // Record --apps in the reproducible command now that the apps exist.
+      const btsConfig = await readBtsConfig(projectDir);
+      if (btsConfig?.reproducibleCommand) {
+        const appSpecs = extraApps.map((app) => `${app.name}:${app.frontend}`).join(" ");
+        await updateBtsConfig(projectDir, {
+          reproducibleCommand: `${btsConfig.reproducibleCommand} --apps ${appSpecs}`,
+        });
+      }
+
+      if (!isSilent()) {
+        log.success(`Added ${addedApps.length} extra app${addedApps.length > 1 ? "s" : ""}`);
+        log.message(
+          buildExtraAppsWiringNote({
+            apps: addedApps,
+            backend: options.backend,
+            auth: options.auth,
+            webDeploy: options.webDeploy,
+            serverDeploy: options.serverDeploy,
+            packageManager: options.packageManager,
+          }),
+        );
+      }
+    }
 
     // Install dependencies if requested
     if (options.install) {

--- a/apps/cli/src/helpers/core/detect-project-config.ts
+++ b/apps/cli/src/helpers/core/detect-project-config.ts
@@ -13,6 +13,7 @@ export async function detectProjectConfig(projectDir: string) {
         return {
           projectDir,
           projectName: path.basename(projectDir),
+          version: btsConfig.version,
           addonOptions: btsConfig.addonOptions,
           dbSetupOptions: btsConfig.dbSetupOptions,
           database: btsConfig.database,
@@ -29,6 +30,7 @@ export async function detectProjectConfig(projectDir: string) {
           api: btsConfig.api,
           webDeploy: btsConfig.webDeploy,
           serverDeploy: btsConfig.serverDeploy,
+          apps: btsConfig.apps,
         };
       }
 

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -6,13 +6,18 @@ import z from "zod";
 
 import { historyHandler } from "./commands/history";
 import { openBuilderCommand, openDocsCommand, showSponsorsCommand } from "./commands/meta";
+import { addAppHandler, type AddAppResult } from "./helpers/core/add-app-handler";
 import { addHandler, type AddResult } from "./helpers/core/add-handler";
 import { createProjectHandler, createProjectHandlerResult } from "./helpers/core/command-handlers";
 import {
+  type AddAppInput,
+  AddAppInputSchema,
+  AddedAppSpecSchema,
   type AddInput,
   type Addons,
   AddonsSchema,
   type AddonOptions,
+  AppNameSchema,
   type DbSetupOptions,
   DbSetupOptionsSchema,
   AddInputSchema,
@@ -53,6 +58,7 @@ import {
   TemplateSchema,
   type WebDeploy,
   WebDeploySchema,
+  WebFrontendSchema,
 } from "./types";
 import {
   CLIError,
@@ -88,6 +94,7 @@ export const SchemaNameSchema = z
     "dbSetupOptions",
     "createInput",
     "addInput",
+    "addAppInput",
     "projectConfig",
     "betterTStackConfig",
     "betterTStackConfigFile",
@@ -161,6 +168,10 @@ export const router = t.router({
           auth: AuthSchema.optional(),
           payments: PaymentsSchema.optional(),
           frontend: z.array(FrontendSchema).optional(),
+          apps: z
+            .array(AddedAppSpecSchema)
+            .optional()
+            .describe("Extra frontend apps as name:framework (e.g. admin:next landing:astro)"),
           addons: z.array(AddonsSchema).optional(),
           examples: z.array(ExamplesSchema).optional(),
           git: z.boolean().optional(),
@@ -264,6 +275,57 @@ export const router = t.router({
     .input(AddInputSchema)
     .mutation(async ({ input }) => {
       const result = await addHandler(input, { silent: true });
+      if (!result) {
+        throw new UserCancelledError({ message: "Operation cancelled" });
+      }
+      if (!result.success) {
+        throw new CLIError({
+          message: result.error || "Unknown error occurred",
+        });
+      }
+      return result;
+    }),
+  addApp: t.procedure
+    .meta({ description: "Add another frontend app to an existing Better-T-Stack project" })
+    .input(
+      z.tuple([
+        AppNameSchema.optional().describe("Name of the new app (e.g. admin)"),
+        z.object({
+          frontend: WebFrontendSchema.optional().describe("Framework for the new app"),
+          port: z
+            .number()
+            .int()
+            .min(1024)
+            .max(65535)
+            .optional()
+            .describe("Dev server port (defaults to the next free port from 3002)"),
+          install: z
+            .boolean()
+            .optional()
+            .default(false)
+            .describe("Install dependencies after adding"),
+          packageManager: PackageManagerSchema.optional().describe("Package manager to use"),
+          projectDir: z.string().optional().describe("Project directory (defaults to current)"),
+          dryRun: z
+            .boolean()
+            .optional()
+            .default(false)
+            .describe("Preview app files without writing them"),
+        }),
+      ]),
+    )
+    .mutation(async ({ input }) => {
+      const [name, options] = input;
+      await addAppHandler({ ...options, name });
+    }),
+  addAppJson: t.procedure
+    .meta({
+      description: "Add an app from a raw JSON payload (agent-friendly)",
+      jsonInput: "always",
+    })
+    .input(AddAppInputSchema)
+    .mutation(async ({ input }) => {
+      const result = await addAppHandler(input, { silent: true });
       if (!result) {
         throw new UserCancelledError({ message: "Operation cancelled" });
       }
@@ -570,6 +632,50 @@ export async function add(options: AddOptions = {}): Promise<AddResult> {
     result ?? {
       success: false,
       addedAddons: [],
+      projectDir: parsedInput.data.projectDir ?? "",
+      error: "Operation cancelled",
+    }
+  );
+}
+
+export type { AddAppResult };
+
+export type AddAppOptions = Pick<
+  AddAppInput,
+  "name" | "frontend" | "port" | "install" | "packageManager" | "projectDir" | "dryRun"
+>;
+
+/**
+ * Programmatic API to add another frontend app to an existing Better-T-Stack project.
+ *
+ * @example
+ * ```typescript
+ * import { addApp } from "create-better-t-stack";
+ *
+ * const result = await addApp({
+ *   name: "admin",
+ *   frontend: "next",
+ * });
+ *
+ * if (result.success) {
+ *   console.log(`Added apps/${result.appName} on port ${result.port}`);
+ * }
+ * ```
+ */
+export async function addApp(options: AddAppOptions = {}): Promise<AddAppResult> {
+  const parsedInput = AddAppInputSchema.safeParse(options);
+  if (!parsedInput.success) {
+    return {
+      success: false,
+      projectDir: "",
+      error: formatInputValidationError("add-app", parsedInput.error),
+    };
+  }
+
+  const result = await addAppHandler(parsedInput.data, { silent: true });
+  return (
+    result ?? {
+      success: false,
       projectDir: parsedInput.data.projectDir ?? "",
       error: "Operation cancelled",
     }

--- a/apps/cli/src/mcp.ts
+++ b/apps/cli/src/mcp.ts
@@ -2,8 +2,9 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import z from "zod";
 
-import { add, create, type SchemaName, SchemaNameSchema, getSchemaResult } from "./index";
+import { add, addApp, create, type SchemaName, SchemaNameSchema, getSchemaResult } from "./index";
 import {
+  AddAppInputSchema,
   AddInputSchema,
   AddonOptionsSchema,
   AddonsSchema,
@@ -70,6 +71,7 @@ type SchemaToolInput = {
 };
 type McpCreateProjectInput = z.infer<typeof McpCreateProjectInputSchema>;
 type McpAddInput = z.infer<typeof AddInputSchema>;
+type McpAddAppInput = z.infer<typeof AddAppInputSchema>;
 
 function formatToolSuccess<T>(data: T) {
   return {
@@ -113,9 +115,9 @@ function getProjectToolAnnotations() {
 
 function getMcpInstallTimeoutMessage(packageManager: string) {
   return [
-    "MCP project creation requires `install: false`.",
+    "MCP execution requires `install: false`.",
     "Dependency installation can exceed common MCP client request timeouts and cause the connection to close before the tool returns.",
-    `Scaffold the project first, then run \`${packageManager} install\` in the generated project directory from a terminal.`,
+    `Scaffold first, then run \`${packageManager} install\` in the project directory from a terminal.`,
   ].join(" ");
 }
 
@@ -127,6 +129,7 @@ function getStackGuidance() {
       "Always call bts_plan_project before bts_create_project.",
       "Only call bts_create_project after the plan succeeds and matches the user's intent.",
       "Use bts_plan_addons before bts_add_addons for existing projects.",
+      "Use bts_plan_app before bts_add_app to add another frontend app to an existing project.",
     ],
     createContract: {
       requiresExplicitFields: [
@@ -154,6 +157,7 @@ function getStackGuidance() {
     fieldNotes: {
       frontend:
         "frontend is for app surfaces only. Choose explicit app targets such as next, react-router, tanstack-router, native-bare, native-uniwind, or native-unistyles.",
+      apps: "apps is optional: extra frontend apps as name:framework strings (e.g. admin:next). They are scaffolded into apps/<name> after create, wired to the project's API and auth. Frameworks are gated by api/auth/backend; fullstack self backends cannot add apps.",
       addons: "addons must be an explicit array. Use [] when no addons are requested.",
       examples: "examples must be an explicit array. Use [] when no examples are requested.",
       dbSetup:
@@ -375,6 +379,74 @@ export function createBtsMcpServer() {
 
         if (!result?.success) {
           return formatToolError(result?.error ?? "Failed to add addons");
+        }
+
+        return formatToolSuccess(result);
+      } catch (error) {
+        return formatToolError(error);
+      }
+    },
+  );
+
+  server.registerTool(
+    "bts_plan_app",
+    {
+      title: "Plan Better T Stack App",
+      description:
+        "Validate and preview adding another frontend app to an existing Better T Stack project without writing files. Always use this before bts_add_app.",
+      inputSchema: AddAppInputSchema,
+      outputSchema: ToolResponseSchema,
+      annotations: {
+        title: "Plan Better T Stack App",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (input: McpAddAppInput) => {
+      try {
+        const result = await addApp({
+          ...input,
+          dryRun: true,
+        });
+
+        if (!result?.success) {
+          return formatToolError(result?.error ?? "Failed to plan app addition");
+        }
+
+        return formatToolSuccess(result);
+      } catch (error) {
+        return formatToolError(error);
+      }
+    },
+  );
+
+  server.registerTool(
+    "bts_add_app",
+    {
+      title: "Add Better T Stack App",
+      description:
+        "Add another frontend app to an existing Better T Stack project using the same silent flow as add-app-json. Call this only after bts_plan_app succeeds and the planned changes match the user's intent.",
+      inputSchema: AddAppInputSchema,
+      outputSchema: ToolResponseSchema,
+      annotations: {
+        title: "Add Better T Stack App",
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
+    },
+    async (input: McpAddAppInput) => {
+      try {
+        if (input.install) {
+          return formatToolError(getMcpInstallTimeoutMessage(input.packageManager ?? "bun"));
+        }
+
+        const result = await addApp(input);
+
+        if (!result?.success) {
+          return formatToolError(result?.error ?? "Failed to add app");
         }
 
         return formatToolSuccess(result);

--- a/apps/cli/src/prompts/add-app.ts
+++ b/apps/cli/src/prompts/add-app.ts
@@ -1,0 +1,108 @@
+import { isCancel as isClackCancel, text } from "@clack/prompts";
+
+import type { AddedApp, ProjectConfig } from "../types";
+import { AppNameSchema } from "../types";
+import { validateAddAppFrontendCompatibility } from "../utils/compatibility-rules";
+import { UserCancelledError } from "../utils/errors";
+import { isCancel, navigableSelect } from "./navigable";
+
+export type AddAppFrontend = AddedApp["frontend"];
+
+const WEB_FRONTEND_OPTIONS: { value: AddAppFrontend; label: string; hint: string }[] = [
+  {
+    value: "tanstack-router",
+    label: "TanStack Router",
+    hint: "Modern and scalable routing for React Applications",
+  },
+  {
+    value: "react-router",
+    label: "React Router",
+    hint: "A user‑obsessed, standards‑focused, multi‑strategy router",
+  },
+  {
+    value: "next",
+    label: "Next.js",
+    hint: "The React Framework for the Web",
+  },
+  {
+    value: "nuxt",
+    label: "Nuxt",
+    hint: "The Progressive Web Framework for Vue.js",
+  },
+  {
+    value: "svelte",
+    label: "Svelte",
+    hint: "web development for the rest of us",
+  },
+  {
+    value: "solid",
+    label: "Solid",
+    hint: "Simple and performant reactivity for building user interfaces",
+  },
+  {
+    value: "astro",
+    label: "Astro",
+    hint: "The web framework for content-driven websites",
+  },
+  {
+    value: "tanstack-start",
+    label: "TanStack Start",
+    hint: "SSR, Server Functions, API Routes and more with TanStack Router",
+  },
+];
+
+/** Validates an app name against the schema and taken names; returns an error message or undefined. */
+export function validateAppName(name: string, takenNames: ReadonlySet<string>) {
+  const result = AppNameSchema.safeParse(name);
+  if (!result.success) {
+    return result.error.issues[0]?.message || "Invalid app name";
+  }
+  if (takenNames.has(name)) {
+    return `An app named '${name}' already exists in this project`;
+  }
+  return undefined;
+}
+
+/** Prompts for the new app's name with live validation. */
+export async function getAppName(takenNames: ReadonlySet<string>): Promise<string> {
+  const response = await text({
+    message: "What should the new app be called?",
+    placeholder: "admin",
+    validate: (value) => validateAppName(String(value ?? "").trim(), takenNames),
+  });
+
+  if (isClackCancel(response)) {
+    throw new UserCancelledError({ message: "Operation cancelled" });
+  }
+
+  return String(response).trim();
+}
+
+/** Frameworks an extra app may use, given the project's api/auth/backend. */
+export function getCompatibleAppFrontends(
+  config: Pick<ProjectConfig, "api" | "auth" | "backend">,
+): AddAppFrontend[] {
+  return WEB_FRONTEND_OPTIONS.filter((option) =>
+    validateAddAppFrontendCompatibility(option.value, config).isOk(),
+  ).map((option) => option.value);
+}
+
+/** Prompts for the new app's framework, offering only compatible options. */
+export async function getAppFrontend(
+  config: Pick<ProjectConfig, "api" | "auth" | "backend">,
+): Promise<AddAppFrontend> {
+  const options = WEB_FRONTEND_OPTIONS.filter((option) =>
+    validateAddAppFrontendCompatibility(option.value, config).isOk(),
+  );
+
+  const response = await navigableSelect<AddAppFrontend>({
+    message: "Choose a framework for the new app",
+    options,
+  });
+
+  if (isCancel(response)) {
+    throw new UserCancelledError({ message: "Operation cancelled" });
+  }
+
+  return response as AddAppFrontend;
+}

--- a/apps/cli/src/utils/bts-config.ts
+++ b/apps/cli/src/utils/bts-config.ts
@@ -27,21 +27,28 @@ export async function readBtsConfig(projectDir: string): Promise<BetterTStackCon
 
 /**
  * Updates specific fields in the BTS configuration file.
+ * Returns true when the file was updated, false when it was missing or the write failed.
  */
 export async function updateBtsConfig(
   projectDir: string,
   updates: Partial<
     Pick<
       BetterTStackConfig,
-      "addons" | "addonOptions" | "dbSetupOptions" | "webDeploy" | "serverDeploy"
+      | "addons"
+      | "addonOptions"
+      | "dbSetupOptions"
+      | "webDeploy"
+      | "serverDeploy"
+      | "apps"
+      | "reproducibleCommand"
     >
   >,
-): Promise<void> {
+): Promise<boolean> {
   try {
     const configPath = path.join(projectDir, BTS_CONFIG_FILE);
 
     if (!(await fs.pathExists(configPath))) {
-      return;
+      return false;
     }
 
     let content = await fs.readFile(configPath, "utf-8");
@@ -53,7 +60,9 @@ export async function updateBtsConfig(
     }
 
     await fs.writeFile(configPath, content, "utf-8");
+    return true;
   } catch {
     // Silent failure
+    return false;
   }
 }

--- a/apps/cli/src/utils/compatibility-rules.ts
+++ b/apps/cli/src/utils/compatibility-rules.ts
@@ -666,6 +666,33 @@ export function validatePaymentsCompatibility(
   return Result.ok(undefined);
 }
 
+/**
+ * Validates that a frontend framework can be added as an extra app to an
+ * existing project, given the project's api/auth/backend choices.
+ */
+export function validateAddAppFrontendCompatibility(
+  frontend: Frontend,
+  config: Pick<ProjectConfig, "api" | "auth" | "backend">,
+): ValidationResult {
+  if (config.backend === "self") {
+    return validationErr(
+      "Cannot add an app to a fullstack (backend 'self') project: the web app serves its own API routes, so additional apps have no shared server to connect to.",
+    );
+  }
+
+  const apiResult = validateApiFrontendCompatibility(config.api, [frontend]);
+  if (apiResult.isErr()) return apiResult;
+
+  if (!isFrontendAllowedWithBackend(frontend, config.backend, config.auth)) {
+    const authSuffix = config.auth && config.auth !== "none" ? ` with ${config.auth} auth` : "";
+    return validationErr(
+      `Frontend '${frontend}' is not compatible with this project's '${config.backend}' backend${authSuffix}.`,
+    );
+  }
+
+  return Result.ok(undefined);
+}
+
 export function validateExamplesCompatibility(
   examples: string[] | undefined,
   backend: ProjectConfig["backend"] | undefined,

--- a/apps/cli/test/add-app.test.ts
+++ b/apps/cli/test/add-app.test.ts
@@ -1,0 +1,473 @@
+import { describe, expect, it } from "bun:test";
+import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { parse as parseJsonc } from "jsonc-parser";
+import { parse as parseYaml } from "yaml";
+
+import { add, addApp, create } from "../src/index";
+import type { BetterTStackConfig } from "../src/types";
+import { SMOKE_DIR } from "./setup";
+import { expectSuccess, runTRPCTest } from "./test-utils";
+
+async function writeSyntheticProject(
+  name: string,
+  overrides: Partial<BetterTStackConfig> = {},
+): Promise<string> {
+  const projectDir = join(SMOKE_DIR, name);
+  await rm(projectDir, { recursive: true, force: true });
+  await mkdir(projectDir, { recursive: true });
+  await writeFile(
+    join(projectDir, "bts.jsonc"),
+    JSON.stringify({
+      version: "0.0.0-test",
+      createdAt: new Date(0).toISOString(),
+      database: "none",
+      orm: "none",
+      backend: "hono",
+      runtime: "bun",
+      frontend: ["tanstack-router"],
+      addons: ["none"],
+      examples: ["none"],
+      auth: "none",
+      payments: "none",
+      packageManager: "bun",
+      dbSetup: "none",
+      api: "trpc",
+      webDeploy: "none",
+      serverDeploy: "none",
+      ...overrides,
+    }),
+  );
+  return projectDir;
+}
+
+async function scaffoldProject(projectName: string) {
+  const result = await runTRPCTest({
+    projectName,
+    frontend: ["tanstack-router"],
+    backend: "hono",
+    runtime: "bun",
+    api: "trpc",
+    database: "none",
+    orm: "none",
+    auth: "none",
+    payments: "none",
+    addons: [],
+    examples: [],
+    dbSetup: "none",
+    webDeploy: "none",
+    serverDeploy: "none",
+    git: false,
+    install: false,
+  });
+  expectSuccess(result);
+  return join(SMOKE_DIR, projectName);
+}
+
+async function collectAppFiles(dir: string): Promise<Map<string, string>> {
+  const files = new Map<string, string>();
+  async function walk(current: string) {
+    for (const entry of await readdir(current, { withFileTypes: true })) {
+      const fullPath = join(current, entry.name);
+      if (entry.isDirectory()) {
+        await walk(fullPath);
+      } else {
+        files.set(fullPath, await readFile(fullPath, "utf-8"));
+      }
+    }
+  }
+  await walk(dir);
+  return files;
+}
+
+describe("addApp()", () => {
+  describe("refusals", () => {
+    it("returns an error in silent mode when the project config is missing", async () => {
+      const projectDir = join(SMOKE_DIR, "add-app-missing-config");
+      await mkdir(projectDir, { recursive: true });
+
+      const result = await addApp({ projectDir, name: "admin", frontend: "next" });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("No Better-T-Stack project found");
+    });
+
+    it("requires name and frontend in silent mode", async () => {
+      const projectDir = await writeSyntheticProject("add-app-silent-args");
+
+      const result = await addApp({ projectDir });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("required in silent mode");
+    });
+
+    it("rejects reserved app names", async () => {
+      const projectDir = await writeSyntheticProject("add-app-reserved-names");
+
+      for (const name of ["web", "server", "native", "env", "ui"]) {
+        const result = await addApp({ projectDir, name, frontend: "next" });
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("reserved");
+      }
+    });
+
+    it("rejects invalid app name syntax", async () => {
+      const projectDir = await writeSyntheticProject("add-app-invalid-names");
+
+      for (const name of ["Admin", "my app", "../evil", "1admin", "-admin"]) {
+        const result = await addApp({ projectDir, name, frontend: "next" });
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("App name");
+      }
+    });
+
+    it("rejects a frontend incompatible with the project's tRPC api", async () => {
+      const projectDir = await writeSyntheticProject("add-app-trpc-nuxt", { api: "trpc" });
+
+      const result = await addApp({ projectDir, name: "admin", frontend: "nuxt" });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("tRPC API is not supported");
+    });
+
+    it("rejects a frontend incompatible with clerk auth", async () => {
+      const projectDir = await writeSyntheticProject("add-app-clerk-svelte", {
+        api: "orpc",
+        auth: "clerk",
+      });
+
+      const result = await addApp({ projectDir, name: "admin", frontend: "svelte" });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("not compatible");
+    });
+
+    it("rejects a frontend incompatible with a convex backend", async () => {
+      const projectDir = await writeSyntheticProject("add-app-convex-solid", {
+        backend: "convex",
+        runtime: "none",
+        api: "none",
+      });
+
+      const result = await addApp({ projectDir, name: "admin", frontend: "solid" });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("not compatible");
+    });
+
+    it("rejects adding an app to a fullstack (self) project", async () => {
+      const projectDir = await writeSyntheticProject("add-app-self", {
+        backend: "self",
+        frontend: ["next"],
+        api: "none",
+        runtime: "none",
+      });
+
+      const result = await addApp({ projectDir, name: "admin", frontend: "next" });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("fullstack");
+    });
+
+    it("rejects an app name already present in bts.jsonc", async () => {
+      const projectDir = await writeSyntheticProject("add-app-duplicate", {
+        apps: [{ name: "admin", frontend: "next", port: 3002 }],
+      });
+
+      const result = await addApp({ projectDir, name: "admin", frontend: "next" });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("already exists");
+    });
+
+    it("rejects when the app directory already exists", async () => {
+      const projectDir = await writeSyntheticProject("add-app-dir-conflict");
+      await mkdir(join(projectDir, "apps", "admin"), { recursive: true });
+      await writeFile(join(projectDir, "apps", "admin", "keep.txt"), "user file");
+
+      const result = await addApp({ projectDir, name: "admin", frontend: "next" });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("already exists");
+      expect(await readFile(join(projectDir, "apps", "admin", "keep.txt"), "utf-8")).toBe(
+        "user file",
+      );
+    });
+
+    it("rejects a port already used by the project", async () => {
+      const projectDir = await writeSyntheticProject("add-app-port-conflict");
+
+      const result = await addApp({ projectDir, name: "admin", frontend: "next", port: 3001 });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("already used");
+    });
+
+    it("returns a validation error for invalid input shapes", async () => {
+      const result = await addApp({
+        name: "admin",
+        // @ts-expect-error - intentionally invalid
+        frontend: "angular",
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+  });
+
+  describe("create --apps", () => {
+    it("scaffolds extra apps as part of project creation", async () => {
+      const projectDir = join(SMOKE_DIR, "create-with-apps");
+      await rm(projectDir, { recursive: true, force: true });
+
+      const result = await create(projectDir, {
+        frontend: ["tanstack-router"],
+        backend: "hono",
+        runtime: "bun",
+        api: "orpc",
+        database: "none",
+        orm: "none",
+        auth: "none",
+        payments: "none",
+        addons: ["turborepo"],
+        examples: ["none"],
+        dbSetup: "none",
+        webDeploy: "none",
+        serverDeploy: "none",
+        apps: ["admin:next", "landing:astro"],
+        install: false,
+        git: false,
+        packageManager: "bun",
+        disableAnalytics: true,
+      });
+      expect(result.isOk()).toBe(true);
+
+      const adminPkg = JSON.parse(
+        await readFile(join(projectDir, "apps", "admin", "package.json"), "utf-8"),
+      );
+      expect(adminPkg.name).toBe("admin");
+      expect(adminPkg.scripts.dev).toContain("--port 3002");
+
+      const landingPkg = JSON.parse(
+        await readFile(join(projectDir, "apps", "landing", "package.json"), "utf-8"),
+      );
+      expect(landingPkg.scripts.dev).toContain("--port 3003");
+
+      const rootPkg = JSON.parse(await readFile(join(projectDir, "package.json"), "utf-8"));
+      expect(rootPkg.scripts["dev:admin"]).toBeDefined();
+      expect(rootPkg.scripts["dev:landing"]).toBeDefined();
+
+      const btsConfig = parseJsonc(
+        await readFile(join(projectDir, "bts.jsonc"), "utf-8"),
+      ) as BetterTStackConfig;
+      expect(btsConfig.apps).toEqual([
+        { name: "admin", frontend: "next", port: 3002 },
+        { name: "landing", frontend: "astro", port: 3003 },
+      ]);
+      expect(btsConfig.reproducibleCommand).toContain("--apps admin:next landing:astro");
+    });
+
+    it("rejects incompatible --apps entries before scaffolding", async () => {
+      const projectDir = join(SMOKE_DIR, "create-with-apps-invalid");
+      await rm(projectDir, { recursive: true, force: true });
+
+      const result = await create(projectDir, {
+        frontend: ["tanstack-router"],
+        backend: "hono",
+        runtime: "bun",
+        api: "trpc",
+        database: "none",
+        orm: "none",
+        auth: "none",
+        payments: "none",
+        addons: ["none"],
+        examples: ["none"],
+        dbSetup: "none",
+        webDeploy: "none",
+        serverDeploy: "none",
+        apps: ["landing:astro"],
+        install: false,
+        git: false,
+        packageManager: "bun",
+        disableAnalytics: true,
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (result.isOk()) throw new Error("Expected create() to reject incompatible apps");
+      expect(result.error.message).toContain("tRPC");
+    });
+  });
+
+  describe("dry run", () => {
+    it("plans without writing any files", async () => {
+      const projectDir = await scaffoldProject("add-app-dry-run");
+      const rootPkgBefore = await readFile(join(projectDir, "package.json"), "utf-8");
+      const btsBefore = await readFile(join(projectDir, "bts.jsonc"), "utf-8");
+
+      const result = await addApp({ projectDir, name: "admin", frontend: "next", dryRun: true });
+
+      expect(result.success).toBe(true);
+      expect(result.dryRun).toBe(true);
+      expect(result.plannedFileCount).toBeGreaterThan(0);
+      expect(result.appName).toBe("admin");
+      expect(result.port).toBe(3002);
+
+      const appsEntries = await readdir(join(projectDir, "apps"));
+      expect(appsEntries).not.toContain("admin");
+      expect(await readFile(join(projectDir, "package.json"), "utf-8")).toBe(rootPkgBefore);
+      expect(await readFile(join(projectDir, "bts.jsonc"), "utf-8")).toBe(btsBefore);
+    });
+  });
+
+  describe("full write", () => {
+    it("scaffolds a cross-framework app wired into the workspace", async () => {
+      const projectDir = await scaffoldProject("add-app-full");
+      const projectName = "add-app-full";
+
+      const result = await addApp({ projectDir, name: "admin", frontend: "next" });
+
+      expect(result.error).toBeUndefined();
+      expect(result.success).toBe(true);
+      expect(result.port).toBe(3002);
+
+      // App identity
+      const appPkg = JSON.parse(
+        await readFile(join(projectDir, "apps", "admin", "package.json"), "utf-8"),
+      );
+      expect(appPkg.name).toBe("admin");
+      expect(appPkg.scripts.dev).toContain("--port 3002");
+
+      // Root dev script mirrors the project's task-runner filter syntax
+      const rootPkg = JSON.parse(await readFile(join(projectDir, "package.json"), "utf-8"));
+      expect(rootPkg.scripts["dev:web"]).toBeDefined();
+      expect(rootPkg.scripts["dev:admin"]).toBe(
+        rootPkg.scripts["dev:web"].replace(/\bweb\b/, "admin"),
+      );
+
+      // Per-app env module and preserved exports
+      const envPkg = JSON.parse(
+        await readFile(join(projectDir, "packages", "env", "package.json"), "utf-8"),
+      );
+      expect(envPkg.exports["./admin"]).toBe("./src/admin.ts");
+      expect(envPkg.exports["./web"]).toBe("./src/web.ts");
+      const envModule = await readFile(
+        join(projectDir, "packages", "env", "src", "admin.ts"),
+        "utf-8",
+      );
+      expect(envModule).toContain("NEXT_PUBLIC_");
+
+      // No dangling references to the primary app's env module, no catalog refs
+      const appFiles = await collectAppFiles(join(projectDir, "apps", "admin"));
+      for (const [filePath, content] of appFiles) {
+        expect(content, `env/web reference left in ${filePath}`).not.toContain(
+          `@${projectName}/env/web`,
+        );
+      }
+      const appPkgRaw = appFiles.get(join(projectDir, "apps", "admin", "package.json"));
+      expect(appPkgRaw).not.toContain('"catalog:"');
+
+      // bts.jsonc updated, comments preserved
+      const btsRaw = await readFile(join(projectDir, "bts.jsonc"), "utf-8");
+      expect(btsRaw).toContain("// Better-T-Stack");
+      const btsConfig = parseJsonc(btsRaw) as BetterTStackConfig;
+      expect(btsConfig.apps).toEqual([{ name: "admin", frontend: "next", port: 3002 }]);
+    });
+
+    it("allocates the next free port and covers routeTree.gen.ts for tanstack apps", async () => {
+      const projectDir = await scaffoldProject("add-app-second");
+
+      const first = await addApp({ projectDir, name: "admin", frontend: "next" });
+      expect(first.success).toBe(true);
+      expect(first.port).toBe(3002);
+
+      const second = await addApp({ projectDir, name: "staff", frontend: "tanstack-router" });
+      expect(second.success).toBe(true);
+      expect(second.port).toBe(3003);
+
+      const viteConfig = await readFile(
+        join(projectDir, "apps", "staff", "vite.config.ts"),
+        "utf-8",
+      );
+      expect(viteConfig).toContain("port: 3003");
+
+      const gitignore = await readFile(join(projectDir, "apps", "staff", ".gitignore"), "utf-8");
+      expect(gitignore).toContain("src/routeTree.gen.ts");
+
+      const btsConfig = parseJsonc(
+        await readFile(join(projectDir, "bts.jsonc"), "utf-8"),
+      ) as BetterTStackConfig;
+      expect(btsConfig.apps).toHaveLength(2);
+    });
+
+    it("unions pnpm allowBuilds and release-age entries when the keys are absent", async () => {
+      const projectDir = join(SMOKE_DIR, "add-app-pnpm-allowbuilds");
+      await rm(projectDir, { recursive: true, force: true });
+      const createResult = await create(projectDir, {
+        frontend: ["tanstack-router"],
+        backend: "hono",
+        runtime: "bun",
+        api: "orpc",
+        database: "none",
+        orm: "none",
+        auth: "none",
+        payments: "none",
+        addons: ["none"],
+        examples: ["none"],
+        dbSetup: "none",
+        webDeploy: "none",
+        serverDeploy: "none",
+        install: false,
+        git: false,
+        packageManager: "pnpm",
+        disableAnalytics: true,
+      });
+      expect(createResult.isOk()).toBe(true);
+
+      // Precondition for the regression: the keys start out absent.
+      const before = parseYaml(
+        await readFile(join(projectDir, "pnpm-workspace.yaml"), "utf-8"),
+      ) as { allowBuilds?: Record<string, boolean>; minimumReleaseAgeExclude?: string[] };
+      expect(before.allowBuilds).toBeUndefined();
+
+      const nuxtResult = await addApp({ projectDir, name: "landing", frontend: "nuxt" });
+      expect(nuxtResult.error).toBeUndefined();
+      expect(nuxtResult.success).toBe(true);
+
+      const afterNuxt = parseYaml(
+        await readFile(join(projectDir, "pnpm-workspace.yaml"), "utf-8"),
+      ) as { allowBuilds?: Record<string, boolean> };
+      // All nuxt entries must survive, not just the last one written.
+      expect(afterNuxt.allowBuilds?.esbuild).toBe(true);
+      expect(afterNuxt.allowBuilds?.["@parcel/watcher"]).toBe(true);
+      expect(afterNuxt.allowBuilds?.["vue-demi"]).toBe(true);
+
+      const solidResult = await addApp({ projectDir, name: "solid-app", frontend: "solid" });
+      expect(solidResult.success).toBe(true);
+
+      const afterSolid = parseYaml(
+        await readFile(join(projectDir, "pnpm-workspace.yaml"), "utf-8"),
+      ) as { minimumReleaseAgeExclude?: string[] };
+      expect(afterSolid.minimumReleaseAgeExclude?.length ?? 0).toBeGreaterThan(1);
+    });
+
+    it("keeps the per-app env export when addons are added later", async () => {
+      const projectDir = await scaffoldProject("add-app-then-addon");
+
+      const appResult = await addApp({ projectDir, name: "admin", frontend: "next" });
+      expect(appResult.success).toBe(true);
+
+      // The scaffolded project already has a task runner, so adding any addon
+      // runs processPackageConfigs — the path that rebuilds env exports.
+      const addonResult = await add({ projectDir, addons: ["biome"], install: false });
+      expect(addonResult.success).toBe(true);
+      expect(addonResult.addedAddons).toContain("biome");
+
+      const envPkg = JSON.parse(
+        await readFile(join(projectDir, "packages", "env", "package.json"), "utf-8"),
+      );
+      expect(envPkg.exports["./admin"]).toBe("./src/admin.ts");
+      expect(envPkg.exports["./web"]).toBe("./src/web.ts");
+    });
+  });
+});

--- a/apps/cli/test/input-schemas.test.ts
+++ b/apps/cli/test/input-schemas.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 
 import {
+  AddAppInputSchema,
   AddInputSchema,
   BetterTStackConfigFileSchema,
   CLIInputSchema,
@@ -71,6 +72,54 @@ describe("Input schemas", () => {
       webDeploy: "none",
       serverDeploy: "none",
       unexpected: true,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts an apps array in bts.jsonc config payloads", () => {
+    const result = BetterTStackConfigFileSchema.safeParse({
+      version: "0.0.0",
+      createdAt: new Date(0).toISOString(),
+      database: "sqlite",
+      orm: "drizzle",
+      backend: "hono",
+      runtime: "bun",
+      frontend: ["tanstack-router"],
+      addons: ["none"],
+      examples: ["none"],
+      auth: "none",
+      payments: "none",
+      packageManager: "bun",
+      dbSetup: "none",
+      api: "trpc",
+      webDeploy: "none",
+      serverDeploy: "none",
+      apps: [{ name: "admin", frontend: "next", port: 3002 }],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("validates --apps specs on create input", () => {
+    expect(
+      CreateInputSchema.safeParse({ projectName: "app", apps: ["admin:next", "landing:astro"] })
+        .success,
+    ).toBe(true);
+
+    for (const spec of ["Admin:next", "admin:angular", "web:next", "admin", "admin:"]) {
+      expect(
+        CreateInputSchema.safeParse({ projectName: "app", apps: [spec] }).success,
+        `expected '${spec}' to be rejected`,
+      ).toBe(false);
+    }
+  });
+
+  it("rejects unknown keys in add-app input", () => {
+    const result = AddAppInputSchema.safeParse({
+      name: "admin",
+      frontend: "next",
+      bogusKey: true,
     });
 
     expect(result.success).toBe(false);

--- a/apps/cli/test/mcp.test.ts
+++ b/apps/cli/test/mcp.test.ts
@@ -91,10 +91,12 @@ describe("MCP server", () => {
 
     expect(toolNames).toEqual([
       "bts_add_addons",
+      "bts_add_app",
       "bts_create_project",
       "bts_get_schema",
       "bts_get_stack_guidance",
       "bts_plan_addons",
+      "bts_plan_app",
       "bts_plan_project",
     ]);
   });
@@ -124,6 +126,17 @@ describe("MCP server", () => {
       openWorldHint: true,
     });
     expect(toolsByName.get("bts_add_addons")?.annotations).toMatchObject({
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    });
+    expect(toolsByName.get("bts_plan_app")?.annotations).toMatchObject({
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    });
+    expect(toolsByName.get("bts_add_app")?.annotations).toMatchObject({
       destructiveHint: true,
       idempotentHint: false,
       openWorldHint: true,
@@ -532,6 +545,129 @@ describe("MCP server", () => {
 
     const after = await readBtsConfig(projectPath);
     expect(after?.addons).toEqual(expect.arrayContaining(["turborepo", "biome"]));
+  });
+
+  it("plans an app addition without mutating the project", async () => {
+    const { client, cleanup } = await connectInMemoryClient();
+    cleanups.push(cleanup);
+
+    const projectPath = path.join(SMOKE_DIR, "mcp-plan-app");
+    await fs.remove(projectPath);
+    const createResult = await create(projectPath, {
+      frontend: ["tanstack-router"],
+      backend: "hono",
+      runtime: "bun",
+      database: "sqlite",
+      orm: "drizzle",
+      api: "trpc",
+      auth: "none",
+      payments: "none",
+      addons: ["turborepo"],
+      examples: ["none"],
+      dbSetup: "none",
+      webDeploy: "none",
+      serverDeploy: "none",
+      install: false,
+      git: true,
+      packageManager: "bun",
+      disableAnalytics: true,
+    });
+    expect(createResult.isOk()).toBe(true);
+
+    const before = await readBtsConfig(projectPath);
+
+    const result = await client.callTool({
+      name: "bts_plan_app",
+      arguments: {
+        projectDir: projectPath,
+        name: "admin",
+        frontend: "next",
+      },
+    });
+
+    const payload = result.structuredContent as {
+      ok: boolean;
+      data?: { success?: boolean; dryRun?: boolean; appName?: string; port?: number };
+    };
+
+    expect(payload.ok).toBe(true);
+    expect(payload.data?.success).toBe(true);
+    expect(payload.data?.dryRun).toBe(true);
+    expect(payload.data?.appName).toBe("admin");
+    expect(payload.data?.port).toBe(3002);
+
+    expect(await fs.pathExists(path.join(projectPath, "apps", "admin"))).toBe(false);
+    const after = await readBtsConfig(projectPath);
+    expect(after).toEqual(before);
+  });
+
+  it("adds an app through MCP and persists it to bts.jsonc", async () => {
+    const { client, cleanup } = await connectInMemoryClient();
+    cleanups.push(cleanup);
+
+    const projectPath = path.join(SMOKE_DIR, "mcp-add-app");
+    await fs.remove(projectPath);
+    const createResult = await create(projectPath, {
+      frontend: ["tanstack-router"],
+      backend: "hono",
+      runtime: "bun",
+      database: "sqlite",
+      orm: "drizzle",
+      api: "trpc",
+      auth: "none",
+      payments: "none",
+      addons: ["turborepo"],
+      examples: ["none"],
+      dbSetup: "none",
+      webDeploy: "none",
+      serverDeploy: "none",
+      install: false,
+      git: true,
+      packageManager: "bun",
+      disableAnalytics: true,
+    });
+    expect(createResult.isOk()).toBe(true);
+
+    const result = await client.callTool({
+      name: "bts_add_app",
+      arguments: {
+        projectDir: projectPath,
+        name: "admin",
+        frontend: "next",
+      },
+    });
+
+    const payload = result.structuredContent as {
+      ok: boolean;
+      data?: { success?: boolean; appName?: string; port?: number };
+    };
+
+    expect(payload.ok).toBe(true);
+    expect(payload.data?.success).toBe(true);
+    expect(payload.data?.appName).toBe("admin");
+
+    expect(await fs.pathExists(path.join(projectPath, "apps", "admin", "package.json"))).toBe(true);
+    const after = await readBtsConfig(projectPath);
+    expect(after?.apps).toEqual([{ name: "admin", frontend: "next", port: 3002 }]);
+  });
+
+  it("rejects unknown keys in bts_plan_app input", async () => {
+    const { client, cleanup } = await connectInMemoryClient();
+    cleanups.push(cleanup);
+
+    const result = await client.callTool({
+      name: "bts_plan_app",
+      arguments: {
+        projectDir: path.join(SMOKE_DIR, "mcp-plan-app-unknown"),
+        name: "admin",
+        frontend: "next",
+        bogusKey: true,
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    const text = getToolText(result as { content: Array<{ type: string; text?: string }> });
+    expect(text).toContain("Unrecognized key");
   });
 
   it("starts over stdio through the CLI entrypoint", async () => {

--- a/apps/cli/test/programmatic-api.test.ts
+++ b/apps/cli/test/programmatic-api.test.ts
@@ -5,6 +5,7 @@ import fs from "fs-extra";
 
 import {
   add,
+  addApp,
   CLIError,
   create,
   createVirtual,
@@ -232,5 +233,16 @@ describe("programmatic API input validation", () => {
     expect(result.addedAddons).toEqual([]);
     expect(result.error).toContain("Invalid add input");
     expect(result.error).toContain("addons");
+  });
+
+  it("returns a structured failure instead of throwing for an invalid add-app input shape", async () => {
+    const result = await addApp({
+      name: "admin",
+      frontend: 42,
+    } as never);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Invalid add-app input");
+    expect(result.error).toContain("frontend");
   });
 });

--- a/apps/cli/test/schema-command.test.ts
+++ b/apps/cli/test/schema-command.test.ts
@@ -14,6 +14,7 @@ describe("Schema command", () => {
     expect(result).toHaveProperty("schemas");
     expect(result.schemas).toHaveProperty("createInput");
     expect(result.schemas).toHaveProperty("addInput");
+    expect(result.schemas).toHaveProperty("addAppInput");
     expect(result.schemas).toHaveProperty("addonOptions");
     expect(result.schemas).toHaveProperty("dbSetupOptions");
     expect(Array.isArray(result.cli.commands)).toBe(true);
@@ -24,6 +25,15 @@ describe("Schema command", () => {
 
     expect(result).toHaveProperty("type", "object");
     expect(result).toHaveProperty("properties");
+  });
+
+  it("exposes reserved app names in the add-app input schema", async () => {
+    const result = (await caller.schema({ name: "addAppInput" })) as {
+      properties?: { name?: { not?: { enum?: string[] } } };
+    };
+
+    expect(result.properties?.name?.not?.enum).toContain("web");
+    expect(result.properties?.name?.not?.enum).toContain("server");
   });
 
   it("includes agent-focused commands in CLI introspection", async () => {

--- a/apps/web/content/docs/bts-config.mdx
+++ b/apps/web/content/docs/bts-config.mdx
@@ -18,7 +18,7 @@ If `bts.jsonc` is missing, the `add` command cannot run because the project cann
 
 ## Safe to delete (with a caveat)
 
-It’s safe to delete for normal development; the generated code in `apps/*` and `packages/*` remains the source of truth. However, if you plan to use the `add` command later, you must keep `bts.jsonc` so the CLI can detect your project.
+It’s safe to delete for normal development; the generated code in `apps/*` and `packages/*` remains the source of truth. However, if you plan to use the `add` or `add-app` commands later, you must keep `bts.jsonc` so the CLI can detect your project.
 
 ## Format
 
@@ -59,6 +59,8 @@ The file is JSONC with comments enabled and includes a `$schema` URL for tooling
   "webDeploy": "none",
   "serverDeploy": "none",
   "packageManager": "bun",
+  // Present only after `add-app` has added extra frontend apps
+  "apps": [{ "name": "admin", "frontend": "next", "port": 3002 }],
 }
 ```
 
@@ -69,6 +71,6 @@ Notes:
 - Deeply nested structured options remain in `addonOptions` or `dbSetupOptions` and may not be fully represented in the one-line command
 - `addonOptions` stores nested configuration for prompt-driven addons
 - `dbSetupOptions` stores structured database setup behavior for automation
-- The file may be updated when you run `add` (addons and addon-specific config)
+- The file may be updated when you run `add` (addons and addon-specific config) or `add-app` (the `apps` array)
 
 See also: [`add` command](/docs/cli#add)

--- a/apps/web/content/docs/cli/agent-workflows.mdx
+++ b/apps/web/content/docs/cli/agent-workflows.mdx
@@ -125,6 +125,8 @@ Exposed tools:
 - `bts_create_project`
 - `bts_plan_addons`
 - `bts_add_addons`
+- `bts_plan_app`
+- `bts_add_app`
 
 This is the best path when an MCP-capable client should scaffold or modify Better-T-Stack projects without shelling out to a prompt-driven CLI flow.
 
@@ -136,6 +138,7 @@ Recommended MCP workflow:
 4. Call `bts_plan_project` before `bts_create_project`.
 5. For MCP execution, use `install: false` when creating projects.
 6. Call `bts_plan_addons` before `bts_add_addons`.
+7. Call `bts_plan_app` before `bts_add_app` when adding another frontend app.
 
 For project creation, the MCP tools now expect a full explicit config, not a partial payload. That means the agent should provide all major stack choices such as:
 

--- a/apps/web/content/docs/cli/compatibility.mdx
+++ b/apps/web/content/docs/cli/compatibility.mdx
@@ -113,9 +113,10 @@ create-better-t-stack --frontend nuxt --api orpc
 
 ### Frontend Restrictions
 
-- **Multiple Web Frontends**: ❌ Only one web framework allowed
+- **Multiple Web Frontends**: ❌ Only one web framework allowed in `--frontend`
 - **Multiple Native Frontends**: ❌ Only one native framework allowed
 - **Web + Native**: ✅ One web and one native framework allowed
+- **Extra web apps**: ✅ Use [`--apps` / `add-app`](/docs/cli#add-app) — each extra app picks its own framework
 
 ```bash
 # ❌ Invalid - Multiple web frontends
@@ -123,6 +124,9 @@ create-better-t-stack --frontend next tanstack-router
 
 # ✅ Valid - Web + native
 create-better-t-stack --frontend next native-uniwind
+
+# ✅ Valid - Primary web app + extra apps
+create-better-t-stack --frontend tanstack-router --api orpc --apps admin:next
 ```
 
 ## Database Setup Compatibility
@@ -280,8 +284,11 @@ create-better-t-stack --runtime workers --backend hono
 ### "Cannot select multiple web frameworks"
 
 ```bash
-# Fix by choosing one web framework
+# Fix by choosing one primary web framework
 create-better-t-stack --frontend tanstack-router
+
+# Or add the second framework as an extra app
+create-better-t-stack --frontend tanstack-router --api orpc --apps admin:next
 ```
 
 ### "Polar payments requires Better Auth"

--- a/apps/web/content/docs/cli/index.mdx
+++ b/apps/web/content/docs/cli/index.mdx
@@ -95,6 +95,46 @@ create-better-t-stack add --addons pwa tauri --install
 create-better-t-stack add --project-dir ./my-app --addons mcp skills
 ```
 
+## `add-app`
+
+Adds another frontend app (for example an admin panel or landing page) to an existing Better-T-Stack project. The new app lands in `apps/<name>`, gets its own dev port and env module, and is wired to the project's existing API, auth, and shared packages.
+
+```bash
+create-better-t-stack add-app [name] [options]
+```
+
+### Options
+
+- `--frontend <framework>`: Framework for the new app (`tanstack-router`, `react-router`, `tanstack-start`, `next`, `nuxt`, `svelte`, `solid`, `astro`)
+- `--port <number>`: Dev server port (defaults to the next free port from 3002)
+- `--project-dir <path>`: Project directory (defaults to current directory)
+- `--install / --no-install`: Install dependencies after adding
+- `--package-manager <pm>`: Package manager to use (`npm`, `pnpm`, `bun`)
+- `--dry-run`: Preview the app files without writing them
+
+The framework can differ from your existing web app, but is validated against the project's stack: tRPC projects and Clerk projects accept React-family frameworks only, Convex projects exclude Solid and Astro, and fullstack (`backend: self`) projects cannot add apps. Extra apps are scaffolded without deploy wiring, and the CLI prints the manual CORS/auth origin steps instead of editing your server code.
+
+For new projects you can skip the second step entirely: `create` accepts `--apps` with the same validation, scaffolding the extra apps in one command (before install and the initial git commit):
+
+```bash
+create-better-t-stack my-app --frontend tanstack-router --backend hono --api orpc --apps admin:next landing:astro
+```
+
+The [Stack Builder](https://better-t-stack.dev/new) has an Extra Apps section that appends `--apps` to the generated command, and shared builder links carry the planned apps.
+
+### Examples
+
+```bash
+# Add an app interactively
+create-better-t-stack add-app
+
+# Add a Next.js admin app
+create-better-t-stack add-app admin --frontend next
+
+# Add an Astro landing page on a specific port
+create-better-t-stack add-app landing --frontend astro --port 3005
+```
+
 ## `create-json`
 
 Create a project from a raw JSON payload.
@@ -111,6 +151,14 @@ Add addons from a raw JSON payload.
 
 ```bash
 create-better-t-stack add-json --input '{"projectDir":"./my-app","addons":["wxt"],"addonOptions":{"wxt":{"template":"react"}}}'
+```
+
+## `add-app-json`
+
+Add an app from a raw JSON payload.
+
+```bash
+create-better-t-stack add-app-json --input '{"projectDir":"./my-app","name":"admin","frontend":"next"}'
 ```
 
 ## `schema`
@@ -134,7 +182,7 @@ Start the Better-T-Stack MCP server over stdio. It is launched by an MCP client 
 create-better-t-stack mcp
 ```
 
-It exposes tools for planning and creating projects (`bts_plan_project`, `bts_create_project`) and managing addons (`bts_plan_addons`, `bts_add_addons`), plus schema and guidance helpers. See [Agent Workflows](/docs/cli/agent-workflows#use-it-inside-your-ai-agent) for setup and the full tool list.
+It exposes tools for planning and creating projects (`bts_plan_project`, `bts_create_project`), managing addons (`bts_plan_addons`, `bts_add_addons`), and adding apps (`bts_plan_app`, `bts_add_app`), plus schema and guidance helpers. See [Agent Workflows](/docs/cli/agent-workflows#use-it-inside-your-ai-agent) for setup and the full tool list.
 
 ## `sponsors`
 

--- a/apps/web/content/docs/cli/options.mdx
+++ b/apps/web/content/docs/cli/options.mdx
@@ -266,6 +266,16 @@ Frontend frameworks (can specify multiple):
 
 - `none`: Backend-only project
 
+### `--apps <specs...>`
+
+Extra frontend apps to scaffold alongside the project, as `name:framework` pairs. Each lands in `apps/<name>` with its own dev port (3002+) and env module, wired to the project's API and auth. Frameworks are validated against the stack: tRPC and Clerk accept React-family frameworks only, Convex excludes Solid and Astro, and fullstack (`self`) backends cannot use `--apps`.
+
+```bash
+create-better-t-stack my-app --frontend tanstack-router --api orpc --apps admin:next landing:astro
+```
+
+Use the [`add-app` command](/docs/cli#add-app) to add apps to an existing project instead.
+
 ```bash
 # Single web frontend
 create-better-t-stack --frontend tanstack-router
@@ -385,6 +395,7 @@ These are part of the CLI contract for agents and scripts even though they are c
 
 - `create-json`
 - `add-json`
+- `add-app-json`
 - `schema --name <schema>`
 - `mcp`
 - `addonOptions`

--- a/apps/web/content/docs/cli/programmatic-api.mdx
+++ b/apps/web/content/docs/cli/programmatic-api.mdx
@@ -108,6 +108,44 @@ if (result.success) {
 `add()` validates its input at runtime and always returns an `AddResult`. Invalid input and
 addon failures return `{ success: false, error }` instead of throwing or exiting the process.
 
+### `addApp(options?)`
+
+Add another frontend app to an existing Better-T-Stack project.
+
+```typescript
+function addApp(options?: {
+  name?: string;
+  frontend?: WebFrontend;
+  port?: number;
+  install?: boolean;
+  packageManager?: PackageManager;
+  projectDir?: string;
+  dryRun?: boolean;
+}): Promise<AddAppResult>;
+```
+
+Example:
+
+```typescript
+import { addApp } from "create-better-t-stack";
+
+const result = await addApp({
+  projectDir: "./my-app",
+  name: "admin",
+  frontend: "next",
+});
+
+if (result.success) {
+  console.log(`Added apps/${result.appName} on port ${result.port}`);
+} else {
+  console.error(result.error ?? "Failed to add app");
+}
+```
+
+`addApp()` validates its input at runtime and always returns an `AddAppResult`. The chosen
+framework is checked against the project's existing api/auth/backend, and `name`/`frontend`
+are required in this silent mode.
+
 ### `createVirtual(options)`
 
 Generate a project in memory without writing to disk.
@@ -185,8 +223,8 @@ type AddResult = {
 - `CLIError`
 - `ProjectCreationError`
 
-The `CreateInput`, `AddOptions`, `ProjectConfig`, `InitResult`, and `AddResult` types are exported
-from `create-better-t-stack`.
+The `CreateInput`, `AddOptions`, `AddAppOptions`, `ProjectConfig`, `InitResult`, `AddResult`,
+and `AddAppResult` types are exported from `create-better-t-stack`.
 
 ## Error Handling Pattern
 

--- a/apps/web/content/docs/index.mdx
+++ b/apps/web/content/docs/index.mdx
@@ -95,11 +95,25 @@ npm create better-t-stack@latest my-workspace \
   --backend none
 ```
 
+### Multi-App Workspace
+
+```npm
+npm create better-t-stack@latest my-platform \
+  --frontend tanstack-router \
+  --backend hono \
+  --api orpc \
+  --database postgres \
+  --orm drizzle \
+  --auth better-auth \
+  --apps admin:next landing:astro
+```
+
 ## Flags Cheat Sheet
 
 See the full list in the [CLI Reference](/docs/cli). Key flags:
 
 - `--frontend`: tanstack-router, react-router, tanstack-start, next, nuxt, svelte, solid, astro, native-bare, native-uniwind, native-unistyles, none
+- `--apps`: extra frontend apps as name:framework (e.g. admin:next landing:astro) — see [add-app](/docs/cli#add-app)
 - `--backend`: hono, express, fastify, elysia, convex, self, none
 - `--runtime`: bun, node, workers, none
 - `--database`: sqlite, postgres, mysql, mongodb, none

--- a/apps/web/content/docs/project-structure.mdx
+++ b/apps/web/content/docs/project-structure.mdx
@@ -443,9 +443,12 @@ Electrobun adds an `apps/desktop` workspace with its own `package.json`, `electr
   "dbSetup": "<turso|neon|prisma-postgres|planetscale|mongodb-atlas|supabase|d1|docker|none>",
   "api": "<none|trpc|orpc>",
   "webDeploy": "<cloudflare|docker|vercel|none>",
-  "serverDeploy": "<cloudflare|docker|vercel|none>"
+  "serverDeploy": "<cloudflare|docker|vercel|none>",
+  "apps": [{ "name": "<app-name>", "frontend": "<web-framework>", "port": 3002 }]
 }
 ```
+
+The optional `apps` array tracks extra frontend apps added with `create-better-t-stack add-app`. Each one lives in `apps/<name>` with its own dev port and env module (`@{project}/env/<name>`), sharing the project's API, auth, and workspace packages.
 
 ### Turborepo Config (turbo.json)
 

--- a/apps/web/src/app/(home)/new/_components/stack-builder/extra-apps-section.tsx
+++ b/apps/web/src/app/(home)/new/_components/stack-builder/extra-apps-section.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import { InfoIcon, Plus, Terminal, X } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import { Input } from "@/components/ui/input";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import type { StackState } from "@/lib/constant";
+import {
+  EXTRA_APP_FRAMEWORKS,
+  formatExtraApp,
+  getExtraAppFrontendDisabledReason,
+  getExtraAppsBlockedReason,
+  parseExtraApp,
+  validateExtraAppName,
+} from "@/lib/extra-apps";
+import { cn } from "@/lib/utils";
+
+import { TechIcon } from "../tech-icon";
+
+type ExtraAppsSectionProps = {
+  stack: StackState;
+  mode: "desktop" | "mobile";
+  onAppsChange: (apps: string[]) => void;
+};
+
+/**
+ * Plan additional frontend apps (name + framework) with the same gating as
+ * the CLI. Renders nothing for fullstack (self) backends.
+ */
+export function ExtraAppsSection({ stack, mode, onAppsChange }: ExtraAppsSectionProps) {
+  const isDesktop = mode === "desktop";
+  const [formOpen, setFormOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [nameTouched, setNameTouched] = useState(false);
+  const [frontend, setFrontend] = useState<string | null>(null);
+
+  const plannedApps = useMemo(
+    () =>
+      stack.apps.flatMap((encoded) => {
+        const app = parseExtraApp(encoded);
+        if (!app) return [];
+        const option = EXTRA_APP_FRAMEWORKS.find((candidate) => candidate.id === app.frontend);
+        return option ? [{ ...app, option }] : [];
+      }),
+    [stack.apps],
+  );
+
+  const takenNames = useMemo(() => new Set(plannedApps.map((app) => app.name)), [plannedApps]);
+
+  // Hidden entirely when unavailable (fullstack self backends) — the
+  // compatibility engine already drops any previously planned apps.
+  if (getExtraAppsBlockedReason(stack)) return null;
+
+  const trimmedName = name.trim();
+  const nameError = validateExtraAppName(trimmedName, takenNames);
+  const firstCompatible =
+    EXTRA_APP_FRAMEWORKS.find((option) => !getExtraAppFrontendDisabledReason(stack, option.id))
+      ?.id ?? null;
+  const selectedFrontend =
+    frontend && !getExtraAppFrontendDisabledReason(stack, frontend) ? frontend : firstCompatible;
+  const canAdd = !nameError && selectedFrontend !== null;
+
+  const resetForm = () => {
+    setFormOpen(false);
+    setName("");
+    setNameTouched(false);
+    setFrontend(null);
+  };
+
+  const addApp = () => {
+    if (!canAdd || selectedFrontend === null) {
+      setNameTouched(true);
+      return;
+    }
+    onAppsChange([
+      ...stack.apps,
+      formatExtraApp({ name: trimmedName, frontend: selectedFrontend }),
+    ]);
+    resetForm();
+  };
+
+  return (
+    <section
+      id={isDesktop ? "section-apps" : "section-mobile-apps"}
+      className={cn("mb-6 scroll-mt-4", isDesktop && "sm:mb-8")}
+    >
+      <div className="mb-3 flex items-center gap-2 text-fd-muted-foreground">
+        <Terminal aria-hidden="true" className="h-3 w-3 shrink-0 text-primary" />
+        <h2 className="font-mono text-[11px] text-fd-muted-foreground uppercase tracking-[0.08em]">
+          EXTRA APPS
+        </h2>
+        <span aria-hidden="true" className="h-px flex-1 bg-fd-border" />
+        <Tooltip delay={100}>
+          <TooltipTrigger
+            render={
+              <InfoIcon className="h-3.5 w-3.5 shrink-0 cursor-help text-fd-muted-foreground transition-colors duration-150 hover:text-fd-foreground" />
+            }
+          />
+          <TooltipContent side="top" align="start">
+            <p className="max-w-64 text-xs">
+              Additional frontend apps (admin panel, landing page, …) created alongside your project
+              via --apps. Each gets its own dev port and env module, sharing your API and auth.
+            </p>
+          </TooltipContent>
+        </Tooltip>
+      </div>
+
+      <div className="space-y-2">
+        {plannedApps.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {plannedApps.map((app) => (
+              <span
+                key={app.name}
+                className="inline-flex items-center gap-1 rounded-[4px] border pr-1 pl-2 font-mono text-[11px] text-fd-foreground"
+              >
+                <span className="flex items-center gap-1.5 py-0.5">
+                  {app.name}
+                  <span className="flex items-center gap-1 text-fd-muted-foreground">
+                    {app.option.icon !== "" && (
+                      <TechIcon icon={app.option.icon} name={app.option.name} className="h-3 w-3" />
+                    )}
+                    {app.option.name}
+                  </span>
+                </span>
+                <button
+                  type="button"
+                  onClick={() =>
+                    onAppsChange(
+                      stack.apps.filter((encoded) => parseExtraApp(encoded)?.name !== app.name),
+                    )
+                  }
+                  aria-label={`Remove planned app ${app.name}`}
+                  className="builder-focus-ring pointer-coarse:p-2 p-0.5 text-fd-muted-foreground transition-colors duration-150 hover:text-destructive"
+                >
+                  <X className="h-2.5 w-2.5" />
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
+
+        {formOpen ? (
+          <div className="space-y-3 rounded-[4px] border p-3">
+            <div className="space-y-1.5">
+              <label
+                htmlFor={`${mode}-extra-app-name`}
+                className="block font-mono text-[10px] text-fd-muted-foreground uppercase tracking-[0.10em]"
+              >
+                App name
+              </label>
+              <Input
+                id={`${mode}-extra-app-name`}
+                value={name}
+                autoFocus
+                placeholder="admin"
+                autoComplete="off"
+                spellCheck={false}
+                onChange={(event) => setName(event.target.value)}
+                onBlur={() => setNameTouched(true)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    event.preventDefault();
+                    addApp();
+                  }
+                  if (event.key === "Escape") resetForm();
+                }}
+                aria-invalid={nameTouched && nameError !== null}
+                className="h-8 font-mono text-[13px]"
+              />
+              {nameTouched && nameError && (
+                <p role="alert" className="font-mono text-[11px] text-destructive leading-[1.5]">
+                  {nameError}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1.5">
+              <p className="font-mono text-[10px] text-fd-muted-foreground uppercase tracking-[0.10em]">
+                Framework
+              </p>
+              <div className="flex flex-wrap gap-1.5">
+                {EXTRA_APP_FRAMEWORKS.map((option) => {
+                  const disabledReason = getExtraAppFrontendDisabledReason(stack, option.id);
+                  const isSelected = selectedFrontend === option.id;
+
+                  const chip = (
+                    <button
+                      key={option.id}
+                      type="button"
+                      disabled={disabledReason !== null}
+                      aria-pressed={isSelected}
+                      aria-label={`${option.name}${disabledReason ? `. ${disabledReason}` : ""}`}
+                      onClick={() => setFrontend(option.id)}
+                      className={cn(
+                        "builder-focus-ring flex items-center gap-1.5 rounded-[4px] border px-2 py-1 font-mono text-[11px] transition-colors duration-150",
+                        disabledReason
+                          ? "cursor-not-allowed border-dashed opacity-60"
+                          : isSelected
+                            ? "border-primary text-fd-foreground"
+                            : "text-fd-muted-foreground hover:border-primary/50 hover:text-fd-foreground",
+                      )}
+                    >
+                      {option.icon !== "" && (
+                        <TechIcon icon={option.icon} name={option.name} className="h-3 w-3" />
+                      )}
+                      {option.name}
+                    </button>
+                  );
+
+                  return disabledReason && isDesktop ? (
+                    <Tooltip key={option.id} delay={100}>
+                      <TooltipTrigger render={chip} />
+                      <TooltipContent side="top" align="start">
+                        <p className="max-w-60 text-xs">{disabledReason}</p>
+                      </TooltipContent>
+                    </Tooltip>
+                  ) : (
+                    chip
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="flex items-center justify-end gap-2">
+              <button
+                type="button"
+                onClick={resetForm}
+                className="builder-focus-ring pointer-coarse:min-h-8 flex items-center justify-center rounded-[4px] border px-2 py-1.5 font-mono text-[10px] text-fd-muted-foreground uppercase tracking-[0.10em] transition-colors duration-150 hover:text-fd-foreground"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={addApp}
+                disabled={!canAdd}
+                className={cn(
+                  "builder-focus-ring pointer-coarse:min-h-8 flex items-center justify-center gap-1.5 rounded-[4px] border px-2 py-1.5 font-mono text-[10px] uppercase tracking-[0.10em] transition-colors duration-150",
+                  canAdd
+                    ? "border-primary text-primary hover:bg-primary/10"
+                    : "cursor-not-allowed border-dashed text-fd-muted-foreground opacity-60",
+                )}
+              >
+                <Plus className="h-3 w-3 shrink-0" />
+                Add app
+              </button>
+            </div>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setFormOpen(true)}
+            className="builder-focus-ring pointer-coarse:min-h-8 flex items-center gap-1.5 rounded-[4px] border border-dashed px-2 py-1.5 font-mono text-[10px] text-fd-muted-foreground uppercase tracking-[0.10em] transition-colors duration-150 hover:border-primary/50 hover:text-fd-foreground"
+          >
+            <Plus className="h-3 w-3 shrink-0" />
+            Add app
+          </button>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/app/(home)/new/_components/stack-builder/index.tsx
+++ b/apps/web/src/app/(home)/new/_components/stack-builder/index.tsx
@@ -253,6 +253,21 @@ export function StackBuilder({ specialSponsors = [] }: StackBuilderProps) {
                         }
                         scrollToCategorySection("section", category);
                       }}
+                      onRemoveApp={(name) =>
+                        setStack({
+                          apps: effectiveStack.apps.filter(
+                            (encoded) => !encoded.startsWith(`${name}:`),
+                          ),
+                        })
+                      }
+                      onJumpToApps={() => {
+                        if (viewMode !== "command") {
+                          startTransition(() => {
+                            setViewMode("command");
+                          });
+                        }
+                        scrollToCategorySection("section", "apps");
+                      }}
                     />
                   </section>
 
@@ -334,6 +349,7 @@ export function StackBuilder({ specialSponsors = [] }: StackBuilderProps) {
                       stack={effectiveStack}
                       compatibilityNotes={compatibilityAnalysis.notes}
                       onSelect={handleTechSelect}
+                      onExtraAppsChange={(apps) => setStack({ apps })}
                       showAllCategories
                     />
                   </main>
@@ -475,6 +491,7 @@ export function StackBuilder({ specialSponsors = [] }: StackBuilderProps) {
                     stack={effectiveStack}
                     compatibilityNotes={compatibilityAnalysis.notes}
                     onSelect={handleTechSelect}
+                    onExtraAppsChange={(apps) => setStack({ apps })}
                     showAllCategories
                   />
                 </main>

--- a/apps/web/src/app/(home)/new/_components/stack-builder/selected-stack-badges.tsx
+++ b/apps/web/src/app/(home)/new/_components/stack-builder/selected-stack-badges.tsx
@@ -2,6 +2,7 @@ import { X } from "lucide-react";
 
 import type { StackState } from "@/lib/constant";
 import { TECH_OPTIONS } from "@/lib/constant";
+import { EXTRA_APP_FRAMEWORKS, parseExtraApp } from "@/lib/extra-apps";
 import { CATEGORY_ORDER } from "@/lib/stack-utils";
 import type { TechCategory } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -13,9 +14,17 @@ type SelectedStackBadgesProps = {
   stack: StackState;
   onRemove?: (category: TechCategory, techId: string) => void;
   onJump?: (category: TechCategory) => void;
+  onRemoveApp?: (name: string) => void;
+  onJumpToApps?: () => void;
 };
 
-export function SelectedStackBadges({ stack, onRemove, onJump }: SelectedStackBadgesProps) {
+export function SelectedStackBadges({
+  stack,
+  onRemove,
+  onJump,
+  onRemoveApp,
+  onJumpToApps,
+}: SelectedStackBadgesProps) {
   const selections = CATEGORY_ORDER.flatMap((category) => {
     const options = TECH_OPTIONS[category];
     const selectedValue = stack[category as keyof StackState];
@@ -35,7 +44,14 @@ export function SelectedStackBadges({ stack, onRemove, onJump }: SelectedStackBa
       });
   });
 
-  if (selections.length === 0) {
+  const extraApps = stack.apps.flatMap((encoded) => {
+    const app = parseExtraApp(encoded);
+    if (!app) return [];
+    const option = EXTRA_APP_FRAMEWORKS.find((candidate) => candidate.id === app.frontend);
+    return option ? [{ ...app, option }] : [];
+  });
+
+  if (selections.length === 0 && extraApps.length === 0) {
     return (
       <p className="font-mono text-[11px] text-fd-muted-foreground uppercase tracking-[0.08em]">
         No selections yet
@@ -90,6 +106,51 @@ export function SelectedStackBadges({ stack, onRemove, onJump }: SelectedStackBa
                 type="button"
                 onClick={() => onRemove(category, tech.id)}
                 aria-label={`Remove ${tech.name} from ${categoryLabel}`}
+                className="builder-focus-ring pointer-coarse:p-2 p-0.5 text-fd-muted-foreground transition-colors duration-150 hover:text-destructive"
+              >
+                <X className="h-2.5 w-2.5" />
+              </button>
+            )}
+          </span>
+        );
+      })}
+      {extraApps.map((app) => {
+        const chipContent = (
+          <>
+            {app.option.icon !== "" && (
+              <TechIcon icon={app.option.icon} name={app.option.name} className="h-3 w-3" />
+            )}
+            {`apps/${app.name}`}
+          </>
+        );
+        const hoverTitle = `Extra app: ${app.name} — ${app.option.name}`;
+
+        return (
+          <span
+            key={`extra-app-${app.name}`}
+            title={onJumpToApps ? undefined : hoverTitle}
+            className={cn(
+              "inline-flex items-center gap-1 rounded-[4px] border pl-2 font-mono text-[11px] text-fd-foreground",
+              onRemoveApp ? "pr-1" : "pr-2",
+            )}
+          >
+            {onJumpToApps ? (
+              <button
+                type="button"
+                onClick={onJumpToApps}
+                title={hoverTitle}
+                className="builder-focus-ring pointer-coarse:py-1.5 flex items-center gap-1.5 py-0.5 transition-colors duration-150 hover:text-primary"
+              >
+                {chipContent}
+              </button>
+            ) : (
+              <span className="flex items-center gap-1.5 py-0.5">{chipContent}</span>
+            )}
+            {onRemoveApp && (
+              <button
+                type="button"
+                onClick={() => onRemoveApp(app.name)}
+                aria-label={`Remove extra app ${app.name}`}
                 className="builder-focus-ring pointer-coarse:p-2 p-0.5 text-fd-muted-foreground transition-colors duration-150 hover:text-destructive"
               >
                 <X className="h-2.5 w-2.5" />

--- a/apps/web/src/app/(home)/new/_components/stack-builder/tech-categories.tsx
+++ b/apps/web/src/app/(home)/new/_components/stack-builder/tech-categories.tsx
@@ -1,4 +1,5 @@
 import { CheckCircle2, InfoIcon, Terminal } from "lucide-react";
+import { Fragment } from "react";
 
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { StackState } from "@/lib/constant";
@@ -9,12 +10,14 @@ import { cn } from "@/lib/utils";
 
 import { TechIcon } from "../tech-icon";
 import { getCategoryDisplayName, getDisabledReason, isOptionCompatible } from "../utils";
+import { ExtraAppsSection } from "./extra-apps-section";
 
 type TechCategoriesProps = {
   mode: "desktop" | "mobile";
   stack: StackState;
   compatibilityNotes: Record<string, { hasIssue: boolean; notes: string[] }>;
   onSelect: (category: keyof typeof TECH_OPTIONS, techId: string) => void;
+  onExtraAppsChange?: (apps: string[]) => void;
   showAllCategories?: boolean;
 };
 
@@ -38,6 +41,7 @@ export function TechCategories({
   stack,
   compatibilityNotes,
   onSelect,
+  onExtraAppsChange,
   showAllCategories = false,
 }: TechCategoriesProps) {
   const isDesktop = mode === "desktop";
@@ -51,7 +55,7 @@ export function TechCategories({
 
         if (categoryOptions.length === 0) return null;
 
-        return (
+        const sectionNode = (
           <section
             key={`${mode}-${categoryKey}`}
             id={isDesktop ? `section-${categoryKey}` : `section-mobile-${categoryKey}`}
@@ -212,6 +216,18 @@ export function TechCategories({
             </div>
           </section>
         );
+
+        // Planned extra apps live right below the web frontend choice.
+        if (categoryKey === "webFrontend" && onExtraAppsChange) {
+          return (
+            <Fragment key={`${mode}-${categoryKey}-with-apps`}>
+              {sectionNode}
+              <ExtraAppsSection stack={stack} mode={mode} onAppsChange={onExtraAppsChange} />
+            </Fragment>
+          );
+        }
+
+        return sectionNode;
       })}
       <div className="h-24" />
     </>

--- a/apps/web/src/app/(home)/new/_components/utils.ts
+++ b/apps/web/src/app/(home)/new/_components/utils.ts
@@ -1,6 +1,11 @@
 import { desktopWebFrontends } from "@better-t-stack/types";
 
 import { DEFAULT_STACK, type StackState, type TECH_OPTIONS } from "@/lib/constant";
+import {
+  getExtraAppFrontendDisabledReason,
+  getExtraAppsBlockedReason,
+  parseExtraApp,
+} from "@/lib/extra-apps";
 import { CATEGORY_ORDER } from "@/lib/stack-utils";
 
 export function validateProjectName(name: string): string | undefined {
@@ -995,6 +1000,44 @@ export const analyzeStackCompatibility = (stack: StackState): CompatibilityResul
       category: "serverDeploy",
       message: "Server deploy set to 'None' (not needed for this backend)",
     });
+  }
+
+  // ============================================
+  // EXTRA APPS (planned add-app commands)
+  // ============================================
+
+  if (nextStack.apps.length > 0) {
+    const blockedReason = getExtraAppsBlockedReason(nextStack);
+    const keptApps: string[] = [];
+
+    for (const encoded of nextStack.apps) {
+      const app = parseExtraApp(encoded);
+      if (!app) continue;
+
+      if (blockedReason) {
+        changes.push({
+          category: "apps",
+          message: `Removed planned app '${app.name}': fullstack (self) backends can't add extra apps`,
+        });
+        continue;
+      }
+
+      const reason = getExtraAppFrontendDisabledReason(nextStack, app.frontend);
+      if (reason) {
+        changes.push({
+          category: "apps",
+          message: `Removed planned app '${app.name}': ${reason}`,
+        });
+        continue;
+      }
+
+      keptApps.push(encoded);
+    }
+
+    if (keptApps.length !== nextStack.apps.length) {
+      nextStack.apps = keptApps;
+      changed = true;
+    }
   }
 
   return {

--- a/apps/web/src/app/(home)/stack/_components/stack-display.tsx
+++ b/apps/web/src/app/(home)/stack/_components/stack-display.tsx
@@ -7,6 +7,7 @@ import { toast } from "sonner";
 
 import { ShareDialog } from "@/components/ui/share-dialog";
 import { TechBadge } from "@/components/ui/tech-badge";
+import { EXTRA_APP_FRAMEWORKS, parseExtraApp } from "@/lib/extra-apps";
 import type { LoadedStackState } from "@/lib/stack-url-state";
 import {
   formatProjectName,
@@ -47,6 +48,13 @@ export function StackDisplay({ stackState }: StackDisplayProps) {
       category={tech.category}
     />
   ));
+
+  const extraApps = stack.apps.flatMap((encoded) => {
+    const app = parseExtraApp(encoded);
+    if (!app) return [];
+    const option = EXTRA_APP_FRAMEWORKS.find((candidate) => candidate.id === app.frontend);
+    return option ? [{ ...app, option }] : [];
+  });
 
   const copyCommand = async () => {
     try {
@@ -166,6 +174,29 @@ export function StackDisplay({ stackState }: StackDisplayProps) {
             </div>
           )}
         </div>
+
+        {extraApps.length > 0 && (
+          <div className="space-y-4">
+            <div className="flex items-center gap-2">
+              <span className="text-primary text-xs">▶</span>
+              <span className="font-mono font-semibold text-foreground text-sm">
+                EXTRA_APPS ({extraApps.length})
+              </span>
+            </div>
+
+            <div className="flex flex-wrap gap-3">
+              {extraApps.map((app) => (
+                <span
+                  key={app.name}
+                  className="flex items-center gap-2 rounded border border-border bg-fd-background px-3 py-2 font-mono text-xs"
+                >
+                  <span className="text-foreground">{app.name}</span>
+                  <span className="text-muted-foreground">{app.option.name}</span>
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
       </div>
     </main>
   );

--- a/apps/web/src/lib/constant.ts
+++ b/apps/web/src/lib/constant.ts
@@ -774,6 +774,7 @@ export const PRESET_TEMPLATES = [
       api: "orpc",
       webDeploy: "none",
       serverDeploy: "none",
+      apps: [],
       yolo: "false",
     },
   },
@@ -800,6 +801,7 @@ export const PRESET_TEMPLATES = [
       api: "trpc",
       webDeploy: "none",
       serverDeploy: "none",
+      apps: [],
       yolo: "false",
     },
   },
@@ -826,6 +828,7 @@ export const PRESET_TEMPLATES = [
       api: "trpc",
       webDeploy: "none",
       serverDeploy: "none",
+      apps: [],
       yolo: "false",
     },
   },
@@ -852,6 +855,7 @@ export const PRESET_TEMPLATES = [
       api: "none",
       webDeploy: "none",
       serverDeploy: "none",
+      apps: [],
       yolo: "false",
     },
   },
@@ -876,6 +880,8 @@ export type StackState = {
   api: string;
   webDeploy: string;
   serverDeploy: string;
+  /** Extra frontend apps planned for `add-app`, encoded as "name:frontend". */
+  apps: string[];
   yolo: string;
 };
 
@@ -898,6 +904,7 @@ export const DEFAULT_STACK: StackState = {
   api: "trpc",
   webDeploy: "none",
   serverDeploy: "none",
+  apps: [],
   yolo: "false",
 };
 

--- a/apps/web/src/lib/extra-apps.ts
+++ b/apps/web/src/lib/extra-apps.ts
@@ -1,0 +1,138 @@
+import { TECH_OPTIONS } from "./constant";
+import type { StackState } from "./constant";
+
+/**
+ * Extra frontend apps planned in the stack builder, scaffolded after create
+ * via the CLI `add-app` command. Encoded in StackState as "name:frontend"
+ * strings so URL/localStorage/share serialization work unchanged.
+ */
+export interface ExtraApp {
+  name: string;
+  frontend: string;
+}
+
+type ExtraAppStack = Pick<StackState, "backend" | "api" | "auth">;
+
+const REACT_FAMILY_FRONTENDS = ["tanstack-router", "react-router", "tanstack-start", "next"];
+
+export const EXTRA_APP_FRAMEWORKS = TECH_OPTIONS.webFrontend.filter(
+  (option) => option.id !== "none",
+);
+
+const EXTRA_APP_FRAMEWORK_IDS = new Set(EXTRA_APP_FRAMEWORKS.map((option) => option.id));
+
+// Mirrors RESERVED_APP_NAMES in packages/types/src/schemas.ts.
+export const RESERVED_EXTRA_APP_NAMES = new Set([
+  "web",
+  "native",
+  "server",
+  "desktop",
+  "docs",
+  "fumadocs",
+  "tui",
+  "extension",
+  "api",
+  "auth",
+  "db",
+  "backend",
+  "config",
+  "env",
+  "infra",
+  "ui",
+]);
+
+const APP_NAME_PATTERN = /^[a-z][a-z0-9-]*$/;
+
+/** Parses a "name:frontend" spec; returns null for malformed input. */
+export function parseExtraApp(encoded: string): ExtraApp | null {
+  const separatorIndex = encoded.indexOf(":");
+  if (separatorIndex <= 0 || separatorIndex === encoded.length - 1) return null;
+  return {
+    name: encoded.slice(0, separatorIndex),
+    frontend: encoded.slice(separatorIndex + 1),
+  };
+}
+
+/** Encodes an extra app as its "name:frontend" spec. */
+export function formatExtraApp(app: ExtraApp): string {
+  return `${app.name}:${app.frontend}`;
+}
+
+/** Returns an error message, or null when the name is valid. */
+export function validateExtraAppName(name: string, takenNames: ReadonlySet<string>): string | null {
+  if (name.length === 0) return "App name cannot be empty";
+  if (name.length > 30) return "App name must be 30 characters or fewer";
+  if (!APP_NAME_PATTERN.test(name)) {
+    return "Use lowercase letters, digits, and dashes, starting with a letter";
+  }
+  if (RESERVED_EXTRA_APP_NAMES.has(name)) return `'${name}' is a reserved name`;
+  if (takenNames.has(name)) return `An app named '${name}' is already planned`;
+  return null;
+}
+
+const isSelfBackend = (backend: string) => backend.startsWith("self-") || backend === "self";
+
+/** Extra apps are unavailable entirely for fullstack (self) backends. */
+export function getExtraAppsBlockedReason(stack: Pick<StackState, "backend">): string | null {
+  if (isSelfBackend(stack.backend)) {
+    return "Fullstack (self) backends serve API routes from the web app itself, so extra apps have no shared server to connect to.";
+  }
+  return null;
+}
+
+/**
+ * Mirrors the CLI's validateAddAppFrontendCompatibility: which frameworks an
+ * extra app may use, given the project's api/auth/backend.
+ */
+export function getExtraAppFrontendDisabledReason(
+  stack: ExtraAppStack,
+  frontend: string,
+): string | null {
+  const isReactFamily = REACT_FAMILY_FRONTENDS.includes(frontend);
+
+  if (stack.api === "trpc" && !isReactFamily) {
+    return "tRPC API supports React-family frameworks only. Use oRPC for this framework.";
+  }
+
+  if (stack.auth === "clerk" && !isReactFamily) {
+    return "Clerk auth supports React-family frameworks only.";
+  }
+
+  if (stack.backend === "convex") {
+    if (frontend === "solid" || frontend === "astro") {
+      return "Convex does not support Solid or Astro.";
+    }
+    if (stack.auth === "better-auth" && !isReactFamily) {
+      return "Better-Auth with Convex supports React-family frameworks only.";
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Drops malformed entries, invalid names/frameworks, duplicates, and apps
+ * incompatible with the current stack. Used when loading URL/localStorage state.
+ */
+export function sanitizeExtraApps(
+  apps: readonly string[] | null | undefined,
+  stack: ExtraAppStack & Pick<StackState, "backend">,
+): string[] {
+  if (apps == null || apps.length === 0) return [];
+  if (getExtraAppsBlockedReason(stack)) return [];
+
+  const seen = new Set<string>();
+  const sanitized: string[] = [];
+
+  for (const encoded of apps) {
+    const app = parseExtraApp(encoded);
+    if (!app) continue;
+    if (validateExtraAppName(app.name, seen)) continue;
+    if (!EXTRA_APP_FRAMEWORK_IDS.has(app.frontend)) continue;
+    if (getExtraAppFrontendDisabledReason(stack, app.frontend)) continue;
+    seen.add(app.name);
+    sanitized.push(formatExtraApp(app));
+  }
+
+  return sanitized;
+}

--- a/apps/web/src/lib/sanitize-stack-addons.ts
+++ b/apps/web/src/lib/sanitize-stack-addons.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_STACK, type StackState, TECH_OPTIONS } from "./constant";
+import { sanitizeExtraApps } from "./extra-apps";
 
 const validWebFrontendIds = new Set(TECH_OPTIONS.webFrontend.map((option) => option.id));
 const validNativeFrontendIds = new Set(TECH_OPTIONS.nativeFrontend.map((option) => option.id));
@@ -88,6 +89,7 @@ export function sanitizeStackState(stack: StackState): StackState {
     nativeFrontend: sanitizeNativeFrontends(stack.nativeFrontend),
     addons: sanitizeAddons(stack.addons),
     examples: sanitizeExamples(stack.examples),
+    apps: sanitizeExtraApps(stack.apps, stack),
   };
 }
 

--- a/apps/web/src/lib/stack-url-keys.ts
+++ b/apps/web/src/lib/stack-url-keys.ts
@@ -23,6 +23,7 @@ export const stackUrlKeys: UrlKeys<StackUrlState> = {
   install: "i",
   webDeploy: "wd",
   serverDeploy: "sd",
+  apps: "apps",
   yolo: "yolo",
   viewMode: "view",
   selectedFile: "file",

--- a/apps/web/src/lib/stack-url-state.client.ts
+++ b/apps/web/src/lib/stack-url-state.client.ts
@@ -48,6 +48,7 @@ export const stackParsers = {
   serverDeploy: parseAsStringEnum<StackState["serverDeploy"]>(
     getValidIds("serverDeploy"),
   ).withDefault(DEFAULT_STACK.serverDeploy),
+  apps: parseAsArrayOf(parseAsString).withDefault(DEFAULT_STACK.apps),
   yolo: parseAsStringEnum<StackState["yolo"]>(["true", "false"]).withDefault(DEFAULT_STACK.yolo),
   viewMode: parseAsStringEnum<"command" | "preview">(["command", "preview"]).withDefault("command"),
   selectedFile: parseAsString.withDefault(""),
@@ -82,6 +83,7 @@ function getStackFromQueryState(queryState: StackState): StackState {
     install: queryState.install,
     webDeploy: queryState.webDeploy,
     serverDeploy: queryState.serverDeploy,
+    apps: queryState.apps,
     yolo: queryState.yolo,
   });
 }

--- a/apps/web/src/lib/stack-url-state.ts
+++ b/apps/web/src/lib/stack-url-state.ts
@@ -60,6 +60,7 @@ const serverStackParsers = {
   serverDeploy: parseAsStringEnumServer<StackState["serverDeploy"]>(
     getValidIds("serverDeploy"),
   ).withDefault(DEFAULT_STACK.serverDeploy),
+  apps: parseAsArrayOfServer(parseAsStringServer).withDefault(DEFAULT_STACK.apps),
   yolo: parseAsStringEnumServer<StackState["yolo"]>(["true", "false"]).withDefault(
     DEFAULT_STACK.yolo,
   ),

--- a/apps/web/src/lib/stack-utils.ts
+++ b/apps/web/src/lib/stack-utils.ts
@@ -208,6 +208,10 @@ export function generateStackCommand(stack: StackState) {
     `--examples ${stack.examples.join(" ") || "none"}`,
   ];
 
+  if (stack.apps.length > 0) {
+    flags.push(`--apps ${stack.apps.join(" ")}`);
+  }
+
   if (stack.yolo === "true") {
     flags.push("--yolo");
   }

--- a/apps/web/test/extra-apps.test.ts
+++ b/apps/web/test/extra-apps.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from "bun:test";
+
+import { analyzeStackCompatibility } from "../src/app/(home)/new/_components/utils";
+import { DEFAULT_STACK, type StackState } from "../src/lib/constant";
+import {
+  formatExtraApp,
+  getExtraAppFrontendDisabledReason,
+  getExtraAppsBlockedReason,
+  parseExtraApp,
+  sanitizeExtraApps,
+  validateExtraAppName,
+} from "../src/lib/extra-apps";
+import { sanitizeStackState } from "../src/lib/sanitize-stack-addons";
+import { generateStackCommand } from "../src/lib/stack-utils";
+
+function createStack(overrides: Partial<StackState> = {}): StackState {
+  return {
+    ...DEFAULT_STACK,
+    ...overrides,
+  };
+}
+
+describe("extra app encoding", () => {
+  test("round-trips name:frontend", () => {
+    expect(parseExtraApp(formatExtraApp({ name: "admin", frontend: "next" }))).toEqual({
+      name: "admin",
+      frontend: "next",
+    });
+  });
+
+  test("rejects malformed entries", () => {
+    expect(parseExtraApp("admin")).toBeNull();
+    expect(parseExtraApp(":next")).toBeNull();
+    expect(parseExtraApp("admin:")).toBeNull();
+  });
+});
+
+describe("validateExtraAppName", () => {
+  const taken = new Set(["admin"]);
+
+  test("accepts valid names", () => {
+    expect(validateExtraAppName("landing", taken)).toBeNull();
+    expect(validateExtraAppName("my-app-2", taken)).toBeNull();
+  });
+
+  test("names the specific problem", () => {
+    expect(validateExtraAppName("", taken)).toContain("empty");
+    expect(validateExtraAppName("Admin", taken)).toContain("lowercase");
+    expect(validateExtraAppName("1app", taken)).toContain("lowercase");
+    expect(validateExtraAppName("web", taken)).toContain("reserved");
+    expect(validateExtraAppName("env", taken)).toContain("reserved");
+    expect(validateExtraAppName("admin", taken)).toContain("already planned");
+    expect(validateExtraAppName("a".repeat(31), taken)).toContain("30 characters");
+  });
+});
+
+describe("getExtraAppFrontendDisabledReason", () => {
+  test("trpc restricts to react-family", () => {
+    const stack = createStack({ api: "trpc" });
+    expect(getExtraAppFrontendDisabledReason(stack, "next")).toBeNull();
+    expect(getExtraAppFrontendDisabledReason(stack, "tanstack-router")).toBeNull();
+    expect(getExtraAppFrontendDisabledReason(stack, "astro")).toContain("tRPC");
+    expect(getExtraAppFrontendDisabledReason(stack, "svelte")).toContain("tRPC");
+  });
+
+  test("orpc allows all frameworks", () => {
+    const stack = createStack({ api: "orpc", auth: "none" });
+    for (const frontend of ["next", "nuxt", "svelte", "solid", "astro"]) {
+      expect(getExtraAppFrontendDisabledReason(stack, frontend)).toBeNull();
+    }
+  });
+
+  test("clerk restricts to react-family", () => {
+    const stack = createStack({ api: "orpc", auth: "clerk" });
+    expect(getExtraAppFrontendDisabledReason(stack, "next")).toBeNull();
+    expect(getExtraAppFrontendDisabledReason(stack, "nuxt")).toContain("Clerk");
+  });
+
+  test("convex excludes solid and astro", () => {
+    const stack = createStack({ backend: "convex", api: "none", auth: "none" });
+    expect(getExtraAppFrontendDisabledReason(stack, "solid")).toContain("Convex");
+    expect(getExtraAppFrontendDisabledReason(stack, "astro")).toContain("Convex");
+    expect(getExtraAppFrontendDisabledReason(stack, "svelte")).toBeNull();
+  });
+
+  test("self backends block extra apps entirely", () => {
+    expect(getExtraAppsBlockedReason(createStack({ backend: "self-next" }))).toContain("Fullstack");
+    expect(getExtraAppsBlockedReason(createStack({ backend: "hono" }))).toBeNull();
+  });
+});
+
+describe("sanitizeExtraApps", () => {
+  test("drops malformed, duplicate, reserved, and incompatible entries", () => {
+    const stack = createStack({ api: "trpc" });
+    expect(
+      sanitizeExtraApps(
+        ["admin:next", "broken", "admin:next", "web:next", "landing:astro", "staff:not-real"],
+        stack,
+      ),
+    ).toEqual(["admin:next"]);
+  });
+
+  test("returns empty for self backends", () => {
+    expect(sanitizeExtraApps(["admin:next"], createStack({ backend: "self-next" }))).toEqual([]);
+  });
+
+  test("runs as part of sanitizeStackState", () => {
+    const sanitized = sanitizeStackState(
+      createStack({ api: "trpc", apps: ["admin:next", "landing:astro"] }),
+    );
+    expect(sanitized.apps).toEqual(["admin:next"]);
+  });
+});
+
+describe("analyzeStackCompatibility apps rule", () => {
+  test("drops planned apps that become incompatible, with a change message", () => {
+    const result = analyzeStackCompatibility(
+      createStack({ api: "trpc", apps: ["admin:next", "landing:astro"] }),
+    );
+    expect(result.adjustedStack?.apps).toEqual(["admin:next"]);
+    expect(
+      result.changes.some(
+        (change) => change.category === "apps" && change.message.includes("landing"),
+      ),
+    ).toBe(true);
+  });
+
+  test("keeps compatible apps untouched", () => {
+    const result = analyzeStackCompatibility(createStack({ apps: ["admin:next"] }));
+    expect(result.adjustedStack?.apps ?? ["admin:next"]).toEqual(["admin:next"]);
+  });
+});
+
+describe("generateStackCommand with extra apps", () => {
+  test("appends --apps to the create command", () => {
+    const command = generateStackCommand(createStack({ apps: ["admin:next", "landing:astro"] }));
+    expect(command).toContain("--apps admin:next landing:astro");
+  });
+
+  test("omits --apps when no apps are planned", () => {
+    expect(generateStackCommand(createStack())).not.toContain("--apps");
+  });
+
+  test("planned apps defeat the all-defaults --yes shortcut", () => {
+    const command = generateStackCommand(createStack({ apps: ["admin:next"] }));
+    expect(command).not.toContain("--yes");
+    expect(command).toContain("--apps admin:next");
+  });
+});

--- a/packages/template-generator/src/core/virtual-fs.ts
+++ b/packages/template-generator/src/core/virtual-fs.ts
@@ -3,8 +3,25 @@ import type { Dirent } from "node:fs";
 import { memfs } from "memfs";
 import { dirname, extname, normalize, join } from "pathe";
 
-import type { VirtualDirectory, VirtualFile } from "../types";
+import type { VirtualDirectory, VirtualFile, VirtualNode } from "../types";
 import type { JsonValue } from "./json-types";
+
+/**
+ * Flatten a virtual tree into a map of relative file path -> file node.
+ */
+export function collectTreeFiles(
+  node: VirtualNode,
+  files = new Map<string, VirtualFile>(),
+): Map<string, VirtualFile> {
+  if (node.type === "file") {
+    files.set(node.path, node);
+  } else {
+    for (const child of node.children) {
+      collectTreeFiles(child, files);
+    }
+  }
+  return files;
+}
 
 export class VirtualFileSystem {
   private _fs: ReturnType<typeof memfs>["fs"];

--- a/packages/template-generator/src/index.ts
+++ b/packages/template-generator/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./types";
+export * from "./core/json-types";
 export * from "./core/virtual-fs";
 export * from "./core/template-processor";
 export * from "./generator";
@@ -7,7 +8,11 @@ export { processAddonsDeps } from "./processors/addons-deps";
 export { processNxConfig } from "./processors/nx-generator";
 export { processTurboConfig } from "./processors/turbo-generator";
 export { processVitePlusConfig } from "./processors/vite-plus-generator";
-export { processPackageConfigs, processVercelConfig } from "./post-process";
+export {
+  getWorkspaceScriptCommand,
+  processPackageConfigs,
+  processVercelConfig,
+} from "./post-process";
 export { writeBtsConfigToVfs } from "./bts-config";
 
 export { EMBEDDED_TEMPLATES, TEMPLATE_COUNT } from "./templates.generated";

--- a/packages/template-generator/src/post-process/index.ts
+++ b/packages/template-generator/src/post-process/index.ts
@@ -7,7 +7,11 @@ import type { ProjectConfig } from "@better-t-stack/types";
 
 import type { VirtualFileSystem } from "../core/virtual-fs";
 import { processCatalogs } from "./catalogs";
-import { finalizeAlchemyDevScripts, processPackageConfigs } from "./package-configs";
+import {
+  finalizeAlchemyDevScripts,
+  getWorkspaceScriptCommand,
+  processPackageConfigs,
+} from "./package-configs";
 import { processVercelConfig } from "./vercel-config";
 
 /**
@@ -19,4 +23,10 @@ export function processPostGeneration(vfs: VirtualFileSystem, config: ProjectCon
   processVercelConfig(vfs, config);
 }
 
-export { finalizeAlchemyDevScripts, processCatalogs, processPackageConfigs, processVercelConfig };
+export {
+  finalizeAlchemyDevScripts,
+  getWorkspaceScriptCommand,
+  processCatalogs,
+  processPackageConfigs,
+  processVercelConfig,
+};

--- a/packages/template-generator/src/post-process/package-configs.ts
+++ b/packages/template-generator/src/post-process/package-configs.ts
@@ -17,6 +17,7 @@ type PackageJson = {
   devDependencies?: Record<string, string>;
   allowScripts?: Record<string, boolean>;
   overrides?: Record<string, string>;
+  exports?: Record<string, string>;
   workspaces?: string[] | { packages?: string[]; catalog?: Record<string, string> };
   packageManager?: string;
   [key: string]: JsonValue | undefined;
@@ -421,6 +422,23 @@ function getPackageManagerConfig(
   }
 }
 
+/**
+ * Build the root-script command that runs `script` in a single workspace,
+ * honoring the project's task runner (turborepo/nx/vite-plus) or package manager.
+ */
+export function getWorkspaceScriptCommand(
+  packageManager: ProjectConfig["packageManager"],
+  addons: ProjectConfig["addons"],
+  workspace: string,
+  script: string,
+): string {
+  return getPackageManagerConfig(packageManager, {
+    hasTurborepo: addons.includes("turborepo"),
+    hasNx: addons.includes("nx"),
+    hasVitePlus: addons.includes("vite-plus"),
+  }).filter(workspace, script);
+}
+
 function getElectrobunRootBuildCommand(
   vfs: VirtualFileSystem,
   packageManager: ProjectConfig["packageManager"],
@@ -652,7 +670,13 @@ function updateEnvPackageJson(vfs: VirtualFileSystem, config: ProjectConfig): vo
   );
   const needsServerEnv = config.backend !== "none" && config.backend !== "convex";
 
-  const exports: Record<string, string> = {};
+  // Preserve export entries this function does not manage (e.g. per-app env
+  // modules created by `add-app`); only the server/web/native keys are rebuilt.
+  const exports = { ...pkgJson.exports };
+
+  delete exports["./server"];
+  delete exports["./web"];
+  delete exports["./native"];
 
   if (needsServerEnv) {
     exports["./server"] = "./src/server.ts";

--- a/packages/types/src/json-schema.ts
+++ b/packages/types/src/json-schema.ts
@@ -21,6 +21,8 @@ import {
   DbSetupOptionsSchema,
   CreateInputSchema,
   AddInputSchema,
+  AddAppInputSchema,
+  RESERVED_APP_NAMES,
   ProjectConfigSchema,
   BetterTStackConfigSchema,
   BetterTStackConfigFileSchema,
@@ -108,6 +110,21 @@ export function getAddInputJsonSchema() {
   return z.toJSONSchema(AddInputSchema);
 }
 
+/** JSON Schema for add-app input, with reserved app names surfaced as a not/enum constraint. */
+export function getAddAppInputJsonSchema() {
+  const schema = z.toJSONSchema(AddAppInputSchema) as {
+    properties?: { name?: { not?: { enum: string[] } } };
+  };
+
+  // The reserved-name rule lives in a zod refinement, which does not
+  // serialize; surface it so JSON-Schema consumers see it too.
+  if (schema.properties?.name) {
+    schema.properties.name.not = { enum: [...RESERVED_APP_NAMES].sort() };
+  }
+
+  return schema;
+}
+
 export function getProjectConfigJsonSchema() {
   return z.toJSONSchema(ProjectConfigSchema);
 }
@@ -147,6 +164,7 @@ export function getAllJsonSchemas() {
     dbSetupOptions: getDbSetupOptionsJsonSchema(),
     createInput: getCreateInputJsonSchema(),
     addInput: getAddInputJsonSchema(),
+    addAppInput: getAddAppInputJsonSchema(),
     projectConfig: getProjectConfigJsonSchema(),
     betterTStackConfig: getBetterTStackConfigJsonSchema(),
     betterTStackConfigFile: getBetterTStackConfigFileJsonSchema(),

--- a/packages/types/src/schemas.ts
+++ b/packages/types/src/schemas.ts
@@ -475,6 +475,66 @@ export const ProjectNameSchema = z
   .refine((name) => name.toLowerCase() !== "node_modules", "Project name is reserved")
   .describe("Project name or path");
 
+export const WebFrontendSchema = z
+  .enum([
+    "tanstack-router",
+    "react-router",
+    "tanstack-start",
+    "next",
+    "nuxt",
+    "svelte",
+    "solid",
+    "astro",
+  ])
+  .describe("Web frontend framework");
+
+export const RESERVED_APP_NAMES = new Set([
+  "web",
+  "native",
+  "server",
+  "desktop",
+  "docs",
+  "fumadocs",
+  "tui",
+  "extension",
+  "api",
+  "auth",
+  "db",
+  "backend",
+  "config",
+  "env",
+  "infra",
+  "ui",
+]);
+
+export const AppNameSchema = z
+  .string()
+  .min(1, "App name cannot be empty")
+  .max(30, "App name must be 30 characters or fewer")
+  .regex(
+    /^[a-z][a-z0-9-]*$/,
+    "App name must use lowercase letters, digits, and dashes, and start with a letter",
+  )
+  .refine((name) => !RESERVED_APP_NAMES.has(name), "App name is reserved")
+  .describe("Name of the app to add");
+
+export const AddedAppSchema = z
+  .strictObject({
+    name: AppNameSchema,
+    frontend: WebFrontendSchema,
+    port: z.number().int().min(1024).max(65535).describe("Dev server port"),
+  })
+  .describe("An additional app added with the add-app command");
+
+export const AddedAppSpecSchema = z
+  .string()
+  .regex(
+    new RegExp(`^[a-z][a-z0-9-]{0,29}:(${WebFrontendSchema.options.join("|")})$`),
+    "Expected <name>:<framework> (e.g. admin:next)",
+  )
+  .refine((spec) => !RESERVED_APP_NAMES.has(spec.split(":")[0] ?? ""), "App name is reserved")
+  .describe("Extra frontend app as name:framework (e.g. admin:next)");
+
 export const CreateInputSchema = z
   .object({
     projectName: z.string().optional(),
@@ -490,6 +550,7 @@ export const CreateInputSchema = z
     auth: AuthSchema.optional(),
     payments: PaymentsSchema.optional(),
     frontend: z.array(FrontendSchema).optional(),
+    apps: z.array(AddedAppSpecSchema).optional(),
     addons: AddonsListSchema.optional(),
     examples: z.array(ExamplesSchema).optional(),
     git: z.boolean().optional(),
@@ -518,6 +579,18 @@ export const AddInputSchema = z
     addonOptions: AddonOptionsSchema.optional(),
     webDeploy: WebDeploySchema.optional(),
     serverDeploy: ServerDeploySchema.optional(),
+    projectDir: z.string().optional(),
+    install: z.boolean().optional(),
+    packageManager: PackageManagerSchema.optional(),
+    dryRun: z.boolean().optional(),
+  })
+  .strict();
+
+export const AddAppInputSchema = z
+  .object({
+    name: AppNameSchema.optional(),
+    frontend: WebFrontendSchema.optional(),
+    port: z.number().int().min(1024).max(65535).optional().describe("Dev server port"),
     projectDir: z.string().optional(),
     install: z.boolean().optional(),
     packageManager: PackageManagerSchema.optional(),
@@ -573,6 +646,7 @@ export const BetterTStackConfigSchema = z.object({
   api: APISchema,
   webDeploy: WebDeploySchema,
   serverDeploy: ServerDeploySchema,
+  apps: z.array(AddedAppSchema).optional().describe("Additional apps added with add-app"),
 });
 
 export const BetterTStackConfigFileSchema = BetterTStackConfigSchema.safeExtend({
@@ -612,3 +686,4 @@ export const WEB_DEPLOY_VALUES = WebDeploySchema.options;
 export const SERVER_DEPLOY_VALUES = ServerDeploySchema.options;
 export const DIRECTORY_CONFLICT_VALUES = DirectoryConflictSchema.options;
 export const TEMPLATE_VALUES = TemplateSchema.options;
+export const WEB_FRONTEND_VALUES = WebFrontendSchema.options;

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -20,8 +20,11 @@ import type {
   AddonOptionsSchema,
   DbSetupOptionsSchema,
   ProjectNameSchema,
+  AppNameSchema,
+  AddedAppSchema,
   CreateInputSchema,
   AddInputSchema,
+  AddAppInputSchema,
   CLIInputSchema,
   ProjectConfigSchema,
   BetterTStackConfigSchema,
@@ -48,9 +51,12 @@ export type Template = z.infer<typeof TemplateSchema>;
 export type AddonOptions = z.infer<typeof AddonOptionsSchema>;
 export type DbSetupOptions = z.infer<typeof DbSetupOptionsSchema>;
 export type ProjectName = z.infer<typeof ProjectNameSchema>;
+export type AppName = z.infer<typeof AppNameSchema>;
+export type AddedApp = z.infer<typeof AddedAppSchema>;
 
 export type CreateInput = z.infer<typeof CreateInputSchema>;
 export type AddInput = z.infer<typeof AddInputSchema>;
+export type AddAppInput = z.infer<typeof AddAppInputSchema>;
 export type CLIInput = z.infer<typeof CLIInputSchema>;
 export type ProjectConfig = z.infer<typeof ProjectConfigSchema>;
 export type BetterTStackConfig = z.infer<typeof BetterTStackConfigSchema>;

--- a/plugin/agents/stack-architect.md
+++ b/plugin/agents/stack-architect.md
@@ -10,7 +10,7 @@ You are a Better-T-Stack architect. You turn a product idea into a concrete, val
 1. **Understand the product.** Identify the surfaces needed (web app, mobile, docs, desktop), whether there's a backend/API, data needs, auth, and payments. Ask at most a couple of clarifying questions; otherwise choose sensible defaults and state them.
 2. **Check the rules.** Call `bts_get_stack_guidance` for combination rules and `bts_get_schema` for the exact, version-current allowed values. Trust these over any memorized list.
 3. **Design a coherent config.** Make every field explicit (`"none"`, `[]`, booleans included). Watch the known constraints:
-   - `frontend` is app surfaces only, not styling.
+   - `frontend` is app surfaces only, not styling. It holds at most one web and one native framework; extra frontend apps (admin panel, landing page) are added after creation via `bts_plan_app` → `bts_add_app`, not by listing multiple web frameworks.
    - `nx`, `turborepo`, and `vite-plus` cannot be combined.
    - `convex` brings its own data layer — don't bolt on a conflicting database/orm/api unless the schema permits it.
    - `mongodb` pairs with `mongoose` or Prisma, not Drizzle.

--- a/plugin/commands/add.md
+++ b/plugin/commands/add.md
@@ -17,4 +17,6 @@ Add tooling/features to the current Better-T-Stack project using the Better-T-St
 4. **Apply with `bts_add_addons`** once confirmed.
 5. **Report** what changed and any follow-up commands.
 
+If the request is for another frontend app (admin panel, landing page) rather than an addon, use `bts_plan_app` → `bts_add_app` with `{ name, frontend }` instead.
+
 Always plan before applying. Don't add addons the user didn't ask for.

--- a/plugin/skills/add-to-project/SKILL.md
+++ b/plugin/skills/add-to-project/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-to-project
-description: Add addons or features (PWA, Tauri, Starlight/Fumadocs docs, Biome/Oxlint, Husky/Lefthook, Turborepo/Nx, the MCP addon, etc.) to an existing Better-T-Stack project. Use when the user wants to extend, enhance, or add tooling to a project that was created with Better-T-Stack.
+description: Add addons, features, or another frontend app (PWA, Tauri, Starlight/Fumadocs docs, Biome/Oxlint, Husky/Lefthook, Turborepo/Nx, the MCP addon, an admin/landing app, etc.) to an existing Better-T-Stack project. Use when the user wants to extend, enhance, or add tooling or apps to a project that was created with Better-T-Stack.
 metadata:
   priority: 7
   docs:
@@ -15,7 +15,7 @@ Use the Better-T-Stack MCP server to install addons into an existing project rat
 
 ## When this applies
 
-The user already has a Better-T-Stack project (look for a `bts.jsonc` config) and wants to add tooling or features — e.g. "add PWA support", "add a docs site", "switch to Biome", "add Turborepo", "wire up the MCP addon".
+The user already has a Better-T-Stack project (look for a `bts.jsonc` config) and wants to add tooling, features, or another frontend app — e.g. "add PWA support", "add a docs site", "switch to Biome", "add Turborepo", "wire up the MCP addon", "add an admin panel app".
 
 For brand-new projects, use the **scaffold-project** skill instead.
 
@@ -26,6 +26,10 @@ For brand-new projects, use the **scaffold-project** skill instead.
 3. **Apply.** Only after the plan succeeds and matches intent, call `bts_add_addons`.
 4. **Report** what changed and the follow-up commands to run.
 
+## Adding another frontend app
+
+When the user wants an additional app surface (admin panel, landing page, storefront) rather than an addon, use `bts_plan_app` → `bts_add_app` with `{ name, frontend }`. The framework may differ from the existing web app but is validated against the project's api/auth/backend (tRPC and Clerk projects accept React-family frameworks only; fullstack `self` projects cannot add apps). The new app lands in `apps/<name>` with its own dev port; relay the manual CORS/auth origin steps the tool returns.
+
 ## Available addons
 
 `pwa`, `tauri`, `electrobun`, `starlight`, `biome`, `lefthook`, `husky`, `mcp`, `turborepo`, `nx`, `vite-plus`, `fumadocs`, `ultracite`, `oxlint`, `opentui`, `wxt`, `skills`, `evlog`.
@@ -34,6 +38,6 @@ Note: `nx`, `turborepo`, and `vite-plus` are mutually exclusive task runners. Us
 
 ## Rules
 
-- Always `bts_plan_addons` before `bts_add_addons`.
-- Don't add addons the user didn't ask for.
+- Always `bts_plan_addons` before `bts_add_addons`, and `bts_plan_app` before `bts_add_app`.
+- Don't add addons or apps the user didn't ask for.
 - Surface any conflicts (e.g. two task runners) from the plan before applying.


### PR DESCRIPTION
Closes #170, closes #201 — the multi-frontend requests (admin panel + storefront + landing sharing one backend) open since April 2025.

## What

Two ways to get additional web frontends into a project, sharing its API, auth, and workspace packages:

```bash
# at creation time — one command; apps land before install and the initial git commit
bun create better-t-stack@latest my-app --frontend tanstack-router --api orpc --apps admin:next landing:astro

# on an existing project
create-better-t-stack add-app admin --frontend next
```

Each app lands in `apps/<name>` with:

- its own package name and a unique dev port (3002+, always pinned — including for react-router/svelte/astro which normally rely on framework defaults; substitution is verified, never a silent no-op)
- its own env module `packages/env/src/<name>.ts` + `exports["./<name>"]` entry with rewritten imports (frameworks have different client prefixes, so a Next admin next to a TanStack web app needs its own validation module — same pattern as the existing `native.ts`); the export is only written when the module is
- wiring to the project's `@{project}/api`, `@{project}/auth`, `@{project}/ui` and a root `dev:<name>` script using the project's task-runner filter syntax
- a `bts.jsonc` record under a new optional `apps` array (`{ name, frontend, port }`), so re-runs allocate the next port and later commands see the extra apps; `create --apps` also records the flag in `reproducibleCommand`

Framework choice may differ from the primary web app and is validated against the stack via the existing helpers: tRPC and Clerk imply React-family, Convex excludes Solid/Astro, `backend: self` is refused (checked before any prompt opens). App names are validated against `^[a-z][a-z0-9-]*$` and a reserved set (`web`, `server`, `env`, `ui`, …) — the reserved set is also surfaced in the published JSON Schema.

Also exposed as `add-app-json`, programmatic `addApp()`, and MCP `bts_plan_app` / `bts_add_app` (mirroring the addon plan/apply pair; `install: true` is rejected like project creation, to avoid MCP client timeouts).

### Stack Builder

A compact **Extra apps** section below the web-frontend grid — zero footprint until used (one dashed "Add app" button), then an inline name + framework form with live validation and framework chips disabled-with-reason using the same gating as the CLI. Planned apps:

- append `--apps` to the generated create command — the builder output stays a single command
- render as `apps/<name>` chips in the Selected stack panel (framework name on hover, click jumps to the section, × removes) and as removable chips in the section itself
- persist in builder URLs (`?apps=admin:next`), saved stacks, and presets/reset behave correctly
- auto-drop with a toast via the existing `analyzeStackCompatibility` engine when a stack change makes them incompatible; the whole section hides for fullstack `self` backends
- show on the shared `/stack` page

State is encoded as `"name:frontend"` strings in a new `StackState.apps: string[]`, so URL/localStorage/share serialization work unchanged. No ports in the UI — the CLI allocates them.

## How

No destPrefix threading through the template handlers. The handler builds a synthetic single-frontend config from the project's bts.jsonc (deploy forced to `none`, addons filtered to task runners so vite-plus/turbo conditionals render correctly) and runs the existing exported `generate()` in memory, then cherry-picks `apps/web/**` into `apps/<name>/**` with the identity rewrites above. Files outside the new app dir touched: root `package.json` (script + npm allowScripts/overrides union), `packages/env/package.json` (exports + missing framework deps), `bts.jsonc`, and on pnpm `pnpm-workspace.yaml` (union of framework-conditional `allowBuilds` map entries and `minimumReleaseAgeExclude`). Catalog references (`"catalog:"`) in cherry-picked package.jsons are resolved back to concrete versions.

`create --apps` reuses the exact same flow inside `createProject`, after files are written and before install/git — so the single install and the initial commit include the apps.

Deliberately conservative about user-owned code: the CLI never edits server source; it prints the exact CORS / better-auth `trustedOrigins` origin additions instead. Two small shared fixes: `updateEnvPackageJson` preserves export entries it doesn't manage (a later `add <addon>` would otherwise delete per-app entries — regression-tested), and the add path preloads extra-app manifests.

## Out of scope (v1)

Deploy wiring for extra apps (alchemy/vercel/docker assume a single `web` identity — apps scaffold without it and warn), a second native app, addons targeting extra apps, interactive prompting for `--apps` during `create` (use `add-app` interactively instead), regenerating the project README, and app removal/renaming.

## Verification

- `bun run check` clean; `bun run build` clean
- CLI: `apps/cli/test/add-app.test.ts` (19 tests: refusals incl. reserved names and per-stack framework gating, dry-run, full write, port allocation, `create --apps` end-to-end, pnpm allowBuilds/release-age union regression, env-export survival across a later `add`), MCP contract tests for the new tool pair, schema/input/programmatic API updates — full suite run with no regressions vs a pristine-main baseline
- Web: `apps/web/test/extra-apps.test.ts` (encoding, validation messages, compat gating, sanitize, `--apps` command generation, compat-engine drops); full web suite green including the random-stack invariant tests carrying the new field
- Manual E2E with the built CLI on Windows: one-command create with 2 cross-framework apps (`--apps admin:next landing:astro`) → single initial commit includes both apps, `bun install` + `turbo run check-types` pass across all 5 workspaces; tanstack+trpc project + `add-app admin --frontend next` → same; trpc+astro correctly refused before any writes; dry-run writes nothing

## Note for maintainer

`BetterTStackConfigSchema` gained the optional `apps` field, so `apps/web/scripts/generate-schema.ts` needs a rerun to republish `schema.json` to R2 (editors fetch it live; no runtime impact since the CLI reads bts.jsonc with a plain jsonc parse).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for creating additional frontend apps during setup or in existing projects.
  - Added interactive, JSON, programmatic, and MCP workflows with dry-run planning.
  - Added Stack Builder controls for selecting, validating, displaying, and removing extra apps.
  - Added automatic ports, configuration, environment integration, workspace wiring, and dependency installation.
- **Bug Fixes**
  - Added validation for duplicate, reserved, incompatible, or conflicting app configurations.
- **Documentation**
  - Documented CLI commands, APIs, configuration, project structure, and MCP workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->