### PR TITLE
feat(cli): scaffold workspace packages from add command

### DIFF
--- a/apps/cli/src/helpers/core/add-handler.ts
+++ b/apps/cli/src/helpers/core/add-handler.ts
@@ -16,6 +16,7 @@ import { intro, log, outro } from "@clack/prompts";
 import { Result } from "better-result";
 import fs from "fs-extra";
 import pc from "picocolors";
+import z from "zod";
 
 import { getAddonsToAdd } from "../../prompts/addons";
 import type { AddInput, Addons, AddonOptions, ProjectConfig } from "../../types";
@@ -41,6 +42,7 @@ export interface AddResult {
   projectDir: string;
   dryRun?: boolean;
   plannedFileCount?: number;
+  addedPackage?: string;
   error?: string;
 }
 
@@ -67,6 +69,72 @@ const ADD_TEXT_FILE_PATHS = ["apps/web/vite.config.ts", "lefthook.yml"];
 const HOOK_ADDONS = ["husky", "lefthook"] as const satisfies readonly Addons[];
 const HOOK_LINTER_ADDONS = ["biome", "oxlint", "vite-plus"] as const satisfies readonly Addons[];
 const TASK_RUNNER_ADDONS = ["turborepo", "nx", "vite-plus"] as const satisfies readonly Addons[];
+const ConfigPackageScopeSchema = z
+  .object({
+    name: z.string().regex(/^@[^/]+\/config$/),
+  })
+  .transform(({ name }) => name.slice(0, -"/config".length));
+
+async function addWorkspacePackage(
+  vfs: VirtualFileSystem,
+  projectDir: string,
+  packageName: string,
+): Promise<Result<void, CLIError>> {
+  const packageDir = path.join(projectDir, "packages", packageName);
+  if (await fs.pathExists(packageDir)) {
+    return Result.err(
+      new CLIError({
+        message: `Workspace package already exists: packages/${packageName}`,
+      }),
+    );
+  }
+
+  const configPackagePath = path.join(projectDir, "packages", "config", "package.json");
+  const packageScopeResult = await Result.tryPromise({
+    try: async () => ConfigPackageScopeSchema.parse(await fs.readJson(configPackagePath)),
+    catch: (cause: unknown) =>
+      new CLIError({
+        message:
+          "Cannot determine the workspace package scope. Expected packages/config/package.json to have a name like @my-app/config.",
+        cause,
+      }),
+  });
+  if (packageScopeResult.isErr()) {
+    return Result.err(packageScopeResult.error);
+  }
+
+  const packageScope = packageScopeResult.value;
+  const packagePath = `packages/${packageName}`;
+  vfs.writeFile(
+    `${packagePath}/package.json`,
+    `${JSON.stringify(
+      {
+        name: `${packageScope}/${packageName}`,
+        version: "0.0.0",
+        private: true,
+        type: "module",
+        exports: { ".": "./src/index.ts" },
+        scripts: { "check-types": "tsc --noEmit" },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  vfs.writeFile(
+    `${packagePath}/tsconfig.json`,
+    `${JSON.stringify(
+      {
+        extends: `${packageScope}/config/tsconfig.base.json`,
+        include: ["src/**/*.ts"],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  vfs.writeFile(`${packagePath}/src/index.ts`, "export {};\n");
+
+  return Result.ok(undefined);
+}
 
 function mergeAddonOptions(
   existingAddonOptions?: AddonOptions,
@@ -231,7 +299,7 @@ async function addHandlerInternal(
       (addon) => addon !== "none" && !existingConfig.addons.includes(addon),
     );
 
-    if (addonsToAdd.length === 0) {
+    if (addonsToAdd.length === 0 && !input.package) {
       if (!isSilent()) {
         log.warn(pc.yellow("Nothing to add — those addons are already installed"));
         outro(pc.dim("Project unchanged"));
@@ -242,10 +310,12 @@ async function addHandlerInternal(
         projectDir,
       });
     }
+  } else if (input.package) {
+    addonsToAdd = [];
   } else if (isSilent()) {
     return Result.err(
       new CLIError({
-        message: "Addons are required in silent mode. Provide them via add() or add-json.",
+        message: "Addons or a package are required in silent mode.",
       }),
     );
   } else {
@@ -289,7 +359,11 @@ async function addHandlerInternal(
   }
 
   if (!isSilent()) {
-    log.info(`${pc.dim("Adding")} ${pc.cyan(formatConfigValue(addonsToAdd))}`);
+    const additions = [
+      addonsToAdd.length > 0 ? formatConfigValue(addonsToAdd) : undefined,
+      input.package ? `package ${input.package}` : undefined,
+    ].filter(Boolean);
+    log.info(`${pc.dim("Adding")} ${pc.cyan(additions.join(" and "))}`);
   }
 
   const mergedAddonOptions = mergeAddonOptions(existingConfig.addonOptions, input.addonOptions);
@@ -320,13 +394,15 @@ async function addHandlerInternal(
     addons: updatedAddons,
   };
 
-  const requirementsResult = await checkLocalRequirements(updatedConfig);
-  if (requirementsResult.isErr()) {
-    return Result.err(requirementsResult.error);
-  }
-  if (!isSilent()) {
-    for (const warning of requirementsResult.value.warnings) {
-      log.warn(pc.yellow(warning));
+  if (addonsToAdd.length > 0) {
+    const requirementsResult = await checkLocalRequirements(updatedConfig);
+    if (requirementsResult.isErr()) {
+      return Result.err(requirementsResult.error);
+    }
+    if (!isSilent()) {
+      for (const warning of requirementsResult.value.warnings) {
+        log.warn(pc.yellow(warning));
+      }
     }
   }
 
@@ -337,54 +413,61 @@ async function addHandlerInternal(
 
   const vfs = new VirtualFileSystem();
 
-  // Pre-load existing files into VFS so addon processors can modify them.
-  for (const pkgPath of ADD_PACKAGE_JSON_PATHS) {
-    const fullPath = path.join(projectDir, pkgPath);
-    if (await fs.pathExists(fullPath)) {
-      const content = await fs.readFile(fullPath, "utf-8");
-      vfs.writeFile(pkgPath, content);
-    }
-  }
-  for (const filePath of ADD_TEXT_FILE_PATHS) {
-    const fullPath = path.join(projectDir, filePath);
-    if (await fs.pathExists(fullPath)) {
-      const content = await fs.readFile(fullPath, "utf-8");
-      vfs.writeFile(filePath, content);
+  if (input.package) {
+    const packageResult = await addWorkspacePackage(vfs, projectDir, input.package);
+    if (packageResult.isErr()) {
+      return Result.err(packageResult.error);
     }
   }
 
-  // Process addon templates
-  await processAddonTemplates(vfs, EMBEDDED_TEMPLATES, config);
+  if (addonsToAdd.length > 0) {
+    // Pre-load existing files into VFS so addon processors can modify them.
+    for (const pkgPath of ADD_PACKAGE_JSON_PATHS) {
+      const fullPath = path.join(projectDir, pkgPath);
+      if (await fs.pathExists(fullPath)) {
+        const content = await fs.readFile(fullPath, "utf-8");
+        vfs.writeFile(pkgPath, content);
+      }
+    }
+    for (const filePath of ADD_TEXT_FILE_PATHS) {
+      const fullPath = path.join(projectDir, filePath);
+      if (await fs.pathExists(fullPath)) {
+        const content = await fs.readFile(fullPath, "utf-8");
+        vfs.writeFile(filePath, content);
+      }
+    }
 
-  // Process addon dependencies (adds deps to package.json files in VFS)
-  processAddonsDeps(vfs, config);
+    // Process addon templates and dependencies using template-generator's logic.
+    await processAddonTemplates(vfs, EMBEDDED_TEMPLATES, config);
+    processAddonsDeps(vfs, config);
 
-  if (addonsToAdd.includes("turborepo")) {
-    processTurboConfig(vfs, updatedConfig);
-  }
+    if (addonsToAdd.includes("turborepo")) {
+      processTurboConfig(vfs, updatedConfig);
+    }
 
-  if (addonsToAdd.includes("nx")) {
-    processNxConfig(vfs, updatedConfig);
-  }
+    if (addonsToAdd.includes("nx")) {
+      processNxConfig(vfs, updatedConfig);
+    }
 
-  if (addonsToAdd.includes("vite-plus")) {
-    processVitePlusConfig(vfs, updatedConfig);
-  }
+    if (addonsToAdd.includes("vite-plus")) {
+      processVitePlusConfig(vfs, updatedConfig);
+    }
 
-  const hasTaskRunner = updatedAddons.some((addon) =>
-    (TASK_RUNNER_ADDONS as readonly Addons[]).includes(addon),
-  );
+    const hasTaskRunner = updatedAddons.some((addon) =>
+      (TASK_RUNNER_ADDONS as readonly Addons[]).includes(addon),
+    );
 
-  if (hasTaskRunner) {
-    processPackageConfigs(vfs, updatedConfig);
-  }
+    if (hasTaskRunner) {
+      processPackageConfigs(vfs, updatedConfig);
+    }
 
-  if (updatedAddons.includes("vite-plus")) {
-    updateViteConfigImportsForVitePlus(vfs);
-  }
+    if (updatedAddons.includes("vite-plus")) {
+      updateViteConfigImportsForVitePlus(vfs);
+    }
 
-  if (shouldRefreshLefthook(addonsToAdd, updatedAddons)) {
-    refreshLefthookTemplate(vfs, updatedConfig);
+    if (shouldRefreshLefthook(addonsToAdd, updatedAddons)) {
+      refreshLefthookTemplate(vfs, updatedConfig);
+    }
   }
 
   // Write VFS to disk
@@ -398,7 +481,7 @@ async function addHandlerInternal(
   if (input.dryRun) {
     if (!isSilent()) {
       log.success(pc.green("Dry run passed · no files written"));
-      log.message(pc.dim(`${vfs.getFileCount()} addon files planned`));
+      log.message(pc.dim(`${vfs.getFileCount()} files planned`));
       outro(pc.dim("Project unchanged"));
     }
 
@@ -408,6 +491,7 @@ async function addHandlerInternal(
       projectDir,
       dryRun: true,
       plannedFileCount: vfs.getFileCount(),
+      addedPackage: input.package,
     });
   }
 
@@ -416,23 +500,26 @@ async function addHandlerInternal(
   if (writeResult.isErr()) {
     return Result.err(
       new CLIError({
-        message: `Failed to write addon files: ${writeResult.error.message}`,
+        message: `Failed to write files: ${writeResult.error.message}`,
       }),
     );
   }
 
   if (vfs.getFileCount() > 0 && !isSilent()) {
-    log.info(pc.dim(`Wrote ${vfs.getFileCount()} addon files`));
+    log.info(pc.dim(`Wrote ${vfs.getFileCount()} files`));
   }
 
   // Run addon setup (handles deps and interactive prompts)
   // Wrap with Result.tryPromise since setupAddons can throw UserCancelledError
   const setupResult = await Result.tryPromise({
-    try: () =>
-      setupAddons({
-        ...config,
-        addons: getSetupAddons(addonsToAdd, updatedAddons),
-      }),
+    try: async () => {
+      if (addonsToAdd.length > 0) {
+        await setupAddons({
+          ...config,
+          addons: getSetupAddons(addonsToAdd, updatedAddons),
+        });
+      }
+    },
     catch: (cause: unknown) => {
       if (UserCancelledError.is(cause)) return cause;
       return new CLIError({
@@ -447,10 +534,12 @@ async function addHandlerInternal(
   }
 
   // Update bts.jsonc with new addons
-  await updateBtsConfig(projectDir, {
-    addons: updatedAddons,
-    addonOptions: updatedConfig.addonOptions,
-  });
+  if (addonsToAdd.length > 0) {
+    await updateBtsConfig(projectDir, {
+      addons: updatedAddons,
+      addonOptions: updatedConfig.addonOptions,
+    });
+  }
 
   // Install dependencies if requested
   if (input.install) {
@@ -458,7 +547,11 @@ async function addHandlerInternal(
   }
 
   if (!isSilent()) {
-    log.success(pc.green(`Added ${formatConfigValue(addonsToAdd)}`));
+    const additions = [
+      addonsToAdd.length > 0 ? formatConfigValue(addonsToAdd) : undefined,
+      input.package ? `package ${input.package}` : undefined,
+    ].filter(Boolean);
+    log.success(pc.green(`Added ${additions.join(" and ")}`));
 
     if (!input.install) {
       const installCommand =
@@ -474,5 +567,6 @@ async function addHandlerInternal(
     addedAddons: addonsToAdd,
     projectDir,
     plannedFileCount: vfs.getFileCount(),
+    addedPackage: input.package,
   });
 }

--- a/apps/cli/src/helpers/core/add-handler.ts
+++ b/apps/cli/src/helpers/core/add-handler.ts
@@ -69,7 +69,7 @@ const ADD_TEXT_FILE_PATHS = ["apps/web/vite.config.ts", "lefthook.yml"];
 const HOOK_ADDONS = ["husky", "lefthook"] as const satisfies readonly Addons[];
 const HOOK_LINTER_ADDONS = ["biome", "oxlint", "vite-plus"] as const satisfies readonly Addons[];
 const TASK_RUNNER_ADDONS = ["turborepo", "nx", "vite-plus"] as const satisfies readonly Addons[];
-const ConfigPackageScopeSchema = z
+const configPackageScopeSchema = z
   .object({
     name: z.string().regex(/^@[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?\/config$/),
   })
@@ -91,7 +91,7 @@ async function addWorkspacePackage(
 
   const configPackagePath = path.join(projectDir, "packages", "config", "package.json");
   const packageScopeResult = await Result.tryPromise({
-    try: async () => ConfigPackageScopeSchema.parse(await fs.readJson(configPackagePath)),
+    try: async () => configPackageScopeSchema.parse(await fs.readJson(configPackagePath)),
     catch: (cause: unknown) =>
       new CLIError({
         message:
@@ -507,6 +507,26 @@ async function addHandlerInternal(
   const writeResult = await writeTree(tree, projectDir);
 
   if (writeResult.isErr()) {
+    if (input.package) {
+      const packageName = input.package;
+      const cleanupResult = await Result.tryPromise({
+        try: () => fs.remove(path.join(projectDir, "packages", packageName)),
+        catch: (cause: unknown) =>
+          new CLIError({
+            message: `Failed to clean up incomplete workspace package: packages/${packageName}`,
+            cause,
+          }),
+      });
+      if (cleanupResult.isErr()) {
+        return Result.err(
+          new CLIError({
+            message: `Failed to write files: ${writeResult.error.message}. ${cleanupResult.error.message}`,
+            cause: cleanupResult.error,
+          }),
+        );
+      }
+    }
+
     return Result.err(
       new CLIError({
         message: `Failed to write files: ${writeResult.error.message}`,

--- a/apps/cli/src/helpers/core/add-handler.ts
+++ b/apps/cli/src/helpers/core/add-handler.ts
@@ -71,7 +71,7 @@ const HOOK_LINTER_ADDONS = ["biome", "oxlint", "vite-plus"] as const satisfies r
 const TASK_RUNNER_ADDONS = ["turborepo", "nx", "vite-plus"] as const satisfies readonly Addons[];
 const ConfigPackageScopeSchema = z
   .object({
-    name: z.string().regex(/^@[^/]+\/config$/),
+    name: z.string().regex(/^@[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?\/config$/),
   })
   .transform(({ name }) => name.slice(0, -"/config".length));
 
@@ -104,12 +104,21 @@ async function addWorkspacePackage(
   }
 
   const packageScope = packageScopeResult.value;
+  const fullPackageName = `${packageScope}/${packageName}`;
+  if (fullPackageName.length > 214) {
+    return Result.err(
+      new CLIError({
+        message: "Workspace package name must not exceed 214 characters including its scope.",
+      }),
+    );
+  }
+
   const packagePath = `packages/${packageName}`;
   vfs.writeFile(
     `${packagePath}/package.json`,
     `${JSON.stringify(
       {
-        name: `${packageScope}/${packageName}`,
+        name: fullPackageName,
         version: "0.0.0",
         private: true,
         type: "module",

--- a/apps/cli/src/helpers/core/add-handler.ts
+++ b/apps/cli/src/helpers/core/add-handler.ts
@@ -75,6 +75,11 @@ const configPackageScopeSchema = z
     name: z.string().regex(/^@[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?\/config$/),
   })
   .transform(({ name }) => name.slice(0, -"/config".length));
+const rootTypescriptVersionSchema = z
+  .object({
+    devDependencies: z.object({ typescript: z.string().min(1) }),
+  })
+  .transform(({ devDependencies }) => devDependencies.typescript);
 
 function isFileExistsError(cause: unknown): boolean {
   return fileExistsErrorSchema.safeParse(cause).success;
@@ -105,6 +110,7 @@ async function addWorkspacePackage(
   vfs: VirtualFileSystem,
   projectDir: string,
   packageName: string,
+  packageManager: ProjectConfig["packageManager"],
 ): Promise<Result<void, CLIError>> {
   const packageDir = path.join(projectDir, "packages", packageName);
   if (await fs.pathExists(packageDir)) {
@@ -129,6 +135,20 @@ async function addWorkspacePackage(
     return Result.err(packageScopeResult.error);
   }
 
+  const typescriptVersionResult = await Result.tryPromise({
+    try: async () =>
+      rootTypescriptVersionSchema.parse(await fs.readJson(path.join(projectDir, "package.json"))),
+    catch: (cause: unknown) =>
+      new CLIError({
+        message:
+          "Cannot determine the TypeScript version. Expected package.json to declare devDependencies.typescript.",
+        cause,
+      }),
+  });
+  if (typescriptVersionResult.isErr()) {
+    return Result.err(typescriptVersionResult.error);
+  }
+
   const packageScope = packageScopeResult.value;
   const fullPackageName = `${packageScope}/${packageName}`;
   if (fullPackageName.length > 214) {
@@ -150,6 +170,10 @@ async function addWorkspacePackage(
         type: "module",
         exports: { ".": "./src/index.ts" },
         scripts: { "check-types": "tsc --noEmit" },
+        devDependencies: {
+          [`${packageScope}/config`]: packageManager === "npm" ? "*" : "workspace:*",
+          typescript: typescriptVersionResult.value,
+        },
       },
       null,
       2,
@@ -449,7 +473,12 @@ async function addHandlerInternal(
   const vfs = new VirtualFileSystem();
 
   if (input.package) {
-    const packageResult = await addWorkspacePackage(vfs, projectDir, input.package);
+    const packageResult = await addWorkspacePackage(
+      vfs,
+      projectDir,
+      input.package,
+      existingConfig.packageManager,
+    );
     if (packageResult.isErr()) {
       return Result.err(packageResult.error);
     }

--- a/apps/cli/src/helpers/core/add-handler.ts
+++ b/apps/cli/src/helpers/core/add-handler.ts
@@ -69,11 +69,37 @@ const ADD_TEXT_FILE_PATHS = ["apps/web/vite.config.ts", "lefthook.yml"];
 const HOOK_ADDONS = ["husky", "lefthook"] as const satisfies readonly Addons[];
 const HOOK_LINTER_ADDONS = ["biome", "oxlint", "vite-plus"] as const satisfies readonly Addons[];
 const TASK_RUNNER_ADDONS = ["turborepo", "nx", "vite-plus"] as const satisfies readonly Addons[];
+const fileExistsErrorSchema = z.object({ code: z.literal("EEXIST") });
 const configPackageScopeSchema = z
   .object({
     name: z.string().regex(/^@[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?\/config$/),
   })
   .transform(({ name }) => name.slice(0, -"/config".length));
+
+function isFileExistsError(cause: unknown): boolean {
+  return fileExistsErrorSchema.safeParse(cause).success;
+}
+
+async function reserveWorkspacePackage(
+  projectDir: string,
+  packageName: string,
+): Promise<Result<string, CLIError>> {
+  const packageDir = path.join(projectDir, "packages", packageName);
+
+  return Result.tryPromise({
+    try: async () => {
+      await fs.mkdir(packageDir);
+      return packageDir;
+    },
+    catch: (cause: unknown) =>
+      new CLIError({
+        message: isFileExistsError(cause)
+          ? `Workspace package already exists: packages/${packageName}`
+          : `Failed to reserve workspace package: packages/${packageName}`,
+        cause,
+      }),
+  });
+}
 
 async function addWorkspacePackage(
   vfs: VirtualFileSystem,
@@ -417,7 +443,7 @@ async function addHandlerInternal(
 
   // Create VFS and process addon templates using template-generator's logic
   if (!isSilent()) {
-    log.info(pc.dim("Preparing addon files…"));
+    log.info(pc.dim("Preparing files…"));
   }
 
   const vfs = new VirtualFileSystem();
@@ -504,16 +530,24 @@ async function addHandlerInternal(
     });
   }
 
+  let reservedPackageDir: string | undefined;
+  if (input.package) {
+    const reservationResult = await reserveWorkspacePackage(projectDir, input.package);
+    if (reservationResult.isErr()) {
+      return Result.err(reservationResult.error);
+    }
+    reservedPackageDir = reservationResult.value;
+  }
+
   const writeResult = await writeTree(tree, projectDir);
 
   if (writeResult.isErr()) {
-    if (input.package) {
-      const packageName = input.package;
+    if (reservedPackageDir && input.package) {
       const cleanupResult = await Result.tryPromise({
-        try: () => fs.remove(path.join(projectDir, "packages", packageName)),
+        try: () => fs.remove(reservedPackageDir),
         catch: (cause: unknown) =>
           new CLIError({
-            message: `Failed to clean up incomplete workspace package: packages/${packageName}`,
+            message: `Failed to clean up incomplete workspace package: packages/${input.package}`,
             cause,
           }),
       });

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -53,6 +53,7 @@ import {
   TemplateSchema,
   type WebDeploy,
   WebDeploySchema,
+  WorkspacePackageNameSchema,
 } from "./types";
 import {
   CLIError,
@@ -235,10 +236,13 @@ export const router = t.router({
     .meta({ description: "Open the web-based stack builder" })
     .mutation(() => openBuilderCommand()),
   add: t.procedure
-    .meta({ description: "Add addons to an existing Better-T-Stack project" })
+    .meta({
+      description: "Add addons or a workspace package to an existing Better-T-Stack project",
+    })
     .input(
       z.object({
         addons: z.array(AddonsSchema).optional().describe("Addons to add"),
+        package: WorkspacePackageNameSchema.optional(),
         install: z
           .boolean()
           .optional()
@@ -258,7 +262,7 @@ export const router = t.router({
     }),
   addJson: t.procedure
     .meta({
-      description: "Add addons from a raw JSON payload (agent-friendly)",
+      description: "Add addons or a workspace package from a raw JSON payload (agent-friendly)",
       jsonInput: "always",
     })
     .input(AddInputSchema)
@@ -534,11 +538,11 @@ export type { AddResult };
 
 export type AddOptions = Pick<
   AddInput,
-  "addons" | "addonOptions" | "install" | "packageManager" | "projectDir" | "dryRun"
+  "addons" | "addonOptions" | "package" | "install" | "packageManager" | "projectDir" | "dryRun"
 >;
 
 /**
- * Programmatic API to add addons to an existing Better-T-Stack project.
+ * Programmatic API to add addons or a workspace package to an existing Better-T-Stack project.
  *
  * @example
  * ```typescript

--- a/apps/cli/src/mcp.ts
+++ b/apps/cli/src/mcp.ts
@@ -126,7 +126,7 @@ function getStackGuidance() {
       "For project creation, build a full explicit config before calling bts_plan_project.",
       "Always call bts_plan_project before bts_create_project.",
       "Only call bts_create_project after the plan succeeds and matches the user's intent.",
-      "Use bts_plan_addons before bts_add_addons for existing projects.",
+      "Use bts_plan_addons before bts_add_addons when adding addons or scaffolding a workspace package in an existing project.",
     ],
     createContract: {
       requiresExplicitFields: [
@@ -323,13 +323,13 @@ export function createBtsMcpServer() {
   server.registerTool(
     "bts_plan_addons",
     {
-      title: "Plan Better T Stack Addons",
+      title: "Plan Better T Stack Project Additions",
       description:
-        "Validate and preview addon installation for an existing Better T Stack project without writing files. Always use this before bts_add_addons when the addon set or nested options are uncertain.",
+        "Validate and preview addon installation or workspace package scaffolding for an existing Better T Stack project without writing files. Always use this before bts_add_addons.",
       inputSchema: AddInputSchema,
       outputSchema: ToolResponseSchema,
       annotations: {
-        title: "Plan Better T Stack Addons",
+        title: "Plan Better T Stack Project Additions",
         readOnlyHint: true,
         destructiveHint: false,
         idempotentHint: true,
@@ -344,7 +344,7 @@ export function createBtsMcpServer() {
         });
 
         if (!result?.success) {
-          return formatToolError(result?.error ?? "Failed to plan addon installation");
+          return formatToolError(result?.error ?? "Failed to plan project additions");
         }
 
         return formatToolSuccess(result);
@@ -357,13 +357,13 @@ export function createBtsMcpServer() {
   server.registerTool(
     "bts_add_addons",
     {
-      title: "Add Better T Stack Addons",
+      title: "Apply Better T Stack Project Additions",
       description:
-        "Install addons into an existing Better T Stack project using the same silent flow as add-json. Call this only after bts_plan_addons succeeds and the planned changes match the user's intent.",
+        "Install addons or scaffold a workspace package in an existing Better T Stack project using the same silent flow as add-json. Call this only after bts_plan_addons succeeds and the planned changes match the user's intent.",
       inputSchema: AddInputSchema,
       outputSchema: ToolResponseSchema,
       annotations: {
-        title: "Add Better T Stack Addons",
+        title: "Apply Better T Stack Project Additions",
         destructiveHint: true,
         idempotentHint: false,
         openWorldHint: true,
@@ -374,7 +374,7 @@ export function createBtsMcpServer() {
         const result = await add(input);
 
         if (!result?.success) {
-          return formatToolError(result?.error ?? "Failed to add addons");
+          return formatToolError(result?.error ?? "Failed to update project");
         }
 
         return formatToolSuccess(result);

--- a/apps/cli/test/add-handler.test.ts
+++ b/apps/cli/test/add-handler.test.ts
@@ -11,26 +11,28 @@ describe("add()", () => {
     const projectDir = join(SMOKE_DIR, "workspace-package-project");
     await rm(projectDir, { recursive: true, force: true });
     await mkdir(join(projectDir, "packages", "config"), { recursive: true });
+    const projectConfig = {
+      version: "0.0.0-test",
+      createdAt: new Date(0).toISOString(),
+      database: "none",
+      orm: "none",
+      backend: "none",
+      runtime: "bun",
+      frontend: ["tanstack-router"],
+      addons: ["none"],
+      examples: ["none"],
+      auth: "none",
+      payments: "none",
+      packageManager: "bun",
+      dbSetup: "none",
+      api: "none",
+      webDeploy: "none",
+      serverDeploy: "none",
+    };
+    await writeFile(join(projectDir, "bts.jsonc"), JSON.stringify(projectConfig));
     await writeFile(
-      join(projectDir, "bts.jsonc"),
-      JSON.stringify({
-        version: "0.0.0-test",
-        createdAt: new Date(0).toISOString(),
-        database: "none",
-        orm: "none",
-        backend: "none",
-        runtime: "bun",
-        frontend: ["tanstack-router"],
-        addons: ["none"],
-        examples: ["none"],
-        auth: "none",
-        payments: "none",
-        packageManager: "bun",
-        dbSetup: "none",
-        api: "none",
-        webDeploy: "none",
-        serverDeploy: "none",
-      }),
+      join(projectDir, "package.json"),
+      JSON.stringify({ private: true, devDependencies: { typescript: "catalog:" } }),
     );
     await writeFile(
       join(projectDir, "packages", "config", "package.json"),
@@ -69,6 +71,10 @@ describe("add()", () => {
       type: "module",
       exports: { ".": "./src/index.ts" },
       scripts: { "check-types": "tsc --noEmit" },
+      devDependencies: {
+        "@acme/config": "workspace:*",
+        typescript: "catalog:",
+      },
     });
     expect(
       JSON.parse(await readFile(join(projectDir, "packages", "shared", "tsconfig.json"), "utf8")),
@@ -106,6 +112,25 @@ describe("add()", () => {
     expect(longNameResult.success).toBe(false);
     expect(longNameResult.error).toContain("must not exceed 214 characters including its scope");
     expect(existsSync(join(projectDir, "packages", longPackageName))).toBe(false);
+
+    await writeFile(
+      join(projectDir, "bts.jsonc"),
+      JSON.stringify({ ...projectConfig, packageManager: "npm" }),
+    );
+    await writeFile(
+      join(projectDir, "package.json"),
+      JSON.stringify({ private: true, devDependencies: { typescript: "^6.0.3" } }),
+    );
+    const npmPackageResult = await add({ projectDir, package: "npm-utils", install: false });
+
+    expect(npmPackageResult.success).toBe(true);
+    expect(
+      JSON.parse(await readFile(join(projectDir, "packages", "npm-utils", "package.json"), "utf8"))
+        .devDependencies,
+    ).toEqual({
+      "@acme/config": "*",
+      typescript: "^6.0.3",
+    });
 
     await writeFile(
       join(projectDir, "packages", "config", "package.json"),

--- a/apps/cli/test/add-handler.test.ts
+++ b/apps/cli/test/add-handler.test.ts
@@ -7,7 +7,7 @@ import { add } from "../src/index";
 import { SMOKE_DIR } from "./setup";
 
 describe("add()", () => {
-  it("scaffolds a workspace package through the Add Path", async () => {
+  it("scaffolds a workspace package through add()", async () => {
     const projectDir = join(SMOKE_DIR, "workspace-package-project");
     await rm(projectDir, { recursive: true, force: true });
     await mkdir(join(projectDir, "packages", "config"), { recursive: true });
@@ -85,6 +85,20 @@ describe("add()", () => {
     expect(duplicateResult.success).toBe(false);
     expect(duplicateResult.error).toContain("Workspace package already exists");
     expect(await readFile(indexPath, "utf8")).toBe("export const existing = true;\n");
+
+    const concurrentResults = await Promise.all([
+      add({ projectDir, package: "concurrent", install: false }),
+      add({ projectDir, package: "concurrent", install: false }),
+    ]);
+
+    expect(concurrentResults.filter((result) => result.success)).toHaveLength(1);
+    expect(concurrentResults.filter((result) => !result.success)).toHaveLength(1);
+    expect(concurrentResults.find((result) => !result.success)?.error).toContain(
+      "Workspace package already exists",
+    );
+    expect(
+      await readFile(join(projectDir, "packages", "concurrent", "src", "index.ts"), "utf8"),
+    ).toBe("export {};\n");
 
     const longPackageName = "a".repeat(209);
     const longNameResult = await add({ projectDir, package: longPackageName, install: false });

--- a/apps/cli/test/add-handler.test.ts
+++ b/apps/cli/test/add-handler.test.ts
@@ -1,11 +1,92 @@
 import { describe, expect, it } from "bun:test";
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { add } from "../src/index";
 import { SMOKE_DIR } from "./setup";
 
 describe("add()", () => {
+  it("scaffolds a workspace package through the Add Path", async () => {
+    const projectDir = join(SMOKE_DIR, "workspace-package-project");
+    await rm(projectDir, { recursive: true, force: true });
+    await mkdir(join(projectDir, "packages", "config"), { recursive: true });
+    await writeFile(
+      join(projectDir, "bts.jsonc"),
+      JSON.stringify({
+        version: "0.0.0-test",
+        createdAt: new Date(0).toISOString(),
+        database: "none",
+        orm: "none",
+        backend: "none",
+        runtime: "bun",
+        frontend: ["tanstack-router"],
+        addons: ["none"],
+        examples: ["none"],
+        auth: "none",
+        payments: "none",
+        packageManager: "bun",
+        dbSetup: "none",
+        api: "none",
+        webDeploy: "none",
+        serverDeploy: "none",
+      }),
+    );
+    await writeFile(
+      join(projectDir, "packages", "config", "package.json"),
+      JSON.stringify({ name: "@acme/config", private: true }),
+    );
+
+    const previewResult = await add({
+      projectDir,
+      package: "shared",
+      install: false,
+      dryRun: true,
+    });
+
+    expect(previewResult).toMatchObject({
+      success: true,
+      dryRun: true,
+      addedPackage: "shared",
+      plannedFileCount: 3,
+    });
+    expect(existsSync(join(projectDir, "packages", "shared"))).toBe(false);
+
+    const result = await add({ projectDir, package: "shared", install: false });
+
+    expect(result).toMatchObject({
+      success: true,
+      addedAddons: [],
+      addedPackage: "shared",
+      plannedFileCount: 3,
+    });
+    expect(
+      JSON.parse(await readFile(join(projectDir, "packages", "shared", "package.json"), "utf8")),
+    ).toEqual({
+      name: "@acme/shared",
+      version: "0.0.0",
+      private: true,
+      type: "module",
+      exports: { ".": "./src/index.ts" },
+      scripts: { "check-types": "tsc --noEmit" },
+    });
+    expect(
+      JSON.parse(await readFile(join(projectDir, "packages", "shared", "tsconfig.json"), "utf8")),
+    ).toEqual({
+      extends: "@acme/config/tsconfig.base.json",
+      include: ["src/**/*.ts"],
+    });
+    const indexPath = join(projectDir, "packages", "shared", "src", "index.ts");
+    expect(await readFile(indexPath, "utf8")).toBe("export {};\n");
+
+    await writeFile(indexPath, "export const existing = true;\n");
+    const duplicateResult = await add({ projectDir, package: "shared", install: false });
+
+    expect(duplicateResult.success).toBe(false);
+    expect(duplicateResult.error).toContain("Workspace package already exists");
+    expect(await readFile(indexPath, "utf8")).toBe("export const existing = true;\n");
+  });
+
   it("returns an error in silent mode instead of exiting when the project config is missing", async () => {
     const projectDir = join(SMOKE_DIR, "missing-bts-config");
     await mkdir(projectDir, { recursive: true });

--- a/apps/cli/test/add-handler.test.ts
+++ b/apps/cli/test/add-handler.test.ts
@@ -85,6 +85,23 @@ describe("add()", () => {
     expect(duplicateResult.success).toBe(false);
     expect(duplicateResult.error).toContain("Workspace package already exists");
     expect(await readFile(indexPath, "utf8")).toBe("export const existing = true;\n");
+
+    const longPackageName = "a".repeat(209);
+    const longNameResult = await add({ projectDir, package: longPackageName, install: false });
+
+    expect(longNameResult.success).toBe(false);
+    expect(longNameResult.error).toContain("must not exceed 214 characters including its scope");
+    expect(existsSync(join(projectDir, "packages", longPackageName))).toBe(false);
+
+    await writeFile(
+      join(projectDir, "packages", "config", "package.json"),
+      JSON.stringify({ name: "@Upper/config", private: true }),
+    );
+    const invalidScopeResult = await add({ projectDir, package: "other", install: false });
+
+    expect(invalidScopeResult.success).toBe(false);
+    expect(invalidScopeResult.error).toContain("Cannot determine the workspace package scope");
+    expect(existsSync(join(projectDir, "packages", "other"))).toBe(false);
   });
 
   it("returns an error in silent mode instead of exiting when the project config is missing", async () => {

--- a/apps/cli/test/addons.test.ts
+++ b/apps/cli/test/addons.test.ts
@@ -1008,6 +1008,7 @@ describe("Addon Configurations", () => {
         rootPackageJsonBefore.workspaces.packages,
       );
       expect(rootPackageJsonAfter.workspaces.catalog).toMatchObject(catalogBefore);
+      expect(rootPackageJsonAfter.packageManager).toBe(rootPackageJsonBefore.packageManager);
       expect(authPackageJson.dependencies["better-auth"]).toBe("catalog:");
     });
 

--- a/apps/cli/test/addons.test.ts
+++ b/apps/cli/test/addons.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { existsSync } from "node:fs";
-import { readdir, readFile } from "node:fs/promises";
+import { readdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import {
@@ -960,7 +960,7 @@ describe("Addon Configurations", () => {
       expect(lefthookConfig).not.toContain("name: oxlint");
     });
 
-    it("should preserve Bun workspace catalogs when package scripts refresh on add", async () => {
+    it("should preserve Bun workspace metadata when package scripts refresh on add", async () => {
       const created = await runTRPCTest({
         projectName: "bun-catalog-add-refresh",
         addons: ["turborepo"],
@@ -1010,6 +1010,24 @@ describe("Addon Configurations", () => {
       expect(rootPackageJsonAfter.workspaces.catalog).toMatchObject(catalogBefore);
       expect(rootPackageJsonAfter.packageManager).toBe(rootPackageJsonBefore.packageManager);
       expect(authPackageJson.dependencies["better-auth"]).toBe("catalog:");
+
+      rootPackageJsonAfter.packageManager = "";
+      await writeFile(
+        join(projectDir, "package.json"),
+        `${JSON.stringify(rootPackageJsonAfter, null, 2)}\n`,
+      );
+
+      const fallbackResult = await add({
+        projectDir,
+        addons: ["pwa"],
+        install: false,
+      });
+      expect(fallbackResult?.success).toBe(true);
+
+      const rootPackageJsonWithFallback = JSON.parse(
+        await readFile(join(projectDir, "package.json"), "utf8"),
+      );
+      expect(rootPackageJsonWithFallback.packageManager).toBe("bun@latest");
     });
 
     it("should deduplicate addons", async () => {

--- a/apps/cli/test/input-schemas.test.ts
+++ b/apps/cli/test/input-schemas.test.ts
@@ -28,6 +28,14 @@ describe("Input schemas", () => {
     expect(result.success).toBe(false);
   });
 
+  it("accepts safe workspace package names and rejects path-like names", () => {
+    expect(AddInputSchema.safeParse({ package: "shared-utils" }).success).toBe(true);
+
+    for (const packageName of ["../shared", "@acme/shared", "Shared", "node_modules"]) {
+      expect(AddInputSchema.safeParse({ package: packageName }).success).toBe(false);
+    }
+  });
+
   it("rejects conflicting task-runner addon combinations", () => {
     const conflictingAddonPairs = [
       ["nx", "vite-plus"],

--- a/apps/cli/test/mcp.test.ts
+++ b/apps/cli/test/mcp.test.ts
@@ -431,7 +431,7 @@ describe("MCP server", () => {
     expect(payload.error).toContain("already exists and is not empty");
   });
 
-  it("plans addon installation without mutating bts.jsonc", async () => {
+  it("plans addons and workspace packages without writing files", async () => {
     const { client, cleanup } = await connectInMemoryClient();
     cleanups.push(cleanup);
 
@@ -465,6 +465,7 @@ describe("MCP server", () => {
       arguments: {
         projectDir: projectPath,
         addons: ["biome"],
+        package: "planned-utils",
         packageManager: "bun",
         install: false,
       },
@@ -472,19 +473,26 @@ describe("MCP server", () => {
 
     const payload = result.structuredContent as {
       ok: boolean;
-      data?: { success?: boolean; dryRun?: boolean; addedAddons?: string[] };
+      data?: {
+        success?: boolean;
+        dryRun?: boolean;
+        addedAddons?: string[];
+        addedPackage?: string;
+      };
     };
 
     expect(payload.ok).toBe(true);
     expect(payload.data?.success).toBe(true);
     expect(payload.data?.dryRun).toBe(true);
     expect(payload.data?.addedAddons).toEqual(["biome"]);
+    expect(payload.data?.addedPackage).toBe("planned-utils");
+    expect(await fs.pathExists(path.join(projectPath, "packages", "planned-utils"))).toBe(false);
 
     const after = await readBtsConfig(projectPath);
     expect(after).toEqual(before);
   });
 
-  it("adds addons through MCP and persists them to bts.jsonc", async () => {
+  it("adds addons and workspace packages through MCP", async () => {
     const { client, cleanup } = await connectInMemoryClient();
     cleanups.push(cleanup);
 
@@ -516,6 +524,7 @@ describe("MCP server", () => {
       arguments: {
         projectDir: projectPath,
         addons: ["biome"],
+        package: "shared-utils",
         packageManager: "bun",
         install: false,
       },
@@ -523,12 +532,16 @@ describe("MCP server", () => {
 
     const payload = result.structuredContent as {
       ok: boolean;
-      data?: { success?: boolean; addedAddons?: string[] };
+      data?: { success?: boolean; addedAddons?: string[]; addedPackage?: string };
     };
 
     expect(payload.ok).toBe(true);
     expect(payload.data?.success).toBe(true);
     expect(payload.data?.addedAddons).toEqual(["biome"]);
+    expect(payload.data?.addedPackage).toBe("shared-utils");
+    expect(
+      await fs.readJson(path.join(projectPath, "packages", "shared-utils", "package.json")),
+    ).toMatchObject({ name: "@mcp-add-addons/shared-utils", private: true });
 
     const after = await readBtsConfig(projectPath);
     expect(after?.addons).toEqual(expect.arrayContaining(["turborepo", "biome"]));

--- a/apps/web/content/docs/cli/index.mdx
+++ b/apps/web/content/docs/cli/index.mdx
@@ -69,7 +69,7 @@ create-better-t-stack my-app --yes --dry-run
 
 ## `add`
 
-Adds addons to an existing Better-T-Stack project.
+Adds addons or scaffolds a workspace package in an existing Better-T-Stack project.
 
 ```bash
 create-better-t-stack add [options]
@@ -78,6 +78,7 @@ create-better-t-stack add [options]
 ### Options
 
 - `--addons <types...>`: Addons to add (see [Addons](/docs/cli/options#addons))
+- `--package <name>`: Scaffold `packages/<name>` with a package manifest, shared TypeScript config, and `src/index.ts`
 - `--project-dir <path>`: Project directory (defaults to current directory)
 - `--install / --no-install`: Install dependencies after adding
 - `--package-manager <pm>`: Package manager to use (`npm`, `pnpm`, `bun`)
@@ -93,6 +94,9 @@ create-better-t-stack add --addons pwa tauri --install
 
 # Add addons in a specific project directory
 create-better-t-stack add --project-dir ./my-app --addons mcp skills
+
+# Scaffold @my-app/shared in packages/shared
+create-better-t-stack add --package shared
 ```
 
 ## `create-json`

--- a/apps/web/content/docs/cli/index.mdx
+++ b/apps/web/content/docs/cli/index.mdx
@@ -80,7 +80,7 @@ create-better-t-stack add [options]
 - `--addons <types...>`: Addons to add (see [Addons](/docs/cli/options#addons))
 - `--package <name>`: Scaffold `packages/<name>` with a package manifest, shared TypeScript config, and `src/index.ts`
 - `--project-dir <path>`: Project directory (defaults to current directory)
-- `--install / --no-install`: Install dependencies after adding
+- `--install [boolean]`: Install dependencies after adding (defaults to `false`)
 - `--package-manager <pm>`: Package manager to use (`npm`, `pnpm`, `bun`)
 
 ### Examples

--- a/apps/web/content/docs/cli/programmatic-api.mdx
+++ b/apps/web/content/docs/cli/programmatic-api.mdx
@@ -67,12 +67,13 @@ Notes:
 
 ### `add(options?)`
 
-Add addons to an existing Better-T-Stack project.
+Add addons or scaffold a workspace package in an existing Better-T-Stack project.
 
 ```typescript
 function add(options?: {
   addons?: Addons[];
   addonOptions?: AddonOptions;
+  package?: string;
   install?: boolean;
   packageManager?: PackageManager;
   projectDir?: string;
@@ -106,7 +107,7 @@ if (result.success) {
 ```
 
 `add()` validates its input at runtime and always returns an `AddResult`. Invalid input and
-addon failures return `{ success: false, error }` instead of throwing or exiting the process.
+addon or package scaffolding failures return `{ success: false, error }` instead of throwing or exiting the process.
 
 ### `createVirtual(options)`
 
@@ -173,6 +174,7 @@ type AddResult = {
   projectDir: string;
   dryRun?: boolean;
   plannedFileCount?: number;
+  addedPackage?: string;
   error?: string;
 };
 ```

--- a/packages/template-generator/src/post-process/package-configs.ts
+++ b/packages/template-generator/src/post-process/package-configs.ts
@@ -226,7 +226,7 @@ function updateRootPackageJson(vfs: VirtualFileSystem, config: ProjectConfig): v
 
   // Note: packageManager version is set by CLI at runtime since it requires running the actual CLI
   // For preview purposes, we just show the configured package manager
-  pkgJson.packageManager ??= `${packageManager}@latest`;
+  pkgJson.packageManager ||= `${packageManager}@latest`;
 
   if (packageManager === "npm") {
     const allowScripts = getNpmAllowedScripts(config);

--- a/packages/template-generator/src/post-process/package-configs.ts
+++ b/packages/template-generator/src/post-process/package-configs.ts
@@ -226,7 +226,7 @@ function updateRootPackageJson(vfs: VirtualFileSystem, config: ProjectConfig): v
 
   // Note: packageManager version is set by CLI at runtime since it requires running the actual CLI
   // For preview purposes, we just show the configured package manager
-  pkgJson.packageManager = `${packageManager}@latest`;
+  pkgJson.packageManager ??= `${packageManager}@latest`;
 
   if (packageManager === "npm") {
     const allowScripts = getNpmAllowedScripts(config);

--- a/packages/types/src/schemas.ts
+++ b/packages/types/src/schemas.ts
@@ -515,7 +515,7 @@ export const CreateInputSchema = z
 export const WorkspacePackageNameSchema = z
   .string()
   .min(1, "Package name cannot be empty")
-  .max(214, "Package name must be less than 214 characters")
+  .max(214, "Package name must not exceed 214 characters")
   .regex(
     /^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$/,
     "Package name must be an unscoped lowercase npm name",

--- a/packages/types/src/schemas.ts
+++ b/packages/types/src/schemas.ts
@@ -512,9 +512,21 @@ export const CreateInputSchema = z
     path: ["dbSetupOptions", "mode"],
   });
 
+export const WorkspacePackageNameSchema = z
+  .string()
+  .min(1, "Package name cannot be empty")
+  .max(214, "Package name must be less than 214 characters")
+  .regex(
+    /^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$/,
+    "Package name must be an unscoped lowercase npm name",
+  )
+  .refine((name) => name !== "node_modules", "Package name is reserved")
+  .describe("Name of a workspace package to scaffold");
+
 export const AddInputSchema = z
   .object({
     addons: AddonsListSchema.optional(),
+    package: WorkspacePackageNameSchema.optional(),
     addonOptions: AddonOptionsSchema.optional(),
     webDeploy: WebDeploySchema.optional(),
     serverDeploy: ServerDeploySchema.optional(),


### PR DESCRIPTION
## Summary

- add `--package <name>` support to the existing `add` command
- scaffold a private `packages/<name>` workspace with a package manifest, shared TypeScript config, and `src/index.ts`
- derive the npm scope from `packages/config/package.json` and validate the final scoped name
- atomically reserve the package directory so duplicate and concurrent runs cannot overwrite or delete another package
- support package-only, package-plus-addon, dry-run, JSON, programmatic, and MCP flows
- preserve the project's pinned package-manager version when `add` refreshes package scripts
- document the CLI and programmatic APIs

## Verification

- `bun run check`
- `bun run build:cli`
- `bun run build:web`
- `cd apps/cli && bun test` — 692 passed, 31 skipped, 0 failed
- real install and typecheck checks with Bun/Turborepo, npm/Nx, and pnpm/Vite+

Fixes #995


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added workspace package scaffolding through the CLI, programmatic API, and MCP tools.
  - Use `--package <name>` to create a validated package with generated files and workspace metadata.
  - Package-only additions are supported without requiring addon installation.
  - Dry runs and results now report newly added packages.

- **Bug Fixes**
  - Prevented duplicate package creation and protected existing files during concurrent operations.
  - Preserved existing package manager settings during project updates.

- **Documentation**
  - Updated CLI and programmatic API documentation with package scaffolding options and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->