### PR TITLE
chore(cli): keep only the cli_failed diagnostic

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -130,7 +130,7 @@ This CLI collects anonymous usage data to help improve the tool. The data collec
 - Platform (OS)
 - How the CLI was driven (prompts, flags, `--yes`, JSON, the programmatic API, or the MCP server)
 
-Separately, a small number of anonymous diagnostic events are sent for failures (stage and error class, never full messages or paths), cancelled prompts, other commands such as `add` and `history`, slow runs, and MCP tool usage. See the [analytics documentation](https://better-t-stack.dev/docs/analytics) for the exact list.
+Separately, one anonymous failure event is sent when a scaffold breaks (stage and error class, never full messages or paths). See the [analytics documentation](https://better-t-stack.dev/docs/analytics) for details.
 
 **Telemetry is enabled by default in published versions** to help us understand usage patterns and improve the tool.
 

--- a/apps/cli/src/helpers/core/add-handler.ts
+++ b/apps/cli/src/helpers/core/add-handler.ts
@@ -23,13 +23,7 @@ import type { AddInput, Addons, AddonOptions, AnalyticsMode, ProjectConfig } fro
 import { updateBtsConfig } from "../../utils/bts-config";
 import { validateAddonsAgainstConfig } from "../../utils/compatibility-rules";
 import { isSilent, resolveInvocationMode, runWithContextAsync } from "../../utils/context";
-import {
-  durationBucket,
-  errorClass,
-  failureStage,
-  reportDiagnostic,
-  scrubReason,
-} from "../../utils/diagnostics";
+import { errorClass, failureStage, reportDiagnostic, scrubReason } from "../../utils/diagnostics";
 import { formatConfigValue } from "../../utils/display-config";
 import { CLIError, UserCancelledError, displayError } from "../../utils/errors";
 import { validateAgentSafePathInput } from "../../utils/input-hardening";
@@ -289,9 +283,8 @@ export async function addHandler(
   const { silent = false, mode } = options;
 
   return runWithContextAsync({ silent, mode }, async () => {
-    const startTime = Date.now();
     const result = await addHandlerInternal(input);
-    await reportAddOutcome(input, result, Date.now() - startTime);
+    await reportAddOutcome(input, result);
 
     if (result.isOk()) {
       return result.value;
@@ -328,30 +321,15 @@ export async function addHandler(
 async function reportAddOutcome(
   input: AddInput,
   result: Result<AddResult, UserCancelledError | CLIError>,
-  elapsedMs: number,
 ): Promise<void> {
-  const mode = resolveInvocationMode(false);
-  const duration = durationBucket(elapsedMs);
-
-  if (result.isOk()) {
-    await reportDiagnostic("cli_command", { command: "add", mode, ok: true, duration });
-    return;
-  }
+  if (result.isOk()) return;
 
   const error = result.error;
-  if (UserCancelledError.is(error)) {
-    await reportDiagnostic("cli_cancelled", {
-      command: "add",
-      mode,
-      prompt: error.prompt ?? "unknown",
-    });
-    return;
-  }
+  if (UserCancelledError.is(error)) return;
 
-  await reportDiagnostic("cli_command", { command: "add", mode, ok: false, duration });
   await reportDiagnostic("cli_failed", {
     command: "add",
-    mode,
+    mode: resolveInvocationMode(false),
     stage: failureStage(error),
     error: errorClass(error),
     reason: scrubReason(error),

--- a/apps/cli/src/helpers/core/command-handlers.ts
+++ b/apps/cli/src/helpers/core/command-handlers.ts
@@ -148,30 +148,19 @@ async function executeCreateProjectHandler(
   );
 }
 
-/** Diagnostics for what the success-only project event cannot show; awaited so it beats process.exit. */
+/** Failure diagnostics, which the success-only project event cannot show; awaited so it beats process.exit. */
 async function reportCreateOutcome(
   input: CreateCommandInput,
   result: Result<CreateProjectResult, CreateHandlerError>,
 ): Promise<void> {
-  const mode = resolveInvocationMode(input.yes);
-
-  // Slow stages are reported from createProject, where scaffolding and install are timed
-  // separately; the total here would include time spent answering prompts.
   if (result.isOk()) return;
 
   const error = result.error;
-  if (UserCancelledError.is(error)) {
-    await reportDiagnostic("cli_cancelled", {
-      command: "create",
-      mode,
-      prompt: error.prompt ?? "unknown",
-    });
-    return;
-  }
+  if (UserCancelledError.is(error)) return;
 
   await reportDiagnostic("cli_failed", {
     command: "create",
-    mode,
+    mode: resolveInvocationMode(input.yes),
     stage: failureStage(error),
     error: errorClass(error),
     reason: scrubReason(error),

--- a/apps/cli/src/helpers/core/create-project.ts
+++ b/apps/cli/src/helpers/core/create-project.ts
@@ -8,7 +8,6 @@ import fs from "fs-extra";
 
 import type { DbSetupOptions, ProjectConfig } from "../../types";
 import { isSilent } from "../../utils/context";
-import { reportSlowStage } from "../../utils/diagnostics";
 import { ProjectCreationError } from "../../utils/errors";
 import { formatProject } from "../../utils/file-formatter";
 import { getLatestCLIVersion } from "../../utils/get-latest-cli-version";
@@ -35,7 +34,6 @@ export async function createProject(
   return Result.gen(async function* () {
     const projectDir = options.projectDir;
     const isConvex = options.backend === "convex";
-    const scaffoldStartTime = Date.now();
 
     // Ensure project directory exists
     yield* Result.await(
@@ -121,27 +119,14 @@ export async function createProject(
     yield* Result.await(formatProject(projectDir));
 
     if (!isSilent()) log.success("Project scaffolded");
-    await reportSlowStage(
-      "create",
-      "scaffold",
-      Date.now() - scaffoldStartTime,
-      options.packageManager,
-    );
 
     // Install dependencies if requested
     if (options.install) {
-      const installStartTime = Date.now();
       yield* Result.await(
         installDependencies({
           projectDir,
           packageManager: options.packageManager,
         }),
-      );
-      await reportSlowStage(
-        "create",
-        "install",
-        Date.now() - installStartTime,
-        options.packageManager,
       );
     }
 

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -56,7 +56,6 @@ import {
   WorkspacePackageNameSchema,
 } from "./types";
 import { getProcessMode } from "./utils/context";
-import { durationBucket, reportDiagnostic } from "./utils/diagnostics";
 import {
   CLIError,
   DirectoryConflictError,
@@ -230,13 +229,13 @@ export const router = t.router({
     .query(({ input }) => getSchemaResult(input.name)),
   sponsors: t.procedure
     .meta({ description: "Show Better-T-Stack sponsors" })
-    .mutation(() => trackCommand("sponsors", () => showSponsorsCommand())),
+    .mutation(() => showSponsorsCommand()),
   docs: t.procedure
     .meta({ description: "Open Better-T-Stack documentation" })
-    .mutation(() => trackCommand("docs", () => openDocsCommand())),
+    .mutation(() => openDocsCommand()),
   builder: t.procedure
     .meta({ description: "Open the web-based stack builder" })
-    .mutation(() => trackCommand("builder", () => openBuilderCommand())),
+    .mutation(() => openBuilderCommand()),
   add: t.procedure
     .meta({
       description: "Add addons or a workspace package to an existing Better-T-Stack project",
@@ -290,38 +289,9 @@ export const router = t.router({
       }),
     )
     .mutation(async ({ input }) => {
-      await trackCommand(
-        "history",
-        () => historyHandler(input),
-        (ok) => ok,
-      );
+      await historyHandler(input);
     }),
 });
-
-/** Usage diagnostics for commands that have no project event of their own. */
-async function trackCommand<T>(
-  command: string,
-  run: () => Promise<T> | T,
-  isOk: (value: T) => boolean = () => true,
-): Promise<T> {
-  const startTime = Date.now();
-  try {
-    const value = await run();
-    await reportDiagnostic("cli_command", {
-      command,
-      ok: isOk(value),
-      duration: durationBucket(Date.now() - startTime),
-    });
-    return value;
-  } catch (cause) {
-    await reportDiagnostic("cli_command", {
-      command,
-      ok: false,
-      duration: durationBucket(Date.now() - startTime),
-    });
-    throw cause;
-  }
-}
 
 export function createBtsCli(): TrpcCli {
   return createCli({

--- a/apps/cli/src/mcp.ts
+++ b/apps/cli/src/mcp.ts
@@ -25,7 +25,6 @@ import {
   WebDeploySchema,
 } from "./types";
 import { setProcessMode } from "./utils/context";
-import { durationBucket, reportDiagnostic, scrubReason } from "./utils/diagnostics";
 import { getLatestCLIVersion } from "./utils/get-latest-cli-version";
 
 const ToolResponseSchema = z.object({
@@ -103,57 +102,6 @@ function formatToolError(cause: unknown) {
     },
     isError: true,
   };
-}
-
-type ToolResult = ReturnType<typeof formatToolSuccess> | ReturnType<typeof formatToolError>;
-
-const reportedSessions = new WeakSet<McpServer>();
-
-/** One session event per connection, sent when the client identity is first known. */
-function reportMcpSession(server: McpServer) {
-  if (reportedSessions.has(server)) return;
-  reportedSessions.add(server);
-  const client = server.server.getClientVersion();
-  void reportDiagnostic("mcp_session", {
-    client: client?.name ?? "unknown",
-    clientVersion: client?.version ?? "unknown",
-  });
-}
-
-/**
- * Times every tool call and reports the outcome. Diagnostics are fire-and-forget here
- * because the server process is long-lived and must not add latency to tool results.
- */
-function instrumentTool<Args extends unknown[]>(
-  server: McpServer,
-  tool: string,
-  handler: (...args: Args) => Promise<ToolResult>,
-  isOptedOut?: (...args: Args) => boolean,
-) {
-  return async (...args: Args): Promise<ToolResult> => {
-    if (isOptedOut?.(...args)) return handler(...args);
-    reportMcpSession(server);
-    const startTime = Date.now();
-    const result = await handler(...args);
-    const ok = !("isError" in result);
-    void reportDiagnostic("mcp_tool", {
-      tool,
-      ok,
-      duration: durationBucket(Date.now() - startTime),
-    });
-    if (!ok) {
-      void reportDiagnostic("mcp_tool_error", {
-        tool,
-        error: "ToolError",
-        reason: scrubReason(result.structuredContent.error),
-      });
-    }
-    return result;
-  };
-}
-
-function isCreateOptedOut(input: McpCreateProjectInput) {
-  return input.disableAnalytics === true;
 }
 
 function getProjectToolAnnotations() {
@@ -259,13 +207,13 @@ export function createBtsMcpServer() {
         openWorldHint: false,
       },
     },
-    instrumentTool(server, "bts_get_stack_guidance", async () => {
+    async () => {
       try {
         return formatToolSuccess(getStackGuidance());
       } catch (error) {
         return formatToolError(error);
       }
-    }),
+    },
   );
 
   server.registerTool(
@@ -284,13 +232,13 @@ export function createBtsMcpServer() {
         openWorldHint: false,
       },
     },
-    instrumentTool(server, "bts_get_schema", async ({ name }: SchemaToolInput) => {
+    async ({ name }: SchemaToolInput) => {
       try {
         return formatToolSuccess(getSchemaResult((name ?? "all") as SchemaName));
       } catch (error) {
         return formatToolError(error);
       }
-    }),
+    },
   );
 
   server.registerTool(
@@ -309,39 +257,34 @@ export function createBtsMcpServer() {
         openWorldHint: false,
       },
     },
-    instrumentTool(
-      server,
-      "bts_plan_project",
-      async (input: McpCreateProjectInput) => {
-        try {
-          const result = await create(input.projectName, {
-            ...input,
-            dryRun: true,
-            disableAnalytics: true,
-          });
+    async (input: McpCreateProjectInput) => {
+      try {
+        const result = await create(input.projectName, {
+          ...input,
+          dryRun: true,
+          disableAnalytics: true,
+        });
 
-          if (result.isErr()) {
-            return formatToolError(result.error);
-          }
-
-          const planningData = input.install
-            ? {
-                ...result.value,
-                warnings: [getMcpInstallTimeoutMessage(input.packageManager)],
-                recommendedMcpExecution: {
-                  ...input,
-                  install: false,
-                },
-              }
-            : result.value;
-
-          return formatToolSuccess(planningData);
-        } catch (error) {
-          return formatToolError(error);
+        if (result.isErr()) {
+          return formatToolError(result.error);
         }
-      },
-      isCreateOptedOut,
-    ),
+
+        const planningData = input.install
+          ? {
+              ...result.value,
+              warnings: [getMcpInstallTimeoutMessage(input.packageManager)],
+              recommendedMcpExecution: {
+                ...input,
+                install: false,
+              },
+            }
+          : result.value;
+
+        return formatToolSuccess(planningData);
+      } catch (error) {
+        return formatToolError(error);
+      }
+    },
   );
 
   server.registerTool(
@@ -357,31 +300,26 @@ export function createBtsMcpServer() {
         ...getProjectToolAnnotations(),
       },
     },
-    instrumentTool(
-      server,
-      "bts_create_project",
-      async (input: McpCreateProjectInput) => {
-        try {
-          if (input.install) {
-            return formatToolError(getMcpInstallTimeoutMessage(input.packageManager));
-          }
-
-          const result = await create(input.projectName, {
-            ...input,
-            disableAnalytics: input.disableAnalytics ?? false,
-          });
-
-          if (result.isErr()) {
-            return formatToolError(result.error);
-          }
-
-          return formatToolSuccess(result.value);
-        } catch (error) {
-          return formatToolError(error);
+    async (input: McpCreateProjectInput) => {
+      try {
+        if (input.install) {
+          return formatToolError(getMcpInstallTimeoutMessage(input.packageManager));
         }
-      },
-      isCreateOptedOut,
-    ),
+
+        const result = await create(input.projectName, {
+          ...input,
+          disableAnalytics: input.disableAnalytics ?? false,
+        });
+
+        if (result.isErr()) {
+          return formatToolError(result.error);
+        }
+
+        return formatToolSuccess(result.value);
+      } catch (error) {
+        return formatToolError(error);
+      }
+    },
   );
 
   server.registerTool(
@@ -400,7 +338,7 @@ export function createBtsMcpServer() {
         openWorldHint: false,
       },
     },
-    instrumentTool(server, "bts_plan_addons", async (input: McpAddInput) => {
+    async (input: McpAddInput) => {
       try {
         const result = await add({
           ...input,
@@ -415,7 +353,7 @@ export function createBtsMcpServer() {
       } catch (error) {
         return formatToolError(error);
       }
-    }),
+    },
   );
 
   server.registerTool(
@@ -433,7 +371,7 @@ export function createBtsMcpServer() {
         openWorldHint: true,
       },
     },
-    instrumentTool(server, "bts_add_addons", async (input: McpAddInput) => {
+    async (input: McpAddInput) => {
       try {
         const result = await add(input);
 
@@ -445,7 +383,7 @@ export function createBtsMcpServer() {
       } catch (error) {
         return formatToolError(error);
       }
-    }),
+    },
   );
 
   return server;

--- a/apps/cli/src/prompts/config-prompts.ts
+++ b/apps/cli/src/prompts/config-prompts.ts
@@ -194,8 +194,8 @@ export async function gatherConfig(
           prompts: ["webDeploy", "serverDeploy", "dbSetupMode", "git", "packageManager", "install"],
         },
       ],
-      onCancel: ({ prompt }) => {
-        throw new UserCancelledError({ message: "Operation cancelled", prompt });
+      onCancel: () => {
+        throw new UserCancelledError({ message: "Operation cancelled" });
       },
     },
   );

--- a/apps/cli/src/prompts/navigable-group.ts
+++ b/apps/cli/src/prompts/navigable-group.ts
@@ -25,10 +25,7 @@ export interface NavigablePromptGroupOptions<T> {
    * Control how the group can be canceled
    * if one of the prompts is canceled.
    */
-  onCancel?: (opts: {
-    results: Prettify<Partial<PromptGroupAwaitedReturn<T>>>;
-    prompt: string;
-  }) => void;
+  onCancel?: (opts: { results: Prettify<Partial<PromptGroupAwaitedReturn<T>>> }) => void;
   /** Group related questions into named stages shown in the prompt chrome. */
   sections?: ReadonlyArray<{
     label: string;
@@ -112,7 +109,7 @@ export async function navigableGroup<T>(
       if (isCancel(result)) {
         if (opts?.onCancel) {
           results[name] = "canceled";
-          opts.onCancel({ results, prompt: String(name) });
+          opts.onCancel({ results });
         }
         return results;
       }

--- a/apps/cli/src/prompts/project-name.ts
+++ b/apps/cli/src/prompts/project-name.ts
@@ -91,7 +91,7 @@ export async function getProjectName(initialName?: string): Promise<string> {
     });
 
     if (isCancel(response)) {
-      throw new UserCancelledError({ message: "Operation cancelled.", prompt: "projectName" });
+      throw new UserCancelledError({ message: "Operation cancelled." });
     }
 
     projectPath = response || defaultName;

--- a/apps/cli/src/utils/diagnostics.ts
+++ b/apps/cli/src/utils/diagnostics.ts
@@ -15,9 +15,8 @@ import { getLatestCLIVersion } from "./get-latest-cli-version";
 import { isTelemetryEnabled } from "./telemetry";
 
 /**
- * Diagnostic events go to the self-hosted Umami instance (a separate "CLI" website),
- * not to the Convex project dataset. They cover what the project-creation event
- * cannot: failures, cancellations, non-create commands, slow stages, and MCP usage.
+ * Failure diagnostics go to the self-hosted Umami instance (a separate "CLI" website),
+ * not to the Convex project dataset, which only records successful creations.
  * Everything is a no-op until UMAMI_CLI_WEBSITE_ID is baked in at build time.
  */
 const UMAMI_HOST_URL = process.env.UMAMI_HOST_URL;
@@ -25,7 +24,6 @@ const UMAMI_CLI_WEBSITE_ID = process.env.UMAMI_CLI_WEBSITE_ID;
 const SEND_TIMEOUT_MS = 3000;
 const MAX_STRING_LENGTH = 500;
 const MAX_REASON_LENGTH = 160;
-export const SLOW_STAGE_THRESHOLD_MS = 60_000;
 
 type DiagnosticValue = string | number | boolean;
 
@@ -39,30 +37,9 @@ export type DiagnosticEvents = {
     packageManager?: string;
     backend?: string;
   };
-  cli_cancelled: { command: string; mode: AnalyticsMode; prompt: string };
-  cli_command: { command: string; mode?: AnalyticsMode; ok: boolean; duration: string };
-  cli_slow: { command: string; stage: string; duration: string; packageManager: string };
-  mcp_session: { client: string; clientVersion: string };
-  mcp_tool: { tool: string; ok: boolean; duration: string };
-  mcp_tool_error: { tool: string; error: string; reason: string };
 };
 
 export type DiagnosticEventName = keyof DiagnosticEvents;
-
-const DURATION_BUCKETS: Array<[number, string]> = [
-  [1_000, "<1s"],
-  [5_000, "1-5s"],
-  [15_000, "5-15s"],
-  [60_000, "15-60s"],
-  [300_000, "1-5m"],
-];
-
-export function durationBucket(elapsedMs: number): string {
-  for (const [limit, label] of DURATION_BUCKETS) {
-    if (elapsedMs < limit) return label;
-  }
-  return ">5m";
-}
 
 /** Class name of the failure, which is stable and never carries user content. */
 export function errorClass(cause: unknown): string {
@@ -83,7 +60,7 @@ export function failureStage(cause: unknown): string {
 
 /**
  * First line of an error message with anything that could identify a machine or
- * project replaced by placeholders: file paths, URLs, emails, and quoted names.
+ * project replaced by placeholders: quoted names, URLs, emails, and paths.
  */
 export function scrubReason(cause: unknown): string {
   const message = cause instanceof Error ? cause.message : String(cause);
@@ -117,12 +94,6 @@ function isDiagnosticsEnabled() {
   );
 }
 
-function eventUrl(name: DiagnosticEventName, data: Record<string, DiagnosticValue>) {
-  if (name.startsWith("mcp_")) return "/mcp";
-  const command = data.command;
-  return command === undefined ? `/${name}` : `/${String(command)}`;
-}
-
 export function buildDiagnosticPayload<Name extends DiagnosticEventName>(
   name: Name,
   data: DiagnosticEvents[Name],
@@ -137,7 +108,7 @@ export function buildDiagnosticPayload<Name extends DiagnosticEventName>(
     payload: {
       website: UMAMI_CLI_WEBSITE_ID,
       hostname: "cli",
-      url: eventUrl(name, eventData),
+      url: `/${data.command}`,
       title: name,
       name,
       data: eventData,
@@ -168,21 +139,5 @@ export async function reportDiagnostic<Name extends DiagnosticEventName>(
         keepalive: true,
       }),
     catch: () => undefined, // Silent failure: diagnostics must never affect the CLI.
-  });
-}
-
-/** Reports a stage only when it crossed the slow threshold, so the event is a signal. */
-export async function reportSlowStage(
-  command: string,
-  stage: string,
-  elapsedMs: number,
-  packageManager: string,
-): Promise<void> {
-  if (elapsedMs < SLOW_STAGE_THRESHOLD_MS) return;
-  await reportDiagnostic("cli_slow", {
-    command,
-    stage,
-    duration: durationBucket(elapsedMs),
-    packageManager,
   });
 }

--- a/apps/cli/src/utils/errors.ts
+++ b/apps/cli/src/utils/errors.ts
@@ -13,11 +13,9 @@ import { cliConsola } from "./terminal-output";
  */
 export class UserCancelledError extends TaggedError("UserCancelledError")<{
   message: string;
-  /** Name of the prompt that was open when the user cancelled, when known. */
-  prompt?: string;
 }> {
-  constructor(args?: { message?: string; prompt?: string }) {
-    super({ message: args?.message ?? "Operation cancelled", prompt: args?.prompt });
+  constructor(args?: { message?: string }) {
+    super({ message: args?.message ?? "Operation cancelled" });
   }
 }
 

--- a/apps/cli/test/diagnostics.test.ts
+++ b/apps/cli/test/diagnostics.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, test } from "bun:test";
 import {
   buildDiagnosticPayload,
   diagnosticUserAgent,
-  durationBucket,
   errorClass,
   reportDiagnostic,
   scrubReason,
@@ -57,19 +56,8 @@ describe("errorClass", () => {
   });
 });
 
-describe("durationBucket", () => {
-  test("maps elapsed milliseconds to coarse buckets", () => {
-    expect(durationBucket(120)).toBe("<1s");
-    expect(durationBucket(4_000)).toBe("1-5s");
-    expect(durationBucket(14_999)).toBe("5-15s");
-    expect(durationBucket(59_000)).toBe("15-60s");
-    expect(durationBucket(200_000)).toBe("1-5m");
-    expect(durationBucket(900_000)).toBe(">5m");
-  });
-});
-
 describe("buildDiagnosticPayload", () => {
-  test("routes CLI events by command and MCP events under /mcp", () => {
+  test("routes events by command and drops undefined properties", () => {
     const failed = buildDiagnosticPayload("cli_failed", {
       command: "create",
       mode: "flags",
@@ -92,13 +80,15 @@ describe("buildDiagnosticPayload", () => {
       packageManager: "bun",
     });
 
-    const tool = buildDiagnosticPayload("mcp_tool", {
-      tool: "bts_plan_project",
-      ok: true,
-      duration: "<1s",
+    const add = buildDiagnosticPayload("cli_failed", {
+      command: "add",
+      mode: "mcp",
+      stage: "config",
+      error: "CLIError",
+      reason: "No Better-T-Stack project found in <name>",
     });
-    expect(tool.payload.url).toBe("/mcp");
-    expect(tool.payload.data.ok).toBe(true);
+    expect(add.payload.url).toBe("/add");
+    expect(add.payload.data.mode).toBe("mcp");
   });
 
   test("uses a browser-compatible user agent so Umami does not drop it as a bot", () => {
@@ -116,7 +106,13 @@ describe("reportDiagnostic", () => {
     }) as typeof fetch;
 
     try {
-      await reportDiagnostic("mcp_session", { client: "test", clientVersion: "1.0.0" });
+      await reportDiagnostic("cli_failed", {
+        command: "create",
+        mode: "flags",
+        stage: "validate",
+        error: "ValidationError",
+        reason: "invalid",
+      });
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/apps/web/content/docs/analytics.mdx
+++ b/apps/web/content/docs/analytics.mdx
@@ -20,15 +20,9 @@ Not collected:
 
 ## Diagnostic events
 
-Separately from the project-creation event, the CLI and its MCP server send a small number of anonymous diagnostic events to the same self-hosted Umami instance that powers the website analytics. They exist to catch problems the success event cannot show:
+Separately from the project-creation event, the CLI sends one anonymous `cli_failed` event to the same self-hosted Umami instance that powers the website analytics when `create` or `add` fails. It exists to catch problems the success event cannot show and contains: the command, how the CLI was driven, the stage that failed (for example `template-generation`, `file-writing`, `database-setup`, `addons-setup`, `dependency-installation`, `git-initialization`, `directory`, `validate`), the error class, the package manager and backend when known, and a scrubbed one-line reason with quoted names, paths, URLs, and emails replaced by placeholders. Cancelled runs send nothing.
 
-- `cli_failed`: command, stage (`validate`, `scaffold`, `install`, `git`, `dbSetup`, `postInstall`), error class, and a scrubbed one-line reason with paths, URLs, emails, and quoted names replaced by placeholders
-- `cli_cancelled`: which prompt was open when a run was cancelled
-- `cli_command`: usage of commands other than `create` (`add`, `history`, `docs`, `sponsors`, `builder`), with outcome and a duration bucket
-- `cli_slow`: scaffolding (template generation, file writing, database and addon setup) or dependency installation that took longer than a minute, with a duration bucket and package manager. Time spent answering prompts is never counted.
-- `mcp_session`, `mcp_tool`, `mcp_tool_error`: MCP client name and version, tool name, outcome, and duration bucket
-
-Umami derives coarse location (country, region, city) from the request IP and a session hash from IP and user agent that rotates monthly; the IP address itself is not stored. Diagnostic events never include project names, paths, file contents, or full error messages. The same `BTS_TELEMETRY_DISABLED=1` or `DO_NOT_TRACK=1` switch and the `--disable-analytics` flag turn them off.
+Umami derives coarse location (country, region, city) from the request IP and a session hash from IP and user agent that rotates monthly; the IP address itself is not stored. The event never includes project names, paths, file contents, or full error messages. The same `BTS_TELEMETRY_DISABLED=1` or `DO_NOT_TRACK=1` switch and the `--disable-analytics` flag turn it off.
 
 ## Disable telemetry
 
@@ -59,7 +53,7 @@ Notes:
 
 ## Full transparency
 
-One project event per successful scaffold plus the diagnostic events listed above; no project identifiers. See source code below.
+One project event per successful scaffold plus one failure event when a scaffold breaks; no project identifiers. See source code below.
 
 If in doubt, set `BTS_TELEMETRY_DISABLED=1` and proceed. You can still use all CLI features.
 

--- a/apps/web/src/app/(home)/privacy/page.tsx
+++ b/apps/web/src/app/(home)/privacy/page.tsx
@@ -57,12 +57,11 @@ export default function PrivacyPage() {
           project identifiers. Aggregate results are published on the analytics page.
         </p>
         <p>
-          The CLI and its MCP server also send a small number of anonymous diagnostic events to the
-          same self-hosted Umami instance as the website: command failures with a stage and error
-          class, cancelled prompts, usage of commands other than create, slow stages, and MCP client
-          and tool names. Umami derives coarse location from the request IP and a session hash that
-          rotates monthly; the IP address itself is not stored. These events never include project
-          names, paths, or full error messages, and the same telemetry switch disables them.
+          When project creation fails, the CLI also sends one anonymous failure event to the same
+          self-hosted Umami instance as the website, with the stage that failed and the error class.
+          Umami derives coarse location from the request IP and a session hash that rotates monthly;
+          the IP address itself is not stored. The event never includes project names, paths, or
+          full error messages, and the same telemetry switch disables it.
         </p>
       </TrustSection>
 

--- a/apps/web/src/lib/agent-content.ts
+++ b/apps/web/src/lib/agent-content.ts
@@ -75,7 +75,7 @@ Use GitHub issues for reproducible bugs and feature requests. Include the CLI ve
 - [Documentation](${SITE_URL}/docs)`,
   privacy: `# Better-T-Stack privacy
 
-The website uses self-hosted Umami analytics. The CLI sends one telemetry event after successful project creation (including how it was driven: prompts, flags, JSON, API, or MCP) plus a small number of anonymous diagnostic events for failures, cancellations, other commands, slow runs, and MCP client sessions and tool usage, unless telemetry is disabled. The CLI payloads do not include project names, paths, file contents, secrets, environment variables, or persistent user identifiers.
+The website uses self-hosted Umami analytics. The CLI sends one telemetry event after successful project creation (including how it was driven: prompts, flags, JSON, API, or MCP) plus one anonymous failure event when a scaffold breaks, unless telemetry is disabled. The CLI payloads do not include project names, paths, file contents, secrets, environment variables, or persistent user identifiers.
 
 - [Full privacy notice](${SITE_URL}/privacy)
 - [Analytics and telemetry details](${SITE_URL}/docs/analytics.mdx)


### PR DESCRIPTION
Simplifies CLI diagnostics to the one event that is actionable. Removes `cli_slow`, `cli_command`, `cli_cancelled`, `mcp_session`, `mcp_tool`, and `mcp_tool_error`, plus the prompt-name and timing plumbing that only existed for them. What remains: the Convex project event with `mode` on success, and a single `cli_failed` event to Umami when `create` or `add` fails (stage, error class, scrubbed reason). Docs, README, privacy page, and agent copy updated to match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated telemetry documentation to describe a single anonymous failure event for unsuccessful project creation or add operations.
  * Clarified that cancelled operations and other CLI or MCP activity do not send diagnostic events.
  * Documented the failure details collected and available telemetry controls.

* **Privacy**
  * Revised privacy messaging to reflect the reduced telemetry scope and retained anonymization protections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->