### PR TITLE
feat(cli): make task runner addons mutually exclusive in the addons prompt

### DIFF
--- a/apps/cli/src/helpers/core/add-handler.ts
+++ b/apps/cli/src/helpers/core/add-handler.ts
@@ -21,7 +21,7 @@ import z from "zod";
 import { getAddonsToAdd } from "../../prompts/addons";
 import type { AddInput, Addons, AddonOptions, AnalyticsMode, ProjectConfig } from "../../types";
 import { updateBtsConfig } from "../../utils/bts-config";
-import { validateAddonsAgainstConfig } from "../../utils/compatibility-rules";
+import { TASK_RUNNER_ADDONS, validateAddonsAgainstConfig } from "../../utils/compatibility-rules";
 import { isSilent, resolveInvocationMode, runWithContextAsync } from "../../utils/context";
 import { errorClass, failureStage, reportDiagnostic, scrubReason } from "../../utils/diagnostics";
 import { formatConfigValue } from "../../utils/display-config";
@@ -70,7 +70,6 @@ const ADD_TEXT_FILE_PATHS = ["apps/web/vite.config.ts", "lefthook.yml"];
 
 const HOOK_ADDONS = ["husky", "lefthook"] as const satisfies readonly Addons[];
 const HOOK_LINTER_ADDONS = ["biome", "oxlint", "vite-plus"] as const satisfies readonly Addons[];
-const TASK_RUNNER_ADDONS = ["turborepo", "nx", "vite-plus"] as const satisfies readonly Addons[];
 const fileExistsErrorSchema = z.object({ code: z.literal("EEXIST") });
 const configPackageScopeSchema = z
   .object({

--- a/apps/cli/src/prompts/addons.ts
+++ b/apps/cli/src/prompts/addons.ts
@@ -8,7 +8,11 @@ import {
   type ProjectConfig,
   type Runtime,
 } from "../types";
-import { getCompatibleAddons, validateAddonCompatibility } from "../utils/compatibility-rules";
+import {
+  TASK_RUNNER_ADDONS,
+  getCompatibleAddons,
+  validateAddonCompatibility,
+} from "../utils/compatibility-rules";
 import { UserCancelledError } from "../utils/errors";
 import { isCancel, navigableGroupMultiselect } from "./navigable";
 
@@ -152,8 +156,7 @@ function sortAndPruneGroupedOptions(groupedOptions: Record<string, AddonOption[]
 }
 
 function validateAddonSelection(selected: Addons[] | undefined) {
-  const selectedTaskRunners =
-    selected?.filter((addon) => ["turborepo", "nx", "vite-plus"].includes(addon)) ?? [];
+  const selectedTaskRunners = selected?.filter((addon) => TASK_RUNNER_ADDONS.includes(addon)) ?? [];
   if (selectedTaskRunners.length > 1) {
     return "Choose Turborepo, Nx, or Vite+ as your task runner, not more than one.";
   }
@@ -202,6 +205,7 @@ export async function getAddonsChoice(
     options: groupedOptions,
     initialValues: initialValues,
     required: false,
+    exclusive: [TASK_RUNNER_ADDONS],
     validate: validateAddonSelection,
   });
 
@@ -240,6 +244,7 @@ export async function getAddonsToAdd(config: AddonProjectConfig) {
     message: "Select addons to add",
     options: groupedOptions,
     required: false,
+    exclusive: [TASK_RUNNER_ADDONS],
     validate: validateAddonSelection,
   });
 

--- a/apps/cli/src/prompts/navigable.ts
+++ b/apps/cli/src/prompts/navigable.ts
@@ -405,13 +405,39 @@ export interface NavigableGroupMultiselectOptions<T> extends NavigableCommonOpti
   cursorAt?: T;
   maxItems?: number;
   required?: boolean;
+  /** Sets of values that cannot be selected together; picking one deselects the others. */
+  exclusive?: ReadonlyArray<ReadonlyArray<T>>;
   validate?: (selected: T[] | undefined) => string | Error | undefined;
+}
+
+/** Keeps at most one value per exclusive set, preferring what was just selected. */
+export function resolveExclusiveSelection<T>(
+  previous: readonly T[],
+  next: readonly T[],
+  exclusive: ReadonlyArray<ReadonlyArray<T>>,
+): T[] {
+  let resolved = [...next];
+  for (const set of exclusive) {
+    const added = resolved.find((value) => set.includes(value) && !previous.includes(value));
+    if (added === undefined) continue;
+    resolved = resolved.filter((value) => !set.includes(value) || value === added);
+  }
+  return resolved;
 }
 
 export async function navigableGroupMultiselect<T>(
   opts: NavigableGroupMultiselectOptions<T>,
 ): Promise<T[] | symbol> {
   const required = opts.required ?? true;
+  const exclusive = opts.exclusive ?? [];
+  const exclusiveValues = new Set(exclusive.flat());
+  const exclusiveGroups = new Set(
+    Object.entries(opts.options)
+      .filter(
+        ([, items]) => items.length > 1 && items.every((item) => exclusiveValues.has(item.value)),
+      )
+      .map(([group]) => group),
+  );
 
   const opt = (
     option: GroupMultiSelectOption<T> & { group: string | boolean },
@@ -426,14 +452,20 @@ export async function navigableGroupMultiselect<T>(
       | "cancelled",
     options: (GroupMultiSelectOption<T> & { group: string | boolean })[] = [],
   ) => {
-    const label = option.label ?? String(option.value);
     const isItem = option.group !== true && option.group !== false;
+    const isGroup = option.group === true;
+    const chooseOne = isGroup && exclusiveGroups.has(String(option.value));
+    const label = `${option.label ?? String(option.value)}${chooseOne ? pc.dim(" (choose one)") : ""}`;
     const next = isItem && (options[options.indexOf(option) + 1] ?? { group: true });
     const isLast = isItem && next && next.group === true;
     const prefix = isItem ? `${isLast ? S_BAR_END : S_BAR} ` : "";
+    const radio = isItem && exclusiveValues.has(option.value);
+    const activeBox = radio ? S_RADIO_INACTIVE : S_CHECKBOX_ACTIVE;
+    const selectedBox = radio ? S_RADIO_ACTIVE : S_CHECKBOX_SELECTED;
+    const inactiveBox = radio ? S_RADIO_INACTIVE : S_CHECKBOX_INACTIVE;
 
     if (state === "active") {
-      return `${pc.dim(prefix)}${pc.cyan(S_CHECKBOX_ACTIVE)} ${label}${option.hint ? ` ${pc.dim(`(${option.hint})`)}` : ""}`;
+      return `${pc.dim(prefix)}${pc.cyan(activeBox)} ${label}${option.hint ? ` ${pc.dim(`(${option.hint})`)}` : ""}`;
     }
     if (state === "group-active") {
       return `${prefix}${pc.cyan(S_CHECKBOX_ACTIVE)} ${pc.dim(label)}`;
@@ -442,19 +474,19 @@ export async function navigableGroupMultiselect<T>(
       return `${prefix}${pc.green(S_CHECKBOX_SELECTED)} ${pc.dim(label)}`;
     }
     if (state === "selected") {
-      const selectedCheckbox = isItem ? pc.green(S_CHECKBOX_SELECTED) : "";
+      const selectedCheckbox = isItem ? pc.green(selectedBox) : "";
       return `${pc.dim(prefix)}${selectedCheckbox} ${pc.dim(label)}${option.hint ? ` ${pc.dim(`(${option.hint})`)}` : ""}`;
     }
     if (state === "cancelled") {
       return `${pc.strikethrough(pc.dim(label))}`;
     }
     if (state === "active-selected") {
-      return `${pc.dim(prefix)}${pc.green(S_CHECKBOX_SELECTED)} ${label}${option.hint ? ` ${pc.dim(`(${option.hint})`)}` : ""}`;
+      return `${pc.dim(prefix)}${pc.green(selectedBox)} ${label}${option.hint ? ` ${pc.dim(`(${option.hint})`)}` : ""}`;
     }
     if (state === "submitted") {
       return `${pc.dim(label)}`;
     }
-    const unselectedCheckbox = isItem ? pc.dim(S_CHECKBOX_INACTIVE) : "";
+    const unselectedCheckbox = isItem ? pc.dim(inactiveBox) : "";
     return `${pc.dim(prefix)}${unselectedCheckbox} ${pc.dim(label)}`;
   };
 
@@ -547,6 +579,16 @@ export async function navigableGroupMultiselect<T>(
       }
     },
   });
+
+  if (exclusive.length > 0) {
+    let previous = [...(opts.initialValues ?? [])];
+    prompt.on("cursor", (key) => {
+      if (key === "space") {
+        prompt.value = resolveExclusiveSelection(previous, prompt.value ?? [], exclusive);
+      }
+      previous = [...(prompt.value ?? [])];
+    });
+  }
 
   return runWithNavigation(prompt) as Promise<T[] | symbol>;
 }

--- a/apps/cli/src/prompts/navigable.ts
+++ b/apps/cli/src/prompts/navigable.ts
@@ -433,8 +433,10 @@ export async function navigableGroupMultiselect<T>(
   const exclusiveValues = new Set(exclusive.flat());
   const exclusiveGroups = new Set(
     Object.entries(opts.options)
-      .filter(
-        ([, items]) => items.length > 1 && items.every((item) => exclusiveValues.has(item.value)),
+      .filter(([, items]) =>
+        exclusive.some(
+          (set) => items.length > 1 && items.every((item) => set.includes(item.value)),
+        ),
       )
       .map(([group]) => group),
   );

--- a/apps/cli/src/utils/compatibility-rules.ts
+++ b/apps/cli/src/utils/compatibility-rules.ts
@@ -22,7 +22,7 @@ type AddonCompatibilityConfig = Pick<
   ProjectConfig,
   "frontend" | "auth" | "backend" | "runtime" | "webDeploy" | "database" | "orm" | "dbSetup"
 >;
-const TASK_RUNNER_ADDONS: readonly Addons[] = ["turborepo", "nx", "vite-plus"];
+export const TASK_RUNNER_ADDONS: readonly Addons[] = ["turborepo", "nx", "vite-plus"];
 const STATIC_DESKTOP_ADDONS: readonly Addons[] = ["tauri", "electrobun"];
 const TAURI_STATIC_EXPORT_FRONTENDS: readonly Frontend[] = ["next", "tanstack-start"];
 

--- a/apps/cli/test/exclusive-selection.test.ts
+++ b/apps/cli/test/exclusive-selection.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "bun:test";
+import { PassThrough } from "node:stream";
+import { stripVTControlCharacters } from "node:util";
 
-import { resolveExclusiveSelection } from "../src/prompts/navigable";
+import { navigableGroupMultiselect, resolveExclusiveSelection } from "../src/prompts/navigable";
+import { runWithContextAsync } from "../src/utils/context";
 
 const TASK_RUNNERS = ["turborepo", "nx", "vite-plus"] as const;
 
@@ -33,5 +36,49 @@ describe("resolveExclusiveSelection", () => {
       "nx",
       "husky",
     ]);
+  });
+});
+
+describe("navigableGroupMultiselect exclusive sets", () => {
+  it("deselects the other task runner when space selects a new one", async () => {
+    const input = new PassThrough();
+    const output = Object.assign(new PassThrough(), { columns: 80, rows: 30 });
+    let rendered = "";
+    output.on("data", (chunk) => (rendered += chunk));
+
+    const resultPromise = runWithContextAsync({}, () =>
+      navigableGroupMultiselect<string>({
+        message: "Pick addons",
+        options: {
+          "Monorepo & Tasks": [
+            { value: "turborepo", label: "Turborepo" },
+            { value: "nx", label: "Nx" },
+            { value: "vite-plus", label: "Vite+" },
+          ],
+          "Code Quality": [{ value: "biome", label: "Biome" }],
+        },
+        initialValues: ["biome"],
+        required: false,
+        exclusive: [TASK_RUNNERS],
+        input,
+        output,
+      }),
+    );
+
+    const press = async (key: string) => {
+      input.write(key);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    };
+    const down = "\x1b[B";
+    await press(down);
+    await press(" ");
+    await press(down);
+    await press(" ");
+    await press("\r");
+
+    expect(await resultPromise).toEqual(["biome", "nx"]);
+    const plain = stripVTControlCharacters(rendered);
+    expect(plain).toContain("Monorepo & Tasks (choose one)");
+    expect(plain).toContain("● Nx");
   });
 });

--- a/apps/cli/test/exclusive-selection.test.ts
+++ b/apps/cli/test/exclusive-selection.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+
+import { resolveExclusiveSelection } from "../src/prompts/navigable";
+
+const TASK_RUNNERS = ["turborepo", "nx", "vite-plus"] as const;
+
+describe("resolveExclusiveSelection", () => {
+  it("drops the other members of a set when a new one is selected", () => {
+    expect(
+      resolveExclusiveSelection(
+        ["turborepo", "biome"],
+        ["turborepo", "biome", "nx"],
+        [TASK_RUNNERS],
+      ),
+    ).toEqual(["biome", "nx"]);
+  });
+
+  it("keeps a single member when a whole exclusive group is toggled on", () => {
+    expect(
+      resolveExclusiveSelection(
+        ["biome"],
+        ["biome", "turborepo", "nx", "vite-plus"],
+        [TASK_RUNNERS],
+      ),
+    ).toEqual(["biome", "turborepo"]);
+  });
+
+  it("leaves deselection and unrelated values untouched", () => {
+    expect(resolveExclusiveSelection(["nx", "biome"], ["biome"], [TASK_RUNNERS])).toEqual([
+      "biome",
+    ]);
+    expect(resolveExclusiveSelection(["nx"], ["nx", "husky"], [TASK_RUNNERS])).toEqual([
+      "nx",
+      "husky",
+    ]);
+  });
+});


### PR DESCRIPTION
## Why

In the custom addons prompt, Turborepo, Nx and Vite+ could all be ticked even though only one task runner is allowed. The mistake was only caught by validation on submit.

## What

- `navigableGroupMultiselect` gains an `exclusive` option (sets of values that cannot be selected together). Selecting one member deselects the others; toggling a whole exclusive group keeps a single member.
- Exclusive items render as radio buttons (`○`/`●`) and the group header shows `(choose one)`, so the constraint is visible before pressing space.
- Both addon prompts (`create` and `add`) pass the task runner set. The existing submit-time validation stays as a safety net.
- `TASK_RUNNER_ADDONS` was defined in two files; it is now exported from `compatibility-rules.ts` and reused.
- Unit tests for the pure `resolveExclusiveSelection` resolver.

## Verification

- `bun run check`, `tsc` (no new errors), `bun test` (742 pass).
- Driven under a real pty with `expect`: select Turborepo → Nx → Vite+ leaves only the last one selected; group-header toggle keeps one runner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task runner addon selections are now mutually exclusive.
  * Addon menus display task runner choices with radio-style indicators and “choose one” guidance.
  * The most recently selected task runner is retained automatically.

* **Bug Fixes**
  * Improved addon selection validation to prevent incompatible task runner combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->