### PR TITLE
fix(cli): keep requirement bullets in failure reasons and skip cancelled setup steps

### DIFF
--- a/apps/cli/src/helpers/core/command-handlers.ts
+++ b/apps/cli/src/helpers/core/command-handlers.ts
@@ -156,7 +156,10 @@ async function reportCreateOutcome(
   if (result.isOk()) return;
 
   const error = result.error;
+  // Cancelling inside a setup step (addons, database) surfaces as a ProjectCreationError
+  // whose cause is the cancellation; that is not a failure either.
   if (UserCancelledError.is(error)) return;
+  if (ProjectCreationError.is(error) && UserCancelledError.is(error.cause)) return;
 
   await reportDiagnostic("cli_failed", {
     command: "create",

--- a/apps/cli/src/helpers/core/command-handlers.ts
+++ b/apps/cli/src/helpers/core/command-handlers.ts
@@ -21,6 +21,7 @@ import {
   ProjectCreationError,
   UserCancelledError,
   displayError,
+  isUserCancellation,
 } from "../../utils/errors";
 import { validateAgentSafePathInput } from "../../utils/input-hardening";
 import {
@@ -156,10 +157,7 @@ async function reportCreateOutcome(
   if (result.isOk()) return;
 
   const error = result.error;
-  // Cancelling inside a setup step (addons, database) surfaces as a ProjectCreationError
-  // whose cause is the cancellation; that is not a failure either.
-  if (UserCancelledError.is(error)) return;
-  if (ProjectCreationError.is(error) && UserCancelledError.is(error.cause)) return;
+  if (isUserCancellation(error)) return;
 
   await reportDiagnostic("cli_failed", {
     command: "create",
@@ -196,8 +194,8 @@ export async function createProjectHandler(
   const error = result.error;
   const elapsedTimeMs = Date.now() - startTime;
 
-  // Handle user cancellation specially
-  if (UserCancelledError.is(error)) {
+  // Handle user cancellation specially, including one raised inside a setup step
+  if (isUserCancellation(error)) {
     if (silent) {
       return createEmptyResult(timeScaffolded, elapsedTimeMs, error.message);
     }

--- a/apps/cli/src/utils/diagnostics.ts
+++ b/apps/cli/src/utils/diagnostics.ts
@@ -64,7 +64,15 @@ export function failureStage(cause: unknown): string {
  */
 export function scrubReason(cause: unknown): string {
   const message = cause instanceof Error ? cause.message : String(cause);
-  const firstLine = message.split(/\r?\n/, 1)[0] ?? "";
+  const lines = message.split(/\r?\n/);
+  // Keep the headline plus any bullet lines directly under it: messages such as the
+  // toolchain check put the actual failing requirement on those bullets.
+  const bullets: string[] = [];
+  for (const line of lines.slice(1)) {
+    if (!line.startsWith("- ")) break;
+    bullets.push(line.slice(2));
+  }
+  const firstLine = [lines[0] ?? "", ...bullets].join(" ");
   const scrubbed = firstLine
     // Quoted spans first: they are user-supplied values whatever they contain.
     .replaceAll(/(["'`])(?:(?!\1).)*\1/g, "<name>")

--- a/apps/cli/src/utils/diagnostics.ts
+++ b/apps/cli/src/utils/diagnostics.ts
@@ -74,8 +74,9 @@ export function scrubReason(cause: unknown): string {
   }
   const firstLine = [lines[0] ?? "", ...bullets].join(" ");
   const scrubbed = firstLine
-    // Quoted spans first: they are user-supplied values whatever they contain.
-    .replaceAll(/(["'`])(?:(?!\1).)*\1/g, "<name>")
+    // Quoted spans first: they are user-supplied values whatever they contain. Apostrophes
+    // inside words ("stack's") are not quote delimiters.
+    .replaceAll(/(?<!\w)(["'`])(?:(?!\1).)*\1(?!\w)/g, "<name>")
     .replaceAll(/https?:\/\/[^\s)\]"'>]+/gi, "<url>")
     .replaceAll(/[\w.+-]+@[\w-]+\.[\w.-]+/g, "<email>")
     // Absolute paths, including segments with spaces ("/Users/Jane Doe/app/file.ts") and a

--- a/apps/cli/src/utils/diagnostics.ts
+++ b/apps/cli/src/utils/diagnostics.ts
@@ -76,7 +76,7 @@ export function scrubReason(cause: unknown): string {
   const scrubbed = firstLine
     // Quoted spans first: they are user-supplied values whatever they contain. Apostrophes
     // inside words ("stack's") are not quote delimiters.
-    .replaceAll(/(?<!\w)(["'`])(?:(?!\1).)*\1(?!\w)/g, "<name>")
+    .replaceAll(/(?<![\p{L}\p{N}\p{M}_])(["'`])(?:(?!\1).)*\1(?![\p{L}\p{N}\p{M}_])/gu, "<name>")
     .replaceAll(/https?:\/\/[^\s)\]"'>]+/gi, "<url>")
     .replaceAll(/[\w.+-]+@[\w-]+\.[\w.-]+/g, "<email>")
     // Absolute paths, including segments with spaces ("/Users/Jane Doe/app/file.ts") and a

--- a/apps/cli/src/utils/errors.ts
+++ b/apps/cli/src/utils/errors.ts
@@ -20,6 +20,15 @@ export class UserCancelledError extends TaggedError("UserCancelledError")<{
 }
 
 /**
+ * True for a direct cancellation or one that a setup step wrapped in a ProjectCreationError
+ * (for example cancelling a prompt inside addon or database setup).
+ */
+export function isUserCancellation(cause: unknown): boolean {
+  if (UserCancelledError.is(cause)) return true;
+  return ProjectCreationError.is(cause) && UserCancelledError.is(cause.cause);
+}
+
+/**
  * General CLI error for validation failures, invalid flags, etc.
  */
 export class CLIError extends TaggedError("CLIError")<{

--- a/apps/cli/test/diagnostics.test.ts
+++ b/apps/cli/test/diagnostics.test.ts
@@ -43,6 +43,18 @@ describe("scrubReason", () => {
     ).toBe("No Better-T-Stack project found in <name>. Make sure bts.jsonc exists.");
   });
 
+  test("keeps bullet lines under the headline, such as toolchain requirement failures", () => {
+    const message = [
+      "Your local toolchain does not meet this stack's requirements:",
+      "- Node.js v20.11.0 does not satisfy >=22.0.0 required by the Next.js template.",
+      "",
+      "Upgrade Node.js from https://nodejs.org",
+    ].join("\n");
+    expect(scrubReason(new Error(message))).toBe(
+      "Your local toolchain does not meet this stack's requirements: Node.js v20.11.0 does not satisfy >=22.0.0 required by the Next.js template.",
+    );
+  });
+
   test("truncates very long reasons", () => {
     expect(scrubReason("x".repeat(400))).toHaveLength(160);
   });

--- a/apps/cli/test/diagnostics.test.ts
+++ b/apps/cli/test/diagnostics.test.ts
@@ -66,6 +66,9 @@ describe("scrubReason", () => {
     expect(scrubReason("Directory 'my app' already exists")).toBe(
       "Directory <name> already exists",
     );
+    expect(scrubReason("Beyoncé's note 'draft' is missing")).toBe(
+      "Beyoncé's note <name> is missing",
+    );
   });
 
   test("truncates very long reasons", () => {

--- a/apps/cli/test/diagnostics.test.ts
+++ b/apps/cli/test/diagnostics.test.ts
@@ -55,6 +55,19 @@ describe("scrubReason", () => {
     );
   });
 
+  test("does not treat apostrophes inside words as quotes", () => {
+    const message = [
+      "Your local toolchain does not meet this stack's requirements:",
+      "- Node.js v20.11.0 does not satisfy >=22.0.0 required by Starlight's Astro toolchain.",
+    ].join("\n");
+    expect(scrubReason(new Error(message))).toBe(
+      "Your local toolchain does not meet this stack's requirements: Node.js v20.11.0 does not satisfy >=22.0.0 required by Starlight's Astro toolchain.",
+    );
+    expect(scrubReason("Directory 'my app' already exists")).toBe(
+      "Directory <name> already exists",
+    );
+  });
+
   test("truncates very long reasons", () => {
     expect(scrubReason("x".repeat(400))).toHaveLength(160);
   });


### PR DESCRIPTION
From the first day of real `cli_failed` data:

- 6 of 13 failures were `Your local toolchain does not meet this stack's requirements:` with nothing after the colon, because the failing requirement is on bullet lines that `scrubReason` dropped. Bullet lines directly under the headline are now kept (still scrubbed and capped), so the reason reads `... requirements: Node.js v20.11.0 does not satisfy >=22.0.0 required by ...`.
- 2 failures were `Failed to setup addons: Operation cancelled`: a user cancelling inside addon setup surfaces as a `ProjectCreationError` whose cause is `UserCancelledError`. That is a cancellation, not a failure, and is now skipped.

Regression test added for the bullet handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved create failure reporting when cancellation occurs, including cancellations wrapped in setup errors.
  - Diagnostic messages now retain relevant toolchain headlines and bullet-point details while removing sensitive or excessive content.
  - Improved redaction so apostrophes within words remain readable while quoted names are scrubbed.

- **Tests**
  - Added coverage for cancellation handling and diagnostic cleanup, including preservation of useful error details and removal of unrelated content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->