### PR TITLE
fix(templates): update Solid v2 dependencies and fix SSR/auth flows

### DIFF
--- a/apps/cli/test/addons.test.ts
+++ b/apps/cli/test/addons.test.ts
@@ -525,10 +525,10 @@ describe("Addon Configurations", () => {
       );
       const webViteConfig = await readFile(join(projectDir!, "apps/web/vite.config.ts"), "utf8");
 
-      expect(rootPackageJson.devDependencies["vite-plus"]).toBe("0.3.0");
+      expect(rootPackageJson.devDependencies["vite-plus"]).toBe("0.3.1");
       expect(rootPackageJson.devDependencies.rolldown).toBe("1.2.7");
       expect(rootPackageJson.overrides).toMatchObject({
-        vite: "npm:@voidzero-dev/vite-plus-core@0.3.0",
+        vite: "npm:@voidzero-dev/vite-plus-core@0.3.1",
       });
       expect(rootPackageJson.overrides.vitest).toBeUndefined();
       expect(rootPackageJson.scripts.dev).toBe("vp run -r dev");
@@ -669,7 +669,7 @@ describe("Addon Configurations", () => {
       const webViteConfig = await readFile(join(projectDir, "apps/web/vite.config.ts"), "utf8");
       const rootViteConfig = await readFile(join(projectDir, "vite.config.ts"), "utf8");
 
-      expect(rootPackageJson.devDependencies["vite-plus"]).toBe("0.3.0");
+      expect(rootPackageJson.devDependencies["vite-plus"]).toBe("0.3.1");
       expect(rootPackageJson.scripts.dev).toBe("vp run -r dev");
       expect(rootPackageJson.scripts.staged).toBe("vp staged");
       expect(rootPackageJson.scripts["hooks:setup"]).toBe("vp config");

--- a/apps/cli/test/deployment.test.ts
+++ b/apps/cli/test/deployment.test.ts
@@ -1993,7 +1993,7 @@ describe("Deployment Configurations", () => {
       const compose = files.get("docker-compose.yml");
 
       expect(webPkg.dependencies["@solidjs/start"]).toBeUndefined();
-      expect(webPkg.dependencies["solid-js"]).toBe("2.0.0-rc.6");
+      expect(webPkg.dependencies["solid-js"]).toBe("2.0.0-rc.7");
       expect(webPkg.devDependencies.nitro).toBeDefined();
       expect(webPkg.devDependencies["@tanstack/solid-router-devtools"]).toBeUndefined();
       expect(files.get("apps/web/vite.config.ts")).toContain("tsconfigPaths: true");

--- a/apps/cli/test/frontend.test.ts
+++ b/apps/cli/test/frontend.test.ts
@@ -176,11 +176,16 @@ describe("Frontend Configurations", () => {
       const tsconfig = await fs.readJson(path.join(webDir, "tsconfig.json"));
       const viteConfig = await fs.readFile(path.join(webDir, "vite.config.ts"), "utf8");
 
+      expect(rootPackageJson.overrides).toEqual({
+        "@solidjs/signals": "2.0.0-rc.7",
+        "@solidjs/compiler": "2.0.0-rc.7",
+        "@solidjs/babel-plugin": "2.0.0-rc.7",
+      });
       expect(packageJson.dependencies).toMatchObject({
         "@solidjs/meta": "1.0.0-next.2",
-        "@solidjs/router": "2.0.0-next.21",
-        "@solidjs/web": "2.0.0-rc.6",
-        "solid-js": "2.0.0-rc.6",
+        "@solidjs/router": "2.0.0-next.23",
+        "@solidjs/web": "2.0.0-rc.7",
+        "solid-js": "2.0.0-rc.7",
       });
       expect(packageJson.devDependencies).toMatchObject({
         "@solidjs/vite-plugin": "3.0.0-next.39",

--- a/apps/cli/test/generated-builds.test.ts
+++ b/apps/cli/test/generated-builds.test.ts
@@ -1044,7 +1044,7 @@ async function bootAndValidatePrismaWebArtifact(sample: SelectedBuildSample, pro
 }
 
 async function bootAndValidateSolidRuntime(sample: SelectedBuildSample, projectDir: string) {
-  if (sample.name !== "solid-v2-self-orpc-no-auth") return;
+  if (!["solid-v2-self-orpc-no-auth", "solid-v2-self-orpc-auth-todo"].includes(sample.name)) return;
 
   const webDir = path.join(projectDir, "apps/web");
   const port = await getAvailablePort();
@@ -1075,6 +1075,14 @@ async function bootAndValidateSolidRuntime(sample: SelectedBuildSample, projectD
     });
     expect(health?.status).toBe(200);
     expect(await health?.json()).toEqual({ json: "OK" });
+
+    if (sample.name === "solid-v2-self-orpc-auth-todo") {
+      const dashboard = await fetchWhenReady(`http://127.0.0.1:${port}/dashboard`, {
+        signal: AbortSignal.timeout(15_000),
+      });
+      expect(dashboard?.status).toBe(200);
+      expect(await dashboard?.text()).toContain("Loading...");
+    }
 
     const missing = await fetchWhenReady(`http://127.0.0.1:${port}/missing-page`);
     expect(missing?.status).toBe(404);

--- a/apps/cli/test/generated-builds.test.ts
+++ b/apps/cli/test/generated-builds.test.ts
@@ -977,18 +977,54 @@ async function getAvailablePort(): Promise<number> {
 async function fetchWhenReady(url: string, init?: RequestInit) {
   for (let attempt = 0; attempt < 100; attempt++) {
     try {
-      const response = await fetch(url, { ...init, signal: AbortSignal.timeout(5000) });
+      const response = await fetch(url, {
+        ...init,
+        signal: init?.signal ?? AbortSignal.timeout(5000),
+      });
       // SSR can send headers before compilation/streaming finishes. Consume the
       // body inside the retry boundary so a timeout does not escape afterwards.
       const body = await response.arrayBuffer();
       return new Response(body, { status: response.status, headers: response.headers });
     } catch {
+      init?.signal?.throwIfAborted();
       await Bun.sleep(100);
     }
   }
 
   return undefined;
 }
+
+describe("Generated runtime readiness", () => {
+  it("stops when the caller cancels a streaming response", async () => {
+    const controller = new AbortController();
+    const reason = new Error("Runtime probe cancelled");
+    let requests = 0;
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch() {
+        requests++;
+        return new Response(
+          new ReadableStream({
+            start(stream) {
+              stream.enqueue(new TextEncoder().encode("pending"));
+              controller.abort(reason);
+            },
+          }),
+        );
+      },
+    });
+
+    try {
+      await expect(fetchWhenReady(server.url.href, { signal: controller.signal })).rejects.toBe(
+        reason,
+      );
+      expect(requests).toBe(1);
+    } finally {
+      await server.stop(true);
+    }
+  });
+});
 
 async function bootAndValidatePrismaWebArtifact(sample: SelectedBuildSample, projectDir: string) {
   if (sample.config.webDeploy !== "prisma") return;

--- a/apps/cli/test/generated-builds.test.ts
+++ b/apps/cli/test/generated-builds.test.ts
@@ -772,8 +772,9 @@ async function validateSolidScaffold(sample: SelectedBuildSample, projectDir: st
 
   const webPackageJson = await fs.readJson(path.join(webDir, "package.json"));
   expect(webPackageJson.dependencies?.["@solidjs/start"]).toBeUndefined();
-  expect(webPackageJson.dependencies?.["solid-js"]).toBe("2.0.0-rc.6");
-  expect(webPackageJson.dependencies?.["@solidjs/web"]).toBe("2.0.0-rc.6");
+  expect(webPackageJson.devDependencies?.["@tanstack/solid-query-devtools"]).toBeUndefined();
+  expect(webPackageJson.dependencies?.["solid-js"]).toBe("2.0.0-rc.7");
+  expect(webPackageJson.dependencies?.["@solidjs/web"]).toBe("2.0.0-rc.7");
   expect(webPackageJson.dependencies?.["@solidjs/router"]).toBeDefined();
   expect(webPackageJson.devDependencies?.["@solidjs/vite-plugin"]).toBeDefined();
   expect(webPackageJson.devDependencies?.["filesystem-routing"]).toBeDefined();
@@ -1115,9 +1116,11 @@ async function bootAndValidateSolidDevRuntime(sample: SelectedBuildSample, proje
 
   let failure: unknown;
   try {
-    const root = await fetchWhenReady(`http://127.0.0.1:${port}/`);
-    expect(root?.status).toBe(200);
-    expect(await root?.text()).toContain("Connected");
+    for (let request = 0; request < 2; request++) {
+      const root = await fetchWhenReady(`http://127.0.0.1:${port}/`);
+      expect(root?.status).toBe(200);
+      expect(await root?.text()).toContain("Connected");
+    }
 
     const health = await fetchWhenReady(`http://127.0.0.1:${port}/rpc/healthCheck`, {
       method: "POST",

--- a/apps/cli/test/pnpm-workspace.test.ts
+++ b/apps/cli/test/pnpm-workspace.test.ts
@@ -19,6 +19,7 @@ async function readPnpmWorkspace(config: TestConfig) {
   const workspacePath = path.join(result.projectDir!, "pnpm-workspace.yaml");
   const content = await readFile(workspacePath, "utf8");
   return yaml.parse(content) as {
+    overrides?: Record<string, string>;
     allowBuilds?: Record<string, boolean>;
     minimumReleaseAgeExclude?: string[];
   };
@@ -43,16 +44,21 @@ describe("pnpm workspace", () => {
       serverDeploy: "none",
     });
 
+    expect(workspace.overrides).toEqual({
+      "@solidjs/signals": "2.0.0-rc.7",
+      "@solidjs/compiler": "2.0.0-rc.7",
+      "@solidjs/babel-plugin": "2.0.0-rc.7",
+    });
     expect(workspace.minimumReleaseAgeExclude).toEqual([
+      "@solidjs/babel-plugin@2.0.0-rc.7",
+      "@solidjs/compiler@2.0.0-rc.7",
       "@solidjs/meta@1.0.0-next.2",
-      "@solidjs/router@2.0.0-next.21",
-      "@solidjs/signals@2.0.0-rc.6",
+      "@solidjs/router@2.0.0-next.23",
+      "@solidjs/signals@2.0.0-rc.7",
       "@solidjs/vite-plugin@3.0.0-next.39",
-      "@solidjs/web@2.0.0-rc.6",
-      "@tanstack/solid-query-devtools@6.0.0-rc.3",
+      "@solidjs/web@2.0.0-rc.7",
       "@tanstack/solid-query@6.0.0-rc.3",
-      "babel-preset-solid@2.0.0-rc.6",
-      "solid-js@2.0.0-rc.6",
+      "solid-js@2.0.0-rc.7",
     ]);
   });
 

--- a/packages/template-generator/src/processors/api-deps.ts
+++ b/packages/template-generator/src/processors/api-deps.ts
@@ -176,7 +176,6 @@ function addWebClientDeps(
         "@orpc/server",
         "@tanstack/solid-query",
       ],
-      devDependencies: ["@tanstack/solid-query-devtools"],
     });
   } else if (api === "orpc" && frontendType.hasAstroWeb) {
     // Astro uses vanilla oRPC client without TanStack Query
@@ -228,7 +227,6 @@ function addQueryDeps(vfs: VirtualFileSystem, frontend: Frontend[], backend: Bac
       vfs,
       packagePath: webPath,
       dependencies: ["@tanstack/solid-query", "@tanstack/query-core"],
-      devDependencies: ["@tanstack/solid-query-devtools"],
     });
   }
 

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -11891,6 +11891,11 @@ export default function SignInForm({ onSwitchToSignUp }: { onSwitchToSignUp: () 
       await authClient.signIn.email(result.data, {
         onSuccess: async () => {
           await authClient.useSession.get().refetch();
+          const session = authClient.useSession.get();
+          if (!session.data) {
+            setError(session.error?.message || "Unable to load your session. Please sign in again.");
+            return;
+          }
           navigate("/dashboard");
         },
         onError: ({ error }) => {
@@ -11973,6 +11978,11 @@ export default function SignUpForm({ onSwitchToSignIn }: { onSwitchToSignIn: () 
       await authClient.signUp.email(result.data, {
         onSuccess: async () => {
           await authClient.useSession.get().refetch();
+          const session = authClient.useSession.get();
+          if (!session.data) {
+            setError(session.error?.message || "Unable to load your session. Please sign in again.");
+            return;
+          }
           navigate("/dashboard");
         },
         onError: ({ error }) => {

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -11889,7 +11889,10 @@ export default function SignInForm({ onSwitchToSignUp }: { onSwitchToSignUp: () 
     setError();
     try {
       await authClient.signIn.email(result.data, {
-        onSuccess: () => navigate("/dashboard"),
+        onSuccess: async () => {
+          await authClient.useSession.get().refetch();
+          navigate("/dashboard");
+        },
         onError: ({ error }) => {
           setError(error.message);
         },
@@ -11968,7 +11971,10 @@ export default function SignUpForm({ onSwitchToSignIn }: { onSwitchToSignIn: () 
     setError();
     try {
       await authClient.signUp.email(result.data, {
-        onSuccess: () => navigate("/dashboard"),
+        onSuccess: async () => {
+          await authClient.useSession.get().refetch();
+          navigate("/dashboard");
+        },
         onError: ({ error }) => {
           setError(error.message);
         },
@@ -15332,6 +15338,13 @@ temp
     "apps/*",
     "packages/*"
   ],
+{{#if (and (includes frontend "solid") (ne packageManager "pnpm"))}}
+  "overrides": {
+    "@solidjs/signals": "2.0.0-rc.7",
+    "@solidjs/compiler": "2.0.0-rc.7",
+    "@solidjs/babel-plugin": "2.0.0-rc.7"
+  },
+{{/if}}
   "scripts": {}
 }
 `],
@@ -25926,16 +25939,21 @@ declare module "cloudflare:workers" {
   - "packages/*"
 {{#if (includes frontend "solid")}}
 
+overrides:
+  "@solidjs/signals": "2.0.0-rc.7"
+  "@solidjs/compiler": "2.0.0-rc.7"
+  "@solidjs/babel-plugin": "2.0.0-rc.7"
+
 minimumReleaseAgeExclude:
+  - "@solidjs/babel-plugin@2.0.0-rc.7"
+  - "@solidjs/compiler@2.0.0-rc.7"
   - "@solidjs/meta@1.0.0-next.2"
-  - "@solidjs/router@2.0.0-next.21"
-  - "@solidjs/signals@2.0.0-rc.6"
+  - "@solidjs/router@2.0.0-next.23"
+  - "@solidjs/signals@2.0.0-rc.7"
   - "@solidjs/vite-plugin@3.0.0-next.39"
-  - "@solidjs/web@2.0.0-rc.6"
-  - "@tanstack/solid-query-devtools@6.0.0-rc.3"
+  - "@solidjs/web@2.0.0-rc.7"
   - "@tanstack/solid-query@6.0.0-rc.3"
-  - "babel-preset-solid@2.0.0-rc.6"
-  - "solid-js@2.0.0-rc.6"
+  - "solid-js@2.0.0-rc.7"
 {{/if}}
 {{#if (or (eq runtime "node") (eq webDeploy "cloudflare") (eq serverDeploy "cloudflare") (eq webDeploy "prisma") (eq serverDeploy "prisma") (eq webDeploy "docker") (eq serverDeploy "docker") (eq webDeploy "vercel") (eq serverDeploy "vercel") (eq orm "prisma") (includes addons "lefthook") (includes addons "nx") (includes addons "pwa") (includes addons "turborepo") (includes addons "vite-plus") (includes frontend "react-router") (includes frontend "next") (includes frontend "nuxt"))}}
 
@@ -32699,9 +32717,9 @@ dist
   },
   "dependencies": {
     "@solidjs/meta": "1.0.0-next.2",
-    "@solidjs/router": "2.0.0-next.21",
-    "@solidjs/web": "2.0.0-rc.6",
-    "solid-js": "2.0.0-rc.6"
+    "@solidjs/router": "2.0.0-next.23",
+    "@solidjs/web": "2.0.0-rc.7",
+    "solid-js": "2.0.0-rc.7"
   },
   "devDependencies": {
     "@solidjs/vite-plugin": "3.0.0-next.39",
@@ -32727,7 +32745,6 @@ import Loader from "~/components/loader";
 import { Router } from "~/router";
 {{#if (eq api "orpc")}}
 import { QueryClientProvider } from "@tanstack/solid-query";
-import { SolidQueryDevtools } from "@tanstack/solid-query-devtools";
 import { createQueryClient } from "~/utils/orpc";
 {{/if}}
 import "./styles.css";
@@ -32753,7 +32770,6 @@ export default function App() {
         )}
       </Router>
 {{#if (eq api "orpc")}}
-      <SolidQueryDevtools />
     </QueryClientProvider>
 {{/if}}
   );
@@ -33004,6 +33020,9 @@ export default defineConfig({
     },
   },
 {{/if}}
+  ssr: {
+    noExternal: ["solid-js", /^@solidjs\\//, "@tanstack/solid-query"],
+  },
   resolve: {
     tsconfigPaths: true,
 {{#if (eq webDeploy "cloudflare")}}

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -12129,13 +12129,6 @@ export default function Dashboard() {
 		},
 	);
 
-	{{#if (eq api "orpc")}}
-	const privateData = useQuery(() => ({
-		...orpc.privateData.queryOptions(),
-		enabled: Boolean(session().data),
-	}));
-	{{/if}}
-
 	{{#if (eq payments "polar")}}
 	const hasProSubscription = () =>
 		(customerState()?.activeSubscriptions?.length ?? 0) > 0;
@@ -12147,7 +12140,7 @@ export default function Dashboard() {
 			<h1>Dashboard</h1>
 			<p>Welcome {session().data?.user.name}</p>
 			{{#if (eq api "orpc")}}
-			<p>API: {privateData.data?.message}</p>
+			<PrivateData />
 			{{/if}}
 			{{#if (eq payments "polar")}}
 			<p>Plan: {hasProSubscription() ? "Pro" : "Free"}</p>
@@ -12167,6 +12160,13 @@ export default function Dashboard() {
 		</Show>
 	);
 }
+
+{{#if (eq api "orpc")}}
+function PrivateData() {
+  const privateData = useQuery(() => orpc.privateData.queryOptions());
+  return <p>API: {privateData.data?.message}</p>;
+}
+{{/if}}
 `],
   ["auth/better-auth/web/solid/src/routes/login.tsx.hbs", `import { createSignal, Match, Switch } from "solid-js";
 import SignInForm from "~/components/sign-in-form";

--- a/packages/template-generator/src/utils/add-deps.ts
+++ b/packages/template-generator/src/utils/add-deps.ts
@@ -100,7 +100,7 @@ export const dependencyVersionMap = {
 
   turbo: "^2.10.12",
   nx: "^23.2.0",
-  "vite-plus": "0.3.0",
+  "vite-plus": "0.3.1",
   rolldown: "1.2.7",
   unwasm: "^0.6.0",
 
@@ -149,7 +149,6 @@ export const dependencyVersionMap = {
 
   // Keep this RC set and its exact Query Core dependency aligned (private class types).
   "@tanstack/solid-query": "6.0.0-rc.3",
-  "@tanstack/solid-query-devtools": "6.0.0-rc.3",
   "@tanstack/query-core": "5.101.4",
 
   wrangler: "^4.129.0",

--- a/packages/template-generator/templates/auth/better-auth/web/solid/src/components/sign-in-form.tsx.hbs
+++ b/packages/template-generator/templates/auth/better-auth/web/solid/src/components/sign-in-form.tsx.hbs
@@ -25,7 +25,10 @@ export default function SignInForm({ onSwitchToSignUp }: { onSwitchToSignUp: () 
     setError();
     try {
       await authClient.signIn.email(result.data, {
-        onSuccess: () => navigate("/dashboard"),
+        onSuccess: async () => {
+          await authClient.useSession.get().refetch();
+          navigate("/dashboard");
+        },
         onError: ({ error }) => {
           setError(error.message);
         },

--- a/packages/template-generator/templates/auth/better-auth/web/solid/src/components/sign-in-form.tsx.hbs
+++ b/packages/template-generator/templates/auth/better-auth/web/solid/src/components/sign-in-form.tsx.hbs
@@ -27,6 +27,11 @@ export default function SignInForm({ onSwitchToSignUp }: { onSwitchToSignUp: () 
       await authClient.signIn.email(result.data, {
         onSuccess: async () => {
           await authClient.useSession.get().refetch();
+          const session = authClient.useSession.get();
+          if (!session.data) {
+            setError(session.error?.message || "Unable to load your session. Please sign in again.");
+            return;
+          }
           navigate("/dashboard");
         },
         onError: ({ error }) => {

--- a/packages/template-generator/templates/auth/better-auth/web/solid/src/components/sign-up-form.tsx.hbs
+++ b/packages/template-generator/templates/auth/better-auth/web/solid/src/components/sign-up-form.tsx.hbs
@@ -26,7 +26,10 @@ export default function SignUpForm({ onSwitchToSignIn }: { onSwitchToSignIn: () 
     setError();
     try {
       await authClient.signUp.email(result.data, {
-        onSuccess: () => navigate("/dashboard"),
+        onSuccess: async () => {
+          await authClient.useSession.get().refetch();
+          navigate("/dashboard");
+        },
         onError: ({ error }) => {
           setError(error.message);
         },

--- a/packages/template-generator/templates/auth/better-auth/web/solid/src/components/sign-up-form.tsx.hbs
+++ b/packages/template-generator/templates/auth/better-auth/web/solid/src/components/sign-up-form.tsx.hbs
@@ -28,6 +28,11 @@ export default function SignUpForm({ onSwitchToSignIn }: { onSwitchToSignIn: () 
       await authClient.signUp.email(result.data, {
         onSuccess: async () => {
           await authClient.useSession.get().refetch();
+          const session = authClient.useSession.get();
+          if (!session.data) {
+            setError(session.error?.message || "Unable to load your session. Please sign in again.");
+            return;
+          }
           navigate("/dashboard");
         },
         onError: ({ error }) => {

--- a/packages/template-generator/templates/auth/better-auth/web/solid/src/routes/dashboard.tsx.hbs
+++ b/packages/template-generator/templates/auth/better-auth/web/solid/src/routes/dashboard.tsx.hbs
@@ -31,13 +31,6 @@ export default function Dashboard() {
 		},
 	);
 
-	{{#if (eq api "orpc")}}
-	const privateData = useQuery(() => ({
-		...orpc.privateData.queryOptions(),
-		enabled: Boolean(session().data),
-	}));
-	{{/if}}
-
 	{{#if (eq payments "polar")}}
 	const hasProSubscription = () =>
 		(customerState()?.activeSubscriptions?.length ?? 0) > 0;
@@ -49,7 +42,7 @@ export default function Dashboard() {
 			<h1>Dashboard</h1>
 			<p>Welcome {session().data?.user.name}</p>
 			{{#if (eq api "orpc")}}
-			<p>API: {privateData.data?.message}</p>
+			<PrivateData />
 			{{/if}}
 			{{#if (eq payments "polar")}}
 			<p>Plan: {hasProSubscription() ? "Pro" : "Free"}</p>
@@ -69,3 +62,10 @@ export default function Dashboard() {
 		</Show>
 	);
 }
+
+{{#if (eq api "orpc")}}
+function PrivateData() {
+  const privateData = useQuery(() => orpc.privateData.queryOptions());
+  return <p>API: {privateData.data?.message}</p>;
+}
+{{/if}}

--- a/packages/template-generator/templates/base/package.json.hbs
+++ b/packages/template-generator/templates/base/package.json.hbs
@@ -6,5 +6,12 @@
     "apps/*",
     "packages/*"
   ],
+{{#if (and (includes frontend "solid") (ne packageManager "pnpm"))}}
+  "overrides": {
+    "@solidjs/signals": "2.0.0-rc.7",
+    "@solidjs/compiler": "2.0.0-rc.7",
+    "@solidjs/babel-plugin": "2.0.0-rc.7"
+  },
+{{/if}}
   "scripts": {}
 }

--- a/packages/template-generator/templates/extras/pnpm-workspace.yaml.hbs
+++ b/packages/template-generator/templates/extras/pnpm-workspace.yaml.hbs
@@ -3,16 +3,21 @@ packages:
   - "packages/*"
 {{#if (includes frontend "solid")}}
 
+overrides:
+  "@solidjs/signals": "2.0.0-rc.7"
+  "@solidjs/compiler": "2.0.0-rc.7"
+  "@solidjs/babel-plugin": "2.0.0-rc.7"
+
 minimumReleaseAgeExclude:
+  - "@solidjs/babel-plugin@2.0.0-rc.7"
+  - "@solidjs/compiler@2.0.0-rc.7"
   - "@solidjs/meta@1.0.0-next.2"
-  - "@solidjs/router@2.0.0-next.21"
-  - "@solidjs/signals@2.0.0-rc.6"
+  - "@solidjs/router@2.0.0-next.23"
+  - "@solidjs/signals@2.0.0-rc.7"
   - "@solidjs/vite-plugin@3.0.0-next.39"
-  - "@solidjs/web@2.0.0-rc.6"
-  - "@tanstack/solid-query-devtools@6.0.0-rc.3"
+  - "@solidjs/web@2.0.0-rc.7"
   - "@tanstack/solid-query@6.0.0-rc.3"
-  - "babel-preset-solid@2.0.0-rc.6"
-  - "solid-js@2.0.0-rc.6"
+  - "solid-js@2.0.0-rc.7"
 {{/if}}
 {{#if (or (eq runtime "node") (eq webDeploy "cloudflare") (eq serverDeploy "cloudflare") (eq webDeploy "prisma") (eq serverDeploy "prisma") (eq webDeploy "docker") (eq serverDeploy "docker") (eq webDeploy "vercel") (eq serverDeploy "vercel") (eq orm "prisma") (includes addons "lefthook") (includes addons "nx") (includes addons "pwa") (includes addons "turborepo") (includes addons "vite-plus") (includes frontend "react-router") (includes frontend "next") (includes frontend "nuxt"))}}
 

--- a/packages/template-generator/templates/frontend/solid/package.json.hbs
+++ b/packages/template-generator/templates/frontend/solid/package.json.hbs
@@ -11,9 +11,9 @@
   },
   "dependencies": {
     "@solidjs/meta": "1.0.0-next.2",
-    "@solidjs/router": "2.0.0-next.21",
-    "@solidjs/web": "2.0.0-rc.6",
-    "solid-js": "2.0.0-rc.6"
+    "@solidjs/router": "2.0.0-next.23",
+    "@solidjs/web": "2.0.0-rc.7",
+    "solid-js": "2.0.0-rc.7"
   },
   "devDependencies": {
     "@solidjs/vite-plugin": "3.0.0-next.39",

--- a/packages/template-generator/templates/frontend/solid/src/App.tsx.hbs
+++ b/packages/template-generator/templates/frontend/solid/src/App.tsx.hbs
@@ -5,7 +5,6 @@ import Loader from "~/components/loader";
 import { Router } from "~/router";
 {{#if (eq api "orpc")}}
 import { QueryClientProvider } from "@tanstack/solid-query";
-import { SolidQueryDevtools } from "@tanstack/solid-query-devtools";
 import { createQueryClient } from "~/utils/orpc";
 {{/if}}
 import "./styles.css";
@@ -31,7 +30,6 @@ export default function App() {
         )}
       </Router>
 {{#if (eq api "orpc")}}
-      <SolidQueryDevtools />
     </QueryClientProvider>
 {{/if}}
   );

--- a/packages/template-generator/templates/frontend/solid/vite.config.ts.hbs
+++ b/packages/template-generator/templates/frontend/solid/vite.config.ts.hbs
@@ -65,6 +65,9 @@ export default defineConfig({
     },
   },
 {{/if}}
+  ssr: {
+    noExternal: ["solid-js", /^@solidjs\//, "@tanstack/solid-query"],
+  },
   resolve: {
     tsconfigPaths: true,
 {{#if (eq webDeploy "cloudflare")}}


### PR DESCRIPTION
Fresh Solid v2 installs mixed core/web rc.6 with signals rc.7 and failed on removed exports. This updates the generated apps to a consistent rc.7 dependency set and fixes dev SSR and authentication issues found while testing real generated apps.

- Update Solid core/web/signals/compiler/Babel plugin to 2.0.0-rc.7, router to 2.0.0-next.23, and Vite+ to 0.3.1. Keep the latest Solid Query 6 RC with its required Query Core version.
- Use package-manager overrides to keep transitive Solid RC packages aligned, with matching pnpm release-age exceptions.
- Configure Vite's public `ssr.noExternal` option for Solid packages and Solid Query so SSR uses one runtime with consistent export conditions. This fixes missing manifests and failures on subsequent dev requests.
- Remove the optional Solid Query Devtools panel: its latest published Solid 2 RC bundles renderer imports removed in rc.7. Query itself remains enabled.
- Await Better Auth's public session refresh before navigating after sign-in/sign-up; show an inline error when the session is unavailable. Mount the dashboard's private query only inside authenticated content, so its initial server response can finish instead of waiting indefinitely on a disabled query.
- Extend existing runtime checks to request the dev page twice and verify the production dashboard response completes. Honor caller cancellation and stop retries after the deadline; add a cancellation regression test.

Validation:

- All 16 Solid install/build/type-check samples passed across Bun, npm and pnpm, including PWA, Vite+, Cloudflare, Docker, Vercel and Prisma configurations.
- Re-ran both self/oRPC samples after the final dashboard changes; production/dev HTTP probes passed, including consecutive dev page requests, API health, dashboard response completion and 404 responses.
- 1,031 CLI tests passed (42 skipped); 78 website/shared-package tests passed. CLI build/publint, source types and formatting/lint passed.
- Created a real app using the built CLI in `~/dev/test/bts-solid-rc7-verified`. Its build/type checks and production HTTP signup/session/todo create/read/toggle/delete checks passed. Browser checks verified dev and production hydration, signup/sign-in redirects, protected dashboard data, sign-out and todo mutations. Simulated session endpoint failures keep both forms on the login page with an error; restoring the endpoint allows sign-in to reach the dashboard.

References: [Solid rc.7](https://github.com/solidjs/solid/releases/tag/solid-js@2.0.0-rc.7), [Vite SSR configuration](https://vite.dev/config/ssr-options), [Better Auth session API](https://better-auth.com/docs/basic-usage#session).

Follows #1226, which was merged before these changes were ready. No live deployments were performed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated generated Solid projects to newer Solid 2 prerelease versions.
  - Added compatibility settings for Solid SSR builds.
  - Added session refreshes after sign-in and sign-up before dashboard navigation.

- **Bug Fixes**
  - Improved dashboard authentication flows so newly authenticated users see private data reliably.
  - Improved request cancellation so aborted requests stop promptly and preserve the cancellation reason.

- **Changes**
  - Removed Solid Query Devtools from generated Solid projects and development dependencies.
  - Updated generated projects to use Vite+ 0.3.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->