### PR TITLE
fix(web): repair Fullstack Solid icon

### DIFF
--- a/apps/web/src/lib/constant.ts
+++ b/apps/web/src/lib/constant.ts
@@ -238,7 +238,7 @@ export const TECH_OPTIONS = {
       id: "self-solid",
       name: "Fullstack Solid",
       description: "Use Solid file-based API routes",
-      icon: `${ICON_BASE_URL}/solidjs.svg`,
+      icon: `${ICON_BASE_URL}/solid.svg`,
       color: "from-blue-400 to-blue-700",
     },
     {


### PR DESCRIPTION
## Summary

- replace the missing Fullstack Solid icon URL with the existing Solid icon asset
- restore the icon in the stack builder backend card

## Verification

- `bunx oxfmt --check apps/web/src/lib/constant.ts`
- `bunx oxlint apps/web/src/lib/constant.ts`
- `bun test apps/web/test/stack-builder-compatibility.test.ts`
- pre-commit `bun check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Solid fullstack backend option to use the correct Solid icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->