### PR TITLE
chore: add Cloud Agent development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,15 @@
+{
+  "name": "Better-T-Stack",
+  "install": "bash .cursor/install.sh",
+  "terminals": [
+    {
+      "name": "web",
+      "command": "export NVM_DIR=\"$HOME/.nvm\"; . \"$NVM_DIR/nvm.sh\" >/dev/null 2>&1; nvm use 24 >/dev/null 2>&1; export PATH=\"$HOME/.bun/bin:$PATH\"; export NEXT_PUBLIC_CONVEX_URL=\"${NEXT_PUBLIC_CONVEX_URL:-https://placeholder.convex.cloud}\"; bun dev:web"
+    },
+    {
+      "name": "cli",
+      "command": "export NVM_DIR=\"$HOME/.nvm\"; . \"$NVM_DIR/nvm.sh\" >/dev/null 2>&1; nvm use 24 >/dev/null 2>&1; export PATH=\"$HOME/.bun/bin:$PATH\"; bun dev:cli"
+    }
+  ],
+  "ports": [3333]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -14,7 +14,8 @@ export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
 nvm install 24 >/dev/null
 nvm alias default 24 >/dev/null
-export PATH="$(dirname "$(nvm which 24)"):$PATH"
+NODE24_BIN="$(dirname "$(nvm which 24)")"
+export PATH="$NODE24_BIN:$PATH"
 
 # --- Bun 1.4.0 (pinned via packageManager) ---
 export BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
@@ -25,6 +26,25 @@ fi
 
 node --version
 bun --version
+
+# Make Node 24 + Bun available in future interactive/login shells (terminals
+# already self-configure, but this helps ad-hoc shells too).
+PATH_MARKER="# >>> better-t-stack cloud agent path >>>"
+persist_path_block() {
+  rc="$1"
+  [ -f "$rc" ] || return 0
+  grep -qF "$PATH_MARKER" "$rc" && return 0
+  {
+    printf '\n%s\n' "$PATH_MARKER"
+    printf 'export BUN_INSTALL="$HOME/.bun"\n'
+    printf 'export NVM_DIR="$HOME/.nvm"\n'
+    printf '[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" >/dev/null 2>&1\n'
+    printf 'export PATH="$BUN_INSTALL/bin:%s:$PATH"\n' "$NODE24_BIN"
+    printf '# <<< better-t-stack cloud agent path <<<\n'
+  } >>"$rc"
+}
+persist_path_block "$HOME/.bashrc"
+persist_path_block "$HOME/.profile"
 
 # --- Dependencies ---
 # --ignore-scripts skips the root `prepare` (lefthook install), which fails in

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Idempotent Cloud Agent bootstrap for the Better-T-Stack monorepo.
+# Installs the pinned toolchain (Node 24 + Bun 1.4), refreshes workspace
+# dependencies, and builds the internal packages the CLI and web app import.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# --- Node 24 (repo requires engines.node "24.x"; tsdown needs native TS config
+# support only available on Node >= 24.11.1 when turbo runs it under node). ---
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+# shellcheck disable=SC1090
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+nvm install 24 >/dev/null
+nvm alias default 24 >/dev/null
+export PATH="$(dirname "$(nvm which 24)"):$PATH"
+
+# --- Bun 1.4.0 (pinned via packageManager) ---
+export BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
+export PATH="$BUN_INSTALL/bin:$PATH"
+if ! command -v bun >/dev/null 2>&1; then
+  curl -fsSL https://bun.sh/install | bash -s "bun-v1.4.0"
+fi
+
+node --version
+bun --version
+
+# --- Dependencies ---
+# --ignore-scripts skips the root `prepare` (lefthook install), which fails in
+# Cloud Agents because a custom git core.hooksPath is set. The only other
+# lifecycle script we need (apps/web postinstall: fumadocs-mdx) is run manually.
+LEFTHOOK=0 bun install --frozen-lockfile --ignore-scripts
+
+# Generate Fumadocs source map for the docs site (apps/web postinstall).
+(cd apps/web && bun run fumadocs-mdx)
+
+# Build internal packages that both apps import at dev/build time.
+(cd packages/types && bun run build)
+(cd packages/template-generator && bun run build)
+(cd apps/cli && bun run build)
+
+echo "Cloud Agent install complete."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a repository-managed Cloud Agent development environment for the Better-T-Stack monorepo so future agents boot into a fully working setup (toolchain + dependencies + built internal packages). Validated end to end on a clean prebuilt environment build.

New files:
- `.cursor/environment.json` — environment definition (`install` command, `web` + `cli` dev terminals, port `3333`).
- `.cursor/install.sh` — idempotent bootstrap: pins Node 24 + Bun 1.4, installs deps, generates the docs source, builds the internal packages the CLI and web app import, and persists Node 24 + Bun on `PATH` for login shells.

## Key environment findings

- The repo requires **Node 24.x** (`engines.node`, CI `node-version-file`). On Node 22 the `tsdown` builds fail under Turbo (`Failed to import module "unrun"`): Turbo runs `tsdown` under `node`, and only Node ≥ 24.11.1 has the native TS-config support `tsdown` needs. The install script installs Node 24 via `nvm`.
- **Bun 1.4.0** (pinned via `packageManager`) is installed via the official installer if missing.
- `bun install` runs with `--ignore-scripts` because the root `prepare` script (`lefthook install`) fails in Cloud Agents (a custom git `core.hooksPath` is set). The only other needed lifecycle script — `apps/web` `postinstall: fumadocs-mdx` — is run explicitly.
- The default `/exec-daemon` Node 22 shim shadows Node 24, so the install script also writes an idempotent PATH block to `~/.bashrc`/`~/.profile` and the dev terminals self-configure PATH.

## Verification

Local VM:
- `bun run check` (oxfmt + oxlint): passed, no changes.
- Full turbo build (`types`, `template-generator`, `create-bts`, `cli`): succeeded.
- CLI test suite: 685 baseline pass; the 30 disk-heavy tests that hit the default 5s Bun timeout in the VM all pass with a larger timeout (252/252 across the affected files, 0 fail).
- CLI end-to-end: scaffolded a default project (React/TanStack Router + Hono + tRPC + SQLite/Drizzle + Better Auth + Turborepo), installed deps, and built it (web + server).
- Web docs site (`bun dev:web` on `:3333`): `/docs` and `/new` (stack builder) serve 200.
- Install script idempotence: passed twice.

Prebuilt environment build + fresh Cloud Agent (booted from the build):
- Node v24.20.0 + Bun 1.4.0 resolved on the default login-shell PATH with no manual export.
- `node_modules`, `apps/web/.source`, and every package `dist/` persisted in the snapshot.
- `bun run check` exit 0.
- Built CLI scaffolded and built a full project end-to-end (turbo: 2 successful).
- Docs dev server served `/docs` and `/new` (200).

## Notes / optional secrets

- The docs site's dynamic homepage/analytics pull live data from the project's Convex backend. Convex 1.43 requires an account to create even a local deployment, so full homepage data needs `NEXT_PUBLIC_CONVEX_URL` (an existing Convex deployment) and `GITHUB_ACCESS_TOKEN`/`GITHUB_WEBHOOK_SECRET` for the backend. These are optional — the `web` terminal falls back to a placeholder Convex URL so documentation and the stack builder work without any secrets.

## Branch naming

The branch uses the Cloud Agent-required `cursor/` prefix rather than the repo's `aman/` convention, per the agent's branch policy.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-398104c9-01e3-4ccd-9b49-d57fef011f00?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-398104c9-01e3-4ccd-9b49-d57fef011f00&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added streamlined development environment setup for Cloud Agent workflows.
  * Configured Node.js and Bun toolchains with automated dependency installation and package builds.
  * Added web terminal support on port 3333, including a fallback connection configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->