### PR TITLE
fix(web): tolerate missing mode distribution during Convex rollout

### DIFF
--- a/apps/web/src/app/(home)/analytics/analytics-client.tsx
+++ b/apps/web/src/app/(home)/analytics/analytics-client.tsx
@@ -37,7 +37,8 @@ type PrecomputedStats = {
   hourlyDistribution: Record<string, number>;
   stackCombinations: Record<string, number>;
   dbOrmCombinations: Record<string, number>;
-  mode: Record<string, number>;
+  /** Absent until the Convex deployment that added it is live. */
+  mode?: Record<string, number>;
 };
 
 type DailyStats = { date: string; count: number };
@@ -179,7 +180,7 @@ function buildFromPrecomputed(
     totalProjects,
   );
   // Mode was added later, so shares are relative to events that carry it.
-  const modeDistribution = withShare(recordToDistribution(stats.mode));
+  const modeDistribution = withShare(recordToDistribution(stats.mode ?? {}));
 
   const timeSeries = buildTimeSeries(dailyStats);
   const monthlyTimeSeries = buildMonthlyTimeSeries(monthlyStats.monthly);


### PR DESCRIPTION
The web deploy from #1195 reads `stats.mode` from `getStats`, but production Convex has not been redeployed with the new field yet, so `/analytics` was returning 500 (`Object.entries(undefined)` during SSR). This makes the field optional on the client so the page renders with or without it. The chart appears once Convex is deployed and events carry `mode`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved analytics compatibility while the latest data deployment is rolling out.
  * Prevented errors when mode distribution data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->