### PR TITLE
feat(web): track builder and site interactions in Umami

### DIFF
--- a/apps/web/content/docs/analytics.mdx
+++ b/apps/web/content/docs/analytics.mdx
@@ -32,7 +32,7 @@ Add `export BTS_TELEMETRY_DISABLED=1` to your shell profile to make it permanent
 ## Where to view analytics
 
 - Charts: [`/analytics`](/analytics)
-- Shared website analytics: [Umami dashboard](https://umami.amanv.cloud/share/pHvqHleyOl9PBfaK) (self-hosted on a Hostinger VPS)
+- Shared website analytics: [Umami dashboard](https://umami.amanv.cloud/share/pHvqHleyOl9PBfaK) (self-hosted on a Hostinger VPS). Besides page views, the website records anonymous interaction events: builder selections, presets, command copies, share actions, docs actions, and outbound link clicks. Event names and their properties are defined in `apps/web/src/lib/analytics.ts`.
 - Aggregate JSON snapshot: `https://r2.better-t-stack.dev/analytics-data.json`
 - Aggregate CSV export: `https://r2.better-t-stack.dev/export.csv`
 

--- a/apps/web/src/app/(home)/_components/rail/panes/install-pane.tsx
+++ b/apps/web/src/app/(home)/_components/rail/panes/install-pane.tsx
@@ -4,6 +4,7 @@ import { Check, Copy } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
 
+import { track } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 
 import PackageIcon from "../../icons";
@@ -25,6 +26,12 @@ export default function InstallPane() {
     navigator.clipboard.writeText(COMMANDS[selected]);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
+    track("home_copy_install", { pm: selected });
+  };
+
+  const select = (pm: PackageManager) => {
+    if (pm !== selected) track("home_pm_select", { pm });
+    setSelected(pm);
   };
 
   return (
@@ -36,7 +43,7 @@ export default function InstallPane() {
             <button
               key={pm}
               type="button"
-              onClick={() => setSelected(pm)}
+              onClick={() => select(pm)}
               aria-pressed={selected === pm}
               className={cn(
                 "builder-focus-ring -my-2 flex items-center gap-2 py-2 font-mono text-[13px] transition-colors duration-150",
@@ -84,12 +91,14 @@ export default function InstallPane() {
         <div className="flex flex-wrap items-baseline gap-x-6 gap-y-1">
           <Link
             href="/new"
+            onClick={() => track("home_cta", { target: "builder" })}
             className="builder-focus-ring font-mono text-[13px] text-primary transition-colors duration-150 hover:text-primary/70"
           >
             open builder -&gt;
           </Link>
           <Link
             href="/docs/cli/agent-workflows#mcp"
+            onClick={() => track("home_cta", { target: "mcp-docs" })}
             className="builder-focus-ring font-mono text-[13px] text-fd-muted-foreground transition-colors duration-150 hover:text-primary"
           >
             or run it as an MCP server -&gt;

--- a/apps/web/src/app/(home)/_components/rail/panes/media.tsx
+++ b/apps/web/src/app/(home)/_components/rail/panes/media.tsx
@@ -4,6 +4,8 @@ import Image from "next/image";
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import type { TwitterComponents } from "react-tweet";
 
+import { track } from "@/lib/analytics";
+
 export const components: TwitterComponents = {
   AvatarImg: (props) => {
     if (!props.src) {
@@ -79,7 +81,10 @@ export function VideoCard({
         ) : (
           <button
             type="button"
-            onClick={() => setPlaying(true)}
+            onClick={() => {
+              track("home_video_play", { video: video.embedId, title: video.title });
+              setPlaying(true);
+            }}
             aria-label={`Play ${video.title}`}
             className="builder-focus-ring group absolute inset-0 h-full w-full"
           >

--- a/apps/web/src/app/(home)/_components/rail/panes/sponsors-pane.tsx
+++ b/apps/web/src/app/(home)/_components/rail/panes/sponsors-pane.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useState } from "react";
 
+import { track, trackAttrs } from "@/lib/analytics";
 import {
   getSponsorUrl,
   getSponsorUrlLabel,
@@ -51,6 +52,11 @@ function SponsorTile({
             href={entry.githubUrl}
             target="_blank"
             rel="noopener noreferrer"
+            {...trackAttrs("sponsor_click", {
+              sponsor: entry.githubId,
+              target: "github",
+              location: "home",
+            })}
             className={cn(
               "builder-focus-ring block wrap-anywhere font-mono leading-[1.4] transition-colors duration-150 hover:text-primary",
               large ? "text-[15px] tracking-[-0.01em]" : "text-[13px]",
@@ -85,6 +91,11 @@ function SponsorTile({
           href={getSponsorUrl(entry)}
           target="_blank"
           rel="noopener noreferrer"
+          {...trackAttrs("sponsor_click", {
+            sponsor: entry.githubId,
+            target: "website",
+            location: "home",
+          })}
           className="builder-focus-ring -mt-1 truncate font-mono text-[11px] text-fd-muted-foreground transition-colors duration-150 hover:text-fd-foreground"
         >
           {getSponsorUrlLabel(entry)}
@@ -126,7 +137,10 @@ export default function SponsorsPane({ sponsorsData }: { sponsorsData: SponsorsD
         <div>
           <button
             type="button"
-            onClick={() => setShowPast(!showPast)}
+            onClick={() => {
+              track("home_past_sponsors", { shown: !showPast });
+              setShowPast(!showPast);
+            }}
             aria-expanded={showPast}
             className="builder-focus-ring -mt-2 mb-1 flex w-full items-center gap-3 py-2 text-left"
           >
@@ -161,6 +175,11 @@ export function SponsorsPaneFooter() {
         href="https://github.com/sponsors/AmanVarshney01"
         target="_blank"
         rel="noopener noreferrer"
+        {...trackAttrs("sponsor_click", {
+          sponsor: "AmanVarshney01",
+          target: "sponsor-me",
+          location: "home",
+        })}
         className="builder-focus-ring font-mono text-[13px] text-primary transition-colors duration-150 hover:text-primary/70"
       >
         become a sponsor -&gt;

--- a/apps/web/src/app/(home)/_components/rail/status-bar.tsx
+++ b/apps/web/src/app/(home)/_components/rail/status-bar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { track } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 
 import { useNpmVersion } from "./_hooks/use-npm-version";
@@ -45,7 +46,10 @@ export default function StatusBar() {
             <button
               key={pane.id}
               type="button"
-              onClick={() => goTo(index)}
+              onClick={() => {
+                track("home_rail_navigate", { pane: pane.id, method: "click" });
+                goTo(index);
+              }}
               aria-current={active ? "true" : undefined}
               className={cn(
                 "builder-focus-ring shrink-0 uppercase tracking-[0.10em] transition-colors duration-150 max-md:py-2",

--- a/apps/web/src/app/(home)/_components/rail/use-rail-nav.ts
+++ b/apps/web/src/app/(home)/_components/rail/use-rail-nav.ts
@@ -2,6 +2,8 @@
 
 import { type RefObject, useCallback, useEffect, useRef, useState } from "react";
 
+import { track } from "@/lib/analytics";
+
 import { PANES } from "./panes-config";
 
 const DESKTOP_QUERY = "(min-width: 768px)";
@@ -164,33 +166,37 @@ export function useRailNav(railRef: RefObject<HTMLDivElement | null>) {
         return;
       }
 
+      const goToByKey = (index: number) => {
+        event.preventDefault();
+        const clamped = Math.min(Math.max(index, 0), PANES.length - 1);
+        if (clamped !== activeIndex) {
+          track("home_rail_navigate", { pane: PANES[clamped].id, method: "keyboard" });
+        }
+        goTo(clamped);
+      };
+
       const digit = Number.parseInt(event.key, 10);
       if (!Number.isNaN(digit) && digit >= 1 && digit <= PANES.length) {
-        event.preventDefault();
-        goTo(digit - 1);
+        goToByKey(digit - 1);
         return;
       }
 
       switch (event.key) {
         case "ArrowRight":
         case "l":
-          event.preventDefault();
-          goTo(activeIndex + 1);
+          goToByKey(activeIndex + 1);
           break;
         case "ArrowLeft":
         case "h":
-          event.preventDefault();
-          goTo(activeIndex - 1);
+          goToByKey(activeIndex - 1);
           break;
         case "Home":
         case "g":
-          event.preventDefault();
-          goTo(0);
+          goToByKey(0);
           break;
         case "End":
         case "G":
-          event.preventDefault();
-          goTo(PANES.length - 1);
+          goToByKey(PANES.length - 1);
           break;
         default:
           break;

--- a/apps/web/src/app/(home)/analytics/_components/live-logs.tsx
+++ b/apps/web/src/app/(home)/analytics/_components/live-logs.tsx
@@ -8,6 +8,7 @@ import { AnimatePresence, motion } from "motion/react";
 import { useState } from "react";
 
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { track } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 
 const LOG_FIELD_ORDER = [
@@ -76,7 +77,10 @@ export function LiveLogs() {
         type="button"
         aria-expanded={isOpen}
         className="builder-focus-ring group flex w-full items-center justify-between gap-4 border-b px-4 py-2.5 text-left"
-        onClick={() => setIsOpen(!isOpen)}
+        onClick={() => {
+          track("analytics_live_feed", { open: !isOpen });
+          setIsOpen(!isOpen);
+        }}
       >
         <span className="flex items-center gap-2.5">
           <ChevronRight

--- a/apps/web/src/app/(home)/new/_components/code-viewer.tsx
+++ b/apps/web/src/app/(home)/new/_components/code-viewer.tsx
@@ -13,6 +13,7 @@ import {
   CodeBlockHeader,
   CodeBlockItem,
 } from "@/components/ui/kibo-ui/code-block";
+import { track } from "@/lib/analytics";
 
 interface CodeViewerProps {
   filePath: string;
@@ -94,7 +95,7 @@ export const CodeViewer = memo(function CodeViewer({
               </CodeBlockFilename>
             )}
           </CodeBlockFiles>
-          <CodeBlockCopyButton />
+          <CodeBlockCopyButton onCopy={() => track("preview_file_copy", { path: filePath })} />
         </CodeBlockHeader>
         <CodeBlockBody className="flex-1 overflow-auto [&_.shiki]:bg-fd-background! dark:[&_.shiki]:bg-fd-background! bg-fd-background">
           {(item) => (

--- a/apps/web/src/app/(home)/new/_components/preview-panel.tsx
+++ b/apps/web/src/app/(home)/new/_components/preview-panel.tsx
@@ -4,6 +4,7 @@ import { Loader2, FolderTree, FileCode2, Info, ChevronLeft } from "lucide-react"
 import { useEffect, useState, useCallback, useRef } from "react";
 
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
+import { track } from "@/lib/analytics";
 import type { StackState } from "@/lib/constant";
 import { cn } from "@/lib/utils";
 
@@ -94,12 +95,16 @@ export function PreviewPanel({ stack, selectedFilePath, onSelectFile }: PreviewP
           setMobileView("tree");
         }
       } else {
-        setError(data.error || "Failed to generate preview");
+        const message = data.error || "Failed to generate preview";
+        setError(message);
+        track("preview_error", { message });
       }
     } catch (err) {
       if (controller.signal.aborted) return;
       if (requestId !== requestIdRef.current) return;
-      setError(err instanceof Error ? err.message : "Failed to fetch preview");
+      const message = err instanceof Error ? err.message : "Failed to fetch preview";
+      setError(message);
+      track("preview_error", { message });
     } finally {
       if (requestId === requestIdRef.current) {
         setIsLoading(false);
@@ -117,6 +122,7 @@ export function PreviewPanel({ stack, selectedFilePath, onSelectFile }: PreviewP
   }, [fetchPreview]);
 
   const handleSelectFile = (file: VirtualFile) => {
+    track("preview_file_open", { path: file.path, extension: file.extension });
     setSelectedFile(file);
     onSelectFile(file.path);
     setMobileView("code");

--- a/apps/web/src/app/(home)/new/_components/share-button.tsx
+++ b/apps/web/src/app/(home)/new/_components/share-button.tsx
@@ -12,7 +12,7 @@ interface ShareButtonProps {
 
 export function ShareButton({ stackUrl, stackState }: ShareButtonProps) {
   return (
-    <ShareDialog stackUrl={stackUrl} stackState={stackState}>
+    <ShareDialog stackUrl={stackUrl} stackState={stackState} page="builder">
       <button
         type="button"
         className="builder-focus-ring pointer-coarse:min-h-8 flex flex-1 items-center justify-center gap-1.5 rounded-[4px] border px-2 py-1.5 font-mono text-[10px] text-primary uppercase tracking-[0.10em] transition-colors duration-150 hover:border-primary"

--- a/apps/web/src/app/(home)/new/_components/special-sponsors-panel.tsx
+++ b/apps/web/src/app/(home)/new/_components/special-sponsors-panel.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import { FaGithub } from "react-icons/fa6";
 
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
+import { trackAttrs } from "@/lib/analytics";
 import { getSponsorUrl, getSponsorUrlLabel, shouldShowLifetimeTotal } from "@/lib/sponsor-utils";
 import type { Sponsor } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -48,6 +49,11 @@ export function SpecialSponsorsPanel({ sponsors, compact = false }: SpecialSpons
                     rel="noopener noreferrer"
                     aria-label={entry.name}
                     className="builder-focus-ring inline-flex shrink-0"
+                    {...trackAttrs("sponsor_click", {
+                      sponsor: entry.githubId,
+                      target: entry.websiteUrl ? "website" : "github",
+                      location: "builder",
+                    })}
                   />
                 }
               >
@@ -104,6 +110,11 @@ export function SpecialSponsorsPanel({ sponsors, compact = false }: SpecialSpons
                       target="_blank"
                       rel="noopener noreferrer"
                       className="group flex items-center gap-2 font-mono text-[11px] text-fd-muted-foreground transition-colors duration-150 hover:text-primary"
+                      {...trackAttrs("sponsor_click", {
+                        sponsor: entry.githubId,
+                        target: "github",
+                        location: "builder",
+                      })}
                     >
                       <FaGithub className="h-3.5 w-3.5" />
                       <span className="truncate">{entry.githubId}</span>
@@ -114,6 +125,11 @@ export function SpecialSponsorsPanel({ sponsors, compact = false }: SpecialSpons
                         target="_blank"
                         rel="noopener noreferrer"
                         className="group flex items-center gap-2 font-mono text-[11px] text-fd-muted-foreground transition-colors duration-150 hover:text-primary"
+                        {...trackAttrs("sponsor_click", {
+                          sponsor: entry.githubId,
+                          target: "website",
+                          location: "builder",
+                        })}
                       >
                         <Globe className="h-3.5 w-3.5" />
                         <span className="truncate">{getSponsorUrlLabel(entry)}</span>
@@ -134,6 +150,11 @@ export function SpecialSponsorsPanel({ sponsors, compact = false }: SpecialSpons
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label="Become a sponsor"
+                {...trackAttrs("sponsor_click", {
+                  sponsor: "AmanVarshney01",
+                  target: "sponsor-me",
+                  location: "builder",
+                })}
                 className={cn(
                   "builder-focus-ring inline-flex shrink-0 items-center justify-center rounded-[4px] border border-dashed text-primary transition-colors duration-150 hover:border-primary",
                   compact ? "h-9 w-9" : "h-10 w-10",

--- a/apps/web/src/app/(home)/new/_components/stack-builder/category-nav.tsx
+++ b/apps/web/src/app/(home)/new/_components/stack-builder/category-nav.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 
+import { track } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 
 import { getCategoryDisplayName } from "../utils";
@@ -98,7 +99,10 @@ export function CategoryNav({ progress, idPrefix }: CategoryNavProps) {
             key={category}
             type="button"
             data-category={category}
-            onClick={() => scrollToCategorySection(idPrefix, category)}
+            onClick={() => {
+              track("builder_category_jump", { category, source: "nav" });
+              scrollToCategorySection(idPrefix, category);
+            }}
             title={`Jump to ${getCategoryDisplayName(category)}`}
             className={cn(
               "builder-focus-ring pointer-coarse:min-h-8 flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-[4px] border px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.10em] transition-colors duration-150",

--- a/apps/web/src/app/(home)/new/_components/stack-builder/index.tsx
+++ b/apps/web/src/app/(home)/new/_components/stack-builder/index.tsx
@@ -13,6 +13,7 @@ import { startTransition, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { track } from "@/lib/analytics";
 import { formatStackCommandForDisplay, getDesktopBuildNote } from "@/lib/stack-utils";
 import type { Sponsor } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -74,7 +75,10 @@ export function StackBuilder({ specialSponsors = [] }: StackBuilderProps) {
       stackUrl={getStackUrl()}
       stackState={effectiveStack}
       yolo={stack.yolo === "true"}
-      onYoloToggle={(yolo) => setStack({ yolo })}
+      onYoloToggle={(yolo) => {
+        track("builder_yolo_toggle", { enabled: yolo === "true" });
+        setStack({ yolo });
+      }}
     />
   );
 
@@ -86,7 +90,10 @@ export function StackBuilder({ specialSponsors = [] }: StackBuilderProps) {
             <div className="flex items-center gap-4">
               <button
                 type="button"
-                onClick={() => setMobileTab("build")}
+                onClick={() => {
+                  track("builder_mobile_tab", { tab: "build" });
+                  setMobileTab("build");
+                }}
                 className={cn(
                   "builder-focus-ring -m-2 flex items-center gap-1.5 p-2 font-mono text-[11px] uppercase tracking-[0.08em] transition-colors duration-150",
                   mobileTab === "build"
@@ -101,7 +108,10 @@ export function StackBuilder({ specialSponsors = [] }: StackBuilderProps) {
               </button>
               <button
                 type="button"
-                onClick={() => setMobileTab("preview")}
+                onClick={() => {
+                  track("builder_mobile_tab", { tab: "preview" });
+                  setMobileTab("preview");
+                }}
                 className={cn(
                   "builder-focus-ring -m-2 flex items-center gap-1.5 p-2 font-mono text-[11px] uppercase tracking-[0.08em] transition-colors duration-150",
                   mobileTab === "preview"
@@ -169,7 +179,10 @@ export function StackBuilder({ specialSponsors = [] }: StackBuilderProps) {
                         {isCommandMultiline && (
                           <button
                             type="button"
-                            onClick={() => setCommandExpanded((prev) => !prev)}
+                            onClick={() => {
+                              track("builder_command_expand", { expanded: !commandExpanded });
+                              setCommandExpanded(!commandExpanded);
+                            }}
                             className="builder-focus-ring flex items-center gap-1 rounded-[4px] border px-2 py-1 font-mono text-[10px] text-fd-muted-foreground uppercase tracking-[0.10em] transition-colors duration-150 hover:text-fd-foreground"
                             title={commandExpanded ? "Collapse command" : "Show full command"}
                           >
@@ -184,7 +197,7 @@ export function StackBuilder({ specialSponsors = [] }: StackBuilderProps) {
                         )}
                         <button
                           type="button"
-                          onClick={copyToClipboard}
+                          onClick={() => copyToClipboard("button")}
                           className={cn(
                             "builder-focus-ring flex items-center gap-1 rounded-[4px] border px-2 py-1 font-mono text-[10px] uppercase tracking-[0.10em] transition-colors duration-150",
                             copied
@@ -205,11 +218,11 @@ export function StackBuilder({ specialSponsors = [] }: StackBuilderProps) {
                     <div
                       role="button"
                       tabIndex={0}
-                      onClick={copyToClipboard}
+                      onClick={() => copyToClipboard("command")}
                       onKeyDown={(event) => {
                         if (event.key === "Enter" || event.key === " ") {
                           event.preventDefault();
-                          copyToClipboard();
+                          copyToClipboard("command");
                         }
                       }}
                       aria-label="Copy CLI command"
@@ -246,6 +259,7 @@ export function StackBuilder({ specialSponsors = [] }: StackBuilderProps) {
                       stack={effectiveStack}
                       onRemove={removeSelectedTech}
                       onJump={(category) => {
+                        track("builder_category_jump", { category, source: "badge" });
                         if (viewMode !== "command") {
                           startTransition(() => {
                             setViewMode("command");
@@ -288,6 +302,7 @@ export function StackBuilder({ specialSponsors = [] }: StackBuilderProps) {
                 <button
                   type="button"
                   onClick={() => {
+                    track("builder_view_mode", { mode: "command" });
                     startTransition(() => {
                       setViewMode("command");
                     });
@@ -305,6 +320,7 @@ export function StackBuilder({ specialSponsors = [] }: StackBuilderProps) {
                 <button
                   type="button"
                   onClick={() => {
+                    track("builder_view_mode", { mode: "preview" });
                     startTransition(() => {
                       setViewMode("preview");
                     });
@@ -396,7 +412,10 @@ export function StackBuilder({ specialSponsors = [] }: StackBuilderProps) {
                           {isCommandMultiline && (
                             <button
                               type="button"
-                              onClick={() => setCommandExpanded((prev) => !prev)}
+                              onClick={() => {
+                                track("builder_command_expand", { expanded: !commandExpanded });
+                                setCommandExpanded(!commandExpanded);
+                              }}
                               className="builder-focus-ring flex items-center gap-1 rounded-[4px] border px-2 py-1 font-mono text-[10px] text-fd-muted-foreground uppercase tracking-[0.10em] transition-colors duration-150 hover:text-fd-foreground"
                               title={commandExpanded ? "Collapse command" : "Show full command"}
                             >
@@ -427,11 +446,11 @@ export function StackBuilder({ specialSponsors = [] }: StackBuilderProps) {
                       <div
                         role="button"
                         tabIndex={0}
-                        onClick={copyToClipboard}
+                        onClick={() => copyToClipboard("mobile-command")}
                         onKeyDown={(event) => {
                           if (event.key === "Enter" || event.key === " ") {
                             event.preventDefault();
-                            copyToClipboard();
+                            copyToClipboard("mobile-command");
                           }
                         }}
                         className={cn(

--- a/apps/web/src/app/(home)/new/_components/stack-builder/use-stack-builder.ts
+++ b/apps/web/src/app/(home)/new/_components/stack-builder/use-stack-builder.ts
@@ -1,6 +1,7 @@
 import { startTransition, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
+import { type BuilderCopySource, stackSnapshot, track } from "@/lib/analytics";
 import { DEFAULT_STACK, PRESET_TEMPLATES, type StackState, TECH_OPTIONS } from "@/lib/constant";
 import { sanitizeStackState, TASK_RUNNER_ADDONS } from "@/lib/sanitize-stack-addons";
 import { useStackState } from "@/lib/stack-url-state.client";
@@ -178,7 +179,19 @@ export function getTechSelectionUpdate(
   return update;
 }
 
+function isTechSelected(stack: StackState, category: keyof typeof TECH_OPTIONS, techId: string) {
+  const value = stack[category as keyof StackState];
+  return Array.isArray(value) ? value.includes(techId) : value === techId;
+}
+
 function showCompatibilityChanges(changes: CompatibilityAnalysis["changes"]) {
+  if (changes.length > 0) {
+    track("builder_compat_adjust", {
+      count: changes.length,
+      message: changes.map((change) => change.message).join(" | "),
+    });
+  }
+
   if (changes.length === 1) {
     toast.info(changes[0].message, { duration: 4000 });
     return;
@@ -347,25 +360,33 @@ export function useStackBuilder() {
     });
 
     contentRef.current?.scrollTo(0, 0);
+    track("builder_randomize", {});
   }
 
   function handleTechSelect(category: keyof typeof TECH_OPTIONS, techId: string) {
+    track("builder_tech_select", {
+      category,
+      tech: techId,
+      selected: !isTechSelected(effectiveStack, category, techId),
+    });
     startTransition(() => {
       setStack((currentStack) => getTechSelectionUpdate(currentStack, category, techId));
     });
   }
 
   function removeSelectedTech(category: TechCategory, techId: string) {
+    track("builder_tech_remove", { category, tech: techId });
     startTransition(() => {
       setStack((currentStack) => getSelectedTechRemovalUpdate(currentStack, category, techId));
     });
   }
 
-  async function copyToClipboard() {
+  async function copyToClipboard(source: BuilderCopySource) {
     try {
       await navigator.clipboard.writeText(command);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
+      track("builder_copy_command", { ...stackSnapshot(effectiveStack), source });
     } catch {
       toast.error("Unable to copy command. Please copy it manually.");
     }
@@ -376,6 +397,7 @@ export function useStackBuilder() {
       setStack(DEFAULT_STACK);
     });
     contentRef.current?.scrollTo(0, 0);
+    track("builder_reset", {});
   }
 
   function saveCurrentStack() {
@@ -383,6 +405,7 @@ export function useStackBuilder() {
     localStorage.setItem("betterTStackPreference", JSON.stringify(stackToSave));
     setLastSavedStack(stackToSave);
     toast.success("Your stack configuration has been saved");
+    track("builder_save", {});
   }
 
   function loadSavedStack() {
@@ -396,6 +419,7 @@ export function useStackBuilder() {
 
     contentRef.current?.scrollTo(0, 0);
     toast.success("Saved configuration loaded");
+    track("builder_load", {});
   }
 
   function applyPreset(presetId: string) {
@@ -410,6 +434,7 @@ export function useStackBuilder() {
 
     contentRef.current?.scrollTo(0, 0);
     toast.success(`Applied preset: ${preset.name}`);
+    track("builder_preset_apply", { preset: preset.id });
   }
 
   return {

--- a/apps/web/src/app/(home)/privacy/page.tsx
+++ b/apps/web/src/app/(home)/privacy/page.tsx
@@ -29,11 +29,14 @@ export default function PrivacyPage() {
     <TrustPage icon={ShieldCheck} title="PRIVACY.TXT" description={description}>
       <TrustSection title="WEBSITE_ANALYTICS">
         <p>
-          The website loads a self-hosted Umami analytics script to understand aggregate traffic and
-          page usage. The site also displays externally hosted content such as videos, social posts,
-          images, and sponsor information. Requests to those external services are governed by their
-          own privacy practices and may expose ordinary connection information such as an IP
-          address, browser headers, and the requested resource.
+          The website loads a self-hosted Umami analytics script to understand aggregate traffic,
+          page usage, and anonymous interaction events such as which stack options are selected in
+          the builder, which commands are copied, and which outbound links are followed. These
+          events do not include project names, personal information, or persistent identifiers. The
+          site also displays externally hosted content such as videos, social posts, images, and
+          sponsor information. Requests to those external services are governed by their own privacy
+          practices and may expose ordinary connection information such as an IP address, browser
+          headers, and the requested resource.
         </p>
         <p>
           Better-T-Stack does not provide user accounts on this website and does not sell personal

--- a/apps/web/src/app/(home)/showcase/_components/showcase-item.tsx
+++ b/apps/web/src/app/(home)/showcase/_components/showcase-item.tsx
@@ -5,6 +5,8 @@ import Image from "next/image";
 import Link from "next/link";
 import { FaGithub } from "react-icons/fa6";
 
+import { track } from "@/lib/analytics";
+
 export interface ShowcaseItemProps {
   title: string;
   description: string;
@@ -78,6 +80,7 @@ export default function ShowcaseItem({
           href={liveUrl}
           target="_blank"
           rel="noopener noreferrer"
+          onClick={() => track("showcase_click", { project: title, target: "demo" })}
           className="builder-focus-ring flex items-center gap-2 border-t px-4 py-2.5 font-mono text-[11px] text-primary uppercase tracking-[0.08em] transition-colors duration-150 hover:text-primary/70"
         >
           <Monitor aria-hidden="true" className="h-3 w-3 shrink-0" />
@@ -90,6 +93,7 @@ export default function ShowcaseItem({
           href={sourceUrl}
           target="_blank"
           rel="noopener noreferrer"
+          onClick={() => track("showcase_click", { project: title, target: "source" })}
           className="builder-focus-ring flex items-center gap-2 border-t px-4 py-2.5 font-mono text-[11px] text-fd-muted-foreground uppercase tracking-[0.08em] transition-colors duration-150 hover:text-fd-foreground"
         >
           <FaGithub aria-hidden="true" className="h-3 w-3 shrink-0" />

--- a/apps/web/src/app/(home)/showcase/_components/showcase-page.tsx
+++ b/apps/web/src/app/(home)/showcase/_components/showcase-page.tsx
@@ -2,6 +2,8 @@
 
 import { Terminal } from "lucide-react";
 
+import { track } from "@/lib/analytics";
+
 import { PageHeader } from "../../_components/page-header";
 import { PageShell } from "../../_components/page-shell";
 import ShowcaseItem from "../_components/showcase-item";
@@ -55,6 +57,7 @@ export function ShowcasePage({ showcaseProjects }: { showcaseProjects: Array<Sho
               href="https://github.com/AmanVarshney01/create-better-t-stack/issues/new/choose"
               target="_blank"
               rel="noreferrer"
+              onClick={() => track("showcase_submit", {})}
               className="builder-focus-ring underline decoration-fd-border underline-offset-4 transition-colors duration-150 hover:text-primary"
             >
               GitHub issues

--- a/apps/web/src/app/(home)/sponsors/_components/sponsors-page.tsx
+++ b/apps/web/src/app/(home)/sponsors/_components/sponsors-page.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { FaGithub } from "react-icons/fa6";
 
+import { trackAttrs } from "@/lib/analytics";
 import {
   getSponsorUrl,
   getSponsorUrlLabel,
@@ -73,12 +74,32 @@ function SponsorLinks({ sponsor, muted = false }: { sponsor: Sponsor; muted?: bo
 
   return (
     <div className="flex flex-col">
-      <a href={sponsor.githubUrl} target="_blank" rel="noopener noreferrer" className={linkClass}>
+      <a
+        href={sponsor.githubUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={linkClass}
+        {...trackAttrs("sponsor_click", {
+          sponsor: sponsor.githubId,
+          target: "github",
+          location: "sponsors",
+        })}
+      >
         <FaGithub aria-hidden="true" className="size-3 shrink-0" />
         <span className="wrap-anywhere">{sponsor.githubId}</span>
       </a>
       {sponsor.websiteUrl && (
-        <a href={sponsorUrl} target="_blank" rel="noopener noreferrer" className={linkClass}>
+        <a
+          href={sponsorUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={linkClass}
+          {...trackAttrs("sponsor_click", {
+            sponsor: sponsor.githubId,
+            target: "website",
+            location: "sponsors",
+          })}
+        >
           <Globe aria-hidden="true" className="size-3 shrink-0" />
           <span className="wrap-anywhere">{getSponsorUrlLabel(sponsor)}</span>
         </a>
@@ -179,6 +200,11 @@ function BackerChip({ sponsor }: { sponsor: Sponsor }) {
       target="_blank"
       rel="noopener noreferrer"
       className="builder-focus-ring group flex items-center gap-2 rounded-[4px] border px-3 py-2"
+      {...trackAttrs("sponsor_click", {
+        sponsor: sponsor.githubId,
+        target: "github",
+        location: "sponsors",
+      })}
     >
       <Image
         src={sponsor.avatarUrl}
@@ -206,6 +232,11 @@ function PastSponsorRow({ sponsor }: { sponsor: Sponsor }) {
       target="_blank"
       rel="noopener noreferrer"
       className="builder-focus-ring group flex items-center gap-3 rounded-[4px] border px-3 py-2"
+      {...trackAttrs("sponsor_click", {
+        sponsor: sponsor.githubId,
+        target: "github",
+        location: "sponsors-past",
+      })}
     >
       <Image
         src={sponsor.avatarUrl}
@@ -255,6 +286,11 @@ export function SponsorsPage({
             href="https://github.com/sponsors/AmanVarshney01"
             target="_blank"
             rel="noopener noreferrer"
+            {...trackAttrs("sponsor_click", {
+              sponsor: "AmanVarshney01",
+              target: "sponsor-me",
+              location: "sponsors",
+            })}
             className="builder-focus-ring flex min-h-8 items-center gap-2 rounded-[4px] border px-3 py-1.5 font-mono text-[10px] text-primary uppercase tracking-[0.10em] transition-colors duration-150 hover:text-fd-foreground"
           >
             <Heart aria-hidden="true" className="h-3 w-3" />
@@ -417,6 +453,11 @@ export function SponsorsPage({
             href="https://github.com/sponsors/AmanVarshney01"
             target="_blank"
             rel="noopener noreferrer"
+            {...trackAttrs("sponsor_click", {
+              sponsor: "AmanVarshney01",
+              target: "sponsor-me",
+              location: "sponsors",
+            })}
             className="builder-focus-ring flex min-h-9 items-center gap-2 rounded-[4px] border px-4 py-2 text-[11px] text-primary uppercase tracking-[0.08em] transition-colors duration-150 hover:text-fd-foreground"
           >
             <Heart aria-hidden="true" className="h-3.5 w-3.5" />

--- a/apps/web/src/app/(home)/stack/_components/stack-display.tsx
+++ b/apps/web/src/app/(home)/stack/_components/stack-display.tsx
@@ -7,6 +7,7 @@ import { toast } from "sonner";
 
 import { ShareDialog } from "@/components/ui/share-dialog";
 import { TechBadge } from "@/components/ui/tech-badge";
+import { stackSnapshot, track } from "@/lib/analytics";
 import type { LoadedStackState } from "@/lib/stack-url-state";
 import {
   formatProjectName,
@@ -54,6 +55,7 @@ export function StackDisplay({ stackState }: StackDisplayProps) {
       setCopied(true);
       toast.success("Command copied to clipboard!");
       setTimeout(() => setCopied(false), 2000);
+      track("stack_copy_command", stackSnapshot(stackState));
     } catch {
       toast.error("Failed to copy command");
     }
@@ -89,7 +91,7 @@ export function StackDisplay({ stackState }: StackDisplayProps) {
         </div>
 
         <div className="flex items-center gap-3">
-          <Link href={editUrl}>
+          <Link href={editUrl} onClick={() => track("stack_edit", {})}>
             <button
               type="button"
               className="flex items-center gap-2 rounded border border-border bg-fd-background px-3 py-2 font-mono text-muted-foreground text-xs transition-all hover:border-muted-foreground/30 hover:bg-muted hover:text-foreground"
@@ -99,7 +101,7 @@ export function StackDisplay({ stackState }: StackDisplayProps) {
             </button>
           </Link>
 
-          <ShareDialog stackUrl={stackUrl} stackState={stackState}>
+          <ShareDialog stackUrl={stackUrl} stackState={stackState} page="stack">
             <button
               type="button"
               className="flex items-center gap-2 rounded border border-border bg-fd-background px-3 py-2 font-mono text-muted-foreground text-xs transition-all hover:border-muted-foreground/30 hover:bg-muted hover:text-foreground"

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import { RootProvider } from "fumadocs-ui/provider/next";
 import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
-import Script from "next/script";
 import type { ReactNode } from "react";
 
 import Providers from "@/components/providers";
@@ -186,11 +185,6 @@ export default function Layout({ children }: { children: ReactNode }) {
           dangerouslySetInnerHTML={{
             __html: JSON.stringify(structuredData).replaceAll("<", "\\u003c"),
           }}
-        />
-        <Script
-          src="https://umami.amanv.cloud/script.js"
-          data-website-id="3fe218f9-a51b-40c3-ab37-d65e6963d686"
-          strategy="afterInteractive"
         />
         <RootProvider
           search={{

--- a/apps/web/src/components/ai/page-actions.tsx
+++ b/apps/web/src/components/ai/page-actions.tsx
@@ -4,8 +4,10 @@ import { buttonVariants } from "fumadocs-ui/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "fumadocs-ui/components/ui/popover";
 import { useCopyButton } from "fumadocs-ui/utils/use-copy-button";
 import { Check, ChevronDown, Copy, ExternalLinkIcon, MessageCircleIcon } from "lucide-react";
+import { usePathname } from "next/navigation";
 import { useMemo, useState } from "react";
 
+import { track } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 
 const cache = new Map<string, string>();
@@ -18,8 +20,10 @@ export function LLMCopyButton({
 }: {
   markdownUrl: string;
 }) {
+  const pathname = usePathname();
   const [isLoading, setLoading] = useState(false);
   const [checked, onClick] = useCopyButton(async () => {
+    track("docs_copy_markdown", { path: pathname });
     const cached = cache.get(markdownUrl);
     if (cached) return navigator.clipboard.writeText(cached);
 
@@ -78,6 +82,7 @@ export function ViewOptions({
    */
   githubUrl: string;
 }) {
+  const pathname = usePathname();
   const items = useMemo(() => {
     const origin = globalThis.window?.location.origin;
     const fullMarkdownUrl = origin ? new URL(markdownUrl, origin) : "loading";
@@ -204,7 +209,11 @@ export function ViewOptions({
   }, [githubUrl, markdownUrl]);
 
   return (
-    <Popover>
+    <Popover
+      onOpenChange={(open) => {
+        if (open) track("docs_view_options_open", { path: pathname });
+      }}
+    >
       <PopoverTrigger
         className={cn(
           buttonVariants({
@@ -224,6 +233,7 @@ export function ViewOptions({
             href={item.href}
             rel="noreferrer noopener"
             target="_blank"
+            onClick={() => track("docs_open_in", { target: item.title, path: pathname })}
             className={cn(optionVariants())}
           >
             {item.icon}

--- a/apps/web/src/components/analytics.tsx
+++ b/apps/web/src/components/analytics.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useSearchContext } from "fumadocs-ui/contexts/search";
+import Script from "next/script";
+import { useEffect, useRef } from "react";
+
+import {
+  beforeSend,
+  flushPendingEvents,
+  getOutboundEvent,
+  readTrackAttrs,
+  track,
+  TRACK_ATTRIBUTE,
+  trackRaw,
+} from "@/lib/analytics";
+import { SITE_URL } from "@/lib/site";
+
+const UMAMI_SCRIPT_URL = "https://umami.amanv.cloud/script.js";
+const UMAMI_WEBSITE_ID = "3fe218f9-a51b-40c3-ab37-d65e6963d686";
+const SITE_HOST = new URL(SITE_URL).hostname;
+const TRACKED_DOMAINS = [SITE_HOST, SITE_HOST.replace(/^www\./, "")].join(",");
+
+function handleDocumentClick(event: MouseEvent) {
+  const target = event.target;
+  if (!(target instanceof Element)) return;
+
+  const declared = target.closest(`[${TRACK_ATTRIBUTE}]`);
+  if (declared) {
+    const parsed = readTrackAttrs(declared);
+    if (parsed) trackRaw(parsed[0], parsed[1]);
+    return;
+  }
+
+  const anchor = target.closest("a[href]");
+  if (!(anchor instanceof HTMLAnchorElement)) return;
+  const outbound = getOutboundEvent(anchor, window.location);
+  if (!outbound) return;
+  trackRaw(outbound[0], outbound[1]);
+}
+
+function SearchOpenTracker() {
+  const { open } = useSearchContext();
+  const wasOpen = useRef(false);
+
+  useEffect(() => {
+    if (open && !wasOpen.current) track("search_open", {});
+    wasOpen.current = open;
+  }, [open]);
+
+  return null;
+}
+
+export function Analytics() {
+  useEffect(() => {
+    window.btsBeforeSend = beforeSend;
+    document.addEventListener("click", handleDocumentClick);
+    return () => {
+      document.removeEventListener("click", handleDocumentClick);
+      delete window.btsBeforeSend;
+    };
+  }, []);
+
+  return (
+    <>
+      <Script
+        src={UMAMI_SCRIPT_URL}
+        data-website-id={UMAMI_WEBSITE_ID}
+        data-domains={TRACKED_DOMAINS}
+        data-before-send="btsBeforeSend"
+        strategy="afterInteractive"
+        onLoad={flushPendingEvents}
+      />
+      <SearchOpenTracker />
+    </>
+  );
+}

--- a/apps/web/src/components/providers.tsx
+++ b/apps/web/src/components/providers.tsx
@@ -3,6 +3,7 @@
 import { ConvexProvider, ConvexReactClient } from "convex/react";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 
+import { Analytics } from "@/components/analytics";
 import { Toaster } from "@/components/ui/sonner";
 
 const convex = new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL || "");
@@ -13,6 +14,7 @@ export default function Providers({ children }: { children: React.ReactNode }) {
       <ConvexProvider client={convex}>
         <NuqsAdapter>{children}</NuqsAdapter>
       </ConvexProvider>
+      <Analytics />
       <Toaster />
     </>
   );

--- a/apps/web/src/components/site-header.tsx
+++ b/apps/web/src/components/site-header.tsx
@@ -10,6 +10,7 @@ import { useTheme } from "next-themes";
 import { type ComponentProps, type ReactNode, useEffect, useState } from "react";
 
 import { baseOptions } from "@/app/layout.config";
+import { track } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 
 type HrefItem = Extract<LinkItemType, { url: string }>;
@@ -29,6 +30,11 @@ const primaryItems = items.filter((item) => !isSecondary(item));
 const secondaryItems = items.filter(isSecondary);
 
 const navTitle = baseOptions.nav?.title;
+
+function navLabel(item: HrefItem) {
+  if ("label" in item && item.label) return item.label;
+  return item.url;
+}
 
 const labelClass = "font-mono text-[11px] uppercase tracking-[0.08em]";
 const iconButtonClass =
@@ -110,7 +116,11 @@ function ThemeToggle({ className }: { className?: string }) {
     <button
       type="button"
       aria-label="Toggle theme"
-      onClick={() => setTheme(isDark ? "light" : "dark")}
+      onClick={() => {
+        const theme = isDark ? "light" : "dark";
+        track("theme_toggle", { theme });
+        setTheme(theme);
+      }}
       className={cn(iconButtonClass, className)}
     >
       {isDark ? <Moon /> : <Sun />}
@@ -153,7 +163,11 @@ export function SiteHeader({ leading, trailing, className, ...props }: SiteHeade
 
         <nav aria-label="Main" className="flex items-center gap-4 max-md:hidden">
           {primaryItems.map((item) => (
-            <NavLink item={item} key={item.url} />
+            <NavLink
+              item={item}
+              key={item.url}
+              onClick={() => track("nav_click", { item: navLabel(item), location: "header" })}
+            />
           ))}
         </nav>
 
@@ -172,7 +186,11 @@ export function SiteHeader({ leading, trailing, className, ...props }: SiteHeade
 
         <div className="flex items-center gap-1 max-md:hidden">
           {secondaryItems.map((item) => (
-            <IconLink item={item} key={item.url} />
+            <IconLink
+              item={item}
+              key={item.url}
+              onClick={() => track("nav_click", { item: navLabel(item), location: "header" })}
+            />
           ))}
         </div>
 
@@ -185,7 +203,10 @@ export function SiteHeader({ leading, trailing, className, ...props }: SiteHeade
           aria-label={open ? "Close menu" : "Open menu"}
           aria-expanded={open}
           aria-controls="site-header-menu"
-          onClick={() => setOpen((prev) => !prev)}
+          onClick={() => {
+            track("mobile_menu", { open: !open });
+            setOpen(!open);
+          }}
           className={cn(iconButtonClass, "md:hidden")}
         >
           {open ? <X /> : <Menu />}
@@ -212,13 +233,23 @@ export function SiteHeader({ leading, trailing, className, ...props }: SiteHeade
                   className="py-2.5"
                   item={item}
                   key={item.url}
-                  onClick={() => setOpen(false)}
+                  onClick={() => {
+                    track("nav_click", { item: navLabel(item), location: "mobile-menu" });
+                    setOpen(false);
+                  }}
                 />
               ))}
             </nav>
             <div className="mt-1 flex items-center gap-1 border-t pt-2">
               {secondaryItems.map((item) => (
-                <IconLink item={item} key={item.url} onClick={() => setOpen(false)} />
+                <IconLink
+                  item={item}
+                  key={item.url}
+                  onClick={() => {
+                    track("nav_click", { item: navLabel(item), location: "mobile-menu" });
+                    setOpen(false);
+                  }}
+                />
               ))}
               <span className="flex-1" />
               <ThemeToggle />

--- a/apps/web/src/components/special-sponsor-banner.tsx
+++ b/apps/web/src/components/special-sponsor-banner.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 import { FaGithub } from "react-icons/fa6";
 
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
+import { trackAttrs } from "@/lib/analytics";
 import { getSponsorUrl, getSponsorUrlLabel, shouldShowLifetimeTotal } from "@/lib/sponsor-utils";
 import { fetchSponsors } from "@/lib/sponsors";
 
@@ -30,6 +31,11 @@ export async function SpecialSponsorBanner() {
                     rel="noopener noreferrer"
                     aria-label={entry.name}
                     className="inline-flex"
+                    {...trackAttrs("sponsor_click", {
+                      sponsor: entry.githubId,
+                      target: entry.websiteUrl ? "website" : "github",
+                      location: "docs-sidebar",
+                    })}
                   />
                 }
               >
@@ -83,6 +89,11 @@ export async function SpecialSponsorBanner() {
                           target="_blank"
                           rel="noopener noreferrer"
                           className="group flex items-center gap-2 text-muted-foreground text-xs transition-colors hover:text-primary"
+                          {...trackAttrs("sponsor_click", {
+                            sponsor: entry.githubId,
+                            target: "github",
+                            location: "docs-sidebar",
+                          })}
                         >
                           <FaGithub className="h-4 w-4" />
                           <span className="truncate">{entry.githubId}</span>
@@ -93,6 +104,11 @@ export async function SpecialSponsorBanner() {
                             target="_blank"
                             rel="noopener noreferrer"
                             className="group flex items-center gap-2 text-muted-foreground text-xs transition-colors hover:text-primary"
+                            {...trackAttrs("sponsor_click", {
+                              sponsor: entry.githubId,
+                              target: "website",
+                              location: "docs-sidebar",
+                            })}
                           >
                             <Globe className="h-4 w-4" />
                             <span className="truncate">{getSponsorUrlLabel(entry)}</span>

--- a/apps/web/src/components/ui/share-dialog.tsx
+++ b/apps/web/src/components/ui/share-dialog.tsx
@@ -16,6 +16,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import { type SharePage, track } from "@/lib/analytics";
 import type { StackState } from "@/lib/constant";
 import {
   formatProjectName,
@@ -29,6 +30,7 @@ interface ShareDialogProps {
   children: React.ReactNode;
   stackUrl: string;
   stackState: StackState;
+  page: SharePage;
 }
 
 type CopyTarget = "url" | "command";
@@ -72,7 +74,7 @@ function CopyRow({
   );
 }
 
-export function ShareDialog({ children, stackUrl, stackState }: ShareDialogProps) {
+export function ShareDialog({ children, stackUrl, stackState, page }: ShareDialogProps) {
   const [copiedTarget, setCopiedTarget] = useState<CopyTarget | null>(null);
   const [showQr, setShowQr] = useState(false);
   const [qrCodeDataUrl, setQrCodeDataUrl] = useState<string>("");
@@ -102,6 +104,7 @@ export function ShareDialog({ children, stackUrl, stackState }: ShareDialogProps
       toast.success(
         target === "url" ? "Link copied to clipboard!" : "Command copied to clipboard!",
       );
+      track("share_copy", { page, target: target === "url" ? "link" : "command" });
       if (copyResetTimer.current) clearTimeout(copyResetTimer.current);
       copyResetTimer.current = setTimeout(() => setCopiedTarget(null), 2000);
     } catch {
@@ -119,12 +122,14 @@ export function ShareDialog({ children, stackUrl, stackState }: ShareDialogProps
   const shareToTwitter = () => {
     const text = encodeURIComponent(shareText());
     const url = encodeURIComponent(stackUrl);
+    track("share_post", { page });
     window.open(`https://twitter.com/intent/tweet?text=${text}&url=${url}`, "_blank");
   };
 
   const nativeShare = async () => {
     try {
       await navigator.share({ title: projectName, text: shareText(), url: stackUrl });
+      track("share_native", { page });
     } catch (error) {
       if (error instanceof DOMException && error.name === "AbortError") return;
       toast.error("Failed to open share sheet");
@@ -151,7 +156,11 @@ export function ShareDialog({ children, stackUrl, stackState }: ShareDialogProps
   }, [showQr, stackUrl, resolvedTheme]);
 
   return (
-    <Dialog>
+    <Dialog
+      onOpenChange={(open) => {
+        if (open) track("share_open", { page });
+      }}
+    >
       <DialogTrigger
         render={
           React.isValidElement(children) ? children : <button type="button">{children}</button>
@@ -240,7 +249,10 @@ export function ShareDialog({ children, stackUrl, stackState }: ShareDialogProps
           )}
           <button
             type="button"
-            onClick={() => setShowQr((prev) => !prev)}
+            onClick={() => {
+              track("share_qr", { page, shown: !showQr });
+              setShowQr(!showQr);
+            }}
             className={cn(
               "builder-focus-ring flex items-center justify-center gap-1.5 rounded border px-2 py-2 font-mono text-xs transition-colors",
               showQr

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -1,0 +1,296 @@
+import { DEFAULT_STACK, isStackDefault, type StackState } from "@/lib/constant";
+
+export type EventValue = string | number | boolean;
+export type EventData = Record<string, EventValue>;
+type EmptyData = Record<string, never>;
+
+export type StackSnapshot = {
+  frontend: string;
+  backend: string;
+  runtime: string;
+  api: string;
+  database: string;
+  orm: string;
+  dbSetup: string;
+  auth: string;
+  payments: string;
+  addons: string;
+  examples: string;
+  packageManager: string;
+  webDeploy: string;
+  serverDeploy: string;
+  git: boolean;
+  install: boolean;
+  yolo: boolean;
+  isDefault: boolean;
+};
+
+export type BuilderCopySource = "button" | "command" | "mobile-command";
+export type SharePage = "builder" | "stack";
+type SponsorTarget = "github" | "website" | "sponsor-me";
+
+export type AnalyticsEvents = {
+  builder_tech_select: { category: string; tech: string; selected: boolean };
+  builder_tech_remove: { category: string; tech: string };
+  builder_category_jump: { category: string; source: "nav" | "badge" };
+  builder_copy_command: StackSnapshot & { source: BuilderCopySource };
+  builder_command_expand: { expanded: boolean };
+  builder_reset: EmptyData;
+  builder_randomize: EmptyData;
+  builder_save: EmptyData;
+  builder_load: EmptyData;
+  builder_preset_apply: { preset: string };
+  builder_yolo_toggle: { enabled: boolean };
+  builder_view_mode: { mode: "command" | "preview" };
+  builder_mobile_tab: { tab: "build" | "preview" };
+  builder_compat_adjust: { count: number; message: string };
+  preview_error: { message: string };
+  preview_file_open: { path: string; extension: string };
+  preview_file_copy: { path: string };
+  share_open: { page: SharePage };
+  share_copy: { page: SharePage; target: "link" | "command" };
+  share_post: { page: SharePage };
+  share_native: { page: SharePage };
+  share_qr: { page: SharePage; shown: boolean };
+  stack_copy_command: StackSnapshot;
+  stack_edit: EmptyData;
+  home_pm_select: { pm: string };
+  home_copy_install: { pm: string };
+  home_cta: { target: "builder" | "mcp-docs" | "sponsors" };
+  home_video_play: { video: string; title: string };
+  home_rail_navigate: { pane: string; method: "click" | "keyboard" };
+  home_past_sponsors: { shown: boolean };
+  nav_click: { item: string; location: "header" | "mobile-menu" };
+  theme_toggle: { theme: "light" | "dark" };
+  search_open: EmptyData;
+  mobile_menu: { open: boolean };
+  docs_copy_markdown: { path: string };
+  docs_view_options_open: { path: string };
+  docs_open_in: { target: string; path: string };
+  sponsor_click: { sponsor: string; target: SponsorTarget; location: string };
+  showcase_click: { project: string; target: "demo" | "source" };
+  showcase_submit: EmptyData;
+  analytics_live_feed: { open: boolean };
+  outbound_click: { host: string; url: string; location: string };
+  email_click: { location: string };
+};
+
+export type AnalyticsEventName = keyof AnalyticsEvents;
+
+type UmamiPayload = {
+  url?: string;
+  referrer?: string;
+  name?: string;
+};
+
+type UmamiTracker = {
+  track: (name: string, data?: EventData) => Promise<string | undefined> | void;
+  identify: (data: EventData) => Promise<string | undefined> | void;
+};
+
+declare global {
+  interface Window {
+    umami?: UmamiTracker;
+    btsBeforeSend?: typeof beforeSend;
+  }
+}
+
+export const MAX_EVENT_NAME_LENGTH = 50;
+export const MAX_STRING_LENGTH = 500;
+const MAX_PENDING_EVENTS = 25;
+const QUERY_STRIPPED_PATHS = new Set(["/new", "/stack"]);
+
+const pending: Array<[string, EventData]> = [];
+let lastPageviewUrl: string | null = null;
+
+function clampString(value: string) {
+  return value.length > MAX_STRING_LENGTH ? value.slice(0, MAX_STRING_LENGTH) : value;
+}
+
+function clampValue(value: EventValue): EventValue {
+  const text = String(value);
+  return text.length > MAX_STRING_LENGTH ? clampString(text) : value;
+}
+
+export function normalizeEventData(data: EventData): EventData {
+  const normalized: EventData = {};
+  for (const [key, value] of Object.entries(data)) {
+    normalized[key] = clampValue(value);
+  }
+  return normalized;
+}
+
+function getTracker() {
+  return globalThis.window?.umami;
+}
+
+function send(tracker: UmamiTracker, name: string, data: EventData) {
+  try {
+    void tracker.track(name.slice(0, MAX_EVENT_NAME_LENGTH), normalizeEventData(data));
+  } catch {
+    // Analytics must never break the page.
+  }
+}
+
+export function trackRaw(name: string, data: EventData = {}) {
+  const tracker = getTracker();
+  if (tracker) {
+    send(tracker, name, data);
+    return;
+  }
+  if (pending.length >= MAX_PENDING_EVENTS) pending.shift();
+  pending.push([name, data]);
+}
+
+export function track<Name extends AnalyticsEventName>(name: Name, data: AnalyticsEvents[Name]) {
+  trackRaw(name, data);
+}
+
+export function flushPendingEvents() {
+  const tracker = getTracker();
+  if (!tracker) return;
+  while (pending.length > 0) {
+    const [name, data] = pending.shift()!;
+    send(tracker, name, data);
+  }
+}
+
+export function pendingEventCount() {
+  return pending.length;
+}
+
+export const TRACK_ATTRIBUTE = "data-track";
+
+/**
+ * Declarative tracking for links and buttons rendered by server components.
+ * The document-level listener in `components/analytics.tsx` reads these back.
+ */
+export function trackAttrs<Name extends AnalyticsEventName>(
+  name: Name,
+  data: AnalyticsEvents[Name],
+) {
+  return Object.fromEntries([
+    [TRACK_ATTRIBUTE, name] as const,
+    ...Object.entries(data).map(
+      ([key, value]) => [`${TRACK_ATTRIBUTE}-${key.toLowerCase()}`, String(value)] as const,
+    ),
+  ]);
+}
+
+export function readTrackAttrs(element: Element): [string, EventData] | null {
+  const name = element.getAttribute(TRACK_ATTRIBUTE);
+  if (!name) return null;
+  const prefix = `${TRACK_ATTRIBUTE}-`;
+  const data: EventData = {};
+  for (const attribute of element.getAttributeNames()) {
+    if (!attribute.startsWith(prefix)) continue;
+    data[attribute.slice(prefix.length)] = element.getAttribute(attribute) ?? "";
+  }
+  return [name, data];
+}
+
+function joinList(values: string[]) {
+  const real = values.filter((value) => value !== "none");
+  return real.length > 0 ? real.join("+") : "none";
+}
+
+export function stackSnapshot(stack: StackState): StackSnapshot {
+  const isDefault = Object.keys(DEFAULT_STACK).every(
+    (key) =>
+      key === "projectName" ||
+      isStackDefault(stack, key as keyof StackState, stack[key as keyof StackState]),
+  );
+
+  return {
+    frontend: joinList([...stack.webFrontend, ...stack.nativeFrontend]),
+    backend: stack.backend,
+    runtime: stack.runtime,
+    api: stack.api,
+    database: stack.database,
+    orm: stack.orm,
+    dbSetup: stack.dbSetup,
+    auth: stack.auth,
+    payments: stack.payments,
+    addons: joinList(stack.addons),
+    examples: joinList(stack.examples),
+    packageManager: stack.packageManager,
+    webDeploy: stack.webDeploy,
+    serverDeploy: stack.serverDeploy,
+    git: stack.git !== "false",
+    install: stack.install !== "false",
+    yolo: stack.yolo === "true",
+    isDefault,
+  };
+}
+
+export function normalizePageviewUrl(rawUrl: string, base: string) {
+  const url = new URL(rawUrl, base);
+  url.hash = "";
+  if (QUERY_STRIPPED_PATHS.has(url.pathname)) url.search = "";
+  return url;
+}
+
+export function resetPageviewDedupe() {
+  lastPageviewUrl = null;
+}
+
+/**
+ * Runs inside the tracker before every request (`data-before-send`).
+ * Pageviews on the builder pages drop their query string, since nuqs rewrites it on
+ * every click and the stack itself is captured by the builder events. Repeated
+ * pageviews for the same URL are collapsed so those rewrites do not inflate counts.
+ */
+export function beforeSend(type: string, payload: UmamiPayload): UmamiPayload | false {
+  if (type !== "event" || payload.name || !payload.url) return payload;
+
+  let url: URL;
+  try {
+    url = normalizePageviewUrl(payload.url, globalThis.location?.href ?? "https://localhost");
+  } catch {
+    return payload;
+  }
+
+  const key = `${url.pathname}${url.search}`;
+  if (key === lastPageviewUrl) return false;
+  lastPageviewUrl = key;
+
+  const next: UmamiPayload = { ...payload, url: url.toString() };
+  if (payload.referrer) {
+    try {
+      next.referrer = normalizePageviewUrl(payload.referrer, url.origin).toString();
+    } catch {
+      // Keep the referrer as sent.
+    }
+  }
+  return next;
+}
+
+export function getOutboundEvent(
+  anchor: HTMLAnchorElement,
+  currentLocation: Location,
+):
+  | ["outbound_click", AnalyticsEvents["outbound_click"]]
+  | ["email_click", AnalyticsEvents["email_click"]]
+  | null {
+  let url: URL;
+  try {
+    url = new URL(anchor.href, currentLocation.href);
+  } catch {
+    return null;
+  }
+
+  if (url.protocol === "mailto:") {
+    return ["email_click", { location: currentLocation.pathname }];
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+  if (url.hostname === currentLocation.hostname) return null;
+
+  return [
+    "outbound_click",
+    {
+      host: url.hostname,
+      url: clampString(`${url.origin}${url.pathname}`),
+      location: currentLocation.pathname,
+    },
+  ];
+}

--- a/apps/web/test/analytics.test.ts
+++ b/apps/web/test/analytics.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  beforeSend,
+  type EventData,
+  flushPendingEvents,
+  MAX_STRING_LENGTH,
+  normalizeEventData,
+  pendingEventCount,
+  resetPageviewDedupe,
+  stackSnapshot,
+  track,
+  trackAttrs,
+} from "../src/lib/analytics";
+import { DEFAULT_STACK } from "../src/lib/constant";
+
+const SITE = "https://www.better-t-stack.dev";
+
+function installFakeTracker() {
+  const calls: Array<[string, EventData | undefined]> = [];
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      umami: {
+        track: (name: string, data?: EventData) => {
+          calls.push([name, data]);
+        },
+        identify: () => {},
+      },
+    },
+  });
+  return calls;
+}
+
+afterEach(() => {
+  resetPageviewDedupe();
+  Reflect.deleteProperty(globalThis, "window");
+});
+
+describe("beforeSend", () => {
+  test("strips the query string from builder pageviews and keeps it elsewhere", () => {
+    const builder = beforeSend("event", { url: `${SITE}/new?fe-w=next&backend=hono` });
+    expect(builder).toEqual({ url: `${SITE}/new` });
+
+    const docs = beforeSend("event", { url: `${SITE}/docs?utm_source=x#install` });
+    expect(docs).toEqual({ url: `${SITE}/docs?utm_source=x` });
+  });
+
+  test("collapses repeated pageviews for the same normalized url", () => {
+    expect(beforeSend("event", { url: `${SITE}/new?a=1` })).not.toBe(false);
+    expect(beforeSend("event", { url: `${SITE}/new?a=2` })).toBe(false);
+    expect(beforeSend("event", { url: `${SITE}/docs` })).not.toBe(false);
+    expect(beforeSend("event", { url: `${SITE}/new?a=3` })).not.toBe(false);
+  });
+
+  test("normalizes a same-site referrer that carried builder params", () => {
+    const result = beforeSend("event", { url: `${SITE}/stack`, referrer: `${SITE}/new?a=1` });
+    expect(result).toEqual({ url: `${SITE}/stack`, referrer: `${SITE}/new` });
+  });
+
+  test("passes custom events and identify payloads through untouched", () => {
+    const custom = { url: `${SITE}/new?a=1`, name: "builder_copy_command" };
+    expect(beforeSend("event", custom)).toBe(custom);
+    const identify = { url: `${SITE}/new?a=1` };
+    expect(beforeSend("identify", identify)).toBe(identify);
+  });
+});
+
+describe("track", () => {
+  test("queues events until the tracker loads, then flushes in order", () => {
+    track("builder_reset", {});
+    track("builder_preset_apply", { preset: "mern" });
+    expect(pendingEventCount()).toBe(2);
+
+    const calls = installFakeTracker();
+    flushPendingEvents();
+
+    expect(pendingEventCount()).toBe(0);
+    expect(calls).toEqual([
+      ["builder_reset", {}],
+      ["builder_preset_apply", { preset: "mern" }],
+    ]);
+
+    track("theme_toggle", { theme: "dark" });
+    expect(calls[2]).toEqual(["theme_toggle", { theme: "dark" }]);
+  });
+
+  test("clamps long strings to the tracker limit and keeps other value types", () => {
+    const long = "x".repeat(MAX_STRING_LENGTH + 40);
+    const data = normalizeEventData({ message: long, count: 3, enabled: true });
+    expect(data.message).toHaveLength(MAX_STRING_LENGTH);
+    expect(data.count).toBe(3);
+    expect(data.enabled).toBe(true);
+  });
+});
+
+describe("trackAttrs", () => {
+  test("emits data attributes the document listener can read back", () => {
+    expect(
+      trackAttrs("sponsor_click", { sponsor: "acme", target: "github", location: "home" }),
+    ).toEqual({
+      "data-track": "sponsor_click",
+      "data-track-sponsor": "acme",
+      "data-track-target": "github",
+      "data-track-location": "home",
+    });
+  });
+});
+
+describe("stackSnapshot", () => {
+  test("flattens the default stack and marks it as default", () => {
+    const snapshot = stackSnapshot(DEFAULT_STACK);
+    expect(snapshot.isDefault).toBe(true);
+    expect(snapshot.frontend).toBe(
+      [...DEFAULT_STACK.webFrontend, ...DEFAULT_STACK.nativeFrontend]
+        .filter((value) => value !== "none")
+        .join("+") || "none",
+    );
+    expect(snapshot.git).toBe(DEFAULT_STACK.git !== "false");
+  });
+
+  test("marks customized stacks and joins multi-select lists", () => {
+    const snapshot = stackSnapshot({
+      ...DEFAULT_STACK,
+      backend: "hono",
+      addons: ["biome", "turborepo"],
+      examples: ["none"],
+      yolo: "true",
+    });
+    expect(snapshot.isDefault).toBe(false);
+    expect(snapshot.backend).toBe("hono");
+    expect(snapshot.addons).toBe("biome+turborepo");
+    expect(snapshot.examples).toBe("none");
+    expect(snapshot.yolo).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

The website previously loaded Umami as a bare `<Script>` tag: pageviews only, no events, and localhost/preview traffic was counted. This adds a typed event layer on top of the existing self-hosted tracker and instruments the site.

- **`lib/analytics.ts`**: typed event catalog, `track()` / `trackAttrs()` helpers (queue until the tracker loads, clamp strings to Umami's 500-char limit), `stackSnapshot()` to flatten a `StackState` into event properties, and a `before-send` hook.
- **`components/analytics.tsx`**: mounts the tracker with `data-domains` set to the production hosts, registers `before-send`, and a document click listener that handles `data-track-*` elements and auto-tracks outbound and `mailto:` links. Also tracks `search_open` via fumadocs' search context (covers ⌘K).
- **Pageview fix**: nuqs uses `history: "replace"` on every builder click and the tracker hooks `replaceState`, so each option click was counted as a pageview on `/new`. `before-send` now strips the query on `/new` and `/stack` pageviews and dedupes same-URL pageviews. The stack itself is captured by the copy/share events instead.
- **Events**: builder (tech select/remove, category jump, copy command with full stack snapshot, presets, reset/random/save/load, YOLO, view mode, compatibility adjustments, preview file open/copy/error), share dialog, `/stack`, home (package manager, install copy, CTAs, video play, rail navigation, past sponsors), header (nav, theme, mobile menu, search), docs (copy markdown, open-in actions), sponsor links on every surface, showcase, analytics live feed.
- Privacy page and `docs/analytics.mdx` now disclose interaction events.

## Notes

- Umami does not skip localhost on its own (checked the tracker source on `master` and the hosted `script.js`; the only disable conditions are `umami.disabled`, `data-domains`, and DNT). `data-domains` is the documented way to restrict it, so local dev and preview deploys no longer send data.
- The hosted tracker is an older v2 build without `data-performance` / `data-auto-pageview`; upgrading the Umami server would unlock Web Vitals.
- `data-umami-event` attributes are intentionally not used on Next `Link`s: the tracker preventDefaults anchors and triggers a full navigation.

## Testing

- `tsc --noEmit` and `bun run check` pass; 9 new unit tests in `apps/web/test/analytics.test.ts` (before-send strip/dedupe, pending queue + flush, clamping, attrs, snapshot).
- Drove the dev server with Playwright while monkeypatching `window.umami.track`: tracker loads with the expected attributes, `before-send` dedupes, and clicking through the builder, presets, theme, search, share, home copy, rail, sponsor links, and outbound/mailto links produced the expected events and payloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added anonymous analytics for interactions across navigation, search, builder selections, command copies, sharing, media playback, showcase links, sponsor links, and preview activity.
  - Analytics now continue to capture interactions reliably while the tracking service loads.
  - Share actions now identify whether they originated from the Builder or Stack pages.

- **Documentation**
  - Updated analytics documentation with the types of anonymous interaction events recorded.
  - Clarified that analytics exclude project names, personal information, and persistent identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->