### PR TITLE
test(templates): evaluate Varlock migration without script wrappers

### DIFF
--- a/.github/workflows/varlock-smoke.yaml
+++ b/.github/workflows/varlock-smoke.yaml
@@ -1,0 +1,36 @@
+name: Varlock Migration Experiment
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - scripts/varlock-smoke.ts
+      - docs/maintenance/varlock-migration.md
+      - .github/workflows/varlock-smoke.yaml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: varlock-smoke-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  varlock-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: package.json
+          package-manager-cache: false
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.4.2"
+      - run: bun install --frozen-lockfile
+        env:
+          BTS_TELEMETRY: 0
+      - run: bun run scripts/varlock-smoke.ts

--- a/docs/maintenance/varlock-migration.md
+++ b/docs/maintenance/varlock-migration.md
@@ -1,0 +1,70 @@
+# Varlock migration experiment
+
+This draft evaluates replacing both dotenv and T3 Env with Varlock while keeping generated application scripts unchanged. It does not change the generator's defaults. The first supported experiment is a CLI-generated Hono/Bun server plus a TanStack Router/Vite frontend, with and without Turborepo.
+
+Run the reproducible check from the repository root:
+
+```sh
+bun run scripts/varlock-smoke.ts
+```
+
+The script builds the CLI, invokes its command-line entry point, migrates only the temporary generated projects, installs Varlock 1.18.0 and its Vite integration 1.5.1, and verifies them. It removes its temporary projects afterward. Network access and Node 22.3+ are required. No real credentials are needed or read from the repository.
+
+The focused `Varlock Migration Experiment` workflow runs this check when the experiment changes and can also be dispatched manually. It remains separate from the Default Suite and Curated Build Set.
+
+## Monorepo design
+
+Each application owns `.env.schema` beside its existing env files. `packages/env` retains separate web/server exports for consumers and contains the generated TypeScript accessors; it does not become a central collection of all application secrets. This follows Varlock's [monorepo schema layout](https://varlock.dev/guides/monorepos/#schema-layout).
+
+App schemas use `@generateTsTypes(..., exposeEnv=local)`. Global module augmentation would combine keys from different schemas in one TypeScript program. The smoke check asserts that web types cannot access the server secret or an unrelated root secret. See [typed ENV across packages](https://varlock.dev/guides/monorepos/#typed-env-across-packages).
+
+Only genuinely shared settings belong in the root schema. The experiment imports `SHARED_LABEL` with `@import(../../, pick=[SHARED_LABEL])`, leaving a root-only secret out of both apps, and checks the value supplied by the root `.env.local`. The import graph flows from applications to the root; the root does not import applications. See [shared configuration](https://varlock.dev/guides/monorepos/#sharing-config-from-the-root-or-siblings).
+
+Varlock loads relative to the application's working directory. Workspace tasks therefore run inside each app. Explicit `loadPath` settings are reserved for tools that run elsewhere, such as database configuration or infrastructure packages.
+
+Turbo's strict mode requires ambient variables to be declared in `globalEnv` or task `env`. The experiment declares its environment selector and synthetic validation inputs, hashes the relevant env files, and checks that a root process override selects the production values. A full migration must also cover CI/provider detection and resolver inputs actually used by each selected stack. See [Turbo environment handling](https://varlock.dev/guides/monorepos/#turborepo-and-strict-env-mode).
+
+## Loading without script wrappers
+
+- The server's env entry imports `varlock/auto-load` before exporting its typed accessor.
+- Vite uses `varlockVitePlugin()` to load and validate configuration and supply public values to the frontend.
+- `bunfig.toml` disables Bun's own dotenv loading. Framework integrations own loading and watching; no global Varlock preload is added.
+- Generated `dev`, `build`, `start`, and type-check scripts stay unchanged. The smoke check compares every script before and after migration.
+
+The auto-load module still calls the Varlock CLI internally. Avoiding a script wrapper does not eliminate that deployment dependency. References: [Node](https://varlock.dev/integrations/javascript/), [Bun](https://varlock.dev/integrations/bun/), and [Vite](https://varlock.dev/integrations/vite/).
+
+## Verification and remaining work
+
+### Imported environment selector discrepancy in 1.18.0
+
+The guide says a root `@currentEnv=$APP_ENV` carries through a partial import that includes `APP_ENV`. In a minimal local reproduction with Varlock 1.18.0, the app received `APP_ENV=preview` from the root `.env.local`, but still used its schema's default URL instead of the URL from its own `.env.preview`. Explicitly adding `@currentEnv=$APP_ENV` to the importing app then failed with `environment flag "APP_ENV" must be defined within this schema`.
+
+Reproduction layout:
+
+```text
+.env.schema         # @currentEnv=$APP_ENV; APP_ENV=development
+.env.local          # APP_ENV=preview
+apps/web/.env.schema # @import(../../, pick=[APP_ENV]); VITE_SERVER_URL=http://localhost:3000
+apps/web/.env.preview # VITE_SERVER_URL=http://localhost:4300
+```
+
+These comments abbreviate separate decorator and value lines. `varlock load --path apps/web/ --agent` returned `APP_ENV=preview` with `VITE_SERVER_URL=http://localhost:3000`. This needs upstream confirmation before relying on inherited selectors. The experiment declares `APP_ENV` and `@currentEnv` locally in each app, an alternative supported by the guide; Turbo forwards a shared process override when one is supplied.
+
+### Coverage
+
+The automated experiment checks installation, generated type isolation, builds in preview and production environments, Node and Bun loading, the built Hono handler and CORS origin, missing-variable failures, unchanged scripts, removal of direct dotenv/T3 Env dependencies, and absence of synthetic secrets in client artifacts.
+
+A separate local production Chromium check of the same Hono/Vite integration rendered the public server URL through the shared env package. Browser automation is not part of this smoke script.
+
+Before replacing the defaults:
+
+- Verify Next.js overrides at the workspace root for Bun, npm, and pnpm, plus standalone/Docker runtime loading. The documented standalone path currently uses `varlock run`.
+- Verify Alchemy/Cloudflare runtime bindings. Varlock's documented deployment integration uses `varlock-wrangler`; plain Vite SSR configuration must not bake secrets into Worker artifacts.
+- Verify Solid, React Router, TanStack Start, Nuxt, Astro, SvelteKit, and all three native choices, including their supported deployment adapters.
+- Preserve Expo's Babel/Metro composition and validate iOS/Android exports.
+- Ensure compiled Bun deployments include the required Varlock CLI and configuration.
+- Migrate database and infrastructure loaders, generated env updates, Add Path behavior, Docker build/runtime separation, and provider-derived defaults.
+- Include imported schema/value files in container contexts, or validate Varlock's flattening workflow.
+- Run the applicable Curated Build Set and browser/runtime checks after generator integration.
+
+References: [Next.js](https://varlock.dev/integrations/nextjs/), [Cloudflare](https://varlock.dev/integrations/cloudflare/), [Expo](https://varlock.dev/integrations/expo/), and [monorepo containers](https://varlock.dev/guides/monorepos/#container-builds).

--- a/docs/maintenance/varlock-migration.md
+++ b/docs/maintenance/varlock-migration.md
@@ -14,7 +14,18 @@ The focused `Varlock Migration Experiment` workflow runs this check when the exp
 
 ## Monorepo design
 
-Each application owns `.env.schema` beside its existing env files. `packages/env` retains separate web/server exports for consumers and contains the generated TypeScript accessors; it does not become a central collection of all application secrets. This follows Varlock's [monorepo schema layout](https://varlock.dev/guides/monorepos/#schema-layout).
+Each application owns `.env.schema` beside its existing env files and generates its own `src/env.ts`. The experiment removes `packages/env` and its workspace dependencies. This follows Varlock's [monorepo schema layout](https://varlock.dev/guides/monorepos/#schema-layout).
+
+```text
+apps/web/.env.schema
+apps/web/src/env.ts       # generated, web schema only
+apps/server/.env.schema
+apps/server/src/env.ts    # generated, server schema only
+```
+
+The generated filename is our convention, not a Varlock default. `exposeEnv=global` is Varlock's default type-generation mode; the monorepo guide recommends `exposeEnv=local` when applications have separate schemas. We configure `@generateTsTypes(path=./src/env.ts, exposeEnv=local)` in each application.
+
+For the full migration, reusable database, auth, payments, and API packages should accept their required configuration or initialized clients from the application. They should not import app source, read a global app env object, or initialize Varlock themselves. Application bootstrap owns initialization and resource lifetime, including request-scoped Worker bindings. Narrow typed configuration keeps these packages independent of Varlock and makes their dependencies explicit. Removing `packages/env` therefore includes refactoring those package APIs; retaining old imports is not a reason to keep the package. This experiment has no database/auth/payments selection, so those refactors remain unverified.
 
 App schemas use `@generateTsTypes(..., exposeEnv=local)`. Global module augmentation would combine keys from different schemas in one TypeScript program. The smoke check asserts that web types cannot access the server secret or an unrelated root secret. See [typed ENV across packages](https://varlock.dev/guides/monorepos/#typed-env-across-packages).
 
@@ -26,7 +37,7 @@ Turbo's strict mode requires ambient variables to be declared in `globalEnv` or 
 
 ## Loading without script wrappers
 
-- The server's env entry imports `varlock/auto-load` before exporting its typed accessor.
+- The server entry imports `varlock/auto-load` before using the app-local generated accessor.
 - Vite uses `varlockVitePlugin()` to load and validate configuration and supply public values to the frontend.
 - `bunfig.toml` disables Bun's own dotenv loading. Framework integrations own loading and watching; no global Varlock preload is added.
 - Generated `dev`, `build`, `start`, and type-check scripts stay unchanged. The smoke check compares every script before and after migration.
@@ -54,7 +65,7 @@ These comments abbreviate separate decorator and value lines. `varlock load --pa
 
 The automated experiment checks installation, generated type isolation, builds in preview and production environments, Node and Bun loading, the built Hono handler and CORS origin, missing-variable failures, unchanged scripts, removal of direct dotenv/T3 Env dependencies, and absence of synthetic secrets in client artifacts.
 
-A separate local production Chromium check of the same Hono/Vite integration rendered the public server URL through the shared env package. Browser automation is not part of this smoke script.
+A separate local production Chromium check of the Hono/Vite prototype, after removing `packages/env`, rendered the public server URL through the app-local generated accessor. Browser automation is not part of this smoke script.
 
 Before replacing the defaults:
 
@@ -64,6 +75,7 @@ Before replacing the defaults:
 - Preserve Expo's Babel/Metro composition and validate iOS/Android exports.
 - Ensure compiled Bun deployments include the required Varlock CLI and configuration.
 - Migrate database and infrastructure loaders, generated env updates, Add Path behavior, Docker build/runtime separation, and provider-derived defaults.
+- Refactor reusable DB/auth/payments/API packages to accept explicit configuration or app-initialized clients, and remove all remaining shared env imports.
 - Include imported schema/value files in container contexts, or validate Varlock's flattening workflow.
 - Run the applicable Curated Build Set and browser/runtime checks after generator integration.
 

--- a/scripts/varlock-smoke.ts
+++ b/scripts/varlock-smoke.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 // Opt-in migration experiment. Changes only CLI-generated temporary projects.
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, relative, resolve } from "node:path";
 
@@ -52,6 +52,7 @@ async function run(
 }
 
 function migrate(project: string) {
+  rmSync(join(project, "packages/env"), { recursive: true });
   const scripts = new Map<string, string>();
   for (const path of files(project).filter((path) => path.endsWith("/package.json"))) {
     const manifest: Manifest = JSON.parse(readFileSync(path, "utf8"));
@@ -59,14 +60,12 @@ function migrate(project: string) {
     for (const dependencies of [manifest.dependencies, manifest.devDependencies]) {
       if (!dependencies) continue;
       for (const name of Object.keys(dependencies)) {
-        if (name === "dotenv" || name.startsWith("@t3-oss/env-")) delete dependencies[name];
+        if (name === "dotenv" || name.startsWith("@t3-oss/env-") || name === "@varlock-smoke/env") {
+          delete dependencies[name];
+        }
       }
     }
-    if (
-      ["apps/server/package.json", "apps/web/package.json", "packages/env/package.json"].includes(
-        relative(project, path),
-      )
-    ) {
+    if (["apps/server/package.json", "apps/web/package.json"].includes(relative(project, path))) {
       manifest.dependencies ??= {};
       manifest.dependencies.varlock = "1.18.0";
     }
@@ -103,7 +102,7 @@ ROOT_ONLY_SECRET=
 # @import(../../, pick=[SHARED_LABEL])
 # @defaultRequired=true
 # @defaultSensitive=true
-# @generateTsTypes(path=../../packages/env/src/${app}-env.ts, exposeEnv=local)
+# @generateTsTypes(path=./src/env.ts, exposeEnv=local)
 # ---
 # @public @type=enum(development,preview,production,test)
 APP_ENV=preview
@@ -116,11 +115,14 @@ ${fields}`,
   }
   write("apps/web/.env.preview", "VITE_SERVER_URL=http://localhost:4300\n");
   write("apps/web/.env.production", "VITE_SERVER_URL=http://localhost:4400\n");
-  write(
-    "packages/env/src/server.ts",
-    'import "varlock/auto-load";\nexport { ENV as env } from "./server-env";\n',
+  const serverEntry = join(project, "apps/server/src/index.ts");
+  writeFileSync(
+    serverEntry,
+    readFileSync(serverEntry, "utf8").replace(
+      'import { env } from "@varlock-smoke/env/server";',
+      'import "varlock/auto-load";\nimport { ENV as env } from "./env";',
+    ),
   );
-  write("packages/env/src/web.ts", 'export { ENV as env } from "./web-env";\n');
   const vite = join(project, "apps/web/vite.config.ts");
   writeFileSync(
     vite,
@@ -130,7 +132,7 @@ ${fields}`,
   const route = join(project, "apps/web/src/routes/index.tsx");
   writeFileSync(
     route,
-    'import { env } from "@varlock-smoke/env/web";\n' +
+    'import { ENV as env } from "@/env";\n' +
       readFileSync(route, "utf8").replace(
         "<h2",
         '<p data-testid="server-url">{env.VITE_SERVER_URL}</p><span>{env.SHARED_LABEL}</span><h2',
@@ -138,7 +140,7 @@ ${fields}`,
   );
   write(
     "apps/web/src/env-isolation.ts",
-    `import { env } from "@varlock-smoke/env/web";
+    `import { ENV as env } from "./env";
 const excludesServerSecret: "BTS_SERVER_SECRET" extends keyof typeof env ? never : true = true;
 const excludesRootSecret: "ROOT_ONLY_SECRET" extends keyof typeof env ? never : true = true;
 void excludesServerSecret;
@@ -200,6 +202,7 @@ async function verify(turbo: boolean) {
       scratch,
     );
     const originalScripts = migrate(project);
+    assert(!existsSync(join(project, "packages/env")), "Apps must own their env accessors");
     if (turbo) {
       const path = join(project, "turbo.json");
       const config = JSON.parse(readFileSync(path, "utf8"));
@@ -219,7 +222,7 @@ async function verify(turbo: boolean) {
     await run(["bun", "install"], project);
     for (const app of ["server", "web"]) {
       await run(["bun", "x", "--no-install", "varlock", "codegen"], join(project, "apps", app));
-      const types = readFileSync(join(project, `packages/env/src/${app}-env.ts`), "utf8");
+      const types = readFileSync(join(project, `apps/${app}/src/env.ts`), "utf8");
       assert(!types.includes("declare module"), "Env types must not augment the global module");
       assert(!types.includes("ROOT_ONLY_SECRET"), "pick must exclude unrelated root config");
     }
@@ -241,13 +244,6 @@ async function verify(turbo: boolean) {
       "Root process override must reach the build in strict Turbo mode",
     );
     assert(!bundle().includes(secret), "Synthetic secret leaked into the production bundle");
-    const invalidBuild = await run(
-      ["bun", "run", "build"],
-      project,
-      { BTS_BUILD_SECRET: "" },
-      true,
-    );
-    assert(invalidBuild.includes("BTS_BUILD_SECRET"), "Build must report the missing variable");
     const server = join(project, "apps/server");
     const invalidStartup = await run(
       ["bun", "run", "start"],
@@ -257,7 +253,7 @@ async function verify(turbo: boolean) {
     );
     assert(
       invalidStartup.includes("BTS_SERVER_SECRET"),
-      "Startup must report the missing variable",
+      `Startup must report the missing variable:\n${invalidStartup}`,
     );
     for (const runtime of ["node", "bun"]) {
       const output = await run(
@@ -281,13 +277,26 @@ async function verify(turbo: boolean) {
       server,
     );
     assert(response.includes("server-ready"));
+    // A failed Turbo build can cancel tsdown after it cleans server/dist.
+    // Run this negative case after probing the successful production artifacts.
+    const invalidBuild = await run(
+      ["bun", "run", "build"],
+      project,
+      { BTS_BUILD_SECRET: "" },
+      true,
+    );
+    assert(
+      invalidBuild.includes("BTS_BUILD_SECRET"),
+      `Build must report the missing variable:\n${invalidBuild}`,
+    );
     for (const [path, original] of originalScripts) {
       const manifest: Manifest = JSON.parse(readFileSync(path, "utf8"));
       assert.equal(JSON.stringify(manifest.scripts), original, "App scripts must remain unchanged");
       for (const dependencies of [manifest.dependencies, manifest.devDependencies]) {
         assert(
           !Object.keys(dependencies ?? {}).some(
-            (name) => name === "dotenv" || name.startsWith("@t3-oss/env-"),
+            (name) =>
+              name === "dotenv" || name.startsWith("@t3-oss/env-") || name === "@varlock-smoke/env",
           ),
         );
       }

--- a/scripts/varlock-smoke.ts
+++ b/scripts/varlock-smoke.ts
@@ -1,0 +1,305 @@
+#!/usr/bin/env bun
+// Opt-in migration experiment. Changes only CLI-generated temporary projects.
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, relative, resolve } from "node:path";
+
+interface Manifest {
+  name: string;
+  scripts?: Record<string, string>;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  workspaces?: { catalog?: Record<string, string> };
+}
+
+const repo = resolve(import.meta.dir, "..");
+const secret = "bts-varlock-synthetic-secret-not-a-real-credential";
+
+function files(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    if (["node_modules", ".git", ".turbo"].includes(entry.name)) return [];
+    const path = join(directory, entry.name);
+    return entry.isDirectory() ? files(path) : [path];
+  });
+}
+
+async function run(
+  command: string[],
+  cwd: string,
+  env: Record<string, string> = {},
+  expectedFailure = false,
+) {
+  const child = Bun.spawn(command, {
+    cwd,
+    env: { ...process.env, ...env },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const timeout = setTimeout(() => child.kill(), 180_000);
+  try {
+    const [code, stdout, stderr] = await Promise.all([
+      child.exited,
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+    ]);
+    const output = stdout + stderr;
+    assert.equal(code !== 0, expectedFailure, `${command.join(" ")}\n${output}`);
+    return output;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function migrate(project: string) {
+  const scripts = new Map<string, string>();
+  for (const path of files(project).filter((path) => path.endsWith("/package.json"))) {
+    const manifest: Manifest = JSON.parse(readFileSync(path, "utf8"));
+    scripts.set(path, JSON.stringify(manifest.scripts));
+    for (const dependencies of [manifest.dependencies, manifest.devDependencies]) {
+      if (!dependencies) continue;
+      for (const name of Object.keys(dependencies)) {
+        if (name === "dotenv" || name.startsWith("@t3-oss/env-")) delete dependencies[name];
+      }
+    }
+    if (
+      ["apps/server/package.json", "apps/web/package.json", "packages/env/package.json"].includes(
+        relative(project, path),
+      )
+    ) {
+      manifest.dependencies ??= {};
+      manifest.dependencies.varlock = "1.18.0";
+    }
+    if (path === join(project, "apps/web/package.json")) {
+      manifest.devDependencies ??= {};
+      manifest.devDependencies["@varlock/vite-integration"] = "1.5.1";
+    }
+    if (manifest.workspaces?.catalog) delete manifest.workspaces.catalog.dotenv;
+    writeFileSync(path, `${JSON.stringify(manifest, null, 2)}\n`);
+  }
+  const write = (path: string, content: string) => writeFileSync(join(project, path), content);
+  for (const path of ["bunfig.toml", "apps/server/bunfig.toml", "apps/web/bunfig.toml"]) {
+    write(path, "env = false\n");
+  }
+  write(
+    ".env.schema",
+    `# @defaultRequired=true
+# @defaultSensitive=true
+# ---
+# @public
+SHARED_LABEL=root-default
+ROOT_ONLY_SECRET=
+`,
+  );
+  write(".env.local", `SHARED_LABEL=root-local\nROOT_ONLY_SECRET=${secret}\n`);
+  for (const app of ["server", "web"]) {
+    const fields =
+      app === "server"
+        ? "# @public @type=url\nCORS_ORIGIN=http://localhost:3001\n# @public @type=enum(development,production,test)\nNODE_ENV=development\n# @type=string(minLength=16)\nBTS_SERVER_SECRET=\n"
+        : "# @public @type=url\nVITE_SERVER_URL=http://localhost:3000\n# @type=string(minLength=16)\nBTS_BUILD_SECRET=\n";
+    write(
+      `apps/${app}/.env.schema`,
+      `# @currentEnv=$APP_ENV
+# @import(../../, pick=[SHARED_LABEL])
+# @defaultRequired=true
+# @defaultSensitive=true
+# @generateTsTypes(path=../../packages/env/src/${app}-env.ts, exposeEnv=local)
+# ---
+# @public @type=enum(development,preview,production,test)
+APP_ENV=preview
+${fields}`,
+    );
+    write(
+      `apps/${app}/.env.local`,
+      `${app === "server" ? "BTS_SERVER_SECRET" : "BTS_BUILD_SECRET"}=${secret}\n`,
+    );
+  }
+  write("apps/web/.env.preview", "VITE_SERVER_URL=http://localhost:4300\n");
+  write("apps/web/.env.production", "VITE_SERVER_URL=http://localhost:4400\n");
+  write(
+    "packages/env/src/server.ts",
+    'import "varlock/auto-load";\nexport { ENV as env } from "./server-env";\n',
+  );
+  write("packages/env/src/web.ts", 'export { ENV as env } from "./web-env";\n');
+  const vite = join(project, "apps/web/vite.config.ts");
+  writeFileSync(
+    vite,
+    'import { varlockVitePlugin } from "@varlock/vite-integration";\n' +
+      readFileSync(vite, "utf8").replace("plugins: [", "plugins: [varlockVitePlugin(),"),
+  );
+  const route = join(project, "apps/web/src/routes/index.tsx");
+  writeFileSync(
+    route,
+    'import { env } from "@varlock-smoke/env/web";\n' +
+      readFileSync(route, "utf8").replace(
+        "<h2",
+        '<p data-testid="server-url">{env.VITE_SERVER_URL}</p><span>{env.SHARED_LABEL}</span><h2',
+      ),
+  );
+  write(
+    "apps/web/src/env-isolation.ts",
+    `import { env } from "@varlock-smoke/env/web";
+const excludesServerSecret: "BTS_SERVER_SECRET" extends keyof typeof env ? never : true = true;
+const excludesRootSecret: "ROOT_ONLY_SECRET" extends keyof typeof env ? never : true = true;
+void excludesServerSecret;
+void excludesRootSecret;
+`,
+  );
+  write(".gitignore", readFileSync(join(project, ".gitignore"), "utf8") + "\n!.env.schema\n");
+  return scripts;
+}
+
+async function verify(turbo: boolean) {
+  const scratch = mkdtempSync(join(tmpdir(), "bts-varlock-"));
+  const project = join(scratch, "varlock-smoke");
+  console.log(`Checking Varlock with ${turbo ? "Turborepo" : "Bun workspaces"}`);
+  try {
+    await run(
+      [
+        "bun",
+        join(repo, "apps/cli/dist/cli.mjs"),
+        "create",
+        "varlock-smoke",
+        "--frontend",
+        "tanstack-router",
+        "--backend",
+        "hono",
+        "--runtime",
+        "bun",
+        "--database",
+        "none",
+        "--orm",
+        "none",
+        "--api",
+        "none",
+        "--auth",
+        "none",
+        "--payments",
+        "none",
+        "--addons",
+        turbo ? "turborepo" : "none",
+        "--examples",
+        "none",
+        "--package-manager",
+        "bun",
+        "--no-git",
+        "--no-install",
+        "--open",
+        "none",
+        "--db-setup",
+        "none",
+        "--web-deploy",
+        "none",
+        "--server-deploy",
+        "none",
+        "--directory-conflict",
+        "error",
+        "--disable-analytics",
+        "--no-render-title",
+      ],
+      scratch,
+    );
+    const originalScripts = migrate(project);
+    if (turbo) {
+      const path = join(project, "turbo.json");
+      const config = JSON.parse(readFileSync(path, "utf8"));
+      config.globalEnv = [
+        ...new Set([
+          ...(config.globalEnv ?? []),
+          "APP_ENV",
+          "BTS_BUILD_SECRET",
+          "BTS_SERVER_SECRET",
+        ]),
+      ];
+      config.globalDependencies = [
+        ...new Set([...(config.globalDependencies ?? []), ".env*", "apps/*/.env*"]),
+      ];
+      writeFileSync(path, `${JSON.stringify(config, null, 2)}\n`);
+    }
+    await run(["bun", "install"], project);
+    for (const app of ["server", "web"]) {
+      await run(["bun", "x", "--no-install", "varlock", "codegen"], join(project, "apps", app));
+      const types = readFileSync(join(project, `packages/env/src/${app}-env.ts`), "utf8");
+      assert(!types.includes("declare module"), "Env types must not augment the global module");
+      assert(!types.includes("ROOT_ONLY_SECRET"), "pick must exclude unrelated root config");
+    }
+    await run(["bun", "run", "check-types"], project);
+    await run(["bun", "run", "build"], project);
+    const bundle = () =>
+      files(join(project, "apps/web/dist"))
+        .map((path) => readFileSync(path, "utf8"))
+        .join("\n");
+    assert(
+      bundle().includes("http://localhost:4300"),
+      "App preview environment must select .env.preview",
+    );
+    assert(bundle().includes("root-local"), "Directory imports must include root value files");
+    assert(!bundle().includes(secret), "Synthetic secret leaked into the browser bundle");
+    await run(["bun", "run", "build"], project, { APP_ENV: "production" });
+    assert(
+      bundle().includes("http://localhost:4400"),
+      "Root process override must reach the build in strict Turbo mode",
+    );
+    assert(!bundle().includes(secret), "Synthetic secret leaked into the production bundle");
+    const invalidBuild = await run(
+      ["bun", "run", "build"],
+      project,
+      { BTS_BUILD_SECRET: "" },
+      true,
+    );
+    assert(invalidBuild.includes("BTS_BUILD_SECRET"), "Build must report the missing variable");
+    const server = join(project, "apps/server");
+    const invalidStartup = await run(
+      ["bun", "run", "start"],
+      server,
+      { BTS_SERVER_SECRET: "" },
+      true,
+    );
+    assert(
+      invalidStartup.includes("BTS_SERVER_SECRET"),
+      "Startup must report the missing variable",
+    );
+    for (const runtime of ["node", "bun"]) {
+      const output = await run(
+        [
+          runtime,
+          "--input-type=module",
+          "-e",
+          'import "varlock/auto-load"; import { ENV } from "varlock/env"; if (ENV.APP_ENV !== "preview" || ENV.CORS_ORIGIN !== "http://localhost:3001" || !ENV.BTS_SERVER_SECRET) throw new Error("Env was not loaded"); console.log("env-ready");',
+        ],
+        server,
+      );
+      assert(output.includes("env-ready"));
+    }
+    // Run the built Hono handler without binding a fixed port.
+    const response = await run(
+      [
+        "bun",
+        "-e",
+        'const {default: app} = await import("./dist/index.mjs"); const response = await app.request("http://localhost/", {headers: {origin: "http://localhost:3001"}}); if (response.status !== 200 || await response.text() !== "OK" || response.headers.get("access-control-allow-origin") !== "http://localhost:3001") throw new Error("Built server failed"); console.log("server-ready");',
+      ],
+      server,
+    );
+    assert(response.includes("server-ready"));
+    for (const [path, original] of originalScripts) {
+      const manifest: Manifest = JSON.parse(readFileSync(path, "utf8"));
+      assert.equal(JSON.stringify(manifest.scripts), original, "App scripts must remain unchanged");
+      for (const dependencies of [manifest.dependencies, manifest.devDependencies]) {
+        assert(
+          !Object.keys(dependencies ?? {}).some(
+            (name) => name === "dotenv" || name.startsWith("@t3-oss/env-"),
+          ),
+        );
+      }
+    }
+    console.log(
+      `Passed: ${turbo ? "Turborepo strict mode" : "Bun workspaces"}, build, types, Node/Bun loading, Hono runtime, missing env, public/secret separation`,
+    );
+  } finally {
+    rmSync(scratch, { recursive: true });
+  }
+}
+
+await run(["bun", "run", "build:cli"], repo);
+await verify(false);
+await verify(true);


### PR DESCRIPTION
Evaluate replacing dotenv loading and T3 Env validation with Varlock while retaining plain application scripts. This draft adds a reproducible Hono/Bun + TanStack Router/Vite migration experiment; it does not switch generator defaults.

Stacked on #1224, which supplies the dependency baseline and CLI/template fixes used by these checks. The diff is limited to the experiment, its CI workflow, and migration notes.

- Scaffold fresh projects through the built CLI, then migrate only those temporary projects to Varlock 1.18.0 and @varlock/vite-integration 1.5.1.
- Keep all generated package scripts unchanged, using varlock/auto-load and the Vite integration. Remove direct dotenv/T3 Env dependencies and disable Bun's competing dotenv loader.
- Follow the [official monorepo guide](https://varlock.dev/guides/monorepos/): app-owned schemas, app-local generated types (exposeEnv=local), removal of packages/env, allowlisted root imports, correct working directories, and explicit Turbo environment inputs.
- Verify plain Bun workspaces and Turbo strict mode, including environment-specific value files, process overrides, type isolation, builds, Node/Bun loading, the built Hono handler, missing-variable failures, and synthetic-secret exclusion from browser artifacts.
- Put loading in application bootstrap. The full migration will pass narrow configuration or initialized clients to reusable DB/auth/payments/API packages, rather than retaining a global env workspace.
- Add a focused CI workflow, plus remaining work for full template adoption.
- Run intentionally failing builds after runtime probes so Turbo cancellation cannot remove artifacts before they are tested.

The monorepo check found a documentation/package discrepancy: with 1.18.0, importing the root APP_ENV selector produced APP_ENV=preview but did not load the app's .env.preview. Adding the selector decorator to the importing app failed because the flag was not locally defined. The notes record the reproduction; the experiment uses the guide's alternative of declaring the selector in each app.

Validation:

- Both reproducible smoke profiles passed locally with Bun 1.4.2 and Node 24.
- Smoke-script TypeScript check, repository formatting/lint, and actionlint passed.
- The earlier CLI-generated prototype also passed production Chromium rendering of the public URL through the app-local generated accessor after removing packages/env, and a real HTTP/CORS probe. Browser automation is not included in this smoke script.

Remaining before a default migration: Next standalone/Docker, workspace overrides across package managers, Alchemy/Cloudflare bindings, other SSR frameworks, Expo exports, compiled Bun packaging, database/infra loaders, and Add Path behavior. No new dependency or env-provider option is added to generated projects by this draft.
