### PR TITLE
feat(template): use cn for class merging

### DIFF
--- a/apps/cli/test/frontend.test.ts
+++ b/apps/cli/test/frontend.test.ts
@@ -139,42 +139,6 @@ describe("Frontend Configurations", () => {
       expect(packageJson.devDependencies["react-router-devtools"]).toBeUndefined();
     });
 
-    for (const frontend of ["tanstack-router", "react-router", "tanstack-start", "next"] as const) {
-      it(`should use cn in the ${frontend} shared UI package`, async () => {
-        const result = await runTRPCTest({
-          projectName: `cn-${frontend}`,
-          frontend: [frontend],
-          backend: "none",
-          runtime: "none",
-          database: "none",
-          orm: "none",
-          auth: "none",
-          api: "none",
-          addons: ["none"],
-          examples: ["none"],
-          dbSetup: "none",
-          webDeploy: "none",
-          serverDeploy: "none",
-          install: false,
-        });
-
-        expectSuccess(result);
-
-        const uiPackageJson = await fs.readJson(
-          path.join(result.projectDir!, "packages/ui/package.json"),
-        );
-        const uiUtils = await fs.readFile(
-          path.join(result.projectDir!, "packages/ui/src/lib/utils.ts"),
-          "utf8",
-        );
-
-        expect(uiPackageJson.dependencies.cn).toBe("^0.2.4");
-        expect(uiPackageJson.dependencies.clsx).toBeUndefined();
-        expect(uiPackageJson.dependencies["tailwind-merge"]).toBeUndefined();
-        expect(uiUtils.trim()).toBe('export { cn } from "cn";');
-      });
-    }
-
     it("should generate the Solid 2 project structure", async () => {
       const result = await runTRPCTest({
         projectName: "solid-v2",

--- a/apps/cli/test/frontend.test.ts
+++ b/apps/cli/test/frontend.test.ts
@@ -114,7 +114,7 @@ describe("Frontend Configurations", () => {
   });
 
   describe("Frontend Compatibility with API", () => {
-    it("should keep React Router on the app's Vite version", async () => {
+    it("should generate current React Router and shared UI dependencies", async () => {
       const result = await runTRPCTest({
         projectName: "react-router-vite",
         frontend: ["react-router"],
@@ -135,8 +135,20 @@ describe("Frontend Configurations", () => {
       expectSuccess(result);
 
       const packageJson = await fs.readJson(path.join(result.projectDir!, "apps/web/package.json"));
+      const uiPackageJson = await fs.readJson(
+        path.join(result.projectDir!, "packages/ui/package.json"),
+      );
+      const uiUtils = await fs.readFile(
+        path.join(result.projectDir!, "packages/ui/src/lib/utils.ts"),
+        "utf8",
+      );
+
       expect(packageJson.devDependencies.vite).toBe("^8.1.5");
       expect(packageJson.devDependencies["react-router-devtools"]).toBeUndefined();
+      expect(uiPackageJson.dependencies.cn).toBe("^0.2.4");
+      expect(uiPackageJson.dependencies.clsx).toBeUndefined();
+      expect(uiPackageJson.dependencies["tailwind-merge"]).toBeUndefined();
+      expect(uiUtils.trim()).toBe('export { cn } from "cn";');
     });
 
     it("should generate the Solid 2 project structure", async () => {

--- a/apps/cli/test/frontend.test.ts
+++ b/apps/cli/test/frontend.test.ts
@@ -114,7 +114,7 @@ describe("Frontend Configurations", () => {
   });
 
   describe("Frontend Compatibility with API", () => {
-    it("should generate current React Router and shared UI dependencies", async () => {
+    it("should keep React Router on the app's Vite version", async () => {
       const result = await runTRPCTest({
         projectName: "react-router-vite",
         frontend: ["react-router"],
@@ -135,21 +135,45 @@ describe("Frontend Configurations", () => {
       expectSuccess(result);
 
       const packageJson = await fs.readJson(path.join(result.projectDir!, "apps/web/package.json"));
-      const uiPackageJson = await fs.readJson(
-        path.join(result.projectDir!, "packages/ui/package.json"),
-      );
-      const uiUtils = await fs.readFile(
-        path.join(result.projectDir!, "packages/ui/src/lib/utils.ts"),
-        "utf8",
-      );
-
       expect(packageJson.devDependencies.vite).toBe("^8.1.5");
       expect(packageJson.devDependencies["react-router-devtools"]).toBeUndefined();
-      expect(uiPackageJson.dependencies.cn).toBe("^0.2.4");
-      expect(uiPackageJson.dependencies.clsx).toBeUndefined();
-      expect(uiPackageJson.dependencies["tailwind-merge"]).toBeUndefined();
-      expect(uiUtils.trim()).toBe('export { cn } from "cn";');
     });
+
+    for (const frontend of ["tanstack-router", "react-router", "tanstack-start", "next"] as const) {
+      it(`should use cn in the ${frontend} shared UI package`, async () => {
+        const result = await runTRPCTest({
+          projectName: `cn-${frontend}`,
+          frontend: [frontend],
+          backend: "none",
+          runtime: "none",
+          database: "none",
+          orm: "none",
+          auth: "none",
+          api: "none",
+          addons: ["none"],
+          examples: ["none"],
+          dbSetup: "none",
+          webDeploy: "none",
+          serverDeploy: "none",
+          install: false,
+        });
+
+        expectSuccess(result);
+
+        const uiPackageJson = await fs.readJson(
+          path.join(result.projectDir!, "packages/ui/package.json"),
+        );
+        const uiUtils = await fs.readFile(
+          path.join(result.projectDir!, "packages/ui/src/lib/utils.ts"),
+          "utf8",
+        );
+
+        expect(uiPackageJson.dependencies.cn).toBe("^0.2.4");
+        expect(uiPackageJson.dependencies.clsx).toBeUndefined();
+        expect(uiPackageJson.dependencies["tailwind-merge"]).toBeUndefined();
+        expect(uiUtils.trim()).toBe('export { cn } from "cn";');
+      });
+    }
 
     it("should generate the Solid 2 project structure", async () => {
       const result = await runTRPCTest({

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -33944,13 +33944,12 @@ export const env = createEnv({
     "@shadcn/react": "^0.2.1",
     "shadcn": "^4.16.0",
     "class-variance-authority": "^0.7.1",
-    "clsx": "^2.1.1",
+    "cn": "^0.2.4",
     "lucide-react": "^1.27.0",
     "next-themes": "^0.4.6",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "sonner": "^2.0.7",
-    "tailwind-merge": "^3.6.0",
     "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {
@@ -35534,12 +35533,7 @@ function TooltipContent({
 export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }
 `],
   ["packages/ui/src/hooks/.gitkeep", ``],
-  ["packages/ui/src/lib/utils.ts.hbs", `import { clsx, type ClassValue } from "clsx";
-import { twMerge } from "tailwind-merge";
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}
+  ["packages/ui/src/lib/utils.ts.hbs", `export { cn } from "cn";
 `],
   ["packages/ui/src/styles/globals.css.hbs", `@import 'tailwindcss';
 @import 'tw-animate-css';

--- a/packages/template-generator/templates/packages/ui/package.json.hbs
+++ b/packages/template-generator/templates/packages/ui/package.json.hbs
@@ -15,13 +15,12 @@
     "@shadcn/react": "^0.2.1",
     "shadcn": "^4.16.0",
     "class-variance-authority": "^0.7.1",
-    "clsx": "^2.1.1",
+    "cn": "^0.2.4",
     "lucide-react": "^1.27.0",
     "next-themes": "^0.4.6",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "sonner": "^2.0.7",
-    "tailwind-merge": "^3.6.0",
     "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {

--- a/packages/template-generator/templates/packages/ui/src/lib/utils.ts.hbs
+++ b/packages/template-generator/templates/packages/ui/src/lib/utils.ts.hbs
@@ -1,6 +1,1 @@
-import { clsx, type ClassValue } from "clsx";
-import { twMerge } from "tailwind-merge";
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}
+export { cn } from "cn";


### PR DESCRIPTION
## Summary

- replace the shared UI template's `clsx` and `tailwind-merge` dependencies with `cn`
- re-export `cn` directly from the generated UI utility module
- regenerate embedded templates

## Verification

- `bun run check`
- `bun run build`
- scaffolded every affected frontend with the locally built CLI: TanStack Router, React Router, TanStack Start, and Next.js
- completed `bun install`, `bun run check-types`, and `bun run build` for each generated project
- verified the generated utility resolves Tailwind conflicts through `cn` at runtime
