### PR TITLE
fix(cli): time scaffold and install separately for cli_slow

### DIFF
--- a/apps/cli/src/helpers/core/command-handlers.ts
+++ b/apps/cli/src/helpers/core/command-handlers.ts
@@ -12,13 +12,7 @@ import type { AnalyticsMode, CreateInput, DirectoryConflict, ProjectConfig } fro
 import { trackProjectCreation } from "../../utils/analytics";
 import { getCliSubcommandCommand } from "../../utils/cli-invocation";
 import { isSilent, resolveInvocationMode, runWithContextAsync } from "../../utils/context";
-import {
-  errorClass,
-  failureStage,
-  reportDiagnostic,
-  reportSlowStage,
-  scrubReason,
-} from "../../utils/diagnostics";
+import { errorClass, failureStage, reportDiagnostic, scrubReason } from "../../utils/diagnostics";
 import { displayConfig } from "../../utils/display-config";
 import {
   type AppError,
@@ -147,7 +141,7 @@ async function executeCreateProjectHandler(
       const startTime = Date.now();
       const timeScaffolded = new Date().toISOString();
       const result = await createProjectHandlerInternal(input, startTime, timeScaffolded);
-      await reportCreateOutcome(input, result, Date.now() - startTime);
+      await reportCreateOutcome(input, result);
 
       return { result, startTime, timeScaffolded };
     },
@@ -158,16 +152,12 @@ async function executeCreateProjectHandler(
 async function reportCreateOutcome(
   input: CreateCommandInput,
   result: Result<CreateProjectResult, CreateHandlerError>,
-  elapsedMs: number,
 ): Promise<void> {
   const mode = resolveInvocationMode(input.yes);
 
-  if (result.isOk()) {
-    if (!input.dryRun) {
-      await reportSlowStage("create", "create", elapsedMs, input.packageManager ?? "unknown");
-    }
-    return;
-  }
+  // Slow stages are reported from createProject, where scaffolding and install are timed
+  // separately; the total here would include time spent answering prompts.
+  if (result.isOk()) return;
 
   const error = result.error;
   if (UserCancelledError.is(error)) {

--- a/apps/cli/src/helpers/core/create-project.ts
+++ b/apps/cli/src/helpers/core/create-project.ts
@@ -35,6 +35,7 @@ export async function createProject(
   return Result.gen(async function* () {
     const projectDir = options.projectDir;
     const isConvex = options.backend === "convex";
+    const scaffoldStartTime = Date.now();
 
     // Ensure project directory exists
     yield* Result.await(
@@ -120,6 +121,12 @@ export async function createProject(
     yield* Result.await(formatProject(projectDir));
 
     if (!isSilent()) log.success("Project scaffolded");
+    await reportSlowStage(
+      "create",
+      "scaffold",
+      Date.now() - scaffoldStartTime,
+      options.packageManager,
+    );
 
     // Install dependencies if requested
     if (options.install) {

--- a/apps/web/content/docs/analytics.mdx
+++ b/apps/web/content/docs/analytics.mdx
@@ -25,7 +25,7 @@ Separately from the project-creation event, the CLI and its MCP server send a sm
 - `cli_failed`: command, stage (`validate`, `scaffold`, `install`, `git`, `dbSetup`, `postInstall`), error class, and a scrubbed one-line reason with paths, URLs, emails, and quoted names replaced by placeholders
 - `cli_cancelled`: which prompt was open when a run was cancelled
 - `cli_command`: usage of commands other than `create` (`add`, `history`, `docs`, `sponsors`, `builder`), with outcome and a duration bucket
-- `cli_slow`: project creation or dependency installation that took longer than a minute, with a duration bucket and package manager
+- `cli_slow`: scaffolding (template generation, file writing, database and addon setup) or dependency installation that took longer than a minute, with a duration bucket and package manager. Time spent answering prompts is never counted.
 - `mcp_session`, `mcp_tool`, `mcp_tool_error`: MCP client name and version, tool name, outcome, and duration bucket
 
 Umami derives coarse location (country, region, city) from the request IP and a session hash from IP and user agent that rotates monthly; the IP address itself is not stored. Diagnostic events never include project names, paths, file contents, or full error messages. The same `BTS_TELEMETRY_DISABLED=1` or `DO_NOT_TRACK=1` switch and the `--disable-analytics` flag turn them off.


### PR DESCRIPTION
The `cli_slow` diagnostic had a `stage: create` variant that measured the whole run, which includes the time a user spends answering prompts, and it fired alongside `stage: install` for the same slow install (the two events visible on the CLI Umami site are one run). This removes the total-run report and times scaffolding (template generation, file writing, db/addon setup, formatting) separately from installation inside `createProject`, so the event only reflects work the CLI did. Docs updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Diagnostics**
  * Improved slow-stage reporting during project creation by separately measuring scaffolding and dependency installation.
  * Slow-stage alerts now more accurately identify whether delays occur while generating files and setup tasks or installing dependencies.
  * Time spent answering setup prompts is excluded from these measurements.
* **Documentation**
  * Clarified the scope and timing of slow project creation diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->