### PR TITLE
feat(cli): check package manager and Node versions before any prompt

### DIFF
--- a/apps/cli/src/helpers/core/command-handlers.ts
+++ b/apps/cli/src/helpers/core/command-handlers.ts
@@ -231,9 +231,15 @@ async function createProjectHandlerInternal(
     // Before any prompt: the package manager that will run the install and the Node.js
     // hosting the CLI. Stack-specific requirements are checked once the config is known.
     if (!isSilent()) {
-      yield* Result.await(
-        checkBaselineRequirements(input.packageManager ?? detectInvokingPackageManager()),
+      const baseline = yield* Result.await(
+        checkBaselineRequirements(
+          input.packageManager ?? detectInvokingPackageManager(),
+          input.packageManager !== undefined,
+        ),
       );
+      for (const warning of baseline.warnings) {
+        log.warn(pc.yellow(warning));
+      }
     }
 
     // Get project name

--- a/apps/cli/src/helpers/core/command-handlers.ts
+++ b/apps/cli/src/helpers/core/command-handlers.ts
@@ -10,7 +10,7 @@ import { gatherConfig } from "../../prompts/config-prompts";
 import { getProjectName } from "../../prompts/project-name";
 import type { AnalyticsMode, CreateInput, DirectoryConflict, ProjectConfig } from "../../types";
 import { trackProjectCreation } from "../../utils/analytics";
-import { getCliSubcommandCommand } from "../../utils/cli-invocation";
+import { detectInvokingPackageManager, getCliSubcommandCommand } from "../../utils/cli-invocation";
 import { isSilent, resolveInvocationMode, runWithContextAsync } from "../../utils/context";
 import { errorClass, failureStage, reportDiagnostic, scrubReason } from "../../utils/diagnostics";
 import { displayConfig } from "../../utils/display-config";
@@ -41,7 +41,7 @@ import {
 } from "../../utils/project-launcher";
 import { validateProjectName } from "../../utils/project-name-validation";
 import { renderTitle } from "../../utils/render-title";
-import { checkLocalRequirements } from "../../utils/requirements";
+import { checkBaselineRequirements, checkLocalRequirements } from "../../utils/requirements";
 import { getTemplateConfig, getTemplateDescription } from "../../utils/templates";
 import {
   getProvidedFlags,
@@ -226,6 +226,14 @@ async function createProjectHandlerInternal(
 
     if (!isSilent() && input.yolo) {
       log.warn(pc.yellow("YOLO mode enabled — compatibility checks are disabled."));
+    }
+
+    // Before any prompt: the package manager that will run the install and the Node.js
+    // hosting the CLI. Stack-specific requirements are checked once the config is known.
+    if (!isSilent()) {
+      yield* Result.await(
+        checkBaselineRequirements(input.packageManager ?? detectInvokingPackageManager()),
+      );
     }
 
     // Get project name

--- a/apps/cli/src/utils/cli-invocation.ts
+++ b/apps/cli/src/utils/cli-invocation.ts
@@ -1,19 +1,22 @@
 import type { PackageManager } from "../types";
 import { getPackageExecutionCommand } from "./package-runner";
 
+/** The package manager that launched the CLI (`bun create`, `pnpm create`, `npx`), when known. */
+export function detectInvokingPackageManager(
+  userAgent = process.env.npm_config_user_agent,
+): PackageManager | undefined {
+  const normalizedUserAgent = userAgent?.toLowerCase();
+  if (normalizedUserAgent?.startsWith("bun")) return "bun";
+  if (normalizedUserAgent?.startsWith("pnpm")) return "pnpm";
+  if (normalizedUserAgent?.startsWith("npm")) return "npm";
+  return undefined;
+}
+
 export function getCliSubcommandCommand(
   subcommand: string,
   fallbackPackageManager: PackageManager,
   userAgent = process.env.npm_config_user_agent,
 ): string {
-  const normalizedUserAgent = userAgent?.toLowerCase();
-  const packageManager = normalizedUserAgent?.startsWith("bun")
-    ? "bun"
-    : normalizedUserAgent?.startsWith("pnpm")
-      ? "pnpm"
-      : normalizedUserAgent?.startsWith("npm")
-        ? "npm"
-        : fallbackPackageManager;
-
+  const packageManager = detectInvokingPackageManager(userAgent) ?? fallbackPackageManager;
   return getPackageExecutionCommand(packageManager, `create-better-t-stack@latest ${subcommand}`);
 }

--- a/apps/cli/src/utils/requirements.ts
+++ b/apps/cli/src/utils/requirements.ts
@@ -202,12 +202,41 @@ function formatRequirementError(
   return null;
 }
 
+/**
+ * The checks that do not depend on the chosen stack: the package manager that will run the
+ * install, and the Node.js version hosting the CLI. Running them before any prompt means a
+ * user with an outdated toolchain finds out immediately instead of after configuring a stack.
+ */
+export function getBaselineRequirements(
+  packageManager: PackageManager | undefined,
+  hostRuntime: "bun" | "node",
+): VersionRequirement[] {
+  const requirements: VersionRequirement[] = [];
+  if (packageManager) {
+    requirements.push({
+      tool: packageManager,
+      range: PACKAGE_MANAGER_VERSION_RANGES[packageManager],
+      reason: PACKAGE_MANAGER_REASONS[packageManager],
+    });
+  }
+  if (hostRuntime === "node") {
+    addNodeRequirement(requirements, ">=22.0.0", "create-better-t-stack");
+  }
+  return requirements;
+}
+
 export function validateLocalToolVersions(
   config: RequirementConfig,
   versions: LocalToolVersions,
   hostRuntime: "bun" | "node",
 ): Result<void, CLIError> {
-  const requirements = getLocalVersionRequirements(config, hostRuntime);
+  return validateRequirements(getLocalVersionRequirements(config, hostRuntime), versions);
+}
+
+export function validateRequirements(
+  requirements: VersionRequirement[],
+  versions: LocalToolVersions,
+): Result<void, CLIError> {
   const failures = requirements
     .map((requirement) => formatRequirementError(requirement, versions[requirement.tool]))
     .filter((failure): failure is string => failure !== null);
@@ -274,6 +303,25 @@ async function readToolVersion(tool: Tool): Promise<string | null> {
   });
 
   return result.isOk() ? result.value : null;
+}
+
+/** Fast pre-prompt check; the full stack-aware check still runs once the config is known. */
+export async function checkBaselineRequirements(
+  packageManager: PackageManager | undefined,
+): Promise<Result<void, CLIError>> {
+  if (shouldSkipExternalCommands()) return Result.ok(undefined);
+
+  const hostRuntime = process.versions.bun ? "bun" : "node";
+  const versions: LocalToolVersions = {};
+  if (packageManager) {
+    const packageManagerVersion = await readToolVersion(packageManager);
+    if (packageManagerVersion) versions[packageManager] = packageManagerVersion;
+  }
+  if (hostRuntime === "node") {
+    versions.node = process.versions.node;
+  }
+
+  return validateRequirements(getBaselineRequirements(packageManager, hostRuntime), versions);
 }
 
 export async function checkLocalRequirements(

--- a/apps/cli/src/utils/requirements.ts
+++ b/apps/cli/src/utils/requirements.ts
@@ -233,9 +233,14 @@ export function validateLocalToolVersions(
   return validateRequirements(getLocalVersionRequirements(config, hostRuntime), versions);
 }
 
+const STACK_REQUIREMENTS_HEADLINE = "Your local toolchain does not meet this stack's requirements:";
+const BASELINE_REQUIREMENTS_HEADLINE =
+  "Your local toolchain does not meet create-better-t-stack's requirements:";
+
 export function validateRequirements(
   requirements: VersionRequirement[],
   versions: LocalToolVersions,
+  headline = STACK_REQUIREMENTS_HEADLINE,
 ): Result<void, CLIError> {
   const failures = requirements
     .map((requirement) => formatRequirementError(requirement, versions[requirement.tool]))
@@ -258,7 +263,7 @@ export function validateRequirements(
   return Result.err(
     new CLIError({
       message: [
-        "Your local toolchain does not meet this stack's requirements:",
+        headline,
         ...failures.map((failure) => `- ${failure}`),
         "",
         ...upgradeInstructions,
@@ -305,11 +310,22 @@ async function readToolVersion(tool: Tool): Promise<string | null> {
   return result.isOk() ? result.value : null;
 }
 
-/** Fast pre-prompt check; the full stack-aware check still runs once the config is known. */
+export type BaselineCheck = {
+  /** Problems with a package manager the user has not committed to yet; shown, not fatal. */
+  warnings: string[];
+};
+
+/**
+ * Fast pre-prompt check; the full stack-aware check still runs once the config is known.
+ * The host Node.js version is always fatal. The package manager is fatal only when it was
+ * passed explicitly: an inferred one (from the launching user agent) can still be swapped at
+ * the package manager prompt, so it is reported as a warning.
+ */
 export async function checkBaselineRequirements(
   packageManager: PackageManager | undefined,
-): Promise<Result<void, CLIError>> {
-  if (shouldSkipExternalCommands()) return Result.ok(undefined);
+  packageManagerIsExplicit: boolean,
+): Promise<Result<BaselineCheck, CLIError>> {
+  if (shouldSkipExternalCommands()) return Result.ok({ warnings: [] });
 
   const hostRuntime = process.versions.bun ? "bun" : "node";
   const versions: LocalToolVersions = {};
@@ -321,7 +337,24 @@ export async function checkBaselineRequirements(
     versions.node = process.versions.node;
   }
 
-  return validateRequirements(getBaselineRequirements(packageManager, hostRuntime), versions);
+  const requirements = getBaselineRequirements(packageManager, hostRuntime);
+  const fatal = requirements.filter(
+    (requirement) => requirement.tool === "node" || packageManagerIsExplicit,
+  );
+  const fatalResult = validateRequirements(fatal, versions, BASELINE_REQUIREMENTS_HEADLINE);
+  if (fatalResult.isErr()) return Result.err(fatalResult.error);
+
+  const advisory = requirements.filter((requirement) => !fatal.includes(requirement));
+  const advisoryResult = validateRequirements(advisory, versions, BASELINE_REQUIREMENTS_HEADLINE);
+  if (advisoryResult.isErr()) {
+    return Result.ok({
+      warnings: [
+        `${advisoryResult.error.message}\nYou can also choose a different package manager at the package manager step.`,
+      ],
+    });
+  }
+
+  return Result.ok({ warnings: [] });
 }
 
 export async function checkLocalRequirements(

--- a/apps/cli/test/requirements.test.ts
+++ b/apps/cli/test/requirements.test.ts
@@ -45,7 +45,23 @@ describe("baseline requirements (before prompts)", () => {
     expect(detectInvokingPackageManager("pnpm/10.26.0 npm/? node/v22.0.0")).toBe("pnpm");
     expect(detectInvokingPackageManager("npm/11.16.0 node/v24.0.0")).toBe("npm");
     expect(detectInvokingPackageManager("yarn/4.0.0 npm/?")).toBeUndefined();
-    expect(detectInvokingPackageManager(undefined)).toBeUndefined();
+    expect(detectInvokingPackageManager("")).toBeUndefined();
+  });
+
+  it("uses a stack-neutral headline for the pre-prompt check", () => {
+    const result = validateRequirements(
+      getBaselineRequirements("pnpm", "node"),
+      { pnpm: "9.15.0", node: "v22.22.0" },
+      "Your local toolchain does not meet create-better-t-stack's requirements:",
+    );
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(
+        result.error.message.startsWith(
+          "Your local toolchain does not meet create-better-t-stack's requirements:",
+        ),
+      ).toBe(true);
+    }
   });
 });
 

--- a/apps/cli/test/requirements.test.ts
+++ b/apps/cli/test/requirements.test.ts
@@ -1,13 +1,53 @@
 import { describe, expect, it } from "bun:test";
 
 import type { ProjectConfig } from "../src/types";
+import { detectInvokingPackageManager } from "../src/utils/cli-invocation";
 import {
   PACKAGE_MANAGER_VERSION_RANGES,
   RECOMMENDED_BUN_VERSION_RANGE,
+  getBaselineRequirements,
   getLocalVersionRequirements,
   getLocalToolRecommendations,
   validateLocalToolVersions,
+  validateRequirements,
 } from "../src/utils/requirements";
+
+describe("baseline requirements (before prompts)", () => {
+  it("covers only the package manager and the host Node.js, never the stack", () => {
+    expect(getBaselineRequirements("pnpm", "node")).toEqual([
+      expect.objectContaining({ tool: "pnpm", range: PACKAGE_MANAGER_VERSION_RANGES.pnpm }),
+      expect.objectContaining({ tool: "node", range: ">=22.0.0" }),
+    ]);
+    expect(getBaselineRequirements(undefined, "bun")).toEqual([]);
+  });
+
+  it("fails an outdated pnpm before any stack is chosen", () => {
+    const result = validateRequirements(getBaselineRequirements("pnpm", "node"), {
+      pnpm: "9.15.0",
+      node: "v22.22.0",
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("pnpm 9.15.0 does not satisfy");
+      expect(result.error.message).toContain("pnpm self-update");
+    }
+
+    expect(
+      validateRequirements(getBaselineRequirements("pnpm", "node"), {
+        pnpm: "10.26.0",
+        node: "v22.22.0",
+      }).isOk(),
+    ).toBe(true);
+  });
+
+  it("detects the launching package manager from the npm user agent", () => {
+    expect(detectInvokingPackageManager("bun/1.4.0 npm/? node/v24.0.0")).toBe("bun");
+    expect(detectInvokingPackageManager("pnpm/10.26.0 npm/? node/v22.0.0")).toBe("pnpm");
+    expect(detectInvokingPackageManager("npm/11.16.0 node/v24.0.0")).toBe("npm");
+    expect(detectInvokingPackageManager("yarn/4.0.0 npm/?")).toBeUndefined();
+    expect(detectInvokingPackageManager(undefined)).toBeUndefined();
+  });
+});
 
 type RequirementConfig = Pick<
   ProjectConfig,


### PR DESCRIPTION
## Why

Day-one `cli_failed` data: 7 of 14 failures were `Your local toolchain does not meet this stack's requirements`, and 8 of 13 failing runs used pnpm, which needs `>=10.26.0`. That check ran at the end of the flow, after the user had answered all 17 prompts.

## What

- New `checkBaselineRequirements(packageManager)` in `utils/requirements.ts`: validates the package manager version (from `--package-manager`, else the launching user agent via `detectInvokingPackageManager()`) and the host Node.js (`>=22`) right after the intro, before the project-name prompt. Interactive runs only; silent/JSON/API/MCP paths keep the existing single check since they have no prompts to waste.
- `validateRequirements()` factored out so the pre-prompt and the full stack-aware check share the same messages and upgrade instructions. The full check still runs once the config is known, for stack-specific Node ranges.
- `getCliSubcommandCommand` reuses the new user-agent detection.

## Verified

- Built CLI with a shimmed `pnpm` reporting 9.15.0 and `npm_config_user_agent=pnpm/9.15.0`: exits 1 immediately after the intro with `pnpm 9.15.0 does not satisfy >=10.26.0 ...` and the `pnpm self-update` hint, no prompt shown.
- Same run with `--package-manager bun` proceeds to the first prompt.
- Tests added for the baseline requirement set, the pnpm failure/pass cases, and user-agent detection; requirements/cli-ux/dry-run/silent/mcp suites pass (57).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an early command-line environment check before project setup prompts.
  * Automatically detects whether npm, pnpm, or Bun initiated the command.
  * Validates the detected package manager and Node.js/Bun runtime versions.

* **Bug Fixes**
  * Provides clearer guidance when required tools are outdated, including package-manager update instructions.
  * Uses the selected package manager when available, with automatic detection as a fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->