### PR TITLE
feat(cli): offer T3 Code when only the desktop app is installed

### DIFF
--- a/apps/cli/src/helpers/core/command-handlers.ts
+++ b/apps/cli/src/helpers/core/command-handlers.ts
@@ -480,6 +480,7 @@ async function createProjectHandlerInternal(
     let projectLauncher: AvailableProjectLauncher | undefined;
     if (!isSilent()) {
       const launcherResult = await getProjectLauncherChoice(input.open, config.projectDir, {
+        packageManager: config.packageManager,
         prompt:
           !input.yes &&
           process.env.CI === undefined &&

--- a/apps/cli/src/utils/project-launcher.ts
+++ b/apps/cli/src/utils/project-launcher.ts
@@ -1,11 +1,17 @@
+import { existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
 import { Result } from "better-result";
-import { execa } from "execa";
+import { $, execa } from "execa";
 import z from "zod";
 
 import { isCancel, navigableSelect, setIsFirstPrompt } from "../prompts/navigable";
+import type { PackageManager } from "../types";
 import { commandExists } from "./command-exists";
 import { CLIError } from "./errors";
 import { shouldSkipExternalCommands } from "./external-commands";
+import { getPackageRunnerPrefix } from "./package-runner";
 
 export const ProjectLauncherSchema = z
   .enum([
@@ -45,6 +51,17 @@ export const ProjectLauncherSchema = z
 export type ProjectLauncher = z.infer<typeof ProjectLauncherSchema>;
 export type ProjectLauncherKind = "editor" | "agent";
 
+/** A macOS app bundle that can open the project even when no CLI is on PATH. */
+interface MacAppDefinition {
+  bundleId: string;
+  names: readonly string[];
+  launchSequence: (
+    projectDir: string,
+    packageManager: PackageManager,
+    cliCommand: string | undefined,
+  ) => ProjectLaunchCommand[];
+}
+
 interface ProjectLauncherDefinition {
   id: Exclude<ProjectLauncher, "none">;
   label: string;
@@ -54,6 +71,7 @@ interface ProjectLauncherDefinition {
   args?: (projectDir: string) => string[];
   cwd?: (projectDir: string) => string;
   launchSequence?: (command: string, projectDir: string) => ProjectLaunchCommand[];
+  macApp?: MacAppDefinition;
   platforms?: readonly NodeJS.Platform[];
 }
 
@@ -72,6 +90,8 @@ export interface AvailableProjectLauncher {
   cwd?: string;
   launchSequence?: ProjectLaunchCommand[];
 }
+
+const T3_CODE_BUNDLE_ID = "com.t3tools.t3code";
 
 export const PROJECT_LAUNCHERS = [
   {
@@ -166,6 +186,19 @@ export const PROJECT_LAUNCHERS = [
     kind: "agent",
     commands: ["t3"],
     cwd: (projectDir) => projectDir,
+    macApp: {
+      bundleId: T3_CODE_BUNDLE_ID,
+      names: ["T3 Code", "T3 Code (Alpha)"],
+      launchSequence: (projectDir, packageManager, cliCommand) => {
+        const [command, ...prefixArgs] = cliCommand
+          ? [cliCommand]
+          : [...getPackageRunnerPrefix(packageManager), "t3@latest"];
+        return [
+          { command, args: [...prefixArgs, "project", "add", projectDir], cwd: projectDir },
+          { command: "open", args: ["-b", T3_CODE_BUNDLE_ID] },
+        ];
+      },
+    },
   },
   {
     id: "claude-code",
@@ -288,12 +321,43 @@ export const PROJECT_LAUNCHERS = [
 ] as const satisfies readonly ProjectLauncherDefinition[];
 
 type CommandDetector = (command: string) => Promise<boolean>;
+type MacAppDetector = (app: MacAppDefinition) => Promise<boolean>;
+
+export async function macAppInstalled(app: MacAppDefinition): Promise<boolean> {
+  const appDirs = ["/Applications", path.join(os.homedir(), "Applications")];
+  const bundleExists = app.names.some((name) =>
+    appDirs.some((dir) => existsSync(path.join(dir, `${name}.app`))),
+  );
+  if (bundleExists) return true;
+
+  const result = await Result.tryPromise({
+    try: async () => {
+      const { stdout } = await $({
+        reject: false,
+      })`mdfind ${`kMDItemCFBundleIdentifier == '${app.bundleId}'`}`;
+      return stdout.trim().length > 0;
+    },
+    catch: () => false,
+  });
+  return result.isOk() ? result.value : false;
+}
+
+export interface DetectProjectLaunchersOptions {
+  detectCommand?: CommandDetector;
+  detectMacApp?: MacAppDetector;
+  platform?: NodeJS.Platform;
+  packageManager?: PackageManager;
+}
 
 export async function detectProjectLaunchers(
   projectDir: string,
-  detectCommand: CommandDetector = commandExists,
-  platform: NodeJS.Platform = process.platform,
+  options: DetectProjectLaunchersOptions = {},
 ): Promise<AvailableProjectLauncher[]> {
+  const detectCommand = options.detectCommand ?? commandExists;
+  const detectMacApp = options.detectMacApp ?? macAppInstalled;
+  const platform = options.platform ?? process.platform;
+  const packageManager = options.packageManager ?? "npm";
+
   const definitions: readonly ProjectLauncherDefinition[] = PROJECT_LAUNCHERS;
   const supportedDefinitions = definitions.filter(
     ({ platforms }) => platforms === undefined || platforms.includes(platform),
@@ -306,9 +370,33 @@ export async function detectProjectLaunchers(
       commands.map(async (command) => [command, await detectCommand(command)] as const),
     ),
   );
+  const detectedMacApps = new Map(
+    await Promise.all(
+      supportedDefinitions
+        .filter((launcher) => platform === "darwin" && launcher.macApp !== undefined)
+        .map(async (launcher) => {
+          const installed = launcher.macApp ? await detectMacApp(launcher.macApp) : false;
+          return [launcher.id, installed] as const;
+        }),
+    ),
+  );
 
   return supportedDefinitions.flatMap((launcher) => {
     const command = commandsFor(launcher).find((candidate) => detectedCommands.get(candidate));
+
+    if (launcher.macApp && detectedMacApps.get(launcher.id)) {
+      return [
+        {
+          id: launcher.id,
+          label: launcher.label,
+          kind: launcher.kind,
+          command: "open",
+          args: ["-b", launcher.macApp.bundleId],
+          launchSequence: launcher.macApp.launchSequence(projectDir, packageManager, command),
+        },
+      ];
+    }
+
     if (!command) return [];
 
     const availableLauncher: AvailableProjectLauncher = {
@@ -329,20 +417,13 @@ export async function detectProjectLaunchers(
 export async function getProjectLauncherChoice(
   requestedLauncher: ProjectLauncher | undefined,
   projectDir: string,
-  options: {
-    detectCommand?: CommandDetector;
-    platform?: NodeJS.Platform;
-    prompt?: boolean;
-  } = {},
+  options: DetectProjectLaunchersOptions & { prompt?: boolean } = {},
 ): Promise<Result<AvailableProjectLauncher | undefined, CLIError>> {
   if (requestedLauncher === "none") return Result.ok(undefined);
   if (!requestedLauncher && options.prompt === false) return Result.ok(undefined);
 
-  const availableLaunchers = await detectProjectLaunchers(
-    projectDir,
-    options.detectCommand,
-    options.platform,
-  );
+  const { prompt: _prompt, ...detectOptions } = options;
+  const availableLaunchers = await detectProjectLaunchers(projectDir, detectOptions);
 
   if (requestedLauncher) {
     const launcher = availableLaunchers.find(({ id }) => id === requestedLauncher);

--- a/apps/cli/test/project-launcher.test.ts
+++ b/apps/cli/test/project-launcher.test.ts
@@ -8,6 +8,8 @@ import {
   launchProject,
 } from "../src/utils/project-launcher";
 
+const noMacApps = async () => false;
+
 describe("project launcher", () => {
   it("defines unique launcher ids accepted by the CLI schema", () => {
     const ids = PROJECT_LAUNCHERS.map(({ id }) => id);
@@ -29,11 +31,11 @@ describe("project launcher", () => {
       "claude",
       "pi",
     ]);
-    const launchers = await detectProjectLaunchers(
-      "/tmp/my-app",
-      async (command) => installed.has(command),
-      "darwin",
-    );
+    const launchers = await detectProjectLaunchers("/tmp/my-app", {
+      detectCommand: async (command) => installed.has(command),
+      detectMacApp: noMacApps,
+      platform: "darwin",
+    });
 
     expect(launchers.map(({ id }) => id)).toEqual([
       "vscode",
@@ -61,11 +63,11 @@ describe("project launcher", () => {
   });
 
   it("opens Neovim on the generated project directory", async () => {
-    const launchers = await detectProjectLaunchers(
-      "/tmp/my-app",
-      async (command) => command === "nvim",
-      "linux",
-    );
+    const launchers = await detectProjectLaunchers("/tmp/my-app", {
+      detectCommand: async (command) => command === "nvim",
+      detectMacApp: noMacApps,
+      platform: "linux",
+    });
 
     expect(launchers).toEqual([
       {
@@ -81,8 +83,16 @@ describe("project launcher", () => {
 
   it("only offers the Codex app launcher on supported platforms", async () => {
     const detectCommand = async (command: string) => command === "codex";
-    const macLaunchers = await detectProjectLaunchers("/tmp/my-app", detectCommand, "darwin");
-    const linuxLaunchers = await detectProjectLaunchers("/tmp/my-app", detectCommand, "linux");
+    const macLaunchers = await detectProjectLaunchers("/tmp/my-app", {
+      detectCommand: detectCommand,
+      detectMacApp: noMacApps,
+      platform: "darwin",
+    });
+    const linuxLaunchers = await detectProjectLaunchers("/tmp/my-app", {
+      detectCommand: detectCommand,
+      detectMacApp: noMacApps,
+      platform: "linux",
+    });
 
     expect(macLaunchers.map(({ id }) => id)).toEqual(["codex-app", "codex"]);
     expect(linuxLaunchers.map(({ id }) => id)).toEqual(["codex"]);
@@ -90,11 +100,11 @@ describe("project launcher", () => {
 
   it("uses the documented entry commands for additional coding agents", async () => {
     const installed = new Set(["kiro-cli", "droid", "goose", "cline", "cn", "crush"]);
-    const launchers = await detectProjectLaunchers(
-      "/tmp/my-app",
-      async (command) => installed.has(command),
-      "darwin",
-    );
+    const launchers = await detectProjectLaunchers("/tmp/my-app", {
+      detectCommand: async (command) => installed.has(command),
+      detectMacApp: noMacApps,
+      platform: "darwin",
+    });
 
     expect(launchers.map(({ id }) => id)).toEqual([
       "kiro-cli",
@@ -118,11 +128,11 @@ describe("project launcher", () => {
 
   it("uses the documented T3 Code and Orca project-opening commands", async () => {
     const installed = new Set(["t3", "orca"]);
-    const launchers = await detectProjectLaunchers(
-      "/tmp/my-app",
-      async (command) => installed.has(command),
-      "darwin",
-    );
+    const launchers = await detectProjectLaunchers("/tmp/my-app", {
+      detectCommand: async (command) => installed.has(command),
+      detectMacApp: noMacApps,
+      platform: "darwin",
+    });
 
     expect(launchers.map(({ id }) => id)).toEqual(["t3-code", "orca"]);
     expect(launchers.find(({ id }) => id === "t3-code")).toMatchObject({
@@ -142,12 +152,40 @@ describe("project launcher", () => {
     });
   });
 
+  it("opens the T3 Code desktop app when only the app bundle is installed", async () => {
+    const launchers = await detectProjectLaunchers("/tmp/my-app", {
+      detectCommand: async () => false,
+      detectMacApp: async (app) => app.bundleId === "com.t3tools.t3code",
+      platform: "darwin",
+      packageManager: "bun",
+    });
+
+    expect(launchers.map(({ id }) => id)).toEqual(["t3-code"]);
+    expect(launchers[0]?.launchSequence).toEqual([
+      { command: "bunx", args: ["t3@latest", "project", "add", "/tmp/my-app"], cwd: "/tmp/my-app" },
+      { command: "open", args: ["-b", "com.t3tools.t3code"] },
+    ]);
+  });
+
+  it("registers the project through the t3 CLI when both the CLI and the app exist", async () => {
+    const launchers = await detectProjectLaunchers("/tmp/my-app", {
+      detectCommand: async (command) => command === "t3",
+      detectMacApp: async () => true,
+      platform: "darwin",
+    });
+
+    expect(launchers.find(({ id }) => id === "t3-code")?.launchSequence).toEqual([
+      { command: "t3", args: ["project", "add", "/tmp/my-app"], cwd: "/tmp/my-app" },
+      { command: "open", args: ["-b", "com.t3tools.t3code"] },
+    ]);
+  });
+
   it("uses Orca's Linux-specific CLI name", async () => {
-    const launchers = await detectProjectLaunchers(
-      "/tmp/my-app",
-      async (command) => command === "orca-ide",
-      "linux",
-    );
+    const launchers = await detectProjectLaunchers("/tmp/my-app", {
+      detectCommand: async (command) => command === "orca-ide",
+      detectMacApp: noMacApps,
+      platform: "linux",
+    });
 
     expect(launchers.map(({ id }) => id)).toEqual(["orca"]);
     expect(launchers[0]).toMatchObject({
@@ -165,6 +203,7 @@ describe("project launcher", () => {
   it("returns a useful error for an explicitly requested missing launcher", async () => {
     const result = await getProjectLauncherChoice("opencode", "/tmp/my-app", {
       detectCommand: async () => false,
+      detectMacApp: noMacApps,
       prompt: false,
     });
 
@@ -182,6 +221,7 @@ describe("project launcher", () => {
         detectionCount += 1;
         return true;
       },
+      detectMacApp: noMacApps,
       prompt: false,
     });
 


### PR DESCRIPTION
## Why

The "Open project with?" picker only listed T3 Code when the \`t3\` npm CLI was on PATH. Most desktop-app users never install that CLI, so the app was missing from the list even though it was installed.

## What

- Launcher definitions can declare a macOS app bundle (\`macApp\`: bundle id + app names). Detection checks \`/Applications\` and \`~/Applications\`, then falls back to \`mdfind\` by bundle id.
- T3 Code (\`com.t3tools.t3code\`, "T3 Code" / "T3 Code (Alpha)"): the desktop app has no folder deep link (its Electron main only handles focus on second instance), but it shares the project store in \`~/.t3\` with the \`t3\` CLI, and \`t3 project add <path>\` dispatches to the running app when there is one. So the launch sequence is \`t3 project add <projectDir>\` (the CLI if on PATH, otherwise \`bunx|npx|pnpm dlx t3@latest\`) followed by \`open -b com.t3tools.t3code\`.
- \`detectProjectLaunchers\` / \`getProjectLauncherChoice\` take an options object (\`detectCommand\`, \`detectMacApp\`, \`platform\`, \`packageManager\`); the create handler passes the selected package manager.
- Behaviour with only the CLI installed is unchanged.

## Verification

- Probed \`t3 project add\` against a running T3 Code (Alpha) 0.0.35: project appears in \`projection_projects\`, removed afterwards.
- Real detector run on a Mac with the app but no CLI: picker now lists \`t3-code\` with the expected sequence.
- Unit tests updated for the options object plus two new T3 desktop cases; \`bun run check\` and tsc clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added macOS desktop-app support for launching projects through T3 Code when its command-line tool isn’t available.
  * Automatically detects installed T3 Code applications and selects the appropriate launch method.
  * Project launch commands now respect the configured package manager when creating a project.
* **Bug Fixes**
  * Improved launcher selection when both the T3 Code desktop app and command-line tool are installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->