### PR TITLE
feat(cli): upgrade MCP SDK to v2, count MCP creations, and add Umami diagnostics

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -104,6 +104,7 @@ jobs:
         env:
           BTS_TELEMETRY: 1
           CONVEX_INGEST_URL: ${{ secrets.CONVEX_INGEST_URL }}
+          UMAMI_CLI_WEBSITE_ID: ${{ secrets.UMAMI_CLI_WEBSITE_ID }}
 
       - name: Update create-bts alias package version
         if: steps.check-version.outputs.exists == 'false'
@@ -131,6 +132,7 @@ jobs:
         env:
           BTS_TELEMETRY: 1
           CONVEX_INGEST_URL: ${{ secrets.CONVEX_INGEST_URL }}
+          UMAMI_CLI_WEBSITE_ID: ${{ secrets.UMAMI_CLI_WEBSITE_ID }}
 
       - name: Publish template-generator to NPM
         if: steps.check-version.outputs.exists == 'false'
@@ -138,6 +140,7 @@ jobs:
         env:
           BTS_TELEMETRY: 1
           CONVEX_INGEST_URL: ${{ secrets.CONVEX_INGEST_URL }}
+          UMAMI_CLI_WEBSITE_ID: ${{ secrets.UMAMI_CLI_WEBSITE_ID }}
 
       - name: Publish CLI to NPM
         if: steps.check-version.outputs.exists == 'false'
@@ -145,6 +148,7 @@ jobs:
         env:
           BTS_TELEMETRY: 1
           CONVEX_INGEST_URL: ${{ secrets.CONVEX_INGEST_URL }}
+          UMAMI_CLI_WEBSITE_ID: ${{ secrets.UMAMI_CLI_WEBSITE_ID }}
 
       - name: Publish create-bts alias to NPM
         if: steps.check-version.outputs.exists == 'false'
@@ -152,6 +156,7 @@ jobs:
         env:
           BTS_TELEMETRY: 1
           CONVEX_INGEST_URL: ${{ secrets.CONVEX_INGEST_URL }}
+          UMAMI_CLI_WEBSITE_ID: ${{ secrets.UMAMI_CLI_WEBSITE_ID }}
 
       - name: Create and push tag
         if: steps.check-version.outputs.exists == 'false'

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -128,6 +128,9 @@ This CLI collects anonymous usage data to help improve the tool. The data collec
 - CLI version
 - Node.js version
 - Platform (OS)
+- How the CLI was driven (prompts, flags, `--yes`, JSON, the programmatic API, or the MCP server)
+
+Separately, a small number of anonymous diagnostic events are sent for failures (stage and error class, never full messages or paths), cancelled prompts, other commands such as `add` and `history`, slow runs, and MCP tool usage. See the [analytics documentation](https://better-t-stack.dev/docs/analytics) for the exact list.
 
 **Telemetry is enabled by default in published versions** to help us understand usage patterns and improve the tool.
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -146,6 +146,8 @@ BTS_TELEMETRY_DISABLED=1 npx create-better-t-stack
 export BTS_TELEMETRY_DISABLED=1
 ```
 
+The CLI also honors the cross-tool `DO_NOT_TRACK=1` convention (https://consoledonottrack.com), and `--disable-analytics` skips telemetry for a single run.
+
 ## Examples
 
 Create a project with default configuration:

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -73,7 +73,7 @@
     "@better-t-stack/types": "workspace:*",
     "@clack/core": "^1.4.3",
     "@clack/prompts": "^1.7.0",
-    "@modelcontextprotocol/sdk": "1.30.0",
+    "@modelcontextprotocol/server": "2.0.0",
     "@trpc/server": "^11.18.0",
     "better-result": "^3.0.0",
     "consola": "^3.4.2",
@@ -93,6 +93,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@modelcontextprotocol/client": "2.0.0",
     "@types/bun": "^1.3.14",
     "@types/fs-extra": "^11.0.4",
     "@types/node": "^26.1.2",

--- a/apps/cli/src/commands/history.ts
+++ b/apps/cli/src/commands/history.ts
@@ -60,27 +60,28 @@ export function formatHistoryEntry(entry: ProjectHistoryEntry, index: number): s
   )}\n${pc.cyan(entry.reproducibleCommand)}`;
 }
 
-export async function historyHandler(input: HistoryCommandInput): Promise<void> {
+/** Resolves to whether the command did what was asked; failures are reported to the user here. */
+export async function historyHandler(input: HistoryCommandInput): Promise<boolean> {
   if (input.clear) {
     const clearResult = await clearHistory();
     if (clearResult.isErr()) {
       log.warn(pc.yellow(clearResult.error.message));
-      return;
+      return false;
     }
     log.success(pc.green("Project history cleared."));
-    return;
+    return true;
   }
 
   const historyResult = await getHistory(input.limit);
   if (historyResult.isErr()) {
     log.warn(pc.yellow(historyResult.error.message));
-    return;
+    return false;
   }
   const entries = historyResult.value;
 
   if (input.json) {
     console.log(JSON.stringify(entries, null, 2));
-    return;
+    return true;
   }
 
   renderTitle();
@@ -92,9 +93,10 @@ export async function historyHandler(input: HistoryCommandInput): Promise<void> 
         "create-better-t-stack my-app",
       )}`,
     );
-    return;
+    return true;
   }
 
   log.message(entries.map(formatHistoryEntry).join("\n\n"));
   outro(pc.dim("Run a command above to recreate that project"));
+  return true;
 }

--- a/apps/cli/src/helpers/core/add-handler.ts
+++ b/apps/cli/src/helpers/core/add-handler.ts
@@ -384,7 +384,7 @@ async function addHandlerInternal(
   if (!existingConfig) {
     return Result.err(
       new CLIError({
-        message: `No Better-T-Stack project found in ${projectDir}. Make sure bts.jsonc exists.`,
+        message: `No Better-T-Stack project found in "${projectDir}". Make sure bts.jsonc exists.`,
       }),
     );
   }

--- a/apps/cli/src/helpers/core/add-handler.ts
+++ b/apps/cli/src/helpers/core/add-handler.ts
@@ -19,10 +19,17 @@ import pc from "picocolors";
 import z from "zod";
 
 import { getAddonsToAdd } from "../../prompts/addons";
-import type { AddInput, Addons, AddonOptions, ProjectConfig } from "../../types";
+import type { AddInput, Addons, AddonOptions, AnalyticsMode, ProjectConfig } from "../../types";
 import { updateBtsConfig } from "../../utils/bts-config";
 import { validateAddonsAgainstConfig } from "../../utils/compatibility-rules";
-import { isSilent, runWithContextAsync } from "../../utils/context";
+import { isSilent, resolveInvocationMode, runWithContextAsync } from "../../utils/context";
+import {
+  durationBucket,
+  errorClass,
+  failureStage,
+  reportDiagnostic,
+  scrubReason,
+} from "../../utils/diagnostics";
 import { formatConfigValue } from "../../utils/display-config";
 import { CLIError, UserCancelledError, displayError } from "../../utils/errors";
 import { validateAgentSafePathInput } from "../../utils/input-hardening";
@@ -34,6 +41,7 @@ import { installDependencies } from "./install-dependencies";
 
 export interface AddHandlerOptions {
   silent?: boolean;
+  mode?: AnalyticsMode;
 }
 
 export interface AddResult {
@@ -278,10 +286,12 @@ export async function addHandler(
   input: AddInput,
   options: AddHandlerOptions = {},
 ): Promise<AddResult | undefined> {
-  const { silent = false } = options;
+  const { silent = false, mode } = options;
 
-  return runWithContextAsync({ silent }, async () => {
+  return runWithContextAsync({ silent, mode }, async () => {
+    const startTime = Date.now();
     const result = await addHandlerInternal(input);
+    await reportAddOutcome(input, result, Date.now() - startTime);
 
     if (result.isOk()) {
       return result.value;
@@ -312,6 +322,40 @@ export async function addHandler(
 
     displayError(error);
     process.exit(1);
+  });
+}
+
+async function reportAddOutcome(
+  input: AddInput,
+  result: Result<AddResult, UserCancelledError | CLIError>,
+  elapsedMs: number,
+): Promise<void> {
+  const mode = resolveInvocationMode(false);
+  const duration = durationBucket(elapsedMs);
+
+  if (result.isOk()) {
+    await reportDiagnostic("cli_command", { command: "add", mode, ok: true, duration });
+    return;
+  }
+
+  const error = result.error;
+  if (UserCancelledError.is(error)) {
+    await reportDiagnostic("cli_cancelled", {
+      command: "add",
+      mode,
+      prompt: error.prompt ?? "unknown",
+    });
+    return;
+  }
+
+  await reportDiagnostic("cli_command", { command: "add", mode, ok: false, duration });
+  await reportDiagnostic("cli_failed", {
+    command: "add",
+    mode,
+    stage: failureStage(error),
+    error: errorClass(error),
+    reason: scrubReason(error),
+    packageManager: input.packageManager,
   });
 }
 

--- a/apps/cli/src/helpers/core/command-handlers.ts
+++ b/apps/cli/src/helpers/core/command-handlers.ts
@@ -8,10 +8,17 @@ import pc from "picocolors";
 import { getDefaultConfig } from "../../constants";
 import { gatherConfig } from "../../prompts/config-prompts";
 import { getProjectName } from "../../prompts/project-name";
-import type { CreateInput, DirectoryConflict, ProjectConfig } from "../../types";
+import type { AnalyticsMode, CreateInput, DirectoryConflict, ProjectConfig } from "../../types";
 import { trackProjectCreation } from "../../utils/analytics";
 import { getCliSubcommandCommand } from "../../utils/cli-invocation";
-import { isSilent, runWithContextAsync } from "../../utils/context";
+import { isSilent, resolveInvocationMode, runWithContextAsync } from "../../utils/context";
+import {
+  errorClass,
+  failureStage,
+  reportDiagnostic,
+  reportSlowStage,
+  scrubReason,
+} from "../../utils/diagnostics";
 import { displayConfig } from "../../utils/display-config";
 import {
   type AppError,
@@ -53,6 +60,7 @@ import { resolveProjectDbSetupOptions } from "./db-setup-options";
 
 export interface CreateHandlerOptions {
   silent?: boolean;
+  mode?: AnalyticsMode;
 }
 
 type CreateCommandInput = CreateInput & {
@@ -131,14 +139,54 @@ async function executeCreateProjectHandler(
   input: CreateCommandInput,
   options: CreateHandlerOptions,
 ): Promise<CreateHandlerExecution> {
-  const { silent = false } = options;
+  const { silent = false, mode } = options;
 
-  return runWithContextAsync({ silent }, async () => {
-    const startTime = Date.now();
-    const timeScaffolded = new Date().toISOString();
-    const result = await createProjectHandlerInternal(input, startTime, timeScaffolded);
+  return runWithContextAsync(
+    { silent, mode, analyticsDisabled: input.disableAnalytics },
+    async () => {
+      const startTime = Date.now();
+      const timeScaffolded = new Date().toISOString();
+      const result = await createProjectHandlerInternal(input, startTime, timeScaffolded);
+      await reportCreateOutcome(input, result, Date.now() - startTime);
 
-    return { result, startTime, timeScaffolded };
+      return { result, startTime, timeScaffolded };
+    },
+  );
+}
+
+/** Diagnostics for what the success-only project event cannot show; awaited so it beats process.exit. */
+async function reportCreateOutcome(
+  input: CreateCommandInput,
+  result: Result<CreateProjectResult, CreateHandlerError>,
+  elapsedMs: number,
+): Promise<void> {
+  const mode = resolveInvocationMode(input.yes);
+
+  if (result.isOk()) {
+    if (!input.dryRun) {
+      await reportSlowStage("create", "create", elapsedMs, input.packageManager ?? "unknown");
+    }
+    return;
+  }
+
+  const error = result.error;
+  if (UserCancelledError.is(error)) {
+    await reportDiagnostic("cli_cancelled", {
+      command: "create",
+      mode,
+      prompt: error.prompt ?? "unknown",
+    });
+    return;
+  }
+
+  await reportDiagnostic("cli_failed", {
+    command: "create",
+    mode,
+    stage: failureStage(error),
+    error: errorClass(error),
+    reason: scrubReason(error),
+    packageManager: input.packageManager,
+    backend: input.backend,
   });
 }
 
@@ -437,7 +485,7 @@ async function createProjectHandlerInternal(
       }),
     );
 
-    await trackProjectCreation(config, input.disableAnalytics);
+    await trackProjectCreation(config, input.disableAnalytics, resolveInvocationMode(input.yes));
 
     // Track locally in history.json (non-fatal)
     const historyResult = await addToHistory(config, reproducibleCommand);

--- a/apps/cli/src/helpers/core/create-project.ts
+++ b/apps/cli/src/helpers/core/create-project.ts
@@ -8,6 +8,7 @@ import fs from "fs-extra";
 
 import type { DbSetupOptions, ProjectConfig } from "../../types";
 import { isSilent } from "../../utils/context";
+import { reportSlowStage } from "../../utils/diagnostics";
 import { ProjectCreationError } from "../../utils/errors";
 import { formatProject } from "../../utils/file-formatter";
 import { getLatestCLIVersion } from "../../utils/get-latest-cli-version";
@@ -122,11 +123,18 @@ export async function createProject(
 
     // Install dependencies if requested
     if (options.install) {
+      const installStartTime = Date.now();
       yield* Result.await(
         installDependencies({
           projectDir,
           packageManager: options.packageManager,
         }),
+      );
+      await reportSlowStage(
+        "create",
+        "install",
+        Date.now() - installStartTime,
+        options.packageManager,
       );
     }
 

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -55,6 +55,8 @@ import {
   WebDeploySchema,
   WorkspacePackageNameSchema,
 } from "./types";
+import { getProcessMode } from "./utils/context";
+import { durationBucket, reportDiagnostic } from "./utils/diagnostics";
 import {
   CLIError,
   DirectoryConflictError,
@@ -207,7 +209,7 @@ export const router = t.router({
     })
     .input(CreateInputSchema)
     .mutation(async ({ input }) => {
-      const result = await createProjectHandler(input, { silent: true });
+      const result = await createProjectHandler(input, { silent: true, mode: "json" });
       if (!result) {
         throw new UserCancelledError({ message: "Operation cancelled" });
       }
@@ -228,13 +230,13 @@ export const router = t.router({
     .query(({ input }) => getSchemaResult(input.name)),
   sponsors: t.procedure
     .meta({ description: "Show Better-T-Stack sponsors" })
-    .mutation(() => showSponsorsCommand()),
+    .mutation(() => trackCommand("sponsors", () => showSponsorsCommand())),
   docs: t.procedure
     .meta({ description: "Open Better-T-Stack documentation" })
-    .mutation(() => openDocsCommand()),
+    .mutation(() => trackCommand("docs", () => openDocsCommand())),
   builder: t.procedure
     .meta({ description: "Open the web-based stack builder" })
-    .mutation(() => openBuilderCommand()),
+    .mutation(() => trackCommand("builder", () => openBuilderCommand())),
   add: t.procedure
     .meta({
       description: "Add addons or a workspace package to an existing Better-T-Stack project",
@@ -267,7 +269,7 @@ export const router = t.router({
     })
     .input(AddInputSchema)
     .mutation(async ({ input }) => {
-      const result = await addHandler(input, { silent: true });
+      const result = await addHandler(input, { silent: true, mode: "json" });
       if (!result) {
         throw new UserCancelledError({ message: "Operation cancelled" });
       }
@@ -288,9 +290,30 @@ export const router = t.router({
       }),
     )
     .mutation(async ({ input }) => {
-      await historyHandler(input);
+      await trackCommand("history", () => historyHandler(input));
     }),
 });
+
+/** Usage diagnostics for commands that have no project event of their own. */
+async function trackCommand<T>(command: string, run: () => Promise<T> | T): Promise<T> {
+  const startTime = Date.now();
+  try {
+    const value = await run();
+    await reportDiagnostic("cli_command", {
+      command,
+      ok: true,
+      duration: durationBucket(Date.now() - startTime),
+    });
+    return value;
+  } catch (cause) {
+    await reportDiagnostic("cli_command", {
+      command,
+      ok: false,
+      duration: durationBucket(Date.now() - startTime),
+    });
+    throw cause;
+  }
+}
 
 export function createBtsCli(): TrpcCli {
   return createCli({
@@ -374,7 +397,10 @@ export async function create(
 
   return Result.tryPromise({
     try: async () => {
-      const result = await createProjectHandlerResult(input, { silent: true });
+      const result = await createProjectHandlerResult(input, {
+        silent: true,
+        mode: getProcessMode() ?? "api",
+      });
       if (result.isErr()) {
         throw result.error;
       }
@@ -569,7 +595,10 @@ export async function add(options: AddOptions = {}): Promise<AddResult> {
     };
   }
 
-  const result = await addHandler(parsedInput.data, { silent: true });
+  const result = await addHandler(parsedInput.data, {
+    silent: true,
+    mode: getProcessMode() ?? "api",
+  });
   return (
     result ?? {
       success: false,

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -290,18 +290,26 @@ export const router = t.router({
       }),
     )
     .mutation(async ({ input }) => {
-      await trackCommand("history", () => historyHandler(input));
+      await trackCommand(
+        "history",
+        () => historyHandler(input),
+        (ok) => ok,
+      );
     }),
 });
 
 /** Usage diagnostics for commands that have no project event of their own. */
-async function trackCommand<T>(command: string, run: () => Promise<T> | T): Promise<T> {
+async function trackCommand<T>(
+  command: string,
+  run: () => Promise<T> | T,
+  isOk: (value: T) => boolean = () => true,
+): Promise<T> {
   const startTime = Date.now();
   try {
     const value = await run();
     await reportDiagnostic("cli_command", {
       command,
-      ok: true,
+      ok: isOk(value),
       duration: durationBucket(Date.now() - startTime),
     });
     return value;

--- a/apps/cli/src/mcp.ts
+++ b/apps/cli/src/mcp.ts
@@ -1,5 +1,5 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { McpServer } from "@modelcontextprotocol/server";
+import { serveStdio } from "@modelcontextprotocol/server/stdio";
 import z from "zod";
 
 import { add, create, type SchemaName, SchemaNameSchema, getSchemaResult } from "./index";
@@ -24,6 +24,8 @@ import {
   ServerDeploySchema,
   WebDeploySchema,
 } from "./types";
+import { setProcessMode } from "./utils/context";
+import { durationBucket, reportDiagnostic, scrubReason } from "./utils/diagnostics";
 import { getLatestCLIVersion } from "./utils/get-latest-cli-version";
 
 const ToolResponseSchema = z.object({
@@ -103,6 +105,51 @@ function formatToolError(cause: unknown) {
   };
 }
 
+type ToolResult = ReturnType<typeof formatToolSuccess> | ReturnType<typeof formatToolError>;
+
+const reportedSessions = new WeakSet<McpServer>();
+
+/** One session event per connection, sent when the client identity is first known. */
+function reportMcpSession(server: McpServer) {
+  if (reportedSessions.has(server)) return;
+  reportedSessions.add(server);
+  const client = server.server.getClientVersion();
+  void reportDiagnostic("mcp_session", {
+    client: client?.name ?? "unknown",
+    clientVersion: client?.version ?? "unknown",
+  });
+}
+
+/**
+ * Times every tool call and reports the outcome. Diagnostics are fire-and-forget here
+ * because the server process is long-lived and must not add latency to tool results.
+ */
+function instrumentTool<Args extends unknown[]>(
+  server: McpServer,
+  tool: string,
+  handler: (...args: Args) => Promise<ToolResult>,
+) {
+  return async (...args: Args): Promise<ToolResult> => {
+    reportMcpSession(server);
+    const startTime = Date.now();
+    const result = await handler(...args);
+    const ok = !("isError" in result);
+    void reportDiagnostic("mcp_tool", {
+      tool,
+      ok,
+      duration: durationBucket(Date.now() - startTime),
+    });
+    if (!ok) {
+      void reportDiagnostic("mcp_tool_error", {
+        tool,
+        error: "ToolError",
+        reason: scrubReason(result.structuredContent.error),
+      });
+    }
+    return result;
+  };
+}
+
 function getProjectToolAnnotations() {
   return {
     destructiveHint: true,
@@ -178,14 +225,15 @@ function getStackGuidance() {
 }
 
 export function createBtsMcpServer() {
+  setProcessMode("mcp");
   const server = new McpServer(
     {
       name: "create-better-t-stack",
       version: getLatestCLIVersion(),
     },
     {
-      capabilities: {
-        logging: {},
+      cacheHints: {
+        "tools/list": { ttlMs: 60 * 60 * 1000, cacheScope: "public" },
       },
     },
   );
@@ -205,13 +253,13 @@ export function createBtsMcpServer() {
         openWorldHint: false,
       },
     },
-    async () => {
+    instrumentTool(server, "bts_get_stack_guidance", async () => {
       try {
         return formatToolSuccess(getStackGuidance());
       } catch (error) {
         return formatToolError(error);
       }
-    },
+    }),
   );
 
   server.registerTool(
@@ -230,13 +278,13 @@ export function createBtsMcpServer() {
         openWorldHint: false,
       },
     },
-    async ({ name }: SchemaToolInput) => {
+    instrumentTool(server, "bts_get_schema", async ({ name }: SchemaToolInput) => {
       try {
         return formatToolSuccess(getSchemaResult((name ?? "all") as SchemaName));
       } catch (error) {
         return formatToolError(error);
       }
-    },
+    }),
   );
 
   server.registerTool(
@@ -255,7 +303,7 @@ export function createBtsMcpServer() {
         openWorldHint: false,
       },
     },
-    async (input: McpCreateProjectInput) => {
+    instrumentTool(server, "bts_plan_project", async (input: McpCreateProjectInput) => {
       try {
         const result = await create(input.projectName, {
           ...input,
@@ -282,7 +330,7 @@ export function createBtsMcpServer() {
       } catch (error) {
         return formatToolError(error);
       }
-    },
+    }),
   );
 
   server.registerTool(
@@ -298,7 +346,7 @@ export function createBtsMcpServer() {
         ...getProjectToolAnnotations(),
       },
     },
-    async (input: McpCreateProjectInput) => {
+    instrumentTool(server, "bts_create_project", async (input: McpCreateProjectInput) => {
       try {
         if (input.install) {
           return formatToolError(getMcpInstallTimeoutMessage(input.packageManager));
@@ -306,7 +354,7 @@ export function createBtsMcpServer() {
 
         const result = await create(input.projectName, {
           ...input,
-          disableAnalytics: true,
+          disableAnalytics: input.disableAnalytics ?? false,
         });
 
         if (result.isErr()) {
@@ -317,7 +365,7 @@ export function createBtsMcpServer() {
       } catch (error) {
         return formatToolError(error);
       }
-    },
+    }),
   );
 
   server.registerTool(
@@ -336,7 +384,7 @@ export function createBtsMcpServer() {
         openWorldHint: false,
       },
     },
-    async (input: McpAddInput) => {
+    instrumentTool(server, "bts_plan_addons", async (input: McpAddInput) => {
       try {
         const result = await add({
           ...input,
@@ -351,7 +399,7 @@ export function createBtsMcpServer() {
       } catch (error) {
         return formatToolError(error);
       }
-    },
+    }),
   );
 
   server.registerTool(
@@ -369,7 +417,7 @@ export function createBtsMcpServer() {
         openWorldHint: true,
       },
     },
-    async (input: McpAddInput) => {
+    instrumentTool(server, "bts_add_addons", async (input: McpAddInput) => {
       try {
         const result = await add(input);
 
@@ -381,14 +429,12 @@ export function createBtsMcpServer() {
       } catch (error) {
         return formatToolError(error);
       }
-    },
+    }),
   );
 
   return server;
 }
 
-export async function startBtsMcpServer() {
-  const server = createBtsMcpServer();
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
+export function startBtsMcpServer() {
+  return serveStdio(() => createBtsMcpServer());
 }

--- a/apps/cli/src/mcp.ts
+++ b/apps/cli/src/mcp.ts
@@ -128,8 +128,10 @@ function instrumentTool<Args extends unknown[]>(
   server: McpServer,
   tool: string,
   handler: (...args: Args) => Promise<ToolResult>,
+  isOptedOut?: (...args: Args) => boolean,
 ) {
   return async (...args: Args): Promise<ToolResult> => {
+    if (isOptedOut?.(...args)) return handler(...args);
     reportMcpSession(server);
     const startTime = Date.now();
     const result = await handler(...args);
@@ -148,6 +150,10 @@ function instrumentTool<Args extends unknown[]>(
     }
     return result;
   };
+}
+
+function isCreateOptedOut(input: McpCreateProjectInput) {
+  return input.disableAnalytics === true;
 }
 
 function getProjectToolAnnotations() {
@@ -303,34 +309,39 @@ export function createBtsMcpServer() {
         openWorldHint: false,
       },
     },
-    instrumentTool(server, "bts_plan_project", async (input: McpCreateProjectInput) => {
-      try {
-        const result = await create(input.projectName, {
-          ...input,
-          dryRun: true,
-          disableAnalytics: true,
-        });
+    instrumentTool(
+      server,
+      "bts_plan_project",
+      async (input: McpCreateProjectInput) => {
+        try {
+          const result = await create(input.projectName, {
+            ...input,
+            dryRun: true,
+            disableAnalytics: true,
+          });
 
-        if (result.isErr()) {
-          return formatToolError(result.error);
+          if (result.isErr()) {
+            return formatToolError(result.error);
+          }
+
+          const planningData = input.install
+            ? {
+                ...result.value,
+                warnings: [getMcpInstallTimeoutMessage(input.packageManager)],
+                recommendedMcpExecution: {
+                  ...input,
+                  install: false,
+                },
+              }
+            : result.value;
+
+          return formatToolSuccess(planningData);
+        } catch (error) {
+          return formatToolError(error);
         }
-
-        const planningData = input.install
-          ? {
-              ...result.value,
-              warnings: [getMcpInstallTimeoutMessage(input.packageManager)],
-              recommendedMcpExecution: {
-                ...input,
-                install: false,
-              },
-            }
-          : result.value;
-
-        return formatToolSuccess(planningData);
-      } catch (error) {
-        return formatToolError(error);
-      }
-    }),
+      },
+      isCreateOptedOut,
+    ),
   );
 
   server.registerTool(
@@ -346,26 +357,31 @@ export function createBtsMcpServer() {
         ...getProjectToolAnnotations(),
       },
     },
-    instrumentTool(server, "bts_create_project", async (input: McpCreateProjectInput) => {
-      try {
-        if (input.install) {
-          return formatToolError(getMcpInstallTimeoutMessage(input.packageManager));
+    instrumentTool(
+      server,
+      "bts_create_project",
+      async (input: McpCreateProjectInput) => {
+        try {
+          if (input.install) {
+            return formatToolError(getMcpInstallTimeoutMessage(input.packageManager));
+          }
+
+          const result = await create(input.projectName, {
+            ...input,
+            disableAnalytics: input.disableAnalytics ?? false,
+          });
+
+          if (result.isErr()) {
+            return formatToolError(result.error);
+          }
+
+          return formatToolSuccess(result.value);
+        } catch (error) {
+          return formatToolError(error);
         }
-
-        const result = await create(input.projectName, {
-          ...input,
-          disableAnalytics: input.disableAnalytics ?? false,
-        });
-
-        if (result.isErr()) {
-          return formatToolError(result.error);
-        }
-
-        return formatToolSuccess(result.value);
-      } catch (error) {
-        return formatToolError(error);
-      }
-    }),
+      },
+      isCreateOptedOut,
+    ),
   );
 
   server.registerTool(

--- a/apps/cli/src/prompts/config-prompts.ts
+++ b/apps/cli/src/prompts/config-prompts.ts
@@ -194,8 +194,8 @@ export async function gatherConfig(
           prompts: ["webDeploy", "serverDeploy", "dbSetupMode", "git", "packageManager", "install"],
         },
       ],
-      onCancel: () => {
-        throw new UserCancelledError({ message: "Operation cancelled" });
+      onCancel: ({ prompt }) => {
+        throw new UserCancelledError({ message: "Operation cancelled", prompt });
       },
     },
   );

--- a/apps/cli/src/prompts/navigable-group.ts
+++ b/apps/cli/src/prompts/navigable-group.ts
@@ -4,6 +4,7 @@
 
 import {
   didLastPromptShowUI,
+  markPromptShown,
   setIsFirstPrompt,
   setLastPromptShownUI,
   setPromptProgress,
@@ -24,7 +25,10 @@ export interface NavigablePromptGroupOptions<T> {
    * Control how the group can be canceled
    * if one of the prompts is canceled.
    */
-  onCancel?: (opts: { results: Prettify<Partial<PromptGroupAwaitedReturn<T>>> }) => void;
+  onCancel?: (opts: {
+    results: Prettify<Partial<PromptGroupAwaitedReturn<T>>>;
+    prompt: string;
+  }) => void;
   /** Group related questions into named stages shown in the prompt chrome. */
   sections?: ReadonlyArray<{
     label: string;
@@ -86,6 +90,7 @@ export async function navigableGroup<T>(
       setLastPromptShownUI(false);
 
       const presetResult = opts?.preselected?.[name];
+      if (presetResult === undefined) markPromptShown();
       const result =
         presetResult !== undefined
           ? presetResult
@@ -107,7 +112,7 @@ export async function navigableGroup<T>(
       if (isCancel(result)) {
         if (opts?.onCancel) {
           results[name] = "canceled";
-          opts.onCancel({ results });
+          opts.onCancel({ results, prompt: String(name) });
         }
         return results;
       }

--- a/apps/cli/src/prompts/project-name.ts
+++ b/apps/cli/src/prompts/project-name.ts
@@ -6,6 +6,7 @@ import pc from "picocolors";
 
 import { DEFAULT_CONFIG } from "../constants";
 import { ProjectNameSchema } from "../types";
+import { markPromptShown } from "../utils/context";
 import { UserCancelledError } from "../utils/errors";
 import { isMissingPathError } from "../utils/fs-error";
 import { cliConsola } from "../utils/terminal-output";
@@ -65,6 +66,7 @@ export async function getProjectName(initialName?: string): Promise<string> {
   }
 
   while (!isValid) {
+    markPromptShown();
     const response = await text({
       message: "Where should we create your project?",
       placeholder: defaultName,
@@ -89,7 +91,7 @@ export async function getProjectName(initialName?: string): Promise<string> {
     });
 
     if (isCancel(response)) {
-      throw new UserCancelledError({ message: "Operation cancelled." });
+      throw new UserCancelledError({ message: "Operation cancelled.", prompt: "projectName" });
     }
 
     projectPath = response || defaultName;

--- a/apps/cli/src/utils/analytics.ts
+++ b/apps/cli/src/utils/analytics.ts
@@ -1,10 +1,16 @@
 import { Result } from "better-result";
 
-import { AnalyticsEventSchema, type AnalyticsEvent, type ProjectConfig } from "../types";
+import {
+  AnalyticsEventSchema,
+  type AnalyticsEvent,
+  type AnalyticsMode,
+  type ProjectConfig,
+} from "../types";
 import { getLatestCLIVersion } from "./get-latest-cli-version";
 import { isTelemetryEnabled } from "./telemetry";
 
 const CONVEX_INGEST_URL = process.env.CONVEX_INGEST_URL;
+const SEND_TIMEOUT_MS = 3000;
 
 async function sendConvexEvent(payload: AnalyticsEvent): Promise<void> {
   if (!CONVEX_INGEST_URL) return;
@@ -17,13 +23,16 @@ async function sendConvexEvent(payload: AnalyticsEvent): Promise<void> {
           "Content-Type": "application/json",
         },
         body: JSON.stringify(payload),
+        signal: AbortSignal.timeout(SEND_TIMEOUT_MS),
+        keepalive: true,
       }),
     catch: () => undefined, // Silent failure
   });
 }
 
-export function buildAnalyticsEvent(config: ProjectConfig): AnalyticsEvent {
+export function buildAnalyticsEvent(config: ProjectConfig, mode?: AnalyticsMode): AnalyticsEvent {
   return AnalyticsEventSchema.parse({
+    mode,
     database: config.database,
     orm: config.orm,
     backend: config.backend,
@@ -49,11 +58,12 @@ export function buildAnalyticsEvent(config: ProjectConfig): AnalyticsEvent {
 export async function trackProjectCreation(
   config: ProjectConfig,
   disableAnalytics = false,
+  mode?: AnalyticsMode,
 ): Promise<void> {
   if (!isTelemetryEnabled() || disableAnalytics) return;
 
   await Result.tryPromise({
-    try: () => sendConvexEvent(buildAnalyticsEvent(config)),
+    try: () => sendConvexEvent(buildAnalyticsEvent(config, mode)),
     catch: () => undefined, // Silent failure
   });
 }

--- a/apps/cli/src/utils/context.ts
+++ b/apps/cli/src/utils/context.ts
@@ -1,6 +1,6 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 
-import type { PackageManager } from "../types";
+import type { AnalyticsMode, PackageManager } from "../types";
 
 export type NavigationState = {
   isFirstPrompt: boolean;
@@ -20,12 +20,28 @@ export type CLIContext = {
   navigation: NavigationState;
   silent: boolean;
   verbose: boolean;
+  /** Set when the caller already knows how the CLI is being driven (json, api, mcp). */
+  mode?: AnalyticsMode;
+  /** True once any interactive prompt was rendered during this run. */
+  promptShown: boolean;
+  analyticsDisabled: boolean;
   projectDir?: string;
   projectName?: string;
   packageManager?: PackageManager;
 };
 
 const cliStorage = new AsyncLocalStorage<CLIContext>();
+
+/** Process-wide mode for hosts that own the whole process, such as the MCP server. */
+let processMode: AnalyticsMode | undefined;
+
+export function setProcessMode(mode: AnalyticsMode | undefined): void {
+  processMode = mode;
+}
+
+export function getProcessMode(): AnalyticsMode | undefined {
+  return processMode;
+}
 
 function defaultContext(): CLIContext {
   return {
@@ -35,6 +51,8 @@ function defaultContext(): CLIContext {
     },
     silent: false,
     verbose: false,
+    promptShown: false,
+    analyticsDisabled: false,
   };
 }
 
@@ -72,6 +90,24 @@ export function didLastPromptShowUI(): boolean {
 
 export function getPromptProgress(): PromptProgress | undefined {
   return getContext().navigation.promptProgress;
+}
+
+export function markPromptShown(): void {
+  const ctx = tryGetContext();
+  if (ctx) {
+    ctx.promptShown = true;
+  }
+}
+
+/**
+ * How this run is being driven. Hosts that know (json, api, mcp) set it up front;
+ * otherwise it is derived from whether prompts were rendered.
+ */
+export function resolveInvocationMode(yes?: boolean): AnalyticsMode {
+  const ctx = getContext();
+  if (ctx.mode) return ctx.mode;
+  if (yes) return "yes";
+  return ctx.promptShown ? "interactive" : "flags";
 }
 
 export function getProjectDir(): string | undefined {
@@ -119,42 +155,37 @@ export function setProjectInfo(info: {
 export type ContextOptions = {
   silent?: boolean;
   verbose?: boolean;
+  mode?: AnalyticsMode;
+  analyticsDisabled?: boolean;
   projectDir?: string;
   projectName?: string;
   packageManager?: PackageManager;
 };
 
-export function runWithContext<T>(options: ContextOptions, fn: () => T): T {
-  const ctx: CLIContext = {
+function createContext(options: ContextOptions): CLIContext {
+  return {
     navigation: {
       isFirstPrompt: false,
       lastPromptShownUI: false,
     },
     silent: options.silent ?? false,
     verbose: options.verbose ?? false,
+    mode: options.mode ?? processMode,
+    promptShown: false,
+    analyticsDisabled: options.analyticsDisabled ?? false,
     projectDir: options.projectDir,
     projectName: options.projectName,
     packageManager: options.packageManager,
   };
+}
 
-  return cliStorage.run(ctx, fn);
+export function runWithContext<T>(options: ContextOptions, fn: () => T): T {
+  return cliStorage.run(createContext(options), fn);
 }
 
 export async function runWithContextAsync<T>(
   options: ContextOptions,
   fn: () => Promise<T>,
 ): Promise<T> {
-  const ctx: CLIContext = {
-    navigation: {
-      isFirstPrompt: false,
-      lastPromptShownUI: false,
-    },
-    silent: options.silent ?? false,
-    verbose: options.verbose ?? false,
-    projectDir: options.projectDir,
-    projectName: options.projectName,
-    packageManager: options.packageManager,
-  };
-
-  return cliStorage.run(ctx, fn);
+  return cliStorage.run(createContext(options), fn);
 }

--- a/apps/cli/src/utils/diagnostics.ts
+++ b/apps/cli/src/utils/diagnostics.ts
@@ -89,13 +89,15 @@ export function scrubReason(cause: unknown): string {
   const message = cause instanceof Error ? cause.message : String(cause);
   const firstLine = message.split(/\r?\n/, 1)[0] ?? "";
   const scrubbed = firstLine
+    // Quoted spans first: they are user-supplied values whatever they contain.
+    .replaceAll(/(["'`])(?:(?!\1).)*\1/g, "<name>")
     .replaceAll(/https?:\/\/[^\s)\]"'>]+/gi, "<url>")
     .replaceAll(/[\w.+-]+@[\w-]+\.[\w.-]+/g, "<email>")
-    // Absolute paths, including segments with spaces ("/Users/Jane Doe/app/file.ts").
-    .replaceAll(/(?:[a-zA-Z]:)?(?:[\\/][\w.@+ -]+)+[\\/][\w.@+-]+/g, "<path>")
+    // Absolute paths, including segments with spaces ("/Users/Jane Doe/app/file.ts") and a
+    // final file name with spaces when it carries an extension ("/Users/jane/report final.txt").
+    .replaceAll(/(?:[a-zA-Z]:)?(?:[\\/][\w.@+ -]+)+[\\/][\w.@+-]+(?:[ \w.@+-]*\.\w+)?/g, "<path>")
     // Anything else containing a separator, such as relative paths and "packages/<name>".
     .replaceAll(/\S*[\\/]\S*/g, "<path>")
-    .replaceAll(/(["'`])(?:(?!\1).)*\1/g, "<name>")
     .replaceAll(/\s+/g, " ")
     .trim();
   return scrubbed.length > MAX_REASON_LENGTH ? scrubbed.slice(0, MAX_REASON_LENGTH) : scrubbed;

--- a/apps/cli/src/utils/diagnostics.ts
+++ b/apps/cli/src/utils/diagnostics.ts
@@ -1,0 +1,183 @@
+import type { AnalyticsMode } from "@better-t-stack/types";
+import { Result } from "better-result";
+
+import { getContext } from "./context";
+import {
+  AddonSetupError,
+  CLIError,
+  CompatibilityError,
+  DatabaseSetupError,
+  DirectoryConflictError,
+  ProjectCreationError,
+  ValidationError,
+} from "./errors";
+import { getLatestCLIVersion } from "./get-latest-cli-version";
+import { isTelemetryEnabled } from "./telemetry";
+
+/**
+ * Diagnostic events go to the self-hosted Umami instance (a separate "CLI" website),
+ * not to the Convex project dataset. They cover what the project-creation event
+ * cannot: failures, cancellations, non-create commands, slow stages, and MCP usage.
+ * Everything is a no-op until UMAMI_CLI_WEBSITE_ID is baked in at build time.
+ */
+const UMAMI_HOST_URL = process.env.UMAMI_HOST_URL;
+const UMAMI_CLI_WEBSITE_ID = process.env.UMAMI_CLI_WEBSITE_ID;
+const SEND_TIMEOUT_MS = 3000;
+const MAX_STRING_LENGTH = 500;
+const MAX_REASON_LENGTH = 160;
+export const SLOW_STAGE_THRESHOLD_MS = 60_000;
+
+type DiagnosticValue = string | number | boolean;
+
+export type DiagnosticEvents = {
+  cli_failed: {
+    command: string;
+    mode: AnalyticsMode;
+    stage: string;
+    error: string;
+    reason: string;
+    packageManager?: string;
+    backend?: string;
+  };
+  cli_cancelled: { command: string; mode: AnalyticsMode; prompt: string };
+  cli_command: { command: string; mode?: AnalyticsMode; ok: boolean; duration: string };
+  cli_slow: { command: string; stage: string; duration: string; packageManager: string };
+  mcp_session: { client: string; clientVersion: string };
+  mcp_tool: { tool: string; ok: boolean; duration: string };
+  mcp_tool_error: { tool: string; error: string; reason: string };
+};
+
+export type DiagnosticEventName = keyof DiagnosticEvents;
+
+const DURATION_BUCKETS: Array<[number, string]> = [
+  [1_000, "<1s"],
+  [5_000, "1-5s"],
+  [15_000, "5-15s"],
+  [60_000, "15-60s"],
+  [300_000, "1-5m"],
+];
+
+export function durationBucket(elapsedMs: number): string {
+  for (const [limit, label] of DURATION_BUCKETS) {
+    if (elapsedMs < limit) return label;
+  }
+  return ">5m";
+}
+
+/** Class name of the failure, which is stable and never carries user content. */
+export function errorClass(cause: unknown): string {
+  if (cause instanceof Error) return cause.name || cause.constructor.name || "Error";
+  return "UnknownError";
+}
+
+/** Coarse stage a create/add failure belongs to, derived from the tagged error types. */
+export function failureStage(cause: unknown): string {
+  if (ProjectCreationError.is(cause)) return cause.phase;
+  if (DatabaseSetupError.is(cause)) return "database-setup";
+  if (AddonSetupError.is(cause)) return "addons-setup";
+  if (DirectoryConflictError.is(cause)) return "directory";
+  if (ValidationError.is(cause) || CompatibilityError.is(cause)) return "validate";
+  if (CLIError.is(cause)) return "config";
+  return "unknown";
+}
+
+/**
+ * First line of an error message with anything that could identify a machine or
+ * project replaced by placeholders: file paths, URLs, emails, and quoted names.
+ */
+export function scrubReason(cause: unknown): string {
+  const message = cause instanceof Error ? cause.message : String(cause);
+  const firstLine = message.split(/\r?\n/, 1)[0] ?? "";
+  const scrubbed = firstLine
+    .replaceAll(/https?:\/\/[^\s)\]"'>]+/gi, "<url>")
+    .replaceAll(/[\w.+-]+@[\w-]+\.[\w.-]+/g, "<email>")
+    .replaceAll(/(?:[a-zA-Z]:)?(?:[\\/][\w.@+-]+){2,}/g, "<path>")
+    .replaceAll(/(["'`])(?:(?!\1).)*\1/g, "<name>")
+    .replaceAll(/\s+/g, " ")
+    .trim();
+  return scrubbed.length > MAX_REASON_LENGTH ? scrubbed.slice(0, MAX_REASON_LENGTH) : scrubbed;
+}
+
+function clampValue(value: DiagnosticValue): DiagnosticValue {
+  const text = String(value);
+  return text.length > MAX_STRING_LENGTH ? text.slice(0, MAX_STRING_LENGTH) : value;
+}
+
+function isDiagnosticsEnabled() {
+  return (
+    Boolean(UMAMI_HOST_URL) &&
+    Boolean(UMAMI_CLI_WEBSITE_ID) &&
+    isTelemetryEnabled() &&
+    !getContext().analyticsDisabled
+  );
+}
+
+function eventUrl(name: DiagnosticEventName, data: Record<string, DiagnosticValue>) {
+  if (name.startsWith("mcp_")) return "/mcp";
+  const command = data.command;
+  return command === undefined ? `/${name}` : `/${String(command)}`;
+}
+
+export function buildDiagnosticPayload<Name extends DiagnosticEventName>(
+  name: Name,
+  data: DiagnosticEvents[Name],
+) {
+  const eventData: Record<string, DiagnosticValue> = {};
+  for (const [key, value] of Object.entries(data)) {
+    if (value !== undefined) eventData[key] = clampValue(value);
+  }
+
+  return {
+    type: "event",
+    payload: {
+      website: UMAMI_CLI_WEBSITE_ID,
+      hostname: "cli",
+      url: eventUrl(name, eventData),
+      title: name,
+      name,
+      data: eventData,
+    },
+  };
+}
+
+export function diagnosticUserAgent() {
+  return `Mozilla/5.0 (compatible; create-better-t-stack/${getLatestCLIVersion()})`;
+}
+
+export async function reportDiagnostic<Name extends DiagnosticEventName>(
+  name: Name,
+  data: DiagnosticEvents[Name],
+): Promise<void> {
+  if (!isDiagnosticsEnabled()) return;
+
+  await Result.tryPromise({
+    try: () =>
+      fetch(`${UMAMI_HOST_URL}/api/send`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "User-Agent": diagnosticUserAgent(),
+        },
+        body: JSON.stringify(buildDiagnosticPayload(name, data)),
+        signal: AbortSignal.timeout(SEND_TIMEOUT_MS),
+        keepalive: true,
+      }),
+    catch: () => undefined, // Silent failure: diagnostics must never affect the CLI.
+  });
+}
+
+/** Reports a stage only when it crossed the slow threshold, so the event is a signal. */
+export async function reportSlowStage(
+  command: string,
+  stage: string,
+  elapsedMs: number,
+  packageManager: string,
+): Promise<void> {
+  if (elapsedMs < SLOW_STAGE_THRESHOLD_MS) return;
+  await reportDiagnostic("cli_slow", {
+    command,
+    stage,
+    duration: durationBucket(elapsedMs),
+    packageManager,
+  });
+}

--- a/apps/cli/src/utils/diagnostics.ts
+++ b/apps/cli/src/utils/diagnostics.ts
@@ -91,7 +91,10 @@ export function scrubReason(cause: unknown): string {
   const scrubbed = firstLine
     .replaceAll(/https?:\/\/[^\s)\]"'>]+/gi, "<url>")
     .replaceAll(/[\w.+-]+@[\w-]+\.[\w.-]+/g, "<email>")
-    .replaceAll(/(?:[a-zA-Z]:)?(?:[\\/][\w.@+-]+){2,}/g, "<path>")
+    // Absolute paths, including segments with spaces ("/Users/Jane Doe/app/file.ts").
+    .replaceAll(/(?:[a-zA-Z]:)?(?:[\\/][\w.@+ -]+)+[\\/][\w.@+-]+/g, "<path>")
+    // Anything else containing a separator, such as relative paths and "packages/<name>".
+    .replaceAll(/\S*[\\/]\S*/g, "<path>")
     .replaceAll(/(["'`])(?:(?!\1).)*\1/g, "<name>")
     .replaceAll(/\s+/g, " ")
     .trim();

--- a/apps/cli/src/utils/errors.ts
+++ b/apps/cli/src/utils/errors.ts
@@ -13,9 +13,11 @@ import { cliConsola } from "./terminal-output";
  */
 export class UserCancelledError extends TaggedError("UserCancelledError")<{
   message: string;
+  /** Name of the prompt that was open when the user cancelled, when known. */
+  prompt?: string;
 }> {
-  constructor(args?: { message?: string }) {
-    super({ message: args?.message ?? "Operation cancelled" });
+  constructor(args?: { message?: string; prompt?: string }) {
+    super({ message: args?.message ?? "Operation cancelled", prompt: args?.prompt });
   }
 }
 

--- a/apps/cli/src/utils/telemetry.ts
+++ b/apps/cli/src/utils/telemetry.ts
@@ -1,13 +1,18 @@
 /**
  * Returns true if telemetry/analytics should be enabled, false otherwise.
  *
+ * - DO_NOT_TRACK=1 (the cross-tool convention from consoledonottrack.com) disables analytics.
  * - If BTS_TELEMETRY_DISABLED is present and "1", disables analytics.
  * - Otherwise, BTS_TELEMETRY: "0" disables, "1" enables (default: enabled).
  */
 export function isTelemetryEnabled() {
+  const DO_NOT_TRACK = process.env.DO_NOT_TRACK;
   const BTS_TELEMETRY_DISABLED = process.env.BTS_TELEMETRY_DISABLED;
   const BTS_TELEMETRY = process.env.BTS_TELEMETRY;
 
+  if (DO_NOT_TRACK === "1" || DO_NOT_TRACK?.toLowerCase() === "true") {
+    return false;
+  }
   if (BTS_TELEMETRY_DISABLED !== undefined) {
     return BTS_TELEMETRY_DISABLED !== "1";
   }

--- a/apps/cli/test/diagnostics.test.ts
+++ b/apps/cli/test/diagnostics.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildDiagnosticPayload,
+  diagnosticUserAgent,
+  durationBucket,
+  errorClass,
+  reportDiagnostic,
+  scrubReason,
+} from "../src/utils/diagnostics";
+import { CLIError } from "../src/utils/errors";
+
+describe("scrubReason", () => {
+  test("keeps the first line and replaces identifying fragments", () => {
+    const error = new Error(
+      `Directory "/Users/jane/work/acme-app" already exists (see https://example.com/docs?x=1)\nstack line 2`,
+    );
+    expect(scrubReason(error)).toBe("Directory <name> already exists (see <url>)");
+  });
+
+  test("scrubs unquoted paths, Windows paths, and emails", () => {
+    expect(scrubReason("ENOENT: no such file, open /tmp/build/project/package.json")).toBe(
+      "ENOENT: no such file, open <path>",
+    );
+    expect(scrubReason("cannot write C:\\Users\\jane\\app\\file.txt")).toBe("cannot write <path>");
+    expect(scrubReason("git author jane@example.com is not configured")).toBe(
+      "git author <email> is not configured",
+    );
+  });
+
+  test("truncates very long reasons", () => {
+    expect(scrubReason("x".repeat(400))).toHaveLength(160);
+  });
+});
+
+describe("errorClass", () => {
+  test("uses the error name and falls back for non-errors", () => {
+    expect(errorClass(new CLIError({ message: "boom" }))).toBe("CLIError");
+    expect(errorClass(new TypeError("bad"))).toBe("TypeError");
+    expect(errorClass("string failure")).toBe("UnknownError");
+  });
+});
+
+describe("durationBucket", () => {
+  test("maps elapsed milliseconds to coarse buckets", () => {
+    expect(durationBucket(120)).toBe("<1s");
+    expect(durationBucket(4_000)).toBe("1-5s");
+    expect(durationBucket(14_999)).toBe("5-15s");
+    expect(durationBucket(59_000)).toBe("15-60s");
+    expect(durationBucket(200_000)).toBe("1-5m");
+    expect(durationBucket(900_000)).toBe(">5m");
+  });
+});
+
+describe("buildDiagnosticPayload", () => {
+  test("routes CLI events by command and MCP events under /mcp", () => {
+    const failed = buildDiagnosticPayload("cli_failed", {
+      command: "create",
+      mode: "flags",
+      stage: "install",
+      error: "CLIError",
+      reason: "install failed",
+      packageManager: "bun",
+      backend: undefined,
+    });
+    expect(failed.type).toBe("event");
+    expect(failed.payload.url).toBe("/create");
+    expect(failed.payload.name).toBe("cli_failed");
+    expect(failed.payload.hostname).toBe("cli");
+    expect(failed.payload.data).toEqual({
+      command: "create",
+      mode: "flags",
+      stage: "install",
+      error: "CLIError",
+      reason: "install failed",
+      packageManager: "bun",
+    });
+
+    const tool = buildDiagnosticPayload("mcp_tool", {
+      tool: "bts_plan_project",
+      ok: true,
+      duration: "<1s",
+    });
+    expect(tool.payload.url).toBe("/mcp");
+    expect(tool.payload.data.ok).toBe(true);
+  });
+
+  test("uses a browser-compatible user agent so Umami does not drop it as a bot", () => {
+    expect(diagnosticUserAgent()).toMatch(/^Mozilla\/5\.0 \(compatible; create-better-t-stack\/\d/);
+  });
+});
+
+describe("reportDiagnostic", () => {
+  test("is a no-op when no CLI website id is configured", async () => {
+    const originalFetch = globalThis.fetch;
+    let called = false;
+    globalThis.fetch = (() => {
+      called = true;
+      return Promise.resolve(new Response("ok"));
+    }) as typeof fetch;
+
+    try {
+      await reportDiagnostic("cli_outdated", { installed: "3.40.5", latest: "3.41.0" });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(called).toBe(false);
+  });
+});

--- a/apps/cli/test/diagnostics.test.ts
+++ b/apps/cli/test/diagnostics.test.ts
@@ -32,6 +32,10 @@ describe("scrubReason", () => {
     expect(scrubReason("error at /Users/Jane Doe/project/file.ts while writing")).toBe(
       "error at <path> while writing",
     );
+    expect(scrubReason("cannot read /Users/jane/report final.txt")).toBe("cannot read <path>");
+    expect(scrubReason('Template "apps/web/src/index.ts" is missing')).toBe(
+      "Template <name> is missing",
+    );
     expect(scrubReason("Workspace package already exists: packages/customer-name")).toBe(
       "Workspace package already exists: <path>",
     );

--- a/apps/cli/test/diagnostics.test.ts
+++ b/apps/cli/test/diagnostics.test.ts
@@ -28,6 +28,18 @@ describe("scrubReason", () => {
     );
   });
 
+  test("scrubs path segments with spaces and relative paths or package names", () => {
+    expect(scrubReason("error at /Users/Jane Doe/project/file.ts while writing")).toBe(
+      "error at <path> while writing",
+    );
+    expect(scrubReason("Workspace package already exists: packages/customer-name")).toBe(
+      "Workspace package already exists: <path>",
+    );
+    expect(
+      scrubReason('No Better-T-Stack project found in "customer-app". Make sure bts.jsonc exists.'),
+    ).toBe("No Better-T-Stack project found in <name>. Make sure bts.jsonc exists.");
+  });
+
   test("truncates very long reasons", () => {
     expect(scrubReason("x".repeat(400))).toHaveLength(160);
   });
@@ -100,7 +112,7 @@ describe("reportDiagnostic", () => {
     }) as typeof fetch;
 
     try {
-      await reportDiagnostic("cli_outdated", { installed: "3.40.5", latest: "3.41.0" });
+      await reportDiagnostic("mcp_session", { client: "test", clientVersion: "1.0.0" });
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/apps/cli/test/invocation-mode.test.ts
+++ b/apps/cli/test/invocation-mode.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { DEFAULT_CONFIG } from "../src/constants";
+import { buildAnalyticsEvent } from "../src/utils/analytics";
+import {
+  markPromptShown,
+  resolveInvocationMode,
+  runWithContext,
+  setProcessMode,
+} from "../src/utils/context";
+
+afterEach(() => {
+  setProcessMode(undefined);
+});
+
+describe("resolveInvocationMode", () => {
+  test("uses the mode the host declared when there is one", () => {
+    expect(runWithContext({ mode: "json" }, () => resolveInvocationMode(true))).toBe("json");
+    expect(runWithContext({ mode: "api" }, () => resolveInvocationMode(false))).toBe("api");
+  });
+
+  test("falls back to the process mode set by the MCP server", () => {
+    setProcessMode("mcp");
+    expect(runWithContext({}, () => resolveInvocationMode(false))).toBe("mcp");
+  });
+
+  test("derives yes, interactive, and flags from the run itself", () => {
+    expect(runWithContext({}, () => resolveInvocationMode(true))).toBe("yes");
+    expect(runWithContext({}, () => resolveInvocationMode(false))).toBe("flags");
+    expect(
+      runWithContext({}, () => {
+        markPromptShown();
+        return resolveInvocationMode(false);
+      }),
+    ).toBe("interactive");
+  });
+
+  test("is carried on the project event", () => {
+    const config = {
+      ...DEFAULT_CONFIG,
+      projectName: "probe",
+      projectDir: "/probe",
+      relativePath: "probe",
+    };
+    expect(buildAnalyticsEvent(config, "mcp").mode).toBe("mcp");
+    expect(buildAnalyticsEvent(config).mode).toBeUndefined();
+  });
+});

--- a/apps/cli/test/mcp.test.ts
+++ b/apps/cli/test/mcp.test.ts
@@ -1,9 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import path from "node:path";
 
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { Client, InMemoryTransport } from "@modelcontextprotocol/client";
+import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
 import fs from "fs-extra";
 
 import { create } from "../src/index";

--- a/apps/cli/test/telemetry.test.ts
+++ b/apps/cli/test/telemetry.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { isTelemetryEnabled } from "../src/utils/telemetry";
+
+const KEYS = ["DO_NOT_TRACK", "BTS_TELEMETRY_DISABLED", "BTS_TELEMETRY"] as const;
+const saved = Object.fromEntries(KEYS.map((key) => [key, process.env[key]]));
+
+function setEnv(values: Partial<Record<(typeof KEYS)[number], string>>) {
+  for (const key of KEYS) {
+    const value = values[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+afterEach(() => {
+  setEnv(saved);
+});
+
+describe("isTelemetryEnabled", () => {
+  test("honors DO_NOT_TRACK regardless of the project switches", () => {
+    setEnv({ DO_NOT_TRACK: "1", BTS_TELEMETRY: "1" });
+    expect(isTelemetryEnabled()).toBe(false);
+    setEnv({ DO_NOT_TRACK: "true", BTS_TELEMETRY_DISABLED: "0" });
+    expect(isTelemetryEnabled()).toBe(false);
+    setEnv({ DO_NOT_TRACK: "0", BTS_TELEMETRY: "1" });
+    expect(isTelemetryEnabled()).toBe(true);
+  });
+
+  test("keeps the existing BTS switches", () => {
+    setEnv({ BTS_TELEMETRY_DISABLED: "1" });
+    expect(isTelemetryEnabled()).toBe(false);
+    setEnv({ BTS_TELEMETRY: "0" });
+    expect(isTelemetryEnabled()).toBe(false);
+    setEnv({ BTS_TELEMETRY: "1" });
+    expect(isTelemetryEnabled()).toBe(true);
+    setEnv({});
+    expect(isTelemetryEnabled()).toBe(true);
+  });
+});

--- a/apps/cli/tsdown.config.ts
+++ b/apps/cli/tsdown.config.ts
@@ -13,5 +13,7 @@ export default defineConfig({
   env: {
     BTS_TELEMETRY: process.env.BTS_TELEMETRY || "0",
     CONVEX_INGEST_URL: process.env.CONVEX_INGEST_URL || "",
+    UMAMI_HOST_URL: process.env.UMAMI_HOST_URL || "https://umami.amanv.cloud",
+    UMAMI_CLI_WEBSITE_ID: process.env.UMAMI_CLI_WEBSITE_ID || "",
   },
 });

--- a/apps/web/content/docs/analytics.mdx
+++ b/apps/web/content/docs/analytics.mdx
@@ -9,6 +9,7 @@ On successful project creation, the CLI sends one anonymous event with:
 
 - Selected options (stack choices), including: `frontend`, `backend`, `runtime`, `database`, `orm`, `api`, `auth`, `payments`, `addons`, `examples`, `dbSetup`, `webDeploy`, `serverDeploy`, `packageManager`, `git`, `install`
 - Environment data: `cli_version`, `node_version`, `platform`
+- How the CLI was driven (`mode`): interactive prompts, flags, `--yes`, JSON output, the programmatic API, or the MCP server
 
 Not collected:
 
@@ -16,6 +17,18 @@ Not collected:
 - Nested addon or database provisioning options
 - Secrets or environment variables from your machine
 - IP addresses or persistent project/user identifiers
+
+## Diagnostic events
+
+Separately from the project-creation event, the CLI and its MCP server send a small number of anonymous diagnostic events to the same self-hosted Umami instance that powers the website analytics. They exist to catch problems the success event cannot show:
+
+- `cli_failed`: command, stage (`validate`, `scaffold`, `install`, `git`, `dbSetup`, `postInstall`), error class, and a scrubbed one-line reason with paths, URLs, emails, and quoted names replaced by placeholders
+- `cli_cancelled`: which prompt was open when a run was cancelled
+- `cli_command`: usage of commands other than `create` (`add`, `history`, `docs`, `sponsors`, `builder`), with outcome and a duration bucket
+- `cli_slow`: project creation or dependency installation that took longer than a minute, with a duration bucket and package manager
+- `mcp_session`, `mcp_tool`, `mcp_tool_error`: MCP client name and version, tool name, outcome, and duration bucket
+
+Umami derives coarse location (country, region, city) from the request IP and a session hash from IP and user agent that rotates monthly; the IP address itself is not stored. Diagnostic events never include project names, paths, file contents, or full error messages. The same `BTS_TELEMETRY_DISABLED=1` switch and `--disable-analytics` flag turn them off.
 
 ## Disable telemetry
 
@@ -44,13 +57,14 @@ Notes:
 
 ## Full transparency
 
-Single event per scaffold; no IP or project identifiers. See source code below.
+One project event per successful scaffold plus the diagnostic events listed above; no project identifiers. See source code below.
 
 If in doubt, set `BTS_TELEMETRY_DISABLED=1` and proceed. You can still use all CLI features.
 
 ## Source code
 
 - CLI event sender: [`apps/cli/src/utils/analytics.ts`](https://github.com/AmanVarshney01/create-better-t-stack/blob/main/apps/cli/src/utils/analytics.ts)
+- CLI diagnostic events: [`apps/cli/src/utils/diagnostics.ts`](https://github.com/AmanVarshney01/create-better-t-stack/blob/main/apps/cli/src/utils/diagnostics.ts)
 - Telemetry toggle logic: [`apps/cli/src/utils/telemetry.ts`](https://github.com/AmanVarshney01/create-better-t-stack/blob/main/apps/cli/src/utils/telemetry.ts)
 - Ingest endpoint: [`packages/backend/convex/http.ts`](https://github.com/AmanVarshney01/create-better-t-stack/blob/main/packages/backend/convex/http.ts)
 - Analytics backend (ingest + aggregation): [`packages/backend/convex/analytics.ts`](https://github.com/AmanVarshney01/create-better-t-stack/blob/main/packages/backend/convex/analytics.ts)

--- a/apps/web/content/docs/analytics.mdx
+++ b/apps/web/content/docs/analytics.mdx
@@ -28,7 +28,7 @@ Separately from the project-creation event, the CLI and its MCP server send a sm
 - `cli_slow`: project creation or dependency installation that took longer than a minute, with a duration bucket and package manager
 - `mcp_session`, `mcp_tool`, `mcp_tool_error`: MCP client name and version, tool name, outcome, and duration bucket
 
-Umami derives coarse location (country, region, city) from the request IP and a session hash from IP and user agent that rotates monthly; the IP address itself is not stored. Diagnostic events never include project names, paths, file contents, or full error messages. The same `BTS_TELEMETRY_DISABLED=1` switch and `--disable-analytics` flag turn them off.
+Umami derives coarse location (country, region, city) from the request IP and a session hash from IP and user agent that rotates monthly; the IP address itself is not stored. Diagnostic events never include project names, paths, file contents, or full error messages. The same `BTS_TELEMETRY_DISABLED=1` or `DO_NOT_TRACK=1` switch and the `--disable-analytics` flag turn them off.
 
 ## Disable telemetry
 
@@ -41,6 +41,8 @@ BTS_TELEMETRY_DISABLED=1 npx create-better-t-stack@latest
 <Callout title="Note">The above command disables it for a single run.</Callout>
 
 Add `export BTS_TELEMETRY_DISABLED=1` to your shell profile to make it permanent.
+
+The CLI also honors the cross-tool [`DO_NOT_TRACK=1`](https://consoledonottrack.com) convention, so one variable can turn off telemetry for every tool that supports it. The `--disable-analytics` flag skips it for a single run.
 
 ## Where to view analytics
 

--- a/apps/web/content/docs/faq.mdx
+++ b/apps/web/content/docs/faq.mdx
@@ -67,7 +67,7 @@ import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
  <Accordion 
     id="faq-10"
     title="How do I disable telemetry?">
-    Set `BTS_TELEMETRY_DISABLED=1` (shell env). For one run, prefix the command; to make it permanent, export it in your shell profile.
+    Set `BTS_TELEMETRY_DISABLED=1` (shell env). For one run, prefix the command; to make it permanent, export it in your shell profile. The cross-tool `DO_NOT_TRACK=1` convention is honored too.
  </Accordion>
 </Accordions>
 

--- a/apps/web/src/app/(home)/analytics/_components/dev-environment-charts.tsx
+++ b/apps/web/src/app/(home)/analytics/_components/dev-environment-charts.tsx
@@ -168,6 +168,17 @@ export function DevToolsSection({ data }: { data: AggregatedAnalyticsData }) {
         />
       </div>
 
+      {data.modeDistribution.length > 0 ? (
+        <PreferenceChartCard
+          title="How the CLI was driven"
+          description="Interactive prompts, flags, --yes, JSON output, the programmatic API, or the MCP server. Counted for runs that report it."
+          data={data.modeDistribution}
+          colorKey="chart2"
+          columnCount={3}
+          columnGridClassName="grid-cols-1 sm:grid-cols-3"
+        />
+      ) : null}
+
       <div
         className={cn(
           "grid gap-4",

--- a/apps/web/src/app/(home)/analytics/_components/live-logs.tsx
+++ b/apps/web/src/app/(home)/analytics/_components/live-logs.tsx
@@ -29,6 +29,7 @@ const LOG_FIELD_ORDER = [
   "cli_version",
   "node_version",
   "platform",
+  "mode",
   "git",
   "install",
 ] as const;

--- a/apps/web/src/app/(home)/analytics/_components/types.ts
+++ b/apps/web/src/app/(home)/analytics/_components/types.ts
@@ -83,6 +83,7 @@ export type AggregatedAnalyticsData = {
   cliVersionDistribution: VersionDistribution;
   stackCombinationDistribution: ShareDistributionItem[];
   databaseORMCombinationDistribution: ShareDistributionItem[];
+  modeDistribution: ShareDistributionItem[];
   summary: {
     mostPopularFrontend: string;
     mostPopularBackend: string;

--- a/apps/web/src/app/(home)/analytics/analytics-client.tsx
+++ b/apps/web/src/app/(home)/analytics/analytics-client.tsx
@@ -37,6 +37,7 @@ type PrecomputedStats = {
   hourlyDistribution: Record<string, number>;
   stackCombinations: Record<string, number>;
   dbOrmCombinations: Record<string, number>;
+  mode: Record<string, number>;
 };
 
 type DailyStats = { date: string; count: number };
@@ -177,6 +178,8 @@ function buildFromPrecomputed(
     recordToDistribution(stats.dbOrmCombinations),
     totalProjects,
   );
+  // Mode was added later, so shares are relative to events that carry it.
+  const modeDistribution = withShare(recordToDistribution(stats.mode));
 
   const timeSeries = buildTimeSeries(dailyStats);
   const monthlyTimeSeries = buildMonthlyTimeSeries(monthlyStats.monthly);
@@ -257,6 +260,7 @@ function buildFromPrecomputed(
     cliVersionDistribution,
     stackCombinationDistribution,
     databaseORMCombinationDistribution,
+    modeDistribution,
     summary: {
       mostPopularFrontend: getMostPopular(frontendDistribution),
       mostPopularBackend: getMostPopular(backendDistribution),
@@ -311,6 +315,7 @@ const emptyData: AggregatedAnalyticsData = {
   cliVersionDistribution: [],
   stackCombinationDistribution: [],
   databaseORMCombinationDistribution: [],
+  modeDistribution: [],
   summary: {
     mostPopularFrontend: "none",
     mostPopularBackend: "none",

--- a/apps/web/src/app/(home)/new/_components/preview-panel.tsx
+++ b/apps/web/src/app/(home)/new/_components/preview-panel.tsx
@@ -4,7 +4,7 @@ import { Loader2, FolderTree, FileCode2, Info, ChevronLeft } from "lucide-react"
 import { useEffect, useState, useCallback, useRef } from "react";
 
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
-import { track } from "@/lib/analytics";
+import { scrubMessage, track } from "@/lib/analytics";
 import type { StackState } from "@/lib/constant";
 import { cn } from "@/lib/utils";
 
@@ -97,14 +97,14 @@ export function PreviewPanel({ stack, selectedFilePath, onSelectFile }: PreviewP
       } else {
         const message = data.error || "Failed to generate preview";
         setError(message);
-        track("preview_error", { message });
+        track("preview_error", { message: scrubMessage(message) });
       }
     } catch (err) {
       if (controller.signal.aborted) return;
       if (requestId !== requestIdRef.current) return;
       const message = err instanceof Error ? err.message : "Failed to fetch preview";
       setError(message);
-      track("preview_error", { message });
+      track("preview_error", { message: scrubMessage(message) });
     } finally {
       if (requestId === requestIdRef.current) {
         setIsLoading(false);

--- a/apps/web/src/app/(home)/privacy/page.tsx
+++ b/apps/web/src/app/(home)/privacy/page.tsx
@@ -71,8 +71,10 @@ export default function PrivacyPage() {
           Disable CLI telemetry for one command with{" "}
           <code className="rounded bg-fd-muted px-1.5 py-0.5">--disable-analytics</code> or set{" "}
           <code className="rounded bg-fd-muted px-1.5 py-0.5">BTS_TELEMETRY_DISABLED=1</code>. The
-          environment variable can be added to a shell profile when telemetry should remain
-          disabled. Project generation continues to work when telemetry is off.
+          cross-tool <code className="rounded bg-fd-muted px-1.5 py-0.5">DO_NOT_TRACK=1</code>{" "}
+          convention is honored as well. Either variable can be added to a shell profile when
+          telemetry should remain disabled. Project generation continues to work when telemetry is
+          off.
         </p>
         <p>
           See the{" "}

--- a/apps/web/src/app/(home)/privacy/page.tsx
+++ b/apps/web/src/app/(home)/privacy/page.tsx
@@ -56,6 +56,14 @@ export default function PrivacyPage() {
           environment variables, nested provisioning options, IP addresses, and persistent user or
           project identifiers. Aggregate results are published on the analytics page.
         </p>
+        <p>
+          The CLI and its MCP server also send a small number of anonymous diagnostic events to the
+          same self-hosted Umami instance as the website: command failures with a stage and error
+          class, cancelled prompts, usage of commands other than create, slow stages, and MCP client
+          and tool names. Umami derives coarse location from the request IP and a session hash that
+          rotates monthly; the IP address itself is not stored. These events never include project
+          names, paths, or full error messages, and the same telemetry switch disables them.
+        </p>
       </TrustSection>
 
       <TrustSection title="CHOICES_AND_CONTROL">

--- a/apps/web/src/app/(home)/privacy/page.tsx
+++ b/apps/web/src/app/(home)/privacy/page.tsx
@@ -32,11 +32,11 @@ export default function PrivacyPage() {
           The website loads a self-hosted Umami analytics script to understand aggregate traffic,
           page usage, and anonymous interaction events such as which stack options are selected in
           the builder, which commands are copied, and which outbound links are followed. These
-          events do not include project names, personal information, or persistent identifiers. The
-          site also displays externally hosted content such as videos, social posts, images, and
-          sponsor information. Requests to those external services are governed by their own privacy
-          practices and may expose ordinary connection information such as an IP address, browser
-          headers, and the requested resource.
+          events do not include the names of projects you build, personal information, or persistent
+          identifiers. The site also displays externally hosted content such as videos, social
+          posts, images, and sponsor information. Requests to those external services are governed
+          by their own privacy practices and may expose ordinary connection information such as an
+          IP address, browser headers, and the requested resource.
         </p>
         <p>
           Better-T-Stack does not provide user accounts on this website and does not sell personal

--- a/apps/web/src/lib/agent-content.ts
+++ b/apps/web/src/lib/agent-content.ts
@@ -56,7 +56,7 @@ The analytics page publishes aggregate usage trends from successful CLI project 
 
 - [Analytics dashboard](${SITE_URL}/analytics)
 - [Analytics and telemetry documentation](${SITE_URL}/docs/analytics.mdx)
-- Disable CLI telemetry with \`BTS_TELEMETRY_DISABLED=1\` or \`--disable-analytics\`.`,
+- Disable CLI telemetry with \`BTS_TELEMETRY_DISABLED=1\`, \`DO_NOT_TRACK=1\`, or \`--disable-analytics\`.`,
   builder: `# Better-T-Stack browser builder
 
 Use the stack builder to choose a frontend, backend, runtime, database, ORM, API layer, authentication, deployment targets, and addons. It produces a reproducible \`create-better-t-stack\` command.
@@ -79,7 +79,7 @@ The website uses self-hosted Umami analytics. The CLI sends one telemetry event 
 
 - [Full privacy notice](${SITE_URL}/privacy)
 - [Analytics and telemetry details](${SITE_URL}/docs/analytics.mdx)
-- Disable CLI telemetry with \`BTS_TELEMETRY_DISABLED=1\` or \`--disable-analytics\`.`,
+- Disable CLI telemetry with \`BTS_TELEMETRY_DISABLED=1\`, \`DO_NOT_TRACK=1\`, or \`--disable-analytics\`.`,
   showcase: `# Better-T-Stack showcase
 
 Community projects generated with Better-T-Stack are listed on the showcase page. Each entry links to the submitted project and identifies its technologies.

--- a/apps/web/src/lib/agent-content.ts
+++ b/apps/web/src/lib/agent-content.ts
@@ -75,7 +75,7 @@ Use GitHub issues for reproducible bugs and feature requests. Include the CLI ve
 - [Documentation](${SITE_URL}/docs)`,
   privacy: `# Better-T-Stack privacy
 
-The website uses self-hosted Umami analytics and the CLI sends one telemetry event after successful project creation unless telemetry is disabled. The CLI payload does not include project names, paths, file contents, secrets, environment variables, IP addresses, or persistent user identifiers.
+The website uses self-hosted Umami analytics. The CLI sends one telemetry event after successful project creation (including how it was driven: prompts, flags, JSON, API, or MCP) plus a small number of anonymous diagnostic events for failures, cancellations, other commands, and MCP tool usage, unless telemetry is disabled. The CLI payloads do not include project names, paths, file contents, secrets, environment variables, or persistent user identifiers.
 
 - [Full privacy notice](${SITE_URL}/privacy)
 - [Analytics and telemetry details](${SITE_URL}/docs/analytics.mdx)

--- a/apps/web/src/lib/agent-content.ts
+++ b/apps/web/src/lib/agent-content.ts
@@ -75,7 +75,7 @@ Use GitHub issues for reproducible bugs and feature requests. Include the CLI ve
 - [Documentation](${SITE_URL}/docs)`,
   privacy: `# Better-T-Stack privacy
 
-The website uses self-hosted Umami analytics. The CLI sends one telemetry event after successful project creation (including how it was driven: prompts, flags, JSON, API, or MCP) plus a small number of anonymous diagnostic events for failures, cancellations, other commands, and MCP tool usage, unless telemetry is disabled. The CLI payloads do not include project names, paths, file contents, secrets, environment variables, or persistent user identifiers.
+The website uses self-hosted Umami analytics. The CLI sends one telemetry event after successful project creation (including how it was driven: prompts, flags, JSON, API, or MCP) plus a small number of anonymous diagnostic events for failures, cancellations, other commands, slow runs, and MCP client sessions and tool usage, unless telemetry is disabled. The CLI payloads do not include project names, paths, file contents, secrets, environment variables, or persistent user identifiers.
 
 - [Full privacy notice](${SITE_URL}/privacy)
 - [Analytics and telemetry details](${SITE_URL}/docs/analytics.mdx)

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -126,10 +126,27 @@ function getTracker() {
 
 function send(tracker: UmamiTracker, name: string, data: EventData) {
   try {
-    void tracker.track(name.slice(0, MAX_EVENT_NAME_LENGTH), normalizeEventData(data));
+    void Promise.resolve(
+      tracker.track(name.slice(0, MAX_EVENT_NAME_LENGTH), normalizeEventData(data)),
+    ).catch(() => undefined);
   } catch {
     // Analytics must never break the page.
   }
+}
+
+const MAX_MESSAGE_LENGTH = 160;
+
+/** Error text safe to send: paths, URLs, and quoted names replaced, first line only. */
+export function scrubMessage(message: string): string {
+  const firstLine = message.split(/\r?\n/, 1)[0] ?? "";
+  const scrubbed = firstLine
+    .replaceAll(/https?:\/\/[^\s)\]"'>]+/gi, "<url>")
+    .replaceAll(/(?:[a-zA-Z]:)?(?:[\\/][\w.@+ -]+)+[\\/][\w.@+-]+/g, "<path>")
+    .replaceAll(/\S*[\\/]\S*/g, "<path>")
+    .replaceAll(/(["'`])(?:(?!\1).)*\1/g, "<name>")
+    .replaceAll(/\s+/g, " ")
+    .trim();
+  return clampString(scrubbed.slice(0, MAX_MESSAGE_LENGTH));
 }
 
 export function trackRaw(name: string, data: EventData = {}) {
@@ -254,7 +271,8 @@ export function beforeSend(type: string, payload: UmamiPayload): UmamiPayload | 
   if (key === lastPageviewUrl) return false;
   lastPageviewUrl = key;
 
-  const next: UmamiPayload = { ...payload, url: url.toString() };
+  // Path form, matching what the tracker sends, so page reports stay continuous.
+  const next: UmamiPayload = { ...payload, url: key };
   if (payload.referrer) {
     try {
       next.referrer = normalizePageviewUrl(payload.referrer, url.origin).toString();

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -140,10 +140,10 @@ const MAX_MESSAGE_LENGTH = 160;
 export function scrubMessage(message: string): string {
   const firstLine = message.split(/\r?\n/, 1)[0] ?? "";
   const scrubbed = firstLine
-    .replaceAll(/https?:\/\/[^\s)\]"'>]+/gi, "<url>")
-    .replaceAll(/(?:[a-zA-Z]:)?(?:[\\/][\w.@+ -]+)+[\\/][\w.@+-]+/g, "<path>")
-    .replaceAll(/\S*[\\/]\S*/g, "<path>")
     .replaceAll(/(["'`])(?:(?!\1).)*\1/g, "<name>")
+    .replaceAll(/https?:\/\/[^\s)\]"'>]+/gi, "<url>")
+    .replaceAll(/(?:[a-zA-Z]:)?(?:[\\/][\w.@+ -]+)+[\\/][\w.@+-]+(?:[ \w.@+-]*\.\w+)?/g, "<path>")
+    .replaceAll(/\S*[\\/]\S*/g, "<path>")
     .replaceAll(/\s+/g, " ")
     .trim();
   return clampString(scrubbed.slice(0, MAX_MESSAGE_LENGTH));

--- a/apps/web/test/analytics.test.ts
+++ b/apps/web/test/analytics.test.ts
@@ -8,6 +8,7 @@ import {
   normalizeEventData,
   pendingEventCount,
   resetPageviewDedupe,
+  scrubMessage,
   stackSnapshot,
   track,
   trackAttrs,
@@ -40,10 +41,14 @@ afterEach(() => {
 describe("beforeSend", () => {
   test("strips the query string from builder pageviews and keeps it elsewhere", () => {
     const builder = beforeSend("event", { url: `${SITE}/new?fe-w=next&backend=hono` });
-    expect(builder).toEqual({ url: `${SITE}/new` });
+    expect(builder).toEqual({ url: "/new" });
 
     const docs = beforeSend("event", { url: `${SITE}/docs?utm_source=x#install` });
-    expect(docs).toEqual({ url: `${SITE}/docs?utm_source=x` });
+    expect(docs).toEqual({ url: "/docs?utm_source=x" });
+  });
+
+  test("keeps the path form the tracker sends", () => {
+    expect(beforeSend("event", { url: "/docs/cli?tab=1#x" })).toEqual({ url: "/docs/cli?tab=1" });
   });
 
   test("collapses repeated pageviews for the same normalized url", () => {
@@ -55,7 +60,7 @@ describe("beforeSend", () => {
 
   test("normalizes a same-site referrer that carried builder params", () => {
     const result = beforeSend("event", { url: `${SITE}/stack`, referrer: `${SITE}/new?a=1` });
-    expect(result).toEqual({ url: `${SITE}/stack`, referrer: `${SITE}/new` });
+    expect(result).toEqual({ url: "/stack", referrer: `${SITE}/new` });
   });
 
   test("passes custom events and identify payloads through untouched", () => {
@@ -91,6 +96,17 @@ describe("track", () => {
     expect(data.message).toHaveLength(MAX_STRING_LENGTH);
     expect(data.count).toBe(3);
     expect(data.enabled).toBe(true);
+  });
+});
+
+describe("scrubMessage", () => {
+  test("removes paths, urls, and quoted names from preview errors", () => {
+    expect(
+      scrubMessage(
+        `Template "apps/web/src/index.ts" failed at /Users/Jane Doe/work/app/file.ts (https://example.com/x)\nstack`,
+      ),
+    ).toBe("Template <name> failed at <path> (<url>)");
+    expect(scrubMessage("Cannot resolve packages/customer-name")).toBe("Cannot resolve <path>");
   });
 });
 

--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
         "@better-t-stack/types": "workspace:*",
         "@clack/core": "^1.4.3",
         "@clack/prompts": "^1.7.0",
-        "@modelcontextprotocol/sdk": "1.30.0",
+        "@modelcontextprotocol/server": "2.0.0",
         "@trpc/server": "^11.18.0",
         "better-result": "^3.0.0",
         "consola": "^3.4.2",
@@ -50,6 +50,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
+        "@modelcontextprotocol/client": "2.0.0",
         "@types/bun": "^1.3.14",
         "@types/fs-extra": "^11.0.4",
         "@types/node": "^26.1.2",
@@ -348,8 +349,6 @@
 
     "@fumadocs/tailwind": ["@fumadocs/tailwind@0.1.1", "", { "peerDependencies": { "tailwindcss": "^4.0.0" }, "optionalPeers": ["tailwindcss"] }, "sha512-BnPe52UxSaG8yKlHMKBxXw8h6GpK5qO55ci6+Qd5JnquTvIw6SpfbC1P+qAi82PuPWv1KZAWY8bxRk4+x9ctXw=="],
 
-    "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
-
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
     "@humanfs/node": ["@humanfs/node@0.16.7", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ=="],
@@ -452,7 +451,11 @@
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
-    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.30.0", "", { "dependencies": { "@hono/node-server": "^1.19.9 || ^2.0.5", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA=="],
+    "@modelcontextprotocol/client": ["@modelcontextprotocol/client@2.0.0", "", { "dependencies": { "@modelcontextprotocol/core": "2.0.0", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "jose": "^6.1.3", "pkce-challenge": "^5.0.0", "zod": "^4.2.0" } }, "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw=="],
+
+    "@modelcontextprotocol/core": ["@modelcontextprotocol/core@2.0.0", "", { "dependencies": { "zod": "^4.2.0" } }, "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA=="],
+
+    "@modelcontextprotocol/server": ["@modelcontextprotocol/server@2.0.0", "", { "dependencies": { "@modelcontextprotocol/core": "2.0.0", "zod": "^4.2.0" } }, "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.2.0", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^2.0.0-alpha.3", "@emnapi/runtime": "^2.0.0-alpha.3" } }, "sha512-kDoONqMa+VnZ4vvvu/ZUurpJ4gkZU57e7g69qpNgWhYcZFPUHZM2CEMKm+cG6ufDVALbjMvfmMjFVqaK7uEMnA=="],
 
@@ -1084,15 +1087,11 @@
 
     "JSONStream": ["JSONStream@1.3.5", "", { "dependencies": { "jsonparse": "^1.2.0", "through": ">=2.2.7 <3" }, "bin": { "JSONStream": "./bin.js" } }, "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ=="],
 
-    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
-
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
-    "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
-
-    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+    "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -1154,8 +1153,6 @@
 
     "binary-extensions": ["binary-extensions@3.1.0", "", {}, "sha512-Jvvd9hy1w+xUad8+ckQsWA/V1AoyubOvqn0aygjMOVM4BfIaRav1NFS3LsTSDaV4n4FtcCtQXvzep1E6MboqwQ=="],
 
-    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
-
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
 
     "bottleneck": ["bottleneck@2.19.5", "", {}, "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="],
@@ -1169,8 +1166,6 @@
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
-
-    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
     "c12": ["c12@3.3.3", "", { "dependencies": { "chokidar": "^5.0.0", "confbox": "^0.2.2", "defu": "^6.1.4", "dotenv": "^17.2.3", "exsolve": "^1.0.8", "giget": "^2.0.0", "jiti": "^2.6.1", "ohash": "^2.0.11", "pathe": "^2.0.3", "perfect-debounce": "^2.0.0", "pkg-types": "^2.3.0", "rc9": "^2.1.2" }, "peerDependencies": { "magicast": "*" }, "optionalPeers": ["magicast"] }, "sha512-750hTRvgBy5kcMNPdh95Qo+XUBeGo8C7nsKSmedDmaQI+E0r82DwHeM6vBewDe4rGFbnxoa4V9pw+sPh5+Iz8Q=="],
 
@@ -1252,10 +1247,6 @@
 
     "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
 
-    "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
-
-    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
-
     "convert-gitmoji": ["convert-gitmoji@0.1.5", "", {}, "sha512-4wqOafJdk2tqZC++cjcbGcaJ13BZ3kwldf06PTiAQRAB76Z1KJwZNL1SaRZMi2w1FM9RYTgZ6QErS8NUl/GBmQ=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
@@ -1263,12 +1254,6 @@
     "convex": ["convex@1.43.0", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0", "ws": "8.21.0" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "@clerk/react": "^6.4.3", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "@clerk/react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-huZWEUZQYxIRG104o22ZI99HkviSEVltwezZRDi+pQDPrQbc5EoCPa4Y7pJDqUBQw9dc/iEEXj2/rLZg1j7Dww=="],
 
     "convex-helpers": ["convex-helpers@0.1.120", "", { "peerDependencies": { "@standard-schema/spec": "^1.0.0", "convex": "^1.32.0", "hono": "^4.0.5", "react": "^17.0.2 || ^18.0.0 || ^19.0.0", "typescript": "^5.5 || ^6.0.0", "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["@standard-schema/spec", "hono", "react", "typescript", "zod"], "bin": { "convex-helpers": "bin.cjs" } }, "sha512-FPqtmN/10uoxmmhVq0ViNi08AnmHKT/eU1R8+ohmPZoHfg8noZEZCltApY/ASDdhq92o0kLZETggzBvMfHJDLQ=="],
-
-    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
-
-    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
-
-    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
     "create-better-t-stack": ["create-better-t-stack@workspace:apps/cli"],
 
@@ -1348,8 +1333,6 @@
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
-    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
-
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
     "destr": ["destr@2.0.5", "", {}, "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA=="],
@@ -1380,15 +1363,11 @@
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
-    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
-
     "electron-to-chromium": ["electron-to-chromium@1.5.307", "", {}, "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg=="],
 
     "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
     "empathic": ["empathic@2.0.1", "", {}, "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q=="],
-
-    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "encoding-sniffer": ["encoding-sniffer@0.2.1", "", { "dependencies": { "iconv-lite": "^0.6.3", "whatwg-encoding": "^3.1.1" } }, "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw=="],
 
@@ -1423,8 +1402,6 @@
     "esbuild": ["esbuild@0.27.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.0", "@esbuild/android-arm": "0.27.0", "@esbuild/android-arm64": "0.27.0", "@esbuild/android-x64": "0.27.0", "@esbuild/darwin-arm64": "0.27.0", "@esbuild/darwin-x64": "0.27.0", "@esbuild/freebsd-arm64": "0.27.0", "@esbuild/freebsd-x64": "0.27.0", "@esbuild/linux-arm": "0.27.0", "@esbuild/linux-arm64": "0.27.0", "@esbuild/linux-ia32": "0.27.0", "@esbuild/linux-loong64": "0.27.0", "@esbuild/linux-mips64el": "0.27.0", "@esbuild/linux-ppc64": "0.27.0", "@esbuild/linux-riscv64": "0.27.0", "@esbuild/linux-s390x": "0.27.0", "@esbuild/linux-x64": "0.27.0", "@esbuild/netbsd-arm64": "0.27.0", "@esbuild/netbsd-x64": "0.27.0", "@esbuild/openbsd-arm64": "0.27.0", "@esbuild/openbsd-x64": "0.27.0", "@esbuild/openharmony-arm64": "0.27.0", "@esbuild/sunos-x64": "0.27.0", "@esbuild/win32-arm64": "0.27.0", "@esbuild/win32-ia32": "0.27.0", "@esbuild/win32-x64": "0.27.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
-
-    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
@@ -1478,19 +1455,13 @@
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
-    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
-
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
-    "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
+    "eventsource-parser": ["eventsource-parser@3.1.1", "", {}, "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ=="],
 
     "execa": ["execa@10.0.0", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "figures": "^6.1.0", "get-stream": "^9.0.1", "human-signals": "^8.0.1", "is-plain-obj": "^4.1.0", "is-stream": "^4.0.1", "npm-run-path": "^6.0.0", "path-key": "^4.0.0", "pretty-ms": "^9.3.0", "signal-exit": "^4.1.0", "strip-final-newline": "^4.0.0", "which-command": "^0.1.0", "yoctocolors": "^2.1.2" } }, "sha512-Cxl6MKxB1dr1H0FHmiizJ+lavKF7pV+fcDZFyqMB8d5m7qUPm/OtZYcD5vPWePKxSnTQ57KuBd9mtdZ3oNCvyQ=="],
-
-    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
-
-    "express-rate-limit": ["express-rate-limit@8.3.0", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-KJzBawY6fB9FiZGdE/0aftepZ91YlaGIrV8vgblRM3J8X+dHx/aiowJWwkx6LIGyuqGiANsjSwwrbb8mifOJ4Q=="],
 
     "exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
 
@@ -1510,8 +1481,6 @@
 
     "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
 
-    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
-
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.0", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w=="],
 
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
@@ -1523,8 +1492,6 @@
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
-
-    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
@@ -1538,11 +1505,7 @@
 
     "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
-    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
-
     "framer-motion": ["framer-motion@11.18.2", "", { "dependencies": { "motion-dom": "^11.18.1", "motion-utils": "^11.18.1", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w=="],
-
-    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "fs-extra": ["fs-extra@11.4.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA=="],
 
@@ -1640,21 +1603,17 @@
 
     "hermes-parser": ["hermes-parser@0.25.1", "", { "dependencies": { "hermes-estree": "0.25.1" } }, "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="],
 
-    "hono": ["hono@4.12.5", "", {}, "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg=="],
-
     "hookable": ["hookable@6.1.1", "", {}, "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ=="],
 
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
     "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
 
-    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
-
     "human-signals": ["human-signals@8.0.1", "", {}, "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ=="],
 
     "hyperdyperid": ["hyperdyperid@1.2.0", "", {}, "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A=="],
 
-    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
@@ -1666,17 +1625,11 @@
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
-    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
-
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
 
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
 
     "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
-
-    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
-
-    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
 
@@ -1734,8 +1687,6 @@
 
     "is-plain-object": ["is-plain-object@2.0.4", "", { "dependencies": { "isobject": "^3.0.1" } }, "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og=="],
 
-    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
-
     "is-regex": ["is-regex@1.2.1", "", { "dependencies": { "call-bound": "^1.0.2", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g=="],
 
     "is-safe-filename": ["is-safe-filename@0.1.1", "", {}, "sha512-4SrR7AdnY11LHfDKTZY1u6Ga3RuxZdl3YKWWShO5iyuG5h8QS4GD2tOb04peBJ5I7pXbR+CGBNEhTcwK+FzN3g=="],
@@ -1772,7 +1723,7 @@
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
-    "jose": ["jose@6.2.0", "", {}, "sha512-xsfE1TcSCbUdo6U07tR0mvhg0flGxU8tPLbF03mirl2ukGQENhUg4ubGYQnhVH0b5stLlPM+WOqDkEl1R1y5sQ=="],
+    "jose": ["jose@6.2.10", "", {}, "sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -1782,9 +1733,7 @@
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
-    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
-    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
@@ -1914,11 +1863,7 @@
 
     "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
 
-    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
-
     "memfs": ["memfs@4.64.0", "", { "dependencies": { "@jsonjoy.com/fs-core": "4.64.0", "@jsonjoy.com/fs-fsa": "4.64.0", "@jsonjoy.com/fs-node": "4.64.0", "@jsonjoy.com/fs-node-builtins": "4.64.0", "@jsonjoy.com/fs-node-to-fsa": "4.64.0", "@jsonjoy.com/fs-node-utils": "4.64.0", "@jsonjoy.com/fs-print": "4.64.0", "@jsonjoy.com/fs-snapshot": "4.64.0", "@jsonjoy.com/json-pack": "^1.11.0", "@jsonjoy.com/util": "^1.9.0", "glob-to-regex.js": "^1.0.1", "thingies": "^2.5.0", "tree-dump": "^1.0.3", "tslib": "^2.0.0" } }, "sha512-Kw72fgY7Wn+sD8KmtNWSafl1dz0UvAsE/PHs3YVfLiaZuA3HxNm9sRLqAu0ATiBGJvME1PxZXbBZPv5GycDeAw=="],
-
-    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
@@ -1994,9 +1939,9 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
-    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
-    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
@@ -2029,8 +1974,6 @@
     "napi-postinstall": ["napi-postinstall@0.3.4", "", { "bin": { "napi-postinstall": "lib/cli.js" } }, "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
-
-    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
 
@@ -2088,10 +2031,6 @@
 
     "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
 
-    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
-
-    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
-
     "oniguruma-parser": ["oniguruma-parser@0.12.2", "", {}, "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw=="],
 
     "oniguruma-to-es": ["oniguruma-to-es@4.3.6", "", { "dependencies": { "oniguruma-parser": "^0.12.2", "regex": "^6.1.0", "regex-recursion": "^6.0.2" } }, "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA=="],
@@ -2130,8 +2069,6 @@
 
     "parse5-parser-stream": ["parse5-parser-stream@7.1.2", "", { "dependencies": { "parse5": "^7.0.0" } }, "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow=="],
 
-    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
-
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
@@ -2139,8 +2076,6 @@
     "path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
-
-    "path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
@@ -2170,8 +2105,6 @@
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
-    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
-
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "publint": ["publint@0.3.22", "", { "dependencies": { "@publint/pack": "^0.1.6", "package-manager-detector": "^1.7.0", "picocolors": "^1.1.1", "sade": "^1.8.1" }, "bin": { "publint": "./src/cli.js" } }, "sha512-6Z/scsr5CA7APdwyF35EY88CqgDj1textWuY788DVTJYPCWVv/Wn9G6KmLnrVRnStgYcahqN4wCDLZGSbQJ69w=="],
@@ -2187,10 +2120,6 @@
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
     "radix-ui": ["radix-ui@1.6.7", "", { "dependencies": { "@radix-ui/primitive": "1.1.7", "@radix-ui/react-accessible-icon": "1.1.15", "@radix-ui/react-accordion": "1.2.20", "@radix-ui/react-alert-dialog": "1.1.23", "@radix-ui/react-arrow": "1.1.15", "@radix-ui/react-aspect-ratio": "1.1.15", "@radix-ui/react-avatar": "1.2.6", "@radix-ui/react-checkbox": "1.3.11", "@radix-ui/react-collapsible": "1.1.20", "@radix-ui/react-collection": "1.1.15", "@radix-ui/react-compose-refs": "1.1.5", "@radix-ui/react-context": "1.2.2", "@radix-ui/react-context-menu": "2.3.7", "@radix-ui/react-dialog": "1.1.23", "@radix-ui/react-direction": "1.1.4", "@radix-ui/react-dismissable-layer": "1.1.19", "@radix-ui/react-dropdown-menu": "2.1.24", "@radix-ui/react-focus-guards": "1.1.6", "@radix-ui/react-focus-scope": "1.1.16", "@radix-ui/react-form": "0.1.16", "@radix-ui/react-hover-card": "1.1.23", "@radix-ui/react-label": "2.1.15", "@radix-ui/react-menu": "2.1.24", "@radix-ui/react-menubar": "1.1.24", "@radix-ui/react-navigation-menu": "1.2.22", "@radix-ui/react-one-time-password-field": "0.1.16", "@radix-ui/react-password-toggle-field": "0.1.11", "@radix-ui/react-popover": "1.1.23", "@radix-ui/react-popper": "1.3.7", "@radix-ui/react-portal": "1.1.17", "@radix-ui/react-presence": "1.1.10", "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-progress": "1.1.16", "@radix-ui/react-radio-group": "1.4.7", "@radix-ui/react-roving-focus": "1.1.19", "@radix-ui/react-scroll-area": "1.2.18", "@radix-ui/react-select": "2.3.7", "@radix-ui/react-separator": "1.1.15", "@radix-ui/react-slider": "1.4.7", "@radix-ui/react-slot": "1.3.3", "@radix-ui/react-switch": "1.3.7", "@radix-ui/react-tabs": "1.1.21", "@radix-ui/react-toast": "1.2.23", "@radix-ui/react-toggle": "1.1.18", "@radix-ui/react-toggle-group": "1.1.19", "@radix-ui/react-toolbar": "1.1.19", "@radix-ui/react-tooltip": "1.2.16", "@radix-ui/react-use-callback-ref": "1.1.4", "@radix-ui/react-use-controllable-state": "1.2.6", "@radix-ui/react-use-effect-event": "0.0.5", "@radix-ui/react-use-escape-keydown": "1.1.5", "@radix-ui/react-use-is-hydrated": "0.1.3", "@radix-ui/react-use-layout-effect": "1.1.4", "@radix-ui/react-use-size": "1.1.4", "@radix-ui/react-visually-hidden": "1.2.11" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-QBdhh1arIEUvPC0dQ5+nwWAxt7+N+oP/9jPwjJkGFoSk/sqxg32gJtSXGtFh8frAIcS6oC9cx2Q+7KYCQLOAeA=="],
-
-    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
-
-    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "rc9": ["rc9@2.1.2", "", { "dependencies": { "defu": "^6.1.4", "destr": "^2.0.3" } }, "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg=="],
 
@@ -2258,8 +2187,6 @@
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
-    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
-
     "require-main-filename": ["require-main-filename@2.0.0", "", {}, "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="],
 
     "reselect": ["reselect@5.2.0", "", {}, "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw=="],
@@ -2277,8 +2204,6 @@
     "rolldown": ["rolldown@1.2.0", "", { "dependencies": { "@oxc-project/types": "=0.140.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.2.0", "@rolldown/binding-darwin-arm64": "1.2.0", "@rolldown/binding-darwin-x64": "1.2.0", "@rolldown/binding-freebsd-x64": "1.2.0", "@rolldown/binding-linux-arm-gnueabihf": "1.2.0", "@rolldown/binding-linux-arm64-gnu": "1.2.0", "@rolldown/binding-linux-arm64-musl": "1.2.0", "@rolldown/binding-linux-ppc64-gnu": "1.2.0", "@rolldown/binding-linux-s390x-gnu": "1.2.0", "@rolldown/binding-linux-x64-gnu": "1.2.0", "@rolldown/binding-linux-x64-musl": "1.2.0", "@rolldown/binding-openharmony-arm64": "1.2.0", "@rolldown/binding-wasm32-wasi": "1.2.0", "@rolldown/binding-win32-arm64-msvc": "1.2.0", "@rolldown/binding-win32-x64-msvc": "1.2.0" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-u7tgm5l4Yw1iTqUL4EcYOAt7fFvCgQMLeidrnD4GALlC6aOznCjezYajgxeyKw27u0Q5N7fwgCzjVyPIWzwuBA=="],
 
     "rolldown-plugin-dts": ["rolldown-plugin-dts@0.27.14", "", { "dependencies": { "dts-resolver": "^3.0.0", "get-tsconfig": "5.0.0-beta.5", "obug": "^2.1.4", "yuku-ast": "^0.8.0", "yuku-codegen": "^0.8.0", "yuku-parser": "^0.8.0" }, "peerDependencies": { "@typescript/native-preview": "*", "@volar/typescript": "~2.4.0", "rolldown": "^1.0.0", "typescript": "^5.0.0 || ^6.0.0 || ~7.0.0", "vue-tsc": "~3.2.0 || ~3.3.0" }, "optionalPeers": ["@typescript/native-preview", "@volar/typescript", "typescript", "vue-tsc"] }, "sha512-ZvuDDwoIpRK9RPxDXratCpklFO9QZZWndf/sd0VBFb4LEj0jj07UcHK9OCh7V4XiFz2Z89ziyBC2K6tJiDjrbw=="],
-
-    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
     "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
 
@@ -2302,10 +2227,6 @@
 
     "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
-    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
-
-    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
-
     "set-blocking": ["set-blocking@2.0.0", "", {}, "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="],
 
     "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
@@ -2315,8 +2236,6 @@
     "set-getter": ["set-getter@0.1.1", "", { "dependencies": { "to-object-path": "^0.3.0" } }, "sha512-9sVWOy+gthr+0G9DzqqLaYNA7+5OKkSmcqjL9cBpDEaZrr3ShQlyX2cZ/O/ozE41oxn/Tt0LGEM/w4Rub3A3gw=="],
 
     "set-proto": ["set-proto@1.0.0", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0" } }, "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw=="],
-
-    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
     "shallow-clone": ["shallow-clone@3.0.1", "", { "dependencies": { "kind-of": "^6.0.2" } }, "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA=="],
 
@@ -2349,8 +2268,6 @@
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
 
     "stable-hash": ["stable-hash@0.0.5", "", {}, "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA=="],
-
-    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
@@ -2424,8 +2341,6 @@
 
     "toad-cache": ["toad-cache@3.7.0", "", {}, "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw=="],
 
-    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
-
     "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
     "tree-dump": ["tree-dump@1.1.0", "", { "peerDependencies": { "tslib": "2" } }, "sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA=="],
@@ -2453,8 +2368,6 @@
     "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
-
-    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
     "typed-array-buffer": ["typed-array-buffer@1.0.3", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-typed-array": "^1.1.14" } }, "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw=="],
 
@@ -2504,8 +2417,6 @@
 
     "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
 
-    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
-
     "unrs-resolver": ["unrs-resolver@1.11.1", "", { "dependencies": { "napi-postinstall": "^0.3.0" }, "optionalDependencies": { "@unrs/resolver-binding-android-arm-eabi": "1.11.1", "@unrs/resolver-binding-android-arm64": "1.11.1", "@unrs/resolver-binding-darwin-arm64": "1.11.1", "@unrs/resolver-binding-darwin-x64": "1.11.1", "@unrs/resolver-binding-freebsd-x64": "1.11.1", "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1", "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1", "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1", "@unrs/resolver-binding-linux-arm64-musl": "1.11.1", "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1", "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-musl": "1.11.1", "@unrs/resolver-binding-wasm32-wasi": "1.11.1", "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1", "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1", "@unrs/resolver-binding-win32-x64-msvc": "1.11.1" } }, "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
@@ -2517,8 +2428,6 @@
     "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
-
-    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "verkit": ["verkit@0.3.1", "", {}, "sha512-w2Eo8LSIIoW7qxNBzT7/17k+bh8plXo7G3dHjEIDqPlnluhzaxr9JX8F28VSYEtDvc1/a3WBDih6xNUZseebXg=="],
 
@@ -2562,8 +2471,6 @@
 
     "wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
-    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
-
     "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
@@ -2592,8 +2499,6 @@
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
-    "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
-
     "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
@@ -2609,8 +2514,6 @@
     "@erquhart/convex-oss-stats/date-fns": ["date-fns@4.1.0", "", {}, "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
-
-    "@eslint/eslintrc/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 
@@ -2722,10 +2625,6 @@
 
     "d3-scale/d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
 
-    "encoding-sniffer/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
-
-    "eslint/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
-
     "eslint/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "eslint-import-resolver-node/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
@@ -2749,8 +2648,6 @@
     "estree-util-to-js/source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
-
-    "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "fs-minipass/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
@@ -2808,8 +2705,6 @@
 
     "victory-vendor/@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
 
-    "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
-
     "yargs/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
     "yuku-analyzer/yuku-ast": ["yuku-ast@0.6.11", "", { "dependencies": { "@yuku-toolchain/types": "0.6.8" } }, "sha512-ZfXkFYVsDewS45+kv3WiA/qNB73CRfxFDEQwfnRMUAR4AD5zRI7PRqxmI2U3Jz/oG41GneTVW6mxDOQal0lgeA=="],
@@ -2819,8 +2714,6 @@
     "yuku-codegen/@yuku-toolchain/types": ["@yuku-toolchain/types@0.8.1", "", {}, "sha512-HcGEV3kOn9evBTm2ARYOFNKAI7sY9twQozCVd9EVdlsBlnKi0a2iv8xXxYVHFCBQpX3SvvPXBhk8lcK6NUTdNg=="],
 
     "yuku-parser/@yuku-toolchain/types": ["@yuku-toolchain/types@0.8.1", "", {}, "sha512-HcGEV3kOn9evBTm2ARYOFNKAI7sY9twQozCVd9EVdlsBlnKi0a2iv8xXxYVHFCBQpX3SvvPXBhk8lcK6NUTdNg=="],
-
-    "@eslint/eslintrc/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "@jsonjoy.com/fs-snapshot/@jsonjoy.com/json-pack/@jsonjoy.com/base64": ["@jsonjoy.com/base64@17.67.0", "", { "peerDependencies": { "tslib": "2" } }, "sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw=="],
 
@@ -2881,10 +2774,6 @@
     "changelogithub/tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "eslint-import-resolver-typescript/tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
-
-    "eslint/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
-
-    "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "fumadocs-mdx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
 

--- a/packages/backend/convex/analytics.ts
+++ b/packages/backend/convex/analytics.ts
@@ -45,12 +45,14 @@ function normalizeStats(stats: {
   hourlyDistribution?: Record<string, number>;
   stackCombinations?: Record<string, number>;
   dbOrmCombinations?: Record<string, number>;
+  mode?: Record<string, number>;
 }): AnalyticsStatsFields {
   return {
     ...stats,
     hourlyDistribution: stats.hourlyDistribution || {},
     stackCombinations: stats.stackCombinations || {},
     dbOrmCombinations: stats.dbOrmCombinations || {},
+    mode: stats.mode || {},
   };
 }
 
@@ -75,6 +77,7 @@ export const ingestEvent = internalMutation({
     cli_version: v.string(),
     node_version: v.string(),
     platform: v.string(),
+    mode: v.optional(v.string()),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
@@ -145,6 +148,7 @@ export const getStats = query({
       hourlyDistribution: distributionValidator,
       stackCombinations: distributionValidator,
       dbOrmCombinations: distributionValidator,
+      mode: distributionValidator,
     }),
     v.null(),
   ),
@@ -176,6 +180,7 @@ export const getStats = query({
       hourlyDistribution: stats.hourlyDistribution || {},
       stackCombinations: stats.stackCombinations || {},
       dbOrmCombinations: stats.dbOrmCombinations || {},
+      mode: stats.mode || {},
     };
   },
 });
@@ -284,6 +289,7 @@ export const getRecentEvents = query({
       cli_version: v.optional(v.string()),
       node_version: v.optional(v.string()),
       platform: v.optional(v.string()),
+      mode: v.optional(v.string()),
     }),
   ),
   handler: async (ctx, args) => {

--- a/packages/backend/convex/analytics_helpers.ts
+++ b/packages/backend/convex/analytics_helpers.ts
@@ -29,6 +29,7 @@ export type AnalyticsStatsFields = {
   hourlyDistribution: Record<string, number>;
   stackCombinations: Record<string, number>;
   dbOrmCombinations: Record<string, number>;
+  mode: Record<string, number>;
 };
 
 export type AnalyticsEventFields = {
@@ -51,6 +52,7 @@ export type AnalyticsEventFields = {
   cli_version?: string;
   node_version?: string;
   platform?: string;
+  mode?: string;
 };
 
 export type TimestampedAnalyticsEvent = {
@@ -81,6 +83,7 @@ const DISTRIBUTION_FIELDS = [
   "hourlyDistribution",
   "stackCombinations",
   "dbOrmCombinations",
+  "mode",
 ] as const satisfies ReadonlyArray<keyof AnalyticsStatsFields>;
 
 type DistributionField = (typeof DISTRIBUTION_FIELDS)[number];
@@ -111,6 +114,7 @@ export function createEmptyAnalyticsStats(): AnalyticsStatsFields {
     hourlyDistribution: {},
     stackCombinations: {},
     dbOrmCombinations: {},
+    mode: {},
   };
 }
 
@@ -227,6 +231,7 @@ export function adjustAnalyticsStats(
     adjustKey(next, "hourlyDistribution", hourKey, delta);
     adjustKey(next, "stackCombinations", `${backend} + ${frontend}`, delta);
     adjustKey(next, "dbOrmCombinations", `${database} + ${orm}`, delta);
+    adjustKey(next, "mode", event.mode, delta);
   }
 
   next.totalProjects = Math.max(next.totalProjects, 0);

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -42,6 +42,7 @@ export default defineSchema({
     cli_version: v.optional(v.string()),
     node_version: v.optional(v.string()),
     platform: v.optional(v.string()),
+    mode: v.optional(v.string()),
     quarantinedAt: v.optional(v.number()),
     quarantineReason: v.optional(v.literal("invalid_payload")),
   }).index("by_quarantined", ["quarantinedAt"]),
@@ -71,6 +72,7 @@ export default defineSchema({
     hourlyDistribution: v.optional(distributionValidator),
     stackCombinations: v.optional(distributionValidator),
     dbOrmCombinations: v.optional(distributionValidator),
+    mode: v.optional(distributionValidator),
   }),
 
   analyticsDailyStats: defineTable({

--- a/packages/backend/test/analytics-helpers.test.ts
+++ b/packages/backend/test/analytics-helpers.test.ts
@@ -61,6 +61,21 @@ describe("adjustAnalyticsStats", () => {
     expect(stats.stackCombinations).toEqual({ "hono + none": 1 });
   });
 
+  test("counts the invocation mode only when an event reports it", () => {
+    const stats = adjustAnalyticsStats(
+      createEmptyAnalyticsStats(),
+      [
+        { event: { ...legitimateEvent, mode: "mcp" }, creationTime: Date.UTC(2026, 7, 10, 4) },
+        { event: { ...legitimateEvent, mode: "mcp" }, creationTime: Date.UTC(2026, 7, 10, 5) },
+        { event: legitimateEvent, creationTime: Date.UTC(2026, 7, 10, 6) },
+      ],
+      1,
+    );
+
+    expect(stats.totalProjects).toBe(3);
+    expect(stats.mode).toEqual({ mcp: 2 });
+  });
+
   test("normalizes version keys during ingestion", () => {
     const stats = adjustAnalyticsStats(
       createEmptyAnalyticsStats(),

--- a/packages/types/src/analytics.ts
+++ b/packages/types/src/analytics.ts
@@ -42,8 +42,13 @@ export const ANALYTICS_CLI_MAX_PATCH = 99;
 export const ANALYTICS_NODE_MIN_MAJOR = 18;
 export const ANALYTICS_NODE_MAX_MAJOR = 30;
 
+/** How the CLI was driven for the run that produced the event. */
+export const ANALYTICS_MODE_VALUES = ["interactive", "flags", "yes", "json", "api", "mcp"] as const;
+
 export const AnalyticsAddonSchema = z.enum(ANALYTICS_ADDON_VALUES);
 export const AnalyticsPlatformSchema = z.enum(ANALYTICS_PLATFORM_VALUES);
+export const AnalyticsModeSchema = z.enum(ANALYTICS_MODE_VALUES);
+export type AnalyticsMode = z.infer<typeof AnalyticsModeSchema>;
 
 const CLIVersionSchema = z
   .string()
@@ -149,6 +154,7 @@ export const AnalyticsEventSchema = z.object({
   cli_version: CLIVersionSchema,
   node_version: NodeVersionSchema,
   platform: AnalyticsPlatformSchema,
+  mode: AnalyticsModeSchema.optional(),
 });
 
 export type AnalyticsEvent = z.infer<typeof AnalyticsEventSchema>;


### PR DESCRIPTION
## Summary

Three related changes in one PR: the MCP SDK v2 upgrade, MCP project creations counted in the Convex dataset, and a Umami diagnostics channel for the CLI and MCP server.

### MCP SDK v2 (spec 2026-07-28)
- `@modelcontextprotocol/sdk@1.30.0` (frozen v1 line, protocol `2025-11-25`) → `@modelcontextprotocol/server@2.0.0` (+ `client` for tests). The dependency tree drops express/hono/cors/ajv 8 etc.
- `startBtsMcpServer` uses `serveStdio(factory)`, the opt-in for the 2026-07-28 wire. Verified against the built `dist/cli.mjs`: raw `server/discover` with the 2026 `_meta` envelope returns `supportedVersions: ["2026-07-28"]`; 2026 `tools/list` returns `resultType`, `ttlMs: 3600000`, `cacheScope: "public"`; a raw legacy `initialize` still negotiates `2025-06-18`; a v1 SDK 1.30.0 client (what Claude Code, Cursor etc. use today) and a v2 client both list and call tools.
- Removed the deprecated `logging` capability (never used). Tool registrations were already the v2 shape.

### Convex project analytics
- New optional `mode` on the event: `interactive | flags | yes | json | api | mcp`. Derived from the CLI context: hosts that know set it (JSON commands, programmatic API, MCP); otherwise `yes` / `interactive` (a prompt was rendered) / `flags`. Added to the zod schema, Convex schema, ingest args, aggregates (`analyticsStats.mode`), `getStats`, the live feed, and a "How the CLI was driven" chart on `/analytics`. Old events without `mode` are simply not counted in that distribution.
- `bts_create_project` no longer hard-codes `disableAnalytics: true` (since #939), so MCP-created projects now count, tagged `mode: "mcp"`. `bts_plan_project` (dry run) stays untracked.
- Ingest request gets a 3s `AbortSignal.timeout` and `keepalive` so a slow endpoint cannot hang the CLI before the outro.

### Umami diagnostics (`apps/cli/src/utils/diagnostics.ts`)
Sent to a separate "CLI" website on the self-hosted Umami via `POST /api/send` (the documented server-side path). Everything is a no-op until `UMAMI_CLI_WEBSITE_ID` is baked at build time (`tsdown` env + `release.yaml` secret), so this can merge before the website exists in Umami.

| Event | Properties |
|---|---|
| `cli_failed` | command, mode, stage (from `ProjectCreationError.phase` / error type), error class, scrubbed reason, packageManager, backend |
| `cli_cancelled` | command, mode, prompt that was open (plumbed from `navigableGroup` into `UserCancelledError.prompt`) |
| `cli_command` | add / history / docs / sponsors / builder with ok + duration bucket |
| `cli_slow` | create or install over 60s, duration bucket, packageManager |
| `mcp_session` | MCP client name and version, once per connection |
| `mcp_tool`, `mcp_tool_error` | tool, ok, duration bucket; scrubbed reason on failure |

- Umami's `isbot` filter rejects `node`/`Bun` user agents, so requests use `Mozilla/5.0 (compatible; create-better-t-stack/<version>)` (verified with the `isbot` package).
- `scrubReason` replaces paths, URLs, emails, and quoted names with placeholders and keeps the first line only.
- Same opt-out as the project event (`BTS_TELEMETRY_DISABLED=1`, `--disable-analytics`). Diagnostics are awaited on CLI exit paths so they beat `process.exit(1)`, and fire-and-forget inside the long-lived MCP server.
- Privacy page and `docs/analytics.mdx` disclose the events and Umami's coarse IP geolocation / monthly session hash.

## Testing
- `bun run check`, `tsc` for cli (only the pre-existing `database-setup.ts` error), web, and backend all clean.
- CLI: 704 tests pass (18 MCP incl. real stdio spawn, 8 new diagnostics, 4 new invocation-mode); web: 65; backend: 4 (new `mode` aggregation test).
- End-to-end with the CLI built against a local capture server for both endpoints: `create --yes` → Convex event `mode: "yes"`; directory conflict → `cli_failed` stage `directory`, reason scrubbed; `history` → `cli_command`; `create-json --json` → Convex `mode: "json"`; MCP via a v2 client → `mcp_session {client: "probe-agent"}`, `mcp_tool`, `bts_create_project` → Convex `mode: "mcp"`, failed `bts_add_addons` → `cli_failed` + `mcp_tool_error`.

## Follow-ups (not in this PR)
- Create the "CLI" website in Umami and add `UMAMI_CLI_WEBSITE_ID` as a repo secret; the next release picks it up.
- Tool argument rejections happen inside the SDK before the handler runs, so they are not counted as `mcp_tool_error`; the SDK's event bus has no hook for them yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added anonymous diagnostics for CLI commands, cancellations, slow operations, failures, and MCP activity.
  - Added invocation-mode tracking for interactive, flags, JSON, API, and MCP usage.
  - Analytics dashboard now displays CLI usage modes and includes mode details in live activity.
  - MCP activity now respects analytics settings.

- **Privacy**
  - Diagnostic data excludes project names, paths, and full error messages.
  - Added support for the standard `DO_NOT_TRACK=1` telemetry opt-out.

- **Documentation**
  - Updated analytics, privacy, FAQ, and CLI documentation with diagnostic and data-handling details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->