### PR TITLE
chore(cli): upgrade Bun 1.4 and Better Auth 1.7

### DIFF
--- a/.github/workflows/pr-preview.yaml
+++ b/.github/workflows/pr-preview.yaml
@@ -35,8 +35,6 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
 
       - name: Install Dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,8 +64,6 @@ jobs:
       - name: Setup Bun
         if: steps.check-version.outputs.exists == 'false'
         uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
 
       - name: Install Dependencies
         if: steps.check-version.outputs.exists == 'false'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,8 +31,6 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
 
       - name: Install Dependencies
         run: bun install --frozen-lockfile

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -30,7 +30,7 @@ Follow the prompts to configure your project or use the `--yes` flag for default
 ## Requirements
 
 - Node.js 22 or newer to run the CLI with Node.js. The selected framework may require a newer release; the CLI checks the exact stack before writing files.
-- Bun 1.3 or newer is recommended. Bun 1.2.14 remains the minimum because generated workspaces use dependency catalogs.
+- Bun 1.4 or newer is recommended. Bun 1.2.14 remains the minimum because generated workspaces use dependency catalogs.
 - pnpm 10.26.0 or newer when using pnpm (catalogs and `allowBuilds`).
 - npm 11.16.0 or newer when using npm (`allowScripts`).
 

--- a/apps/cli/src/utils/requirements.ts
+++ b/apps/cli/src/utils/requirements.ts
@@ -43,7 +43,7 @@ export const PACKAGE_MANAGER_VERSION_RANGES = {
   pnpm: ">=10.26.0",
 } as const satisfies Record<PackageManager, string>;
 
-export const RECOMMENDED_BUN_VERSION_RANGE = ">=1.3.0";
+export const RECOMMENDED_BUN_VERSION_RANGE = ">=1.4.0";
 
 const PACKAGE_MANAGER_REASONS = {
   bun: "generated Bun workspaces use dependency catalogs",
@@ -257,7 +257,7 @@ export function getLocalToolRecommendations(
   }
 
   return [
-    `Bun ${version} meets the minimum requirement, but Bun 1.3 or newer is recommended. Run \`bun upgrade\`.`,
+    `Bun ${version} meets the minimum requirement, but Bun 1.4 or newer is recommended. Run \`bun upgrade\`.`,
   ];
 }
 

--- a/apps/cli/test/api.test.ts
+++ b/apps/cli/test/api.test.ts
@@ -588,7 +588,7 @@ describe("API Configurations", () => {
             'import { authClient } from "@/lib/auth-client";',
             'import { Platform } from "react-native";',
             'credentials: Platform.OS === "web" ? "include" : "omit"',
-            "const cookies = authClient.getCookie();",
+            "const cookies = await authClient.getCookie();",
             "return expoFetch(request, {",
           ],
         },

--- a/apps/cli/test/auth.test.ts
+++ b/apps/cli/test/auth.test.ts
@@ -29,6 +29,16 @@ describe("Authentication Configurations", () => {
         });
 
         expectSuccess(result);
+        if (!result.projectDir) {
+          throw new Error("Expected projectDir to be defined");
+        }
+
+        const authSchema = await fs.readFile(
+          path.join(result.projectDir, "packages/db/src/schema/auth.ts"),
+          "utf8",
+        );
+        expect(authSchema).toContain("issuer:");
+        expect(authSchema).toContain('uniqueIndex("account_issuer_accountId_uidx")');
       });
     }
 
@@ -87,6 +97,10 @@ describe("Authentication Configurations", () => {
       expect(authModels).toContain("_id: { type: ObjectId, auto: true }");
       expect(authModels).toContain('userId: { type: ObjectId, ref: "User", required: true }');
       expect(authModels).toContain("sessionSchema.index({ userId: 1 })");
+      expect(authModels).toContain("issuer: { type: String, required: true }");
+      expect(authModels).toContain(
+        "accountSchema.index({ issuer: 1, accountId: 1 }, { unique: true })",
+      );
       expect(authModels).toContain("verificationSchema.index({ identifier: 1 })");
     });
 
@@ -796,7 +810,7 @@ describe("Authentication Configurations", () => {
         const packageJson = JSON.parse(
           await fs.readFile(path.join(result.projectDir, "package.json"), "utf8"),
         );
-        expect(packageJson.workspaces.catalog["better-auth"]).toBe("1.6.30");
+        expect(packageJson.workspaces.catalog["better-auth"]).toBe("1.7.1");
       });
     }
   });
@@ -1222,6 +1236,20 @@ describe("Authentication Configurations", () => {
         });
 
         expectSuccess(result);
+        if (!result.projectDir) {
+          throw new Error("Expected projectDir to be defined");
+        }
+
+        if (orm === "prisma") {
+          const authSchema = await fs.readFile(
+            path.join(result.projectDir, "packages/db/prisma/schema/auth.prisma"),
+            "utf8",
+          );
+          expect(authSchema).toContain("issuer                String");
+          expect(authSchema).toContain(
+            '@@unique([issuer, accountId], map: "account_issuer_accountId_uidx")',
+          );
+        }
       });
     }
   });

--- a/apps/cli/test/requirements.test.ts
+++ b/apps/cli/test/requirements.test.ts
@@ -46,16 +46,19 @@ describe("local tool requirements", () => {
       npm: ">=11.16.0",
       pnpm: ">=10.26.0",
     });
-    expect(RECOMMENDED_BUN_VERSION_RANGE).toBe(">=1.3.0");
+    expect(RECOMMENDED_BUN_VERSION_RANGE).toBe(">=1.4.0");
   });
 
-  it("recommends Bun 1.3 without rejecting the catalog-compatible minimum", () => {
+  it("recommends Bun 1.4 without rejecting the catalog-compatible minimum", () => {
     const project = config();
 
     expect(getLocalToolRecommendations(project, { bun: "1.2.14" })).toEqual([
-      "Bun 1.2.14 meets the minimum requirement, but Bun 1.3 or newer is recommended. Run `bun upgrade`.",
+      "Bun 1.2.14 meets the minimum requirement, but Bun 1.4 or newer is recommended. Run `bun upgrade`.",
     ]);
-    expect(getLocalToolRecommendations(project, { bun: "1.3.0" })).toEqual([]);
+    expect(getLocalToolRecommendations(project, { bun: "1.3.14" })).toEqual([
+      "Bun 1.3.14 meets the minimum requirement, but Bun 1.4 or newer is recommended. Run `bun upgrade`.",
+    ]);
+    expect(getLocalToolRecommendations(project, { bun: "1.4.0" })).toEqual([]);
   });
 
   it.each([

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -79,5 +79,5 @@
     "tw-animate-css": "^1.4.0",
     "typescript": "catalog:"
   },
-  "packageManager": "bun@1.3.14"
+  "packageManager": "bun@1.4.0"
 }

--- a/package.json
+++ b/package.json
@@ -70,5 +70,5 @@
   "engines": {
     "node": "24.x"
   },
-  "packageManager": "bun@1.3.14"
+  "packageManager": "bun@1.4.0"
 }

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -843,12 +843,12 @@ export const link = new RPCLink({
 			credentials: Platform.OS === "web" ? "include" : "omit",
 		});
 	},
-	headers() {
+	async headers() {
 		if (Platform.OS === "web") {
 			return {};
 		}
 		const headers = new Map<string, string>();
-		const cookies = authClient.getCookie();
+		const cookies = await authClient.getCookie();
 		if (cookies) {
 			headers.set("Cookie", cookies);
 		}
@@ -1888,12 +1888,12 @@ const trpcClient = createTRPCClient<AppRouter>({
 						credentials: Platform.OS === "web" ? "include" : "omit",
 					});
 				},
-			headers() {
+			async headers() {
 				if (Platform.OS === "web") {
 					return {};
 				}
 				const headers = new Map<string, string>();
-				const cookies = authClient.getCookie();
+				const cookies = await authClient.getCookie();
 				if (cookies) {
 					headers.set("Cookie", cookies);
 				}
@@ -8425,6 +8425,7 @@ import {
   timestamp,
   boolean,
   index,
+  uniqueIndex,
 } from "drizzle-orm/mysql-core";
 
 export const user = mysqlTable("user", {
@@ -8463,7 +8464,8 @@ export const account = mysqlTable(
   "account",
   {
     id: varchar("id", { length: 36 }).primaryKey(),
-    accountId: text("account_id").notNull(),
+    issuer: varchar("issuer", { length: 191 }).notNull(),
+    accountId: varchar("account_id", { length: 191 }).notNull(),
     providerId: text("provider_id").notNull(),
     userId: varchar("user_id", { length: 36 })
       .notNull()
@@ -8480,7 +8482,10 @@ export const account = mysqlTable(
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),
   },
-  (table) => [index("account_userId_idx").on(table.userId)],
+  (table) => [
+    uniqueIndex("account_issuer_accountId_uidx").on(table.issuer, table.accountId),
+    index("account_userId_idx").on(table.userId),
+  ],
 );
 
 export const verification = mysqlTable(
@@ -8519,7 +8524,7 @@ export const accountRelations = relations(account, ({ one }) => ({
 }));
 `],
   ["auth/better-auth/server/db/drizzle/postgres/src/schema/auth.ts.hbs", `import { relations } from "drizzle-orm";
-import { pgTable, text, timestamp, boolean, index } from "drizzle-orm/pg-core";
+import { pgTable, text, timestamp, boolean, index, uniqueIndex } from "drizzle-orm/pg-core";
 
 export const user = pgTable("user", {
   id: text("id").primaryKey(),
@@ -8557,6 +8562,7 @@ export const account = pgTable(
   "account",
   {
     id: text("id").primaryKey(),
+    issuer: text("issuer").notNull(),
     accountId: text("account_id").notNull(),
     providerId: text("provider_id").notNull(),
     userId: text("user_id")
@@ -8574,7 +8580,10 @@ export const account = pgTable(
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),
   },
-  (table) => [index("account_userId_idx").on(table.userId)],
+  (table) => [
+    uniqueIndex("account_issuer_accountId_uidx").on(table.issuer, table.accountId),
+    index("account_userId_idx").on(table.userId),
+  ],
 );
 
 export const verification = pgTable(
@@ -8613,7 +8622,7 @@ export const accountRelations = relations(account, ({ one }) => ({
 }));
 `],
   ["auth/better-auth/server/db/drizzle/sqlite/src/schema/auth.ts.hbs", `import { relations, sql } from "drizzle-orm";
-import { sqliteTable, text, integer, index } from "drizzle-orm/sqlite-core";
+import { sqliteTable, text, integer, index, uniqueIndex } from "drizzle-orm/sqlite-core";
 
 export const user = sqliteTable("user", {
   id: text("id").primaryKey(),
@@ -8657,6 +8666,7 @@ export const account = sqliteTable(
   "account",
   {
     id: text("id").primaryKey(),
+    issuer: text("issuer").notNull(),
     accountId: text("account_id").notNull(),
     providerId: text("provider_id").notNull(),
     userId: text("user_id")
@@ -8680,7 +8690,10 @@ export const account = sqliteTable(
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),
   },
-  (table) => [index("account_userId_idx").on(table.userId)],
+  (table) => [
+    uniqueIndex("account_issuer_accountId_uidx").on(table.issuer, table.accountId),
+    index("account_userId_idx").on(table.userId),
+  ],
 );
 
 export const verification = sqliteTable(
@@ -8756,6 +8769,7 @@ sessionSchema.index({ userId: 1 });
 const accountSchema = new Schema(
     {
         _id: { type: ObjectId, auto: true },
+        issuer: { type: String, required: true },
         accountId: { type: String, required: true },
         providerId: { type: String, required: true },
         userId: { type: ObjectId, ref: 'User', required: true },
@@ -8771,6 +8785,7 @@ const accountSchema = new Schema(
     },
     { collection: 'account' }
 );
+accountSchema.index({ issuer: 1, accountId: 1 }, { unique: true });
 accountSchema.index({ userId: 1 });
 
 const verificationSchema = new Schema(
@@ -8826,6 +8841,7 @@ model Session {
 
 model Account {
   id                    String    @id @map("_id")
+  issuer                String
   accountId             String
   providerId            String
   userId                String
@@ -8840,6 +8856,7 @@ model Account {
   createdAt             DateTime  @default(now())
   updatedAt             DateTime  @updatedAt
 
+  @@unique([issuer, accountId], map: "account_issuer_accountId_uidx")
   @@index([userId])
   @@map("account")
 }
@@ -8889,7 +8906,8 @@ model Session {
 
 model Account {
   id                    String    @id
-  accountId             String    @db.Text
+  issuer                String    @db.VarChar(191)
+  accountId             String    @db.VarChar(191)
   providerId            String    @db.Text
   userId                String
   user                  User      @relation(fields: [userId], references: [id], onDelete: Cascade)
@@ -8903,6 +8921,7 @@ model Account {
   createdAt             DateTime  @default(now())
   updatedAt             DateTime  @updatedAt
 
+  @@unique([issuer, accountId], map: "account_issuer_accountId_uidx")
   @@index([userId(length: 191)])
   @@map("account")
 }
@@ -8952,6 +8971,7 @@ model Session {
 
 model Account {
   id                    String    @id
+  issuer                String
   accountId             String
   providerId            String
   userId                String
@@ -8966,6 +8986,7 @@ model Account {
   createdAt             DateTime  @default(now())
   updatedAt             DateTime  @updatedAt
 
+  @@unique([issuer, accountId], map: "account_issuer_accountId_uidx")
   @@index([userId])
   @@map("account")
 }
@@ -9015,6 +9036,7 @@ model Session {
 
 model Account {
   id                    String    @id
+  issuer                String
   accountId             String
   providerId            String
   userId                String
@@ -9029,6 +9051,7 @@ model Account {
   createdAt             DateTime  @default(now())
   updatedAt             DateTime  @updatedAt
 
+  @@unique([issuer, accountId], map: "account_issuer_accountId_uidx")
   @@index([userId])
   @@map("account")
 }
@@ -15783,7 +15806,8 @@ CREATE TABLE \`session\` (
 -- CreateTable
 CREATE TABLE \`account\` (
     \`id\` VARCHAR(191) NOT NULL,
-    \`accountId\` TEXT NOT NULL,
+    \`issuer\` VARCHAR(191) NOT NULL,
+    \`accountId\` VARCHAR(191) NOT NULL,
     \`providerId\` TEXT NOT NULL,
     \`userId\` VARCHAR(191) NOT NULL,
     \`accessToken\` TEXT NULL,
@@ -15796,6 +15820,7 @@ CREATE TABLE \`account\` (
     \`createdAt\` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
     \`updatedAt\` DATETIME(3) NOT NULL,
 
+    UNIQUE INDEX \`account_issuer_accountId_uidx\`(\`issuer\`, \`accountId\`),
     INDEX \`account_userId_idx\`(\`userId\`(191)),
     PRIMARY KEY (\`id\`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
@@ -15978,6 +16003,7 @@ CREATE TABLE "session" (
 -- CreateTable
 CREATE TABLE "account" (
     "id" TEXT NOT NULL,
+    "issuer" TEXT NOT NULL,
     "accountId" TEXT NOT NULL,
     "providerId" TEXT NOT NULL,
     "userId" TEXT NOT NULL,
@@ -16030,6 +16056,9 @@ CREATE UNIQUE INDEX "session_token_key" ON "session"("token");
 
 -- CreateIndex
 CREATE INDEX "account_userId_idx" ON "account"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "account_issuer_accountId_uidx" ON "account"("issuer", "accountId");
 
 -- CreateIndex
 CREATE INDEX "verification_identifier_idx" ON "verification"("identifier");

--- a/packages/template-generator/src/utils/add-deps.ts
+++ b/packages/template-generator/src/utils/add-deps.ts
@@ -15,8 +15,8 @@ type PackageJson = {
 export const dependencyVersionMap = {
   typescript: "^6.0.3",
 
-  "better-auth": "1.6.30",
-  "@better-auth/expo": "1.6.30",
+  "better-auth": "1.7.1",
+  "@better-auth/expo": "1.7.1",
 
   "@clerk/backend": "^3.16.10",
   "@clerk/express": "^2.1.61",

--- a/packages/template-generator/templates/api/orpc/native/utils/orpc.ts.hbs
+++ b/packages/template-generator/templates/api/orpc/native/utils/orpc.ts.hbs
@@ -49,12 +49,12 @@ export const link = new RPCLink({
 			credentials: Platform.OS === "web" ? "include" : "omit",
 		});
 	},
-	headers() {
+	async headers() {
 		if (Platform.OS === "web") {
 			return {};
 		}
 		const headers = new Map<string, string>();
-		const cookies = authClient.getCookie();
+		const cookies = await authClient.getCookie();
 		if (cookies) {
 			headers.set("Cookie", cookies);
 		}

--- a/packages/template-generator/templates/api/trpc/native/utils/trpc.ts.hbs
+++ b/packages/template-generator/templates/api/trpc/native/utils/trpc.ts.hbs
@@ -29,12 +29,12 @@ const trpcClient = createTRPCClient<AppRouter>({
 						credentials: Platform.OS === "web" ? "include" : "omit",
 					});
 				},
-			headers() {
+			async headers() {
 				if (Platform.OS === "web") {
 					return {};
 				}
 				const headers = new Map<string, string>();
-				const cookies = authClient.getCookie();
+				const cookies = await authClient.getCookie();
 				if (cookies) {
 					headers.set("Cookie", cookies);
 				}

--- a/packages/template-generator/templates/auth/better-auth/server/db/drizzle/mysql/src/schema/auth.ts.hbs
+++ b/packages/template-generator/templates/auth/better-auth/server/db/drizzle/mysql/src/schema/auth.ts.hbs
@@ -6,6 +6,7 @@ import {
   timestamp,
   boolean,
   index,
+  uniqueIndex,
 } from "drizzle-orm/mysql-core";
 
 export const user = mysqlTable("user", {
@@ -44,7 +45,8 @@ export const account = mysqlTable(
   "account",
   {
     id: varchar("id", { length: 36 }).primaryKey(),
-    accountId: text("account_id").notNull(),
+    issuer: varchar("issuer", { length: 191 }).notNull(),
+    accountId: varchar("account_id", { length: 191 }).notNull(),
     providerId: text("provider_id").notNull(),
     userId: varchar("user_id", { length: 36 })
       .notNull()
@@ -61,7 +63,10 @@ export const account = mysqlTable(
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),
   },
-  (table) => [index("account_userId_idx").on(table.userId)],
+  (table) => [
+    uniqueIndex("account_issuer_accountId_uidx").on(table.issuer, table.accountId),
+    index("account_userId_idx").on(table.userId),
+  ],
 );
 
 export const verification = mysqlTable(

--- a/packages/template-generator/templates/auth/better-auth/server/db/drizzle/postgres/src/schema/auth.ts.hbs
+++ b/packages/template-generator/templates/auth/better-auth/server/db/drizzle/postgres/src/schema/auth.ts.hbs
@@ -1,5 +1,5 @@
 import { relations } from "drizzle-orm";
-import { pgTable, text, timestamp, boolean, index } from "drizzle-orm/pg-core";
+import { pgTable, text, timestamp, boolean, index, uniqueIndex } from "drizzle-orm/pg-core";
 
 export const user = pgTable("user", {
   id: text("id").primaryKey(),
@@ -37,6 +37,7 @@ export const account = pgTable(
   "account",
   {
     id: text("id").primaryKey(),
+    issuer: text("issuer").notNull(),
     accountId: text("account_id").notNull(),
     providerId: text("provider_id").notNull(),
     userId: text("user_id")
@@ -54,7 +55,10 @@ export const account = pgTable(
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),
   },
-  (table) => [index("account_userId_idx").on(table.userId)],
+  (table) => [
+    uniqueIndex("account_issuer_accountId_uidx").on(table.issuer, table.accountId),
+    index("account_userId_idx").on(table.userId),
+  ],
 );
 
 export const verification = pgTable(

--- a/packages/template-generator/templates/auth/better-auth/server/db/drizzle/sqlite/src/schema/auth.ts.hbs
+++ b/packages/template-generator/templates/auth/better-auth/server/db/drizzle/sqlite/src/schema/auth.ts.hbs
@@ -1,5 +1,5 @@
 import { relations, sql } from "drizzle-orm";
-import { sqliteTable, text, integer, index } from "drizzle-orm/sqlite-core";
+import { sqliteTable, text, integer, index, uniqueIndex } from "drizzle-orm/sqlite-core";
 
 export const user = sqliteTable("user", {
   id: text("id").primaryKey(),
@@ -43,6 +43,7 @@ export const account = sqliteTable(
   "account",
   {
     id: text("id").primaryKey(),
+    issuer: text("issuer").notNull(),
     accountId: text("account_id").notNull(),
     providerId: text("provider_id").notNull(),
     userId: text("user_id")
@@ -66,7 +67,10 @@ export const account = sqliteTable(
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),
   },
-  (table) => [index("account_userId_idx").on(table.userId)],
+  (table) => [
+    uniqueIndex("account_issuer_accountId_uidx").on(table.issuer, table.accountId),
+    index("account_userId_idx").on(table.userId),
+  ],
 );
 
 export const verification = sqliteTable(

--- a/packages/template-generator/templates/auth/better-auth/server/db/mongoose/mongodb/src/models/auth.model.ts.hbs
+++ b/packages/template-generator/templates/auth/better-auth/server/db/mongoose/mongodb/src/models/auth.model.ts.hbs
@@ -34,6 +34,7 @@ sessionSchema.index({ userId: 1 });
 const accountSchema = new Schema(
     {
         _id: { type: ObjectId, auto: true },
+        issuer: { type: String, required: true },
         accountId: { type: String, required: true },
         providerId: { type: String, required: true },
         userId: { type: ObjectId, ref: 'User', required: true },
@@ -49,6 +50,7 @@ const accountSchema = new Schema(
     },
     { collection: 'account' }
 );
+accountSchema.index({ issuer: 1, accountId: 1 }, { unique: true });
 accountSchema.index({ userId: 1 });
 
 const verificationSchema = new Schema(

--- a/packages/template-generator/templates/auth/better-auth/server/db/prisma/mongodb/prisma/schema/auth.prisma.hbs
+++ b/packages/template-generator/templates/auth/better-auth/server/db/prisma/mongodb/prisma/schema/auth.prisma.hbs
@@ -31,6 +31,7 @@ model Session {
 
 model Account {
   id                    String    @id @map("_id")
+  issuer                String
   accountId             String
   providerId            String
   userId                String
@@ -45,6 +46,7 @@ model Account {
   createdAt             DateTime  @default(now())
   updatedAt             DateTime  @updatedAt
 
+  @@unique([issuer, accountId], map: "account_issuer_accountId_uidx")
   @@index([userId])
   @@map("account")
 }

--- a/packages/template-generator/templates/auth/better-auth/server/db/prisma/mysql/prisma/schema/auth.prisma.hbs
+++ b/packages/template-generator/templates/auth/better-auth/server/db/prisma/mysql/prisma/schema/auth.prisma.hbs
@@ -31,7 +31,8 @@ model Session {
 
 model Account {
   id                    String    @id
-  accountId             String    @db.Text
+  issuer                String    @db.VarChar(191)
+  accountId             String    @db.VarChar(191)
   providerId            String    @db.Text
   userId                String
   user                  User      @relation(fields: [userId], references: [id], onDelete: Cascade)
@@ -45,6 +46,7 @@ model Account {
   createdAt             DateTime  @default(now())
   updatedAt             DateTime  @updatedAt
 
+  @@unique([issuer, accountId], map: "account_issuer_accountId_uidx")
   @@index([userId(length: 191)])
   @@map("account")
 }

--- a/packages/template-generator/templates/auth/better-auth/server/db/prisma/postgres/prisma/schema/auth.prisma.hbs
+++ b/packages/template-generator/templates/auth/better-auth/server/db/prisma/postgres/prisma/schema/auth.prisma.hbs
@@ -31,6 +31,7 @@ model Session {
 
 model Account {
   id                    String    @id
+  issuer                String
   accountId             String
   providerId            String
   userId                String
@@ -45,6 +46,7 @@ model Account {
   createdAt             DateTime  @default(now())
   updatedAt             DateTime  @updatedAt
 
+  @@unique([issuer, accountId], map: "account_issuer_accountId_uidx")
   @@index([userId])
   @@map("account")
 }

--- a/packages/template-generator/templates/auth/better-auth/server/db/prisma/sqlite/prisma/schema/auth.prisma.hbs
+++ b/packages/template-generator/templates/auth/better-auth/server/db/prisma/sqlite/prisma/schema/auth.prisma.hbs
@@ -31,6 +31,7 @@ model Session {
 
 model Account {
   id                    String    @id
+  issuer                String
   accountId             String
   providerId            String
   userId                String
@@ -45,6 +46,7 @@ model Account {
   createdAt             DateTime  @default(now())
   updatedAt             DateTime  @updatedAt
 
+  @@unique([issuer, accountId], map: "account_issuer_accountId_uidx")
   @@index([userId])
   @@map("account")
 }

--- a/packages/template-generator/templates/db/prisma/mysql/prisma/migrations/0000_init/migration.sql.hbs
+++ b/packages/template-generator/templates/db/prisma/mysql/prisma/migrations/0000_init/migration.sql.hbs
@@ -32,7 +32,8 @@ CREATE TABLE `session` (
 -- CreateTable
 CREATE TABLE `account` (
     `id` VARCHAR(191) NOT NULL,
-    `accountId` TEXT NOT NULL,
+    `issuer` VARCHAR(191) NOT NULL,
+    `accountId` VARCHAR(191) NOT NULL,
     `providerId` TEXT NOT NULL,
     `userId` VARCHAR(191) NOT NULL,
     `accessToken` TEXT NULL,
@@ -45,6 +46,7 @@ CREATE TABLE `account` (
     `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
     `updatedAt` DATETIME(3) NOT NULL,
 
+    UNIQUE INDEX `account_issuer_accountId_uidx`(`issuer`, `accountId`),
     INDEX `account_userId_idx`(`userId`(191)),
     PRIMARY KEY (`id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/packages/template-generator/templates/db/prisma/postgres/prisma/migrations/0000_init/migration.sql.hbs
+++ b/packages/template-generator/templates/db/prisma/postgres/prisma/migrations/0000_init/migration.sql.hbs
@@ -32,6 +32,7 @@ CREATE TABLE "session" (
 -- CreateTable
 CREATE TABLE "account" (
     "id" TEXT NOT NULL,
+    "issuer" TEXT NOT NULL,
     "accountId" TEXT NOT NULL,
     "providerId" TEXT NOT NULL,
     "userId" TEXT NOT NULL,
@@ -84,6 +85,9 @@ CREATE UNIQUE INDEX "session_token_key" ON "session"("token");
 
 -- CreateIndex
 CREATE INDEX "account_userId_idx" ON "account"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "account_issuer_accountId_uidx" ON "account"("issuer", "accountId");
 
 -- CreateIndex
 CREATE INDEX "verification_identifier_idx" ON "verification"("identifier");


### PR DESCRIPTION
## Summary

- upgrade the repository toolchain and CLI recommendation to Bun 1.4
- let GitHub Actions use the Bun version declared by the repository
- update standard Better Auth templates to 1.7.1
- align Drizzle, Prisma, Mongoose, and initial SQL schemas with Better Auth 1.7 account issuers
- use the async Expo cookie API introduced in Better Auth 1.7

Convex Better Auth projects remain on 1.6.17 because the current `@convex-dev/better-auth` release requires Better Auth below 1.7 and rejects newer 1.6 client types.

## Verification

- `bun run check`
- `bun run build`
- `cd apps/cli && bun test` — 690 passed, 31 skipped
- compared every Drizzle and Prisma schema dialect with output from `auth@1.7.1 generate`
- compared the Mongoose model with Better Auth 1.7.1's canonical database schema and index definitions
- generated Hono/Drizzle, Next/Prisma, Solid, Expo+tRPC, Expo+oRPC, and Mongoose projects installed, built, and typechecked with Bun 1.4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated authentication templates to support account issuers and enforce unique account identification across supported databases.
  * Improved native authentication requests by reliably including session cookies.
* **Bug Fixes**
  * Fixed authentication data handling and updated generated integrations for the latest Better Auth release.
* **Documentation**
  * Updated Bun guidance to recommend version 1.4 while retaining support for the minimum compatible version.
* **Tests**
  * Expanded coverage for authentication schema compatibility and Bun version requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
