### PR TITLE
feat(cli): support --disable-analytics on add

### DIFF
--- a/apps/cli/src/helpers/core/add-handler.ts
+++ b/apps/cli/src/helpers/core/add-handler.ts
@@ -282,17 +282,30 @@ export async function addHandler(
 ): Promise<AddResult | undefined> {
   const { silent = false, mode } = options;
 
-  return runWithContextAsync({ silent, mode }, async () => {
-    const result = await addHandlerInternal(input);
-    await reportAddOutcome(input, result);
+  return runWithContextAsync(
+    { silent, mode, analyticsDisabled: input.disableAnalytics },
+    async () => {
+      const result = await addHandlerInternal(input);
+      await reportAddOutcome(input, result);
 
-    if (result.isOk()) {
-      return result.value;
-    }
+      if (result.isOk()) {
+        return result.value;
+      }
 
-    const error = result.error;
+      const error = result.error;
 
-    if (UserCancelledError.is(error)) {
+      if (UserCancelledError.is(error)) {
+        if (isSilent()) {
+          return {
+            success: false,
+            addedAddons: [],
+            projectDir: "",
+            error: error.message,
+          };
+        }
+        return undefined;
+      }
+
       if (isSilent()) {
         return {
           success: false,
@@ -301,21 +314,11 @@ export async function addHandler(
           error: error.message,
         };
       }
-      return undefined;
-    }
 
-    if (isSilent()) {
-      return {
-        success: false,
-        addedAddons: [],
-        projectDir: "",
-        error: error.message,
-      };
-    }
-
-    displayError(error);
-    process.exit(1);
-  });
+      displayError(error);
+      process.exit(1);
+    },
+  );
 }
 
 async function reportAddOutcome(

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -256,6 +256,7 @@ export const router = t.router({
           .optional()
           .default(false)
           .describe("Preview addon changes without writing files"),
+        disableAnalytics: z.boolean().optional().default(false).describe("Disable analytics"),
       }),
     )
     .mutation(async ({ input }) => {

--- a/apps/web/content/docs/cli/index.mdx
+++ b/apps/web/content/docs/cli/index.mdx
@@ -82,6 +82,8 @@ create-better-t-stack add [options]
 - `--project-dir <path>`: Project directory (defaults to current directory)
 - `--install [boolean]`: Install dependencies after adding (defaults to `false`)
 - `--package-manager <pm>`: Package manager to use (`npm`, `pnpm`, `bun`)
+- `--dry-run`: Preview the changes without writing files
+- `--disable-analytics`: Skip the anonymous failure event for this run (see [Analytics](/docs/analytics))
 
 ### Examples
 

--- a/packages/types/src/schemas.ts
+++ b/packages/types/src/schemas.ts
@@ -534,6 +534,7 @@ export const AddInputSchema = z
     install: z.boolean().optional(),
     packageManager: PackageManagerSchema.optional(),
     dryRun: z.boolean().optional(),
+    disableAnalytics: z.boolean().optional(),
   })
   .strict();
 


### PR DESCRIPTION
Follow-up to a Codex comment on #1203: `--disable-analytics` only existed on `create`, so the per-run opt-out could not suppress the `add` failure event. The flag is now accepted by `add`, `add-json`, the programmatic `add()`, and the `bts_add_addons` MCP tool (via `AddInputSchema`), and it sets `analyticsDisabled` in the add handler's context. Docs list the flag under the add command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--disable-analytics` option to the `add` command.
  * Added support for previewing changes with the documented `--dry-run` option.
* **Documentation**
  * Updated CLI documentation to describe the new `add` command options.
* **Bug Fixes**
  * Improved error handling so cancelled operations and other failures are reported consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->