### PR TITLE
fix(cli): expose disableAnalytics on AddOptions

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -543,7 +543,14 @@ export type { AddResult };
 
 export type AddOptions = Pick<
   AddInput,
-  "addons" | "addonOptions" | "package" | "install" | "packageManager" | "projectDir" | "dryRun"
+  | "addons"
+  | "addonOptions"
+  | "package"
+  | "install"
+  | "packageManager"
+  | "projectDir"
+  | "dryRun"
+  | "disableAnalytics"
 >;
 
 /**


### PR DESCRIPTION
Follow-up to a Codex comment on #1204: the runtime schema accepted `disableAnalytics` on `add()` but the exported `AddOptions` pick omitted it, so TypeScript consumers got an excess-property error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to disable analytics during project setup.
* **Refactor**
  * Updated setup option handling to support the new analytics preference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->