### PR TITLE
fix(cli): check the toolchain before prompts and keep going when the install fails

### DIFF
--- a/apps/cli/src/helpers/addons/addons-setup.ts
+++ b/apps/cli/src/helpers/addons/addons-setup.ts
@@ -2,13 +2,11 @@ import path from "node:path";
 
 import { Result } from "better-result";
 import fs from "fs-extra";
-import pc from "picocolors";
 
 import { desktopWebFrontends, type ProjectConfig } from "../../types";
 import { addPackageDependency } from "../../utils/add-package-deps";
 import { AddonSetupError, UserCancelledError } from "../../utils/errors";
-import { wasInterrupted } from "../../utils/interrupt";
-import { cliConsola, cliLog } from "../../utils/terminal-output";
+import { runOptionalStep } from "../../utils/optional-step";
 import { setupEvlog } from "./evlog-setup";
 import { setupFumadocs } from "./fumadocs-setup";
 import { setupMcp } from "./mcp-setup";
@@ -20,41 +18,23 @@ import { setupTui } from "./tui-setup";
 import { setupUltracite } from "./ultracite-setup";
 import { setupWxt } from "./wxt-setup";
 
-// Helper to run setup and handle Result
-async function runSetup<T, E extends AddonSetupError | UserCancelledError>(
-  setupFn: () => Promise<Result<T, E>>,
-): Promise<void> {
-  const result = await setupFn();
-  if (result.isErr()) {
-    // The project is already on disk, so cancelling here only skips this step
-    if (UserCancelledError.is(result.error) || wasInterrupted()) {
-      cliLog.warn(pc.yellow("Addon setup cancelled."));
-      return;
-    }
-    // Log other errors but don't fail the overall project creation
-    cliConsola.error(pc.red(result.error.message));
-  }
-}
+const runSetup = <T>(setupFn: () => Promise<Result<T, AddonSetupError | UserCancelledError>>) =>
+  runOptionalStep(setupFn, "Addon setup cancelled.");
 
-async function runAddonStep(addon: string, step: () => Promise<void>): Promise<void> {
-  const result = await Result.tryPromise({
-    try: async () => step(),
-    catch: (e) =>
-      new AddonSetupError({
-        addon,
-        message: `Failed to set up ${addon}: ${e instanceof Error ? e.message : String(e)}`,
-        cause: e,
+const runAddonStep = (addon: string, step: () => Promise<void>) =>
+  runOptionalStep(
+    () =>
+      Result.tryPromise({
+        try: async () => step(),
+        catch: (e) =>
+          new AddonSetupError({
+            addon,
+            message: `Failed to set up ${addon}: ${e instanceof Error ? e.message : String(e)}`,
+            cause: e,
+          }),
       }),
-  });
-
-  if (result.isErr()) {
-    if (wasInterrupted()) {
-      cliLog.warn(pc.yellow(`${addon} setup cancelled.`));
-      return;
-    }
-    cliConsola.error(pc.red(result.error.message));
-  }
-}
+    `${addon} setup cancelled.`,
+  );
 
 export async function setupAddons(config: ProjectConfig): Promise<void> {
   const { addons, frontend, projectDir } = config;

--- a/apps/cli/src/helpers/addons/addons-setup.ts
+++ b/apps/cli/src/helpers/addons/addons-setup.ts
@@ -7,7 +7,8 @@ import pc from "picocolors";
 import { desktopWebFrontends, type ProjectConfig } from "../../types";
 import { addPackageDependency } from "../../utils/add-package-deps";
 import { AddonSetupError, UserCancelledError } from "../../utils/errors";
-import { cliConsola } from "../../utils/terminal-output";
+import { wasInterrupted } from "../../utils/interrupt";
+import { cliConsola, cliLog } from "../../utils/terminal-output";
 import { setupEvlog } from "./evlog-setup";
 import { setupFumadocs } from "./fumadocs-setup";
 import { setupMcp } from "./mcp-setup";
@@ -25,9 +26,10 @@ async function runSetup<T, E extends AddonSetupError | UserCancelledError>(
 ): Promise<void> {
   const result = await setupFn();
   if (result.isErr()) {
-    // Re-throw user cancellation to propagate up
-    if (UserCancelledError.is(result.error)) {
-      throw result.error;
+    // The project is already on disk, so cancelling here only skips this step
+    if (UserCancelledError.is(result.error) || wasInterrupted()) {
+      cliLog.warn(pc.yellow("Addon setup cancelled."));
+      return;
     }
     // Log other errors but don't fail the overall project creation
     cliConsola.error(pc.red(result.error.message));
@@ -46,6 +48,10 @@ async function runAddonStep(addon: string, step: () => Promise<void>): Promise<v
   });
 
   if (result.isErr()) {
+    if (wasInterrupted()) {
+      cliLog.warn(pc.yellow(`${addon} setup cancelled.`));
+      return;
+    }
     cliConsola.error(pc.red(result.error.message));
   }
 }

--- a/apps/cli/src/helpers/core/add-handler.ts
+++ b/apps/cli/src/helpers/core/add-handler.ts
@@ -27,6 +27,7 @@ import { errorClass, failureStage, reportDiagnostic, scrubReason } from "../../u
 import { formatConfigValue } from "../../utils/display-config";
 import { CLIError, UserCancelledError, displayError } from "../../utils/errors";
 import { validateAgentSafePathInput } from "../../utils/input-hardening";
+import { beginInterruptibleScope, endInterruptibleScope } from "../../utils/interrupt";
 import { renderTitle } from "../../utils/render-title";
 import { checkLocalRequirements } from "../../utils/requirements";
 import { setupAddons } from "../addons/addons-setup";
@@ -286,6 +287,7 @@ export async function addHandler(
     { silent, mode, analyticsDisabled: input.disableAnalytics },
     async () => {
       const result = await addHandlerInternal(input);
+      endInterruptibleScope();
       await reportAddOutcome(input, result);
 
       if (result.isOk()) {
@@ -625,6 +627,9 @@ async function addHandlerInternal(
   if (vfs.getFileCount() > 0 && !isSilent()) {
     log.info(pc.dim(`Wrote ${vfs.getFileCount()} files`));
   }
+
+  // Files are on disk from here: Ctrl-C only stops the current step
+  beginInterruptibleScope();
 
   // Run addon setup (handles deps and interactive prompts)
   // Wrap with Result.tryPromise since setupAddons can throw UserCancelledError

--- a/apps/cli/src/helpers/core/command-handlers.ts
+++ b/apps/cli/src/helpers/core/command-handlers.ts
@@ -10,7 +10,7 @@ import { gatherConfig } from "../../prompts/config-prompts";
 import { getProjectName } from "../../prompts/project-name";
 import type { AnalyticsMode, CreateInput, DirectoryConflict, ProjectConfig } from "../../types";
 import { trackProjectCreation } from "../../utils/analytics";
-import { detectInvokingPackageManager, getCliSubcommandCommand } from "../../utils/cli-invocation";
+import { getCliSubcommandCommand } from "../../utils/cli-invocation";
 import { isSilent, resolveInvocationMode, runWithContextAsync } from "../../utils/context";
 import { errorClass, failureStage, reportDiagnostic, scrubReason } from "../../utils/diagnostics";
 import { displayConfig } from "../../utils/display-config";
@@ -23,6 +23,7 @@ import {
   displayError,
   isUserCancellation,
 } from "../../utils/errors";
+import { getUserPkgManager } from "../../utils/get-package-manager";
 import { validateAgentSafePathInput } from "../../utils/input-hardening";
 import {
   findAvailableIncrementedPath,
@@ -235,7 +236,7 @@ async function createProjectHandlerInternal(
     if (!isSilent()) {
       const baseline = yield* Result.await(
         checkBaselineRequirements(
-          input.packageManager ?? detectInvokingPackageManager(),
+          input.packageManager ?? getUserPkgManager(),
           input.packageManager !== undefined,
         ),
       );

--- a/apps/cli/src/helpers/core/command-handlers.ts
+++ b/apps/cli/src/helpers/core/command-handlers.ts
@@ -484,7 +484,7 @@ async function createProjectHandlerInternal(
 
     const warnings: string[] = [];
     if (created.interrupted) {
-      warnings.push("Setup was interrupted; the remaining setup steps were skipped.");
+      warnings.push("One or more setup steps were cancelled.");
     }
     if (created.installError) {
       warnings.push(created.installError.message);

--- a/apps/cli/src/helpers/core/command-handlers.ts
+++ b/apps/cli/src/helpers/core/command-handlers.ts
@@ -483,6 +483,9 @@ async function createProjectHandlerInternal(
     await trackProjectCreation(config, input.disableAnalytics, mode);
 
     const warnings: string[] = [];
+    if (created.install === "cancelled") {
+      warnings.push("Dependency install was cancelled.");
+    }
     if (created.installError) {
       warnings.push(created.installError.message);
       await reportDiagnostic("cli_failed", {

--- a/apps/cli/src/helpers/core/command-handlers.ts
+++ b/apps/cli/src/helpers/core/command-handlers.ts
@@ -483,8 +483,8 @@ async function createProjectHandlerInternal(
     await trackProjectCreation(config, input.disableAnalytics, mode);
 
     const warnings: string[] = [];
-    if (created.install === "cancelled") {
-      warnings.push("Dependency install was cancelled.");
+    if (created.interrupted) {
+      warnings.push("Setup was interrupted; the remaining setup steps were skipped.");
     }
     if (created.installError) {
       warnings.push(created.installError.message);

--- a/apps/cli/src/helpers/core/command-handlers.ts
+++ b/apps/cli/src/helpers/core/command-handlers.ts
@@ -75,6 +75,8 @@ export interface CreateProjectResult {
   projectDirectory: string;
   relativePath: string;
   error?: string;
+  /** Non-fatal problems, such as a dependency install that failed after the files were written. */
+  warnings?: string[];
 }
 
 /**
@@ -457,7 +459,7 @@ async function createProjectHandlerInternal(
     }
 
     // Create the project
-    yield* Result.await(
+    const created = yield* Result.await(
       createProject(config, {
         manualDb: cliInput.manualDb ?? input.manualDb,
         dbSetupOptions: effectiveDbSetupOptions,
@@ -465,7 +467,23 @@ async function createProjectHandlerInternal(
       }),
     );
 
-    await trackProjectCreation(config, input.disableAnalytics, resolveInvocationMode(input.yes));
+    const mode = resolveInvocationMode(input.yes);
+    await trackProjectCreation(config, input.disableAnalytics, mode);
+
+    // The project exists even when the install failed; keep that visible in diagnostics.
+    const warnings: string[] = [];
+    if (created.installError) {
+      warnings.push(created.installError.message);
+      await reportDiagnostic("cli_failed", {
+        command: "create",
+        mode,
+        stage: "dependency-installation",
+        error: errorClass(created.installError),
+        reason: scrubReason(created.installError),
+        packageManager: config.packageManager,
+        backend: config.backend,
+      });
+    }
 
     // Track locally in history.json (non-fatal)
     const historyResult = await addToHistory(config, reproducibleCommand);
@@ -515,6 +533,7 @@ async function createProjectHandlerInternal(
       elapsedTimeMs,
       projectDirectory: config.projectDir,
       relativePath: config.relativePath,
+      warnings: warnings.length > 0 ? warnings : undefined,
     });
   });
 }

--- a/apps/cli/src/helpers/core/command-handlers.ts
+++ b/apps/cli/src/helpers/core/command-handlers.ts
@@ -76,7 +76,6 @@ export interface CreateProjectResult {
   projectDirectory: string;
   relativePath: string;
   error?: string;
-  /** Non-fatal problems, such as a dependency install that failed after the files were written. */
   warnings?: string[];
 }
 
@@ -231,8 +230,6 @@ async function createProjectHandlerInternal(
       log.warn(pc.yellow("YOLO mode enabled — compatibility checks are disabled."));
     }
 
-    // Before any prompt: the package manager that will run the install and the Node.js
-    // hosting the CLI. Stack-specific requirements are checked once the config is known.
     if (!isSilent()) {
       const baseline = yield* Result.await(
         checkBaselineRequirements(
@@ -485,7 +482,6 @@ async function createProjectHandlerInternal(
     const mode = resolveInvocationMode(input.yes);
     await trackProjectCreation(config, input.disableAnalytics, mode);
 
-    // The project exists even when the install failed; keep that visible in diagnostics.
     const warnings: string[] = [];
     if (created.installError) {
       warnings.push(created.installError.message);

--- a/apps/cli/src/helpers/core/command-handlers.ts
+++ b/apps/cli/src/helpers/core/command-handlers.ts
@@ -231,9 +231,15 @@ async function createProjectHandlerInternal(
     // Before any prompt: the package manager that will run the install and the Node.js
     // hosting the CLI. Stack-specific requirements are checked once the config is known.
     if (!isSilent()) {
-      yield* Result.await(
-        checkBaselineRequirements(input.packageManager ?? detectInvokingPackageManager()),
+      const baseline = yield* Result.await(
+        checkBaselineRequirements(
+          input.packageManager ?? detectInvokingPackageManager(),
+          input.packageManager !== undefined,
+        ),
       );
+      for (const warning of baseline.warnings) {
+        log.warn(pc.yellow(warning));
+      }
     }
 
     // Get project name

--- a/apps/cli/src/helpers/core/command-handlers.ts
+++ b/apps/cli/src/helpers/core/command-handlers.ts
@@ -10,7 +10,7 @@ import { gatherConfig } from "../../prompts/config-prompts";
 import { getProjectName } from "../../prompts/project-name";
 import type { AnalyticsMode, CreateInput, DirectoryConflict, ProjectConfig } from "../../types";
 import { trackProjectCreation } from "../../utils/analytics";
-import { getCliSubcommandCommand } from "../../utils/cli-invocation";
+import { detectInvokingPackageManager, getCliSubcommandCommand } from "../../utils/cli-invocation";
 import { isSilent, resolveInvocationMode, runWithContextAsync } from "../../utils/context";
 import { errorClass, failureStage, reportDiagnostic, scrubReason } from "../../utils/diagnostics";
 import { displayConfig } from "../../utils/display-config";
@@ -41,7 +41,7 @@ import {
 } from "../../utils/project-launcher";
 import { validateProjectName } from "../../utils/project-name-validation";
 import { renderTitle } from "../../utils/render-title";
-import { checkLocalRequirements } from "../../utils/requirements";
+import { checkBaselineRequirements, checkLocalRequirements } from "../../utils/requirements";
 import { getTemplateConfig, getTemplateDescription } from "../../utils/templates";
 import {
   getProvidedFlags,
@@ -226,6 +226,14 @@ async function createProjectHandlerInternal(
 
     if (!isSilent() && input.yolo) {
       log.warn(pc.yellow("YOLO mode enabled — compatibility checks are disabled."));
+    }
+
+    // Before any prompt: the package manager that will run the install and the Node.js
+    // hosting the CLI. Stack-specific requirements are checked once the config is known.
+    if (!isSilent()) {
+      yield* Result.await(
+        checkBaselineRequirements(input.packageManager ?? detectInvokingPackageManager()),
+      );
     }
 
     // Get project name

--- a/apps/cli/src/helpers/core/create-project.ts
+++ b/apps/cli/src/helpers/core/create-project.ts
@@ -14,7 +14,7 @@ import { getLatestCLIVersion } from "../../utils/get-latest-cli-version";
 import {
   beginInterruptibleScope,
   endInterruptibleScope,
-  wasInterrupted,
+  wasAnyStepInterrupted,
 } from "../../utils/interrupt";
 import { setupAddons } from "../addons/addons-setup";
 import { setupDatabase } from "../core/db-setup";
@@ -115,7 +115,7 @@ async function* runPostScaffoldSteps(
   isConvex: boolean,
 ) {
   // Setup database if needed
-  if (!isConvex && options.database !== "none" && !wasInterrupted()) {
+  if (!isConvex && options.database !== "none") {
     yield* Result.await(
       Result.tryPromise({
         try: () => setupDatabase(options, cliInput),
@@ -130,7 +130,7 @@ async function* runPostScaffoldSteps(
   }
 
   // Setup addons if any
-  if (options.addons.length > 0 && options.addons[0] !== "none" && !wasInterrupted()) {
+  if (options.addons.length > 0 && options.addons[0] !== "none") {
     yield* Result.await(
       Result.tryPromise({
         try: () => setupAddons(options),
@@ -152,9 +152,7 @@ async function* runPostScaffoldSteps(
   // Install dependencies if requested
   let install: CreateProjectOutcome["install"] = "skipped";
   let installError: ProjectCreationError | null = null;
-  if (options.install && wasInterrupted()) {
-    install = "cancelled";
-  } else if (options.install) {
+  if (options.install) {
     const installResult = await installDependencies({
       projectDir,
       packageManager: options.packageManager,
@@ -178,7 +176,7 @@ async function* runPostScaffoldSteps(
     });
   }
 
-  return Result.ok({ projectDir, install, installError, interrupted: wasInterrupted() });
+  return Result.ok({ projectDir, install, installError, interrupted: wasAnyStepInterrupted() });
 }
 
 async function setPackageManagerVersion(

--- a/apps/cli/src/helpers/core/create-project.ts
+++ b/apps/cli/src/helpers/core/create-project.ts
@@ -26,14 +26,13 @@ export interface CreateProjectOptions {
 
 export interface CreateProjectOutcome {
   projectDir: string;
-  /** Set when the files were written but the dependency install failed. */
   installError: ProjectCreationError | null;
 }
 
 /**
  * Creates a new project with the given configuration.
- * Returns a Result with the outcome on success, or an error on failure. A failed dependency
- * install is not a failure: the project exists on disk, so it is reported as a warning.
+ * A failed dependency install is returned in the outcome instead of failing, since the project
+ * is already on disk by then.
  */
 export async function createProject(
   options: ProjectConfig,
@@ -128,8 +127,7 @@ export async function createProject(
 
     if (!isSilent()) log.success("Project scaffolded");
 
-    // Install dependencies if requested. The project is already on disk at this point, so a
-    // failed install must not fail the run: warn, and the next steps below include the install.
+    // Install dependencies if requested
     let installError: ProjectCreationError | null = null;
     if (options.install) {
       const installResult = await installDependencies({

--- a/apps/cli/src/helpers/core/create-project.ts
+++ b/apps/cli/src/helpers/core/create-project.ts
@@ -11,6 +11,11 @@ import { isSilent } from "../../utils/context";
 import { ProjectCreationError } from "../../utils/errors";
 import { formatProject } from "../../utils/file-formatter";
 import { getLatestCLIVersion } from "../../utils/get-latest-cli-version";
+import {
+  beginInterruptibleScope,
+  endInterruptibleScope,
+  wasInterrupted,
+} from "../../utils/interrupt";
 import { setupAddons } from "../addons/addons-setup";
 import { setupDatabase } from "../core/db-setup";
 import { initializeGit } from "./git";
@@ -27,6 +32,7 @@ export interface CreateProjectOutcome {
   projectDir: string;
   install: "installed" | "skipped" | "cancelled" | "failed";
   installError: ProjectCreationError | null;
+  interrupted: boolean;
 }
 
 /**
@@ -92,70 +98,87 @@ export async function createProject(
       setPackageManagerVersion(projectDir, options.packageManager, cliInput.packageManagerVersion),
     );
 
-    // Setup database if needed
-    if (!isConvex && options.database !== "none") {
-      yield* Result.await(
-        Result.tryPromise({
-          try: () => setupDatabase(options, cliInput),
-          catch: (e) =>
-            new ProjectCreationError({
-              phase: "database-setup",
-              message: `Failed to setup database: ${e instanceof Error ? e.message : String(e)}`,
-              cause: e,
-            }),
-        }),
-      );
+    // Files are on disk from here: Ctrl-C only stops the current step
+    beginInterruptibleScope();
+    try {
+      return yield* runPostScaffoldSteps(options, cliInput, projectDir, isConvex);
+    } finally {
+      endInterruptibleScope();
     }
-
-    // Setup addons if any
-    if (options.addons.length > 0 && options.addons[0] !== "none") {
-      yield* Result.await(
-        Result.tryPromise({
-          try: () => setupAddons(options),
-          catch: (e) =>
-            new ProjectCreationError({
-              phase: "addons-setup",
-              message: `Failed to setup addons: ${e instanceof Error ? e.message : String(e)}`,
-              cause: e,
-            }),
-        }),
-      );
-    }
-
-    // Format project
-    yield* Result.await(formatProject(projectDir));
-
-    if (!isSilent()) log.success("Project scaffolded");
-
-    // Install dependencies if requested
-    let install: CreateProjectOutcome["install"] = "skipped";
-    let installError: ProjectCreationError | null = null;
-    if (options.install) {
-      const installResult = await installDependencies({
-        projectDir,
-        packageManager: options.packageManager,
-      });
-      if (installResult.isErr()) {
-        install = "failed";
-        installError = installResult.error;
-      } else {
-        install = installResult.value;
-      }
-    }
-
-    // Initialize git if requested
-    yield* Result.await(initializeGit(projectDir, options.git));
-
-    // Display post-install instructions
-    if (!isSilent()) {
-      await displayPostInstallInstructions({
-        ...options,
-        depsInstalled: install === "installed",
-      });
-    }
-
-    return Result.ok({ projectDir, install, installError });
   });
+}
+
+async function* runPostScaffoldSteps(
+  options: ProjectConfig,
+  cliInput: CreateProjectOptions,
+  projectDir: string,
+  isConvex: boolean,
+) {
+  // Setup database if needed
+  if (!isConvex && options.database !== "none" && !wasInterrupted()) {
+    yield* Result.await(
+      Result.tryPromise({
+        try: () => setupDatabase(options, cliInput),
+        catch: (e) =>
+          new ProjectCreationError({
+            phase: "database-setup",
+            message: `Failed to setup database: ${e instanceof Error ? e.message : String(e)}`,
+            cause: e,
+          }),
+      }),
+    );
+  }
+
+  // Setup addons if any
+  if (options.addons.length > 0 && options.addons[0] !== "none" && !wasInterrupted()) {
+    yield* Result.await(
+      Result.tryPromise({
+        try: () => setupAddons(options),
+        catch: (e) =>
+          new ProjectCreationError({
+            phase: "addons-setup",
+            message: `Failed to setup addons: ${e instanceof Error ? e.message : String(e)}`,
+            cause: e,
+          }),
+      }),
+    );
+  }
+
+  // Format project
+  yield* Result.await(formatProject(projectDir));
+
+  if (!isSilent()) log.success("Project scaffolded");
+
+  // Install dependencies if requested
+  let install: CreateProjectOutcome["install"] = "skipped";
+  let installError: ProjectCreationError | null = null;
+  if (options.install && wasInterrupted()) {
+    install = "cancelled";
+  } else if (options.install) {
+    const installResult = await installDependencies({
+      projectDir,
+      packageManager: options.packageManager,
+    });
+    if (installResult.isErr()) {
+      install = "failed";
+      installError = installResult.error;
+    } else {
+      install = installResult.value;
+    }
+  }
+
+  // Initialize git if requested
+  yield* Result.await(initializeGit(projectDir, options.git));
+
+  // Display post-install instructions
+  if (!isSilent()) {
+    await displayPostInstallInstructions({
+      ...options,
+      depsInstalled: install === "installed",
+    });
+  }
+
+  return Result.ok({ projectDir, install, installError, interrupted: wasInterrupted() });
 }
 
 async function setPackageManagerVersion(

--- a/apps/cli/src/helpers/core/create-project.ts
+++ b/apps/cli/src/helpers/core/create-project.ts
@@ -26,6 +26,7 @@ export interface CreateProjectOptions {
 
 export interface CreateProjectOutcome {
   projectDir: string;
+  install: "installed" | "skipped" | "cancelled" | "failed";
   installError: ProjectCreationError | null;
 }
 
@@ -128,6 +129,7 @@ export async function createProject(
     if (!isSilent()) log.success("Project scaffolded");
 
     // Install dependencies if requested
+    let install: CreateProjectOutcome["install"] = "skipped";
     let installError: ProjectCreationError | null = null;
     if (options.install) {
       const installResult = await installDependencies({
@@ -135,14 +137,17 @@ export async function createProject(
         packageManager: options.packageManager,
       });
       if (installResult.isErr()) {
+        install = "failed";
         installError = installResult.error;
-        if (!isSilent()) {
-          log.warn(
-            pc.yellow(
-              `Dependencies were not installed. Run \`${options.packageManager} install\` in ${options.relativePath} and continue with the steps below.`,
-            ),
-          );
-        }
+      } else {
+        install = installResult.value;
+      }
+      if (install !== "installed" && !isSilent()) {
+        log.warn(
+          pc.yellow(
+            `Dependencies were not installed. Run \`${options.packageManager} install\` in ${options.relativePath} and continue with the steps below.`,
+          ),
+        );
       }
     }
 
@@ -153,11 +158,11 @@ export async function createProject(
     if (!isSilent()) {
       await displayPostInstallInstructions({
         ...options,
-        depsInstalled: options.install && installError === null,
+        depsInstalled: install === "installed",
       });
     }
 
-    return Result.ok({ projectDir, installError });
+    return Result.ok({ projectDir, install, installError });
   });
 }
 

--- a/apps/cli/src/helpers/core/create-project.ts
+++ b/apps/cli/src/helpers/core/create-project.ts
@@ -5,6 +5,7 @@ import { writeTree } from "@better-t-stack/template-generator/fs-writer";
 import { log } from "@clack/prompts";
 import { Result } from "better-result";
 import fs from "fs-extra";
+import pc from "picocolors";
 
 import type { DbSetupOptions, ProjectConfig } from "../../types";
 import { isSilent } from "../../utils/context";
@@ -23,14 +24,21 @@ export interface CreateProjectOptions {
   packageManagerVersion: string;
 }
 
+export interface CreateProjectOutcome {
+  projectDir: string;
+  /** Set when the files were written but the dependency install failed. */
+  installError: ProjectCreationError | null;
+}
+
 /**
  * Creates a new project with the given configuration.
- * Returns a Result with the project directory path on success, or an error on failure.
+ * Returns a Result with the outcome on success, or an error on failure. A failed dependency
+ * install is not a failure: the project exists on disk, so it is reported as a warning.
  */
 export async function createProject(
   options: ProjectConfig,
   cliInput: CreateProjectOptions,
-): Promise<Result<string, ProjectCreationError>> {
+): Promise<Result<CreateProjectOutcome, ProjectCreationError>> {
   return Result.gen(async function* () {
     const projectDir = options.projectDir;
     const isConvex = options.backend === "convex";
@@ -120,14 +128,24 @@ export async function createProject(
 
     if (!isSilent()) log.success("Project scaffolded");
 
-    // Install dependencies if requested
+    // Install dependencies if requested. The project is already on disk at this point, so a
+    // failed install must not fail the run: warn, and the next steps below include the install.
+    let installError: ProjectCreationError | null = null;
     if (options.install) {
-      yield* Result.await(
-        installDependencies({
-          projectDir,
-          packageManager: options.packageManager,
-        }),
-      );
+      const installResult = await installDependencies({
+        projectDir,
+        packageManager: options.packageManager,
+      });
+      if (installResult.isErr()) {
+        installError = installResult.error;
+        if (!isSilent()) {
+          log.warn(
+            pc.yellow(
+              `Dependencies were not installed. Run \`${options.packageManager} install\` in ${options.relativePath} and continue with the steps below.`,
+            ),
+          );
+        }
+      }
     }
 
     // Initialize git if requested
@@ -137,11 +155,11 @@ export async function createProject(
     if (!isSilent()) {
       await displayPostInstallInstructions({
         ...options,
-        depsInstalled: options.install,
+        depsInstalled: options.install && installError === null,
       });
     }
 
-    return Result.ok(projectDir);
+    return Result.ok({ projectDir, installError });
   });
 }
 

--- a/apps/cli/src/helpers/core/create-project.ts
+++ b/apps/cli/src/helpers/core/create-project.ts
@@ -5,7 +5,6 @@ import { writeTree } from "@better-t-stack/template-generator/fs-writer";
 import { log } from "@clack/prompts";
 import { Result } from "better-result";
 import fs from "fs-extra";
-import pc from "picocolors";
 
 import type { DbSetupOptions, ProjectConfig } from "../../types";
 import { isSilent } from "../../utils/context";
@@ -141,13 +140,6 @@ export async function createProject(
         installError = installResult.error;
       } else {
         install = installResult.value;
-      }
-      if (install !== "installed" && !isSilent()) {
-        log.warn(
-          pc.yellow(
-            `Dependencies were not installed. Run \`${options.packageManager} install\` in ${options.relativePath} and continue with the steps below.`,
-          ),
-        );
       }
     }
 

--- a/apps/cli/src/helpers/core/db-setup.ts
+++ b/apps/cli/src/helpers/core/db-setup.ts
@@ -13,7 +13,8 @@ import pc from "picocolors";
 
 import type { ProjectConfig } from "../../types";
 import { DatabaseSetupError, UserCancelledError } from "../../utils/errors";
-import { cliConsola } from "../../utils/terminal-output";
+import { wasInterrupted } from "../../utils/interrupt";
+import { cliConsola, cliLog } from "../../utils/terminal-output";
 import { setupCloudflareD1 } from "../database-providers/d1-setup";
 import { setupDockerCompose } from "../database-providers/docker-compose-setup";
 import { setupMongoDBAtlas } from "../database-providers/mongodb-atlas-setup";
@@ -58,9 +59,10 @@ export async function setupDatabase(
   ): Promise<void> {
     const result = await setupFn();
     if (result.isErr()) {
-      // Re-throw user cancellation to propagate up
-      if (UserCancelledError.is(result.error)) {
-        throw result.error;
+      // The project is already on disk, so cancelling here only skips this step
+      if (UserCancelledError.is(result.error) || wasInterrupted()) {
+        cliLog.warn(pc.yellow("Database setup cancelled. Configure the connection manually."));
+        return;
       }
       // Log other errors but don't fail the overall project creation
       cliConsola.error(pc.red(result.error.message));

--- a/apps/cli/src/helpers/core/db-setup.ts
+++ b/apps/cli/src/helpers/core/db-setup.ts
@@ -9,12 +9,10 @@ import path from "node:path";
 import { usesAlchemyManagedDatabase } from "@better-t-stack/types";
 import { Result } from "better-result";
 import fs from "fs-extra";
-import pc from "picocolors";
 
 import type { ProjectConfig } from "../../types";
 import { DatabaseSetupError, UserCancelledError } from "../../utils/errors";
-import { wasInterrupted } from "../../utils/interrupt";
-import { cliConsola, cliLog } from "../../utils/terminal-output";
+import { runOptionalStep } from "../../utils/optional-step";
 import { setupCloudflareD1 } from "../database-providers/d1-setup";
 import { setupDockerCompose } from "../database-providers/docker-compose-setup";
 import { setupMongoDBAtlas } from "../database-providers/mongodb-atlas-setup";
@@ -53,21 +51,9 @@ export async function setupDatabase(
     return;
   }
 
-  // Helper to run setup and handle Result
-  async function runSetup<T, E extends UserCancelledError | DatabaseSetupError>(
-    setupFn: () => Promise<Result<T, E>>,
-  ): Promise<void> {
-    const result = await setupFn();
-    if (result.isErr()) {
-      // The project is already on disk, so cancelling here only skips this step
-      if (UserCancelledError.is(result.error) || wasInterrupted()) {
-        cliLog.warn(pc.yellow("Database setup cancelled. Configure the connection manually."));
-        return;
-      }
-      // Log other errors but don't fail the overall project creation
-      cliConsola.error(pc.red(result.error.message));
-    }
-  }
+  const runSetup = <T>(
+    setupFn: () => Promise<Result<T, DatabaseSetupError | UserCancelledError>>,
+  ) => runOptionalStep(setupFn, "Database setup cancelled. Configure the connection manually.");
 
   const resolvedCliInput: DatabaseSetupCliOptions = {
     ...cliInput,

--- a/apps/cli/src/helpers/core/install-dependencies.ts
+++ b/apps/cli/src/helpers/core/install-dependencies.ts
@@ -7,6 +7,15 @@ import { ProjectCreationError } from "../../utils/errors";
 import { shouldSkipExternalCommands } from "../../utils/external-commands";
 import { createSpinner } from "../../utils/terminal-output";
 
+export type InstallStatus = "installed" | "cancelled";
+
+const FORCE_KILL_AFTER_MS = 2000;
+
+/**
+ * Ctrl-C during the install only stops the install: the CLI keeps its own SIGINT listener
+ * while the package manager runs so the process is not terminated, and execa's cancelSignal
+ * ends the subprocess.
+ */
 export async function installDependencies({
   projectDir,
   packageManager,
@@ -14,20 +23,25 @@ export async function installDependencies({
   projectDir: string;
   packageManager: PackageManager;
   addons?: Addons[];
-}): Promise<Result<void, ProjectCreationError>> {
+}): Promise<Result<InstallStatus, ProjectCreationError>> {
   if (shouldSkipExternalCommands()) {
-    return Result.ok(undefined);
+    return Result.ok("installed");
   }
 
   const s = createSpinner();
-
   s.start(`Running ${packageManager} install...`);
+
+  const controller = new AbortController();
+  const onSigint = () => controller.abort();
+  process.on("SIGINT", onSigint);
 
   const result = await Result.tryPromise({
     try: async () => {
       await $({
         cwd: projectDir,
         stderr: "inherit",
+        cancelSignal: controller.signal,
+        forceKillAfterDelay: FORCE_KILL_AFTER_MS,
       })`${packageManager} install`;
     },
     catch: (e) =>
@@ -38,11 +52,18 @@ export async function installDependencies({
       }),
   });
 
-  if (result.isOk()) {
-    s.stop("Dependencies installed");
-  } else {
-    s.stop(pc.red("Failed to install dependencies"));
+  process.off("SIGINT", onSigint);
+
+  if (controller.signal.aborted) {
+    s.stop(pc.yellow("Dependency install cancelled"));
+    return Result.ok("cancelled");
   }
 
-  return result;
+  if (result.isOk()) {
+    s.stop("Dependencies installed");
+    return Result.ok("installed");
+  }
+
+  s.stop(pc.red("Failed to install dependencies"));
+  return Result.err(result.error);
 }

--- a/apps/cli/src/helpers/core/install-dependencies.ts
+++ b/apps/cli/src/helpers/core/install-dependencies.ts
@@ -1,22 +1,17 @@
-import { log } from "@clack/prompts";
 import { Result } from "better-result";
 import { $ } from "execa";
 import pc from "picocolors";
 
 import type { Addons, PackageManager } from "../../types";
-import { isSilent } from "../../utils/context";
 import { ProjectCreationError } from "../../utils/errors";
 import { shouldSkipExternalCommands } from "../../utils/external-commands";
+import { getInterruptSignal, wasInterrupted } from "../../utils/interrupt";
+import { createSpinner } from "../../utils/terminal-output";
 
 export type InstallStatus = "installed" | "cancelled";
 
 const FORCE_KILL_AFTER_MS = 2000;
 
-/**
- * Ctrl-C during the install only stops the install. No spinner here on purpose: clack's spinner
- * puts stdin in raw mode and exits the process on Ctrl-C itself; without it Ctrl-C is a SIGINT,
- * which the listener below turns into a cancelled subprocess while the CLI keeps running.
- */
 export async function installDependencies({
   projectDir,
   packageManager,
@@ -29,18 +24,15 @@ export async function installDependencies({
     return Result.ok("installed");
   }
 
-  if (!isSilent()) log.step(`Running ${packageManager} install...`);
-
-  const controller = new AbortController();
-  const onSigint = () => controller.abort();
-  process.on("SIGINT", onSigint);
+  const s = createSpinner();
+  s.start(`Running ${packageManager} install...`);
 
   const result = await Result.tryPromise({
     try: async () => {
       await $({
         cwd: projectDir,
         stderr: "inherit",
-        cancelSignal: controller.signal,
+        cancelSignal: getInterruptSignal(),
         forceKillAfterDelay: FORCE_KILL_AFTER_MS,
       })`${packageManager} install`;
     },
@@ -52,18 +44,16 @@ export async function installDependencies({
       }),
   });
 
-  process.off("SIGINT", onSigint);
-
-  if (controller.signal.aborted) {
-    if (!isSilent()) log.warn(pc.yellow("Dependency install cancelled"));
+  if (wasInterrupted()) {
+    s.stop();
     return Result.ok("cancelled");
   }
 
   if (result.isOk()) {
-    if (!isSilent()) log.success("Dependencies installed");
+    s.stop("Dependencies installed");
     return Result.ok("installed");
   }
 
-  if (!isSilent()) log.error(pc.red("Failed to install dependencies"));
+  s.stop(pc.red("Failed to install dependencies"));
   return Result.err(result.error);
 }

--- a/apps/cli/src/helpers/core/install-dependencies.ts
+++ b/apps/cli/src/helpers/core/install-dependencies.ts
@@ -1,20 +1,21 @@
+import { log } from "@clack/prompts";
 import { Result } from "better-result";
 import { $ } from "execa";
 import pc from "picocolors";
 
 import type { Addons, PackageManager } from "../../types";
+import { isSilent } from "../../utils/context";
 import { ProjectCreationError } from "../../utils/errors";
 import { shouldSkipExternalCommands } from "../../utils/external-commands";
-import { createSpinner } from "../../utils/terminal-output";
 
 export type InstallStatus = "installed" | "cancelled";
 
 const FORCE_KILL_AFTER_MS = 2000;
 
 /**
- * Ctrl-C during the install only stops the install: the CLI keeps its own SIGINT listener
- * while the package manager runs so the process is not terminated, and execa's cancelSignal
- * ends the subprocess.
+ * Ctrl-C during the install only stops the install. No spinner here on purpose: clack's spinner
+ * puts stdin in raw mode and exits the process on Ctrl-C itself; without it Ctrl-C is a SIGINT,
+ * which the listener below turns into a cancelled subprocess while the CLI keeps running.
  */
 export async function installDependencies({
   projectDir,
@@ -28,8 +29,7 @@ export async function installDependencies({
     return Result.ok("installed");
   }
 
-  const s = createSpinner();
-  s.start(`Running ${packageManager} install...`);
+  if (!isSilent()) log.step(`Running ${packageManager} install...`);
 
   const controller = new AbortController();
   const onSigint = () => controller.abort();
@@ -55,15 +55,15 @@ export async function installDependencies({
   process.off("SIGINT", onSigint);
 
   if (controller.signal.aborted) {
-    s.stop(pc.yellow("Dependency install cancelled"));
+    if (!isSilent()) log.warn(pc.yellow("Dependency install cancelled"));
     return Result.ok("cancelled");
   }
 
   if (result.isOk()) {
-    s.stop("Dependencies installed");
+    if (!isSilent()) log.success("Dependencies installed");
     return Result.ok("installed");
   }
 
-  s.stop(pc.red("Failed to install dependencies"));
+  if (!isSilent()) log.error(pc.red("Failed to install dependencies"));
   return Result.err(result.error);
 }

--- a/apps/cli/src/helpers/core/install-dependencies.ts
+++ b/apps/cli/src/helpers/core/install-dependencies.ts
@@ -5,7 +5,7 @@ import pc from "picocolors";
 import type { Addons, PackageManager } from "../../types";
 import { ProjectCreationError } from "../../utils/errors";
 import { shouldSkipExternalCommands } from "../../utils/external-commands";
-import { getInterruptSignal, wasInterrupted } from "../../utils/interrupt";
+import { getInterruptSignal, startInterruptibleStep, wasInterrupted } from "../../utils/interrupt";
 import { createSpinner } from "../../utils/terminal-output";
 
 export type InstallStatus = "installed" | "cancelled";
@@ -24,6 +24,7 @@ export async function installDependencies({
     return Result.ok("installed");
   }
 
+  startInterruptibleStep();
   const s = createSpinner();
   s.start(`Running ${packageManager} install...`);
 

--- a/apps/cli/src/prompts/navigable.ts
+++ b/apps/cli/src/prompts/navigable.ts
@@ -24,21 +24,22 @@ import {
   setIsFirstPrompt as ctxSetIsFirstPrompt,
   setLastPromptShownUI as ctxSetLastPromptShownUI,
 } from "../utils/context";
+import {
+  S_BAR,
+  S_BAR_END,
+  S_CHECKBOX_ACTIVE,
+  S_CHECKBOX_INACTIVE,
+  S_CHECKBOX_SELECTED,
+  S_RADIO_ACTIVE,
+  S_RADIO_INACTIVE,
+  S_STEP_ACTIVE,
+  S_STEP_BACK,
+  S_STEP_CANCEL,
+  S_STEP_ERROR,
+  S_STEP_SUBMIT,
+} from "../utils/glyphs";
 import { GO_BACK_SYMBOL } from "../utils/navigation";
 
-const unicode = process.platform !== "win32";
-const S_STEP_ACTIVE = unicode ? "◆" : "*";
-const S_STEP_CANCEL = unicode ? "■" : "x";
-const S_STEP_ERROR = unicode ? "▲" : "x";
-const S_STEP_SUBMIT = unicode ? "◇" : "o";
-const S_STEP_BACK = unicode ? "↶" : "<";
-const S_BAR = unicode ? "│" : "|";
-const S_BAR_END = unicode ? "└" : "—";
-const S_RADIO_ACTIVE = unicode ? "●" : ">";
-const S_RADIO_INACTIVE = unicode ? "○" : " ";
-const S_CHECKBOX_ACTIVE = unicode ? "◻" : "[•]";
-const S_CHECKBOX_SELECTED = unicode ? "◼" : "[+]";
-const S_CHECKBOX_INACTIVE = unicode ? "◻" : "[ ]";
 const promptsNavigatingBack = new WeakSet<object>();
 
 function keycap(label: string): string {

--- a/apps/cli/src/utils/cli-invocation.ts
+++ b/apps/cli/src/utils/cli-invocation.ts
@@ -1,19 +1,22 @@
 import type { PackageManager } from "../types";
 import { getPackageExecutionCommand } from "./package-runner";
 
+/** The package manager that launched the CLI (`bun create`, `pnpm create`, `npx`), when known. */
+export function detectInvokingPackageManager(
+  userAgent = process.env.npm_config_user_agent,
+): PackageManager | undefined {
+  const normalizedUserAgent = userAgent?.toLowerCase();
+  if (normalizedUserAgent?.startsWith("bun")) return "bun";
+  if (normalizedUserAgent?.startsWith("pnpm")) return "pnpm";
+  if (normalizedUserAgent?.startsWith("npm")) return "npm";
+  return undefined;
+}
+
 export function getCliSubcommandCommand(
   subcommand: string,
   fallbackPackageManager: PackageManager,
   userAgent = process.env.npm_config_user_agent,
 ): string {
-  const normalizedUserAgent = userAgent?.toLowerCase();
-  const packageManager = normalizedUserAgent?.startsWith("bun")
-    ? "bun"
-    : normalizedUserAgent?.startsWith("pnpm")
-      ? "pnpm"
-      : normalizedUserAgent?.startsWith("npm")
-        ? "npm"
-        : fallbackPackageManager;
-
+  const packageManager = detectInvokingPackageManager(userAgent) ?? fallbackPackageManager;
   return getPackageExecutionCommand(packageManager, `create-better-t-stack@latest ${subcommand}`);
 }

--- a/apps/cli/src/utils/cli-invocation.ts
+++ b/apps/cli/src/utils/cli-invocation.ts
@@ -1,22 +1,19 @@
 import type { PackageManager } from "../types";
 import { getPackageExecutionCommand } from "./package-runner";
 
-/** The package manager that launched the CLI (`bun create`, `pnpm create`, `npx`), when known. */
-export function detectInvokingPackageManager(
-  userAgent = process.env.npm_config_user_agent,
-): PackageManager | undefined {
-  const normalizedUserAgent = userAgent?.toLowerCase();
-  if (normalizedUserAgent?.startsWith("bun")) return "bun";
-  if (normalizedUserAgent?.startsWith("pnpm")) return "pnpm";
-  if (normalizedUserAgent?.startsWith("npm")) return "npm";
-  return undefined;
-}
-
 export function getCliSubcommandCommand(
   subcommand: string,
   fallbackPackageManager: PackageManager,
   userAgent = process.env.npm_config_user_agent,
 ): string {
-  const packageManager = detectInvokingPackageManager(userAgent) ?? fallbackPackageManager;
+  const normalizedUserAgent = userAgent?.toLowerCase();
+  const packageManager = normalizedUserAgent?.startsWith("bun")
+    ? "bun"
+    : normalizedUserAgent?.startsWith("pnpm")
+      ? "pnpm"
+      : normalizedUserAgent?.startsWith("npm")
+        ? "npm"
+        : fallbackPackageManager;
+
   return getPackageExecutionCommand(packageManager, `create-better-t-stack@latest ${subcommand}`);
 }

--- a/apps/cli/src/utils/glyphs.ts
+++ b/apps/cli/src/utils/glyphs.ts
@@ -1,0 +1,14 @@
+export const unicode = process.platform !== "win32";
+export const S_STEP_ACTIVE = unicode ? "◆" : "*";
+export const S_STEP_CANCEL = unicode ? "■" : "x";
+export const S_STEP_ERROR = unicode ? "▲" : "x";
+export const S_STEP_SUBMIT = unicode ? "◇" : "o";
+export const S_STEP_BACK = unicode ? "↶" : "<";
+export const S_BAR = unicode ? "│" : "|";
+export const S_BAR_END = unicode ? "└" : "—";
+export const S_RADIO_ACTIVE = unicode ? "●" : ">";
+export const S_RADIO_INACTIVE = unicode ? "○" : " ";
+export const S_CHECKBOX_ACTIVE = unicode ? "◻" : "[•]";
+export const S_CHECKBOX_SELECTED = unicode ? "◼" : "[+]";
+export const S_CHECKBOX_INACTIVE = unicode ? "◻" : "[ ]";
+export const SPINNER_FRAMES = unicode ? ["◒", "◐", "◓", "◑"] : ["•", "o", "O", "0"];

--- a/apps/cli/src/utils/interrupt.ts
+++ b/apps/cli/src/utils/interrupt.ts
@@ -1,18 +1,20 @@
-let interrupted = false;
+let stepInterrupted = false;
+let anyStepInterrupted = false;
 let controller: AbortController | null = null;
 let listener: (() => void) | null = null;
 
 /**
  * Once files are on disk, Ctrl-C should only stop the step that is running. Holding a SIGINT
- * listener keeps the CLI alive (the terminal's signal already ends the subprocess), and the
- * remaining optional steps check wasInterrupted() to skip themselves.
+ * listener keeps the CLI alive; the terminal's signal already ends the subprocess. Each
+ * optional step starts with startInterruptibleStep() so a cancel applies to that step only.
  */
 export function beginInterruptibleScope(): void {
   endInterruptibleScope();
-  interrupted = false;
-  controller = new AbortController();
+  stepInterrupted = false;
+  anyStepInterrupted = false;
   listener = () => {
-    interrupted = true;
+    stepInterrupted = true;
+    anyStepInterrupted = true;
     controller?.abort();
   };
   process.on("SIGINT", listener);
@@ -24,8 +26,18 @@ export function endInterruptibleScope(): void {
   controller = null;
 }
 
+export function startInterruptibleStep(): void {
+  stepInterrupted = false;
+  controller = listener ? new AbortController() : null;
+}
+
+/** True if the user pressed Ctrl-C during the current step. */
 export function wasInterrupted(): boolean {
-  return interrupted;
+  return stepInterrupted;
+}
+
+export function wasAnyStepInterrupted(): boolean {
+  return anyStepInterrupted;
 }
 
 export function getInterruptSignal(): AbortSignal | undefined {

--- a/apps/cli/src/utils/interrupt.ts
+++ b/apps/cli/src/utils/interrupt.ts
@@ -1,0 +1,33 @@
+let interrupted = false;
+let controller: AbortController | null = null;
+let listener: (() => void) | null = null;
+
+/**
+ * Once files are on disk, Ctrl-C should only stop the step that is running. Holding a SIGINT
+ * listener keeps the CLI alive (the terminal's signal already ends the subprocess), and the
+ * remaining optional steps check wasInterrupted() to skip themselves.
+ */
+export function beginInterruptibleScope(): void {
+  endInterruptibleScope();
+  interrupted = false;
+  controller = new AbortController();
+  listener = () => {
+    interrupted = true;
+    controller?.abort();
+  };
+  process.on("SIGINT", listener);
+}
+
+export function endInterruptibleScope(): void {
+  if (listener) process.off("SIGINT", listener);
+  listener = null;
+  controller = null;
+}
+
+export function wasInterrupted(): boolean {
+  return interrupted;
+}
+
+export function getInterruptSignal(): AbortSignal | undefined {
+  return controller?.signal;
+}

--- a/apps/cli/src/utils/optional-step.ts
+++ b/apps/cli/src/utils/optional-step.ts
@@ -1,0 +1,24 @@
+import type { Result } from "better-result";
+import pc from "picocolors";
+
+import { UserCancelledError } from "./errors";
+import { wasInterrupted } from "./interrupt";
+import { cliConsola, cliLog } from "./terminal-output";
+
+/**
+ * Runs a setup step after the files are on disk. A failure is reported and the run continues;
+ * a cancellation (prompt or Ctrl-C) is only a warning.
+ */
+export async function runOptionalStep<T>(
+  step: () => Promise<Result<T, { message: string }>>,
+  cancelledMessage: string,
+): Promise<void> {
+  const result = await step();
+  if (result.isOk()) return;
+
+  if (UserCancelledError.is(result.error) || wasInterrupted()) {
+    cliLog.warn(pc.yellow(cancelledMessage));
+    return;
+  }
+  cliConsola.error(pc.red(result.error.message));
+}

--- a/apps/cli/src/utils/optional-step.ts
+++ b/apps/cli/src/utils/optional-step.ts
@@ -2,7 +2,7 @@ import type { Result } from "better-result";
 import pc from "picocolors";
 
 import { UserCancelledError } from "./errors";
-import { wasInterrupted } from "./interrupt";
+import { startInterruptibleStep, wasInterrupted } from "./interrupt";
 import { cliConsola, cliLog } from "./terminal-output";
 
 /**
@@ -13,6 +13,7 @@ export async function runOptionalStep<T>(
   step: () => Promise<Result<T, { message: string }>>,
   cancelledMessage: string,
 ): Promise<void> {
+  startInterruptibleStep();
   const result = await step();
   if (result.isOk()) return;
 

--- a/apps/cli/src/utils/requirements.ts
+++ b/apps/cli/src/utils/requirements.ts
@@ -368,9 +368,10 @@ export async function checkLocalRequirements(
   const versions = await readLocalToolVersions(
     config.packageManager,
     hostRuntime,
-    getLocalVersionRequirements(config, hostRuntime).some(
-      (requirement) => requirement.tool === "node",
-    ),
+    !shouldSkipExternalCommands() &&
+      getLocalVersionRequirements(config, hostRuntime).some(
+        (requirement) => requirement.tool === "node",
+      ),
   );
   const packageManagerVersion = versions[config.packageManager];
 

--- a/apps/cli/src/utils/requirements.ts
+++ b/apps/cli/src/utils/requirements.ts
@@ -156,21 +156,36 @@ function getNodeToolingRequirements(config: RequirementConfig): VersionRequireme
   return requirements;
 }
 
-export function getLocalVersionRequirements(
-  config: RequirementConfig,
-  hostRuntime: "bun" | "node",
-): VersionRequirement[] {
-  const requirements: VersionRequirement[] = [
-    {
-      tool: config.packageManager,
-      range: PACKAGE_MANAGER_VERSION_RANGES[config.packageManager],
-      reason: PACKAGE_MANAGER_REASONS[config.packageManager],
-    },
-  ];
+type HostRuntime = "bun" | "node";
 
+function getHostRuntime(): HostRuntime {
+  return process.versions.bun ? "bun" : "node";
+}
+
+/** Requirements that do not depend on the chosen stack, so they can run before any prompt. */
+export function getBaselineRequirements(
+  packageManager: PackageManager | undefined,
+  hostRuntime: HostRuntime,
+): VersionRequirement[] {
+  const requirements: VersionRequirement[] = [];
+  if (packageManager) {
+    requirements.push({
+      tool: packageManager,
+      range: PACKAGE_MANAGER_VERSION_RANGES[packageManager],
+      reason: PACKAGE_MANAGER_REASONS[packageManager],
+    });
+  }
   if (hostRuntime === "node") {
     addNodeRequirement(requirements, ">=22.0.0", "create-better-t-stack");
   }
+  return requirements;
+}
+
+export function getLocalVersionRequirements(
+  config: RequirementConfig,
+  hostRuntime: HostRuntime,
+): VersionRequirement[] {
+  const requirements = getBaselineRequirements(config.packageManager, hostRuntime);
 
   if (config.packageManager !== "bun") {
     requirements.push(...getNodeToolingRequirements(config));
@@ -202,33 +217,10 @@ function formatRequirementError(
   return null;
 }
 
-/**
- * The checks that do not depend on the chosen stack: the package manager that will run the
- * install, and the Node.js version hosting the CLI. Running them before any prompt means a
- * user with an outdated toolchain finds out immediately instead of after configuring a stack.
- */
-export function getBaselineRequirements(
-  packageManager: PackageManager | undefined,
-  hostRuntime: "bun" | "node",
-): VersionRequirement[] {
-  const requirements: VersionRequirement[] = [];
-  if (packageManager) {
-    requirements.push({
-      tool: packageManager,
-      range: PACKAGE_MANAGER_VERSION_RANGES[packageManager],
-      reason: PACKAGE_MANAGER_REASONS[packageManager],
-    });
-  }
-  if (hostRuntime === "node") {
-    addNodeRequirement(requirements, ">=22.0.0", "create-better-t-stack");
-  }
-  return requirements;
-}
-
 export function validateLocalToolVersions(
   config: RequirementConfig,
   versions: LocalToolVersions,
-  hostRuntime: "bun" | "node",
+  hostRuntime: HostRuntime,
 ): Result<void, CLIError> {
   return validateRequirements(getLocalVersionRequirements(config, hostRuntime), versions);
 }
@@ -310,16 +302,32 @@ async function readToolVersion(tool: Tool): Promise<string | null> {
   return result.isOk() ? result.value : null;
 }
 
+async function readLocalToolVersions(
+  packageManager: PackageManager | undefined,
+  hostRuntime: HostRuntime,
+  needsNode: boolean,
+): Promise<LocalToolVersions> {
+  const versions: LocalToolVersions = {};
+  if (packageManager) {
+    const packageManagerVersion = await readToolVersion(packageManager);
+    if (packageManagerVersion) versions[packageManager] = packageManagerVersion;
+  }
+  if (needsNode) {
+    versions.node =
+      hostRuntime === "node"
+        ? process.versions.node
+        : ((await readToolVersion("node")) ?? undefined);
+  }
+  return versions;
+}
+
 export type BaselineCheck = {
-  /** Problems with a package manager the user has not committed to yet; shown, not fatal. */
   warnings: string[];
 };
 
 /**
- * Fast pre-prompt check; the full stack-aware check still runs once the config is known.
- * The host Node.js version is always fatal. The package manager is fatal only when it was
- * passed explicitly: an inferred one (from the launching user agent) can still be swapped at
- * the package manager prompt, so it is reported as a warning.
+ * Pre-prompt check. An inferred package manager can still be changed at its prompt, so it only
+ * warns; an explicit one and the host Node.js version are fatal.
  */
 export async function checkBaselineRequirements(
   packageManager: PackageManager | undefined,
@@ -327,17 +335,13 @@ export async function checkBaselineRequirements(
 ): Promise<Result<BaselineCheck, CLIError>> {
   if (shouldSkipExternalCommands()) return Result.ok({ warnings: [] });
 
-  const hostRuntime = process.versions.bun ? "bun" : "node";
-  const versions: LocalToolVersions = {};
-  if (packageManager) {
-    const packageManagerVersion = await readToolVersion(packageManager);
-    if (packageManagerVersion) versions[packageManager] = packageManagerVersion;
-  }
-  if (hostRuntime === "node") {
-    versions.node = process.versions.node;
-  }
-
+  const hostRuntime = getHostRuntime();
   const requirements = getBaselineRequirements(packageManager, hostRuntime);
+  const versions = await readLocalToolVersions(
+    packageManager,
+    hostRuntime,
+    requirements.some((requirement) => requirement.tool === "node"),
+  );
   const fatal = requirements.filter(
     (requirement) => requirement.tool === "node" || packageManagerIsExplicit,
   );
@@ -360,23 +364,15 @@ export async function checkBaselineRequirements(
 export async function checkLocalRequirements(
   config: RequirementConfig,
 ): Promise<Result<LocalRequirements, CLIError>> {
-  const hostRuntime = process.versions.bun ? "bun" : "node";
-  const versions: LocalToolVersions = {};
-
-  const packageManagerVersion = await readToolVersion(config.packageManager);
-  if (packageManagerVersion) {
-    versions[config.packageManager] = packageManagerVersion;
-  }
-
-  const needsNode = getLocalVersionRequirements(config, hostRuntime).some(
-    (requirement) => requirement.tool === "node",
+  const hostRuntime = getHostRuntime();
+  const versions = await readLocalToolVersions(
+    config.packageManager,
+    hostRuntime,
+    getLocalVersionRequirements(config, hostRuntime).some(
+      (requirement) => requirement.tool === "node",
+    ),
   );
-  if (needsNode) {
-    versions.node =
-      hostRuntime === "node"
-        ? process.versions.node
-        : ((await readToolVersion("node")) ?? undefined);
-  }
+  const packageManagerVersion = versions[config.packageManager];
 
   if (!shouldSkipExternalCommands()) {
     const validationResult = validateLocalToolVersions(config, versions, hostRuntime);

--- a/apps/cli/src/utils/requirements.ts
+++ b/apps/cli/src/utils/requirements.ts
@@ -202,12 +202,41 @@ function formatRequirementError(
   return null;
 }
 
+/**
+ * The checks that do not depend on the chosen stack: the package manager that will run the
+ * install, and the Node.js version hosting the CLI. Running them before any prompt means a
+ * user with an outdated toolchain finds out immediately instead of after configuring a stack.
+ */
+export function getBaselineRequirements(
+  packageManager: PackageManager | undefined,
+  hostRuntime: "bun" | "node",
+): VersionRequirement[] {
+  const requirements: VersionRequirement[] = [];
+  if (packageManager) {
+    requirements.push({
+      tool: packageManager,
+      range: PACKAGE_MANAGER_VERSION_RANGES[packageManager],
+      reason: PACKAGE_MANAGER_REASONS[packageManager],
+    });
+  }
+  if (hostRuntime === "node") {
+    addNodeRequirement(requirements, ">=22.0.0", "create-better-t-stack");
+  }
+  return requirements;
+}
+
 export function validateLocalToolVersions(
   config: RequirementConfig,
   versions: LocalToolVersions,
   hostRuntime: "bun" | "node",
 ): Result<void, CLIError> {
-  const requirements = getLocalVersionRequirements(config, hostRuntime);
+  return validateRequirements(getLocalVersionRequirements(config, hostRuntime), versions);
+}
+
+export function validateRequirements(
+  requirements: VersionRequirement[],
+  versions: LocalToolVersions,
+): Result<void, CLIError> {
   const failures = requirements
     .map((requirement) => formatRequirementError(requirement, versions[requirement.tool]))
     .filter((failure): failure is string => failure !== null);
@@ -274,6 +303,25 @@ async function readToolVersion(tool: Tool): Promise<string | null> {
   });
 
   return result.isOk() ? result.value : null;
+}
+
+/** Fast pre-prompt check; the full stack-aware check still runs once the config is known. */
+export async function checkBaselineRequirements(
+  packageManager: PackageManager | undefined,
+): Promise<Result<void, CLIError>> {
+  if (shouldSkipExternalCommands()) return Result.ok(undefined);
+
+  const hostRuntime = process.versions.bun ? "bun" : "node";
+  const versions: LocalToolVersions = {};
+  if (packageManager) {
+    const packageManagerVersion = await readToolVersion(packageManager);
+    if (packageManagerVersion) versions[packageManager] = packageManagerVersion;
+  }
+  if (hostRuntime === "node") {
+    versions.node = process.versions.node;
+  }
+
+  return validateRequirements(getBaselineRequirements(packageManager, hostRuntime), versions);
 }
 
 export async function checkLocalRequirements(

--- a/apps/cli/src/utils/requirements.ts
+++ b/apps/cli/src/utils/requirements.ts
@@ -233,9 +233,14 @@ export function validateLocalToolVersions(
   return validateRequirements(getLocalVersionRequirements(config, hostRuntime), versions);
 }
 
+const STACK_REQUIREMENTS_HEADLINE = "Your local toolchain does not meet this stack's requirements:";
+const BASELINE_REQUIREMENTS_HEADLINE =
+  "Your local toolchain does not meet create-better-t-stack's requirements:";
+
 export function validateRequirements(
   requirements: VersionRequirement[],
   versions: LocalToolVersions,
+  headline = STACK_REQUIREMENTS_HEADLINE,
 ): Result<void, CLIError> {
   const failures = requirements
     .map((requirement) => formatRequirementError(requirement, versions[requirement.tool]))
@@ -258,7 +263,7 @@ export function validateRequirements(
   return Result.err(
     new CLIError({
       message: [
-        "Your local toolchain does not meet this stack's requirements:",
+        headline,
         ...failures.map((failure) => `- ${failure}`),
         "",
         ...upgradeInstructions,
@@ -305,11 +310,22 @@ async function readToolVersion(tool: Tool): Promise<string | null> {
   return result.isOk() ? result.value : null;
 }
 
-/** Fast pre-prompt check; the full stack-aware check still runs once the config is known. */
+export type BaselineCheck = {
+  /** Problems with a package manager the user has not committed to yet; shown, not fatal. */
+  warnings: string[];
+};
+
+/**
+ * Fast pre-prompt check; the full stack-aware check still runs once the config is known.
+ * The host Node.js version is always fatal. The package manager is fatal only when it was
+ * passed explicitly: an inferred one (from the launching user agent) can still be swapped at
+ * the package manager prompt, so it is reported as a warning.
+ */
 export async function checkBaselineRequirements(
   packageManager: PackageManager | undefined,
-): Promise<Result<void, CLIError>> {
-  if (shouldSkipExternalCommands()) return Result.ok(undefined);
+  packageManagerIsExplicit: boolean,
+): Promise<Result<BaselineCheck, CLIError>> {
+  if (shouldSkipExternalCommands()) return Result.ok({ warnings: [] });
 
   const hostRuntime = process.versions.bun ? "bun" : "node";
   const versions: LocalToolVersions = {};
@@ -321,7 +337,24 @@ export async function checkBaselineRequirements(
     versions.node = process.versions.node;
   }
 
-  return validateRequirements(getBaselineRequirements(packageManager, hostRuntime), versions);
+  const requirements = getBaselineRequirements(packageManager, hostRuntime);
+  const fatal = requirements.filter(
+    (requirement) => requirement.tool === "node" || packageManagerIsExplicit,
+  );
+  const fatalResult = validateRequirements(fatal, versions, BASELINE_REQUIREMENTS_HEADLINE);
+  if (fatalResult.isErr()) return Result.err(fatalResult.error);
+
+  const advisory = requirements.filter((requirement) => !fatal.includes(requirement));
+  const advisoryResult = validateRequirements(advisory, versions, BASELINE_REQUIREMENTS_HEADLINE);
+  if (advisoryResult.isErr()) {
+    return Result.ok({
+      warnings: [
+        `${advisoryResult.error.message}\nYou can also choose a different package manager at the package manager step.`,
+      ],
+    });
+  }
+
+  return Result.ok({ warnings: [] });
 }
 
 export async function checkLocalRequirements(

--- a/apps/cli/src/utils/terminal-output.ts
+++ b/apps/cli/src/utils/terminal-output.ts
@@ -3,6 +3,7 @@ import { consola, createConsola } from "consola";
 import pc from "picocolors";
 
 import { isSilent } from "./context";
+import { S_BAR, S_STEP_CANCEL, S_STEP_SUBMIT, SPINNER_FRAMES } from "./glyphs";
 import { wasInterrupted } from "./interrupt";
 
 type SpinnerLike = {
@@ -17,14 +18,6 @@ const noopSpinner: SpinnerLike = {
   message() {},
 };
 
-const unicode =
-  process.platform !== "win32" ||
-  Boolean(process.env.WT_SESSION) ||
-  process.env.TERM_PROGRAM === "vscode";
-const FRAMES = unicode ? ["◒", "◐", "◓", "◑"] : ["•", "o", "O", "0"];
-const BAR = unicode ? "│" : "|";
-const STEP = unicode ? "◇" : "o";
-const CANCEL = unicode ? "■" : "x";
 const FRAME_MS = 80;
 const HIDE_CURSOR = "\x1b[?25l";
 const SHOW_CURSOR = "\x1b[?25h";
@@ -60,9 +53,12 @@ function createTerminalSpinner(): SpinnerLike {
 
   const render = () => {
     const suffix = ".".repeat(Math.floor(dots)).slice(0, 3);
-    out.write(`${CLEAR_LINE}${pc.magenta(FRAMES[frame])}  ${text}${suffix}`);
-    frame = (frame + 1) % FRAMES.length;
+    out.write(`${CLEAR_LINE}${pc.magenta(SPINNER_FRAMES[frame])}  ${text}${suffix}`);
+    frame = (frame + 1) % SPINNER_FRAMES.length;
     dots = dots < 4 ? dots + 0.125 : 0;
+  };
+  const setText = (message: string) => {
+    text = message.replace(/\.+$/, "");
   };
 
   return {
@@ -70,19 +66,17 @@ function createTerminalSpinner(): SpinnerLike {
       if (active) return;
       active = true;
       interruptedBefore = wasInterrupted();
-      text = message.replace(/\.+$/, "");
-      out.write(`${pc.gray(BAR)}\n`);
+      setText(message);
+      out.write(`${pc.gray(S_BAR)}\n`);
       if (animate) {
         hideCursor();
         render();
         timer = setInterval(render, FRAME_MS);
       } else {
-        out.write(`${pc.magenta(FRAMES[0])}  ${text}\n`);
+        out.write(`${pc.magenta(SPINNER_FRAMES[0])}  ${text}\n`);
       }
     },
-    message(message) {
-      text = message.replace(/\.+$/, "");
-    },
+    message: setText,
     stop(message) {
       if (!active) return;
       active = false;
@@ -94,8 +88,8 @@ function createTerminalSpinner(): SpinnerLike {
       const cancelled = wasInterrupted() && !interruptedBefore;
       out.write(
         cancelled
-          ? `${pc.yellow(CANCEL)}  ${text} (cancelled)\n`
-          : `${pc.green(STEP)}  ${message || text}\n`,
+          ? `${pc.yellow(S_STEP_CANCEL)}  ${text} (cancelled)\n`
+          : `${pc.green(S_STEP_SUBMIT)}  ${message || text}\n`,
       );
     },
   };

--- a/apps/cli/src/utils/terminal-output.ts
+++ b/apps/cli/src/utils/terminal-output.ts
@@ -117,8 +117,9 @@ export const cliLog = {
   success(message: string) {
     if (!isSilent()) log.success(message);
   },
+  /** Silent after a Ctrl-C in the current step: the cancelled line already said it. */
   error(message: string) {
-    if (!isSilent()) log.error(message);
+    if (!isSilent() && !wasInterrupted()) log.error(message);
   },
   message(message: string) {
     if (!isSilent()) log.message(message);
@@ -127,7 +128,7 @@ export const cliLog = {
 
 export const cliConsola = {
   error(message: string) {
-    if (!isSilent()) baseConsola.error(message);
+    if (!isSilent() && !wasInterrupted()) baseConsola.error(message);
   },
   warn(message: string) {
     if (!isSilent()) baseConsola.warn(message);

--- a/apps/cli/src/utils/terminal-output.ts
+++ b/apps/cli/src/utils/terminal-output.ts
@@ -1,7 +1,9 @@
-import { log, spinner } from "@clack/prompts";
+import { log } from "@clack/prompts";
 import { consola, createConsola } from "consola";
+import pc from "picocolors";
 
 import { isSilent } from "./context";
+import { wasInterrupted } from "./interrupt";
 
 type SpinnerLike = {
   start(message: string): void;
@@ -15,8 +17,92 @@ const noopSpinner: SpinnerLike = {
   message() {},
 };
 
+const unicode =
+  process.platform !== "win32" ||
+  Boolean(process.env.WT_SESSION) ||
+  process.env.TERM_PROGRAM === "vscode";
+const FRAMES = unicode ? ["◒", "◐", "◓", "◑"] : ["•", "o", "O", "0"];
+const BAR = unicode ? "│" : "|";
+const STEP = unicode ? "◇" : "o";
+const CANCEL = unicode ? "■" : "x";
+const FRAME_MS = 80;
+const HIDE_CURSOR = "\x1b[?25l";
+const SHOW_CURSOR = "\x1b[?25h";
+const CLEAR_LINE = "\r\x1b[2K";
+
+let cursorHidden = false;
+function hideCursor(): void {
+  if (cursorHidden) return;
+  cursorHidden = true;
+  process.stdout.write(HIDE_CURSOR);
+  process.once("exit", () => process.stdout.write(SHOW_CURSOR));
+}
+function showCursor(): void {
+  if (!cursorHidden) return;
+  cursorHidden = false;
+  process.stdout.write(SHOW_CURSOR);
+}
+
+/**
+ * The clack spinner puts stdin in raw mode and exits the process on Ctrl-C from its own
+ * keypress handler. This one never touches stdin, so Ctrl-C stays a SIGINT and the
+ * interrupt scope decides what happens.
+ */
+function createTerminalSpinner(): SpinnerLike {
+  const out = process.stdout;
+  const animate = out.isTTY && !process.env.CI;
+  let text = "";
+  let active = false;
+  let interruptedBefore = false;
+  let frame = 0;
+  let dots = 0;
+  let timer: ReturnType<typeof setInterval> | undefined;
+
+  const render = () => {
+    const suffix = ".".repeat(Math.floor(dots)).slice(0, 3);
+    out.write(`${CLEAR_LINE}${pc.magenta(FRAMES[frame])}  ${text}${suffix}`);
+    frame = (frame + 1) % FRAMES.length;
+    dots = dots < 4 ? dots + 0.125 : 0;
+  };
+
+  return {
+    start(message) {
+      if (active) return;
+      active = true;
+      interruptedBefore = wasInterrupted();
+      text = message.replace(/\.+$/, "");
+      out.write(`${pc.gray(BAR)}\n`);
+      if (animate) {
+        hideCursor();
+        render();
+        timer = setInterval(render, FRAME_MS);
+      } else {
+        out.write(`${pc.magenta(FRAMES[0])}  ${text}\n`);
+      }
+    },
+    message(message) {
+      text = message.replace(/\.+$/, "");
+    },
+    stop(message) {
+      if (!active) return;
+      active = false;
+      if (timer) clearInterval(timer);
+      if (animate) {
+        out.write(CLEAR_LINE);
+        showCursor();
+      }
+      const cancelled = wasInterrupted() && !interruptedBefore;
+      out.write(
+        cancelled
+          ? `${pc.yellow(CANCEL)}  ${text} (cancelled)\n`
+          : `${pc.green(STEP)}  ${message || text}\n`,
+      );
+    },
+  };
+}
+
 export function createSpinner(): SpinnerLike {
-  return isSilent() ? noopSpinner : spinner();
+  return isSilent() ? noopSpinner : createTerminalSpinner();
 }
 
 const baseConsola = createConsola({

--- a/apps/cli/test/requirements.test.ts
+++ b/apps/cli/test/requirements.test.ts
@@ -45,7 +45,23 @@ describe("baseline requirements (before prompts)", () => {
     expect(detectInvokingPackageManager("pnpm/10.26.0 npm/? node/v22.0.0")).toBe("pnpm");
     expect(detectInvokingPackageManager("npm/11.16.0 node/v24.0.0")).toBe("npm");
     expect(detectInvokingPackageManager("yarn/4.0.0 npm/?")).toBeUndefined();
-    expect(detectInvokingPackageManager(undefined)).toBeUndefined();
+    expect(detectInvokingPackageManager("")).toBeUndefined();
+  });
+
+  it("uses a stack-neutral headline for the pre-prompt check", () => {
+    const result = validateRequirements(
+      getBaselineRequirements("pnpm", "node"),
+      { pnpm: "9.15.0", node: "v22.22.0" },
+      "Your local toolchain does not meet create-better-t-stack's requirements:",
+    );
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(
+        result.error.message.startsWith(
+          "Your local toolchain does not meet create-better-t-stack's requirements:",
+        ),
+      ).toBe(true);
+    }
   });
 });
 

--- a/apps/cli/test/requirements.test.ts
+++ b/apps/cli/test/requirements.test.ts
@@ -1,13 +1,53 @@
 import { describe, expect, it } from "bun:test";
 
 import type { ProjectConfig } from "../src/types";
+import { detectInvokingPackageManager } from "../src/utils/cli-invocation";
 import {
   PACKAGE_MANAGER_VERSION_RANGES,
   RECOMMENDED_BUN_VERSION_RANGE,
+  getBaselineRequirements,
   getLocalVersionRequirements,
   getLocalToolRecommendations,
   validateLocalToolVersions,
+  validateRequirements,
 } from "../src/utils/requirements";
+
+describe("baseline requirements (before prompts)", () => {
+  it("covers only the package manager and the host Node.js, never the stack", () => {
+    expect(getBaselineRequirements("pnpm", "node")).toEqual([
+      expect.objectContaining({ tool: "pnpm", range: PACKAGE_MANAGER_VERSION_RANGES.pnpm }),
+      expect.objectContaining({ tool: "node", range: ">=22.0.0" }),
+    ]);
+    expect(getBaselineRequirements(undefined, "bun")).toEqual([]);
+  });
+
+  it("fails an outdated pnpm before any stack is chosen", () => {
+    const result = validateRequirements(getBaselineRequirements("pnpm", "node"), {
+      pnpm: "9.15.0",
+      node: "v22.22.0",
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("pnpm 9.15.0 does not satisfy");
+      expect(result.error.message).toContain("pnpm self-update");
+    }
+
+    expect(
+      validateRequirements(getBaselineRequirements("pnpm", "node"), {
+        pnpm: "10.26.0",
+        node: "v22.22.0",
+      }).isOk(),
+    ).toBe(true);
+  });
+
+  it("detects the launching package manager from the npm user agent", () => {
+    expect(detectInvokingPackageManager("bun/1.4.0 npm/? node/v24.0.0")).toBe("bun");
+    expect(detectInvokingPackageManager("pnpm/10.26.0 npm/? node/v22.0.0")).toBe("pnpm");
+    expect(detectInvokingPackageManager("npm/11.16.0 node/v24.0.0")).toBe("npm");
+    expect(detectInvokingPackageManager("yarn/4.0.0 npm/?")).toBeUndefined();
+    expect(detectInvokingPackageManager(undefined)).toBeUndefined();
+  });
+});
 
 type RequirementConfig = Pick<
   ProjectConfig,

--- a/apps/cli/test/requirements.test.ts
+++ b/apps/cli/test/requirements.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
 import type { ProjectConfig } from "../src/types";
-import { detectInvokingPackageManager } from "../src/utils/cli-invocation";
 import {
   PACKAGE_MANAGER_VERSION_RANGES,
   RECOMMENDED_BUN_VERSION_RANGE,
@@ -38,14 +37,6 @@ describe("baseline requirements (before prompts)", () => {
         node: "v22.22.0",
       }).isOk(),
     ).toBe(true);
-  });
-
-  it("detects the launching package manager from the npm user agent", () => {
-    expect(detectInvokingPackageManager("bun/1.4.0 npm/? node/v24.0.0")).toBe("bun");
-    expect(detectInvokingPackageManager("pnpm/10.26.0 npm/? node/v22.0.0")).toBe("pnpm");
-    expect(detectInvokingPackageManager("npm/11.16.0 node/v24.0.0")).toBe("npm");
-    expect(detectInvokingPackageManager("yarn/4.0.0 npm/?")).toBeUndefined();
-    expect(detectInvokingPackageManager("")).toBeUndefined();
   });
 
   it("uses a stack-neutral headline for the pre-prompt check", () => {

--- a/packages/types/src/schemas.ts
+++ b/packages/types/src/schemas.ts
@@ -607,7 +607,6 @@ export const InitResultSchema = z.object({
   projectDirectory: z.string(),
   relativePath: z.string(),
   error: z.string().optional(),
-  /** Non-fatal problems, such as a dependency install that failed after the files were written. */
   warnings: z.array(z.string()).optional(),
 });
 

--- a/packages/types/src/schemas.ts
+++ b/packages/types/src/schemas.ts
@@ -607,6 +607,8 @@ export const InitResultSchema = z.object({
   projectDirectory: z.string(),
   relativePath: z.string(),
   error: z.string().optional(),
+  /** Non-fatal problems, such as a dependency install that failed after the files were written. */
+  warnings: z.array(z.string()).optional(),
 });
 
 export const DATABASE_VALUES = DatabaseSchema.options;


### PR DESCRIPTION
Single PR for the two fixes from the first day of `cli_failed` data (14 failures, about 1 in 5 runs).

## 1. Toolchain check before any prompt

7 of 14 failures were toolchain version mismatches, reported only after the user had answered all 17 prompts; 8 of 13 failing runs used pnpm (needs `>=10.26.0`).

- Package manager (from `--package-manager`, else the launching user agent via the existing `getUserPkgManager()`) and host Node.js (`>=22`) are validated right after the intro.
- An explicit `--package-manager` that is too old is a hard stop. An inferred one is a warning that also points out the package manager can be changed at that prompt, since the user has not committed to it yet. Host Node is always a hard stop. Stack-specific Node ranges are still checked once the config is known.
- `validateRequirements()` factored out with a stack-neutral headline for the pre-prompt case. Silent/JSON/API/MCP paths are unchanged (no prompts to waste).

Verified on the built CLI with a shimmed pnpm 9.15: inferred → warning then first prompt; explicit → exits 1 immediately with the requirement and `pnpm self-update` hint.

## 2. Install failure no longer fails `create`

3 of 14 failures were `bun install` exiting 1 after every file was already written.

- `createProject` returns `{ projectDir, installError }`. On failure the CLI warns (`Dependencies were not installed. Run pnpm install in <dir> ...`), the next-steps box lists the install as step 2, history is saved, `Project ready` prints, exit code 0.
- JSON/API/MCP results stay `success: true` with the message in a new optional `warnings` array on `InitResult`.
- Still recorded as `cli_failed` with `stage: dependency-installation`.

Verified with a pnpm shim that passes `--version` and fails `install`: exit 0, warning, next steps `cd probe` then `pnpm install`, history saved, files present.

Tests: requirements (baseline set, pnpm fail/pass, user-agent detection, headline), cli-ux, dry-run, silent, mcp, diagnostics suites pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pre-prompt checks for Node.js and package manager requirements.
  * Project creation now completes even if dependency installation fails or is cancelled.
  * Installation issues are reported as warnings while preserving the created project.
  * Initialization results now include warnings for non-fatal problems.

* **Bug Fixes**
  * Post-install guidance accurately reflects whether dependencies were installed successfully.

* **Tests**
  * Added coverage for baseline requirement checks, outdated package managers, and warning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 3. Ctrl-C after files are written only stops the current step

Previously a Ctrl-C during any loader (`pnpm install`, Neon, Prisma Postgres, Turso, the addon inits for Tauri, WXT, Ultracite, Starlight, Fumadocs, MCP, skills, oxlint, TUI) killed the whole CLI, even though the project was already on disk. Two causes: nothing held a SIGINT listener, and in a real terminal the clack spinner puts stdin in raw mode and its own keypress handler calls `process.exit(0)` on Ctrl-C, so a SIGINT listener would never even run.

- `createSpinner()` now returns a small spinner of our own that never touches stdin (same `start`/`stop`/`message` API, all 19 call sites unchanged). Ctrl-C is a plain SIGINT everywhere.
- `utils/interrupt.ts`: an interrupt scope around everything after the files are written (`create` and `add`). It holds a SIGINT listener so the process survives; the terminal's own signal ends the running subprocess (the install additionally passes the scope's `AbortSignal` as execa `cancelSignal` with a 2s force kill). The spinner prints `■ <step> (cancelled)` instead of a red failure and the provider's own failure log for that step is suppressed. Only the current step is cancelled: later steps (addons, install) still run and can be cancelled on their own. Git init and next steps still run, exit 0.
- `runSetup` in `db-setup.ts` and `addons-setup.ts`: a cancellation (Ctrl-C at a provider prompt or during its subprocess) now logs a warning and continues instead of failing the run. Cancelled steps send no failure diagnostic; the JSON/API result carries `warnings: ["One or more setup steps were cancelled."]`.

Verified under a real pty with `expect` (Ctrl-C as `\x03`): during a sleeping `pnpm install` → `■ Running pnpm install (cancelled)`, next steps with `pnpm install`, history saved, `Project ready`, exit 0; during a sleeping `npx` oxlint init in JSON mode, then again during the following `npm install` → both cancelled independently, exit 0, project on disk, warning in the result.