### PR TITLE
docs(web): note that invocation mode tracking started with CLI v3.41.0

### DIFF
--- a/apps/web/src/app/(home)/analytics/_components/dev-environment-charts.tsx
+++ b/apps/web/src/app/(home)/analytics/_components/dev-environment-charts.tsx
@@ -171,7 +171,7 @@ export function DevToolsSection({ data }: { data: AggregatedAnalyticsData }) {
       {data.modeDistribution.length > 0 ? (
         <PreferenceChartCard
           title="How the CLI was driven"
-          description="Interactive prompts, flags, --yes, JSON output, the programmatic API, or the MCP server. Counted for runs that report it."
+          description="Interactive prompts, flags, --yes, JSON output, the programmatic API, or the MCP server (new: tracked since CLI v3.41.0 in August 2026, so counts start small)."
           data={data.modeDistribution}
           colorKey="chart2"
           columnCount={3}


### PR DESCRIPTION
Adds a short parenthetical to the "How the CLI was driven" card on /analytics explaining that the field is new (CLI v3.41.0, August 2026), so readers know why the counts are small compared to the all-time totals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the CLI mode analytics description to include MCP server usage.
  * Clarified that mode tracking begins with CLI v3.41.0 in August 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->