### PR TITLE
fix(templates): preserve oRPC types across package boundaries

### DIFF
--- a/apps/cli/test/deployment.test.ts
+++ b/apps/cli/test/deployment.test.ts
@@ -1167,8 +1167,8 @@ describe("Deployment Configurations", () => {
       );
       expect(nuxtPackage.devDependencies?.["nitro-cloudflare-dev"]).toBeUndefined();
       expect(nuxtPackage.devDependencies?.wrangler).toBeUndefined();
-      expect((nuxtPackage as { scripts?: Record<string, string> }).scripts?.build).toBe(
-        "nuxt build",
+      expect((nuxtPackage as { scripts?: Record<string, string> }).scripts?.build).toMatch(
+        /(?:^|&& )nuxt build$/,
       );
       expect(nuxtRootPackage.scripts?.build).toBe("pnpm -r --if-present build");
       expect(nuxtFiles.has("apps/web/cloudflare-workers.dev.ts")).toBe(false);
@@ -1675,7 +1675,7 @@ describe("Deployment Configurations", () => {
       const viteConfig = files.get("apps/web/vite.config.ts");
       const compose = files.get("docker-compose.yml");
 
-      expect(webPkg.scripts.build).toBe("vp build");
+      expect(webPkg.scripts.build).toMatch(/(?:^|&& )vp build$/);
       expect(viteConfig).toContain('nitro({ preset: "bun" }),');
       expect(webDockerfile).toContain("FROM node:24 AS builder");
       expect(webDockerfile).toContain("FROM oven/bun:1 AS runner");

--- a/apps/cli/test/generated-builds.test.ts
+++ b/apps/cli/test/generated-builds.test.ts
@@ -1350,11 +1350,12 @@ export type TypeBoundaryProbeClient = RouterClient<typeof typeBoundaryProbe>;\n`
   const checks = [
     `import type { AppRouterClient, TypeBoundaryProbeClient } from "@${root.name}/api/routers/index";`,
     "type IsAny<T> = 0 extends (1 & T) ? true : false;",
+    "type IsEqual<A, B> = (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;",
     "type Assert<T extends true> = T;",
     "type Health = Awaited<ReturnType<AppRouterClient['healthCheck']>>;",
     "export type HealthIsTyped = Assert<IsAny<Health> extends false ? true : false>;",
     "type IndexedOutput = Awaited<ReturnType<TypeBoundaryProbeClient['read']>>;",
-    "export type ServerOptionsPreserved = Assert<undefined extends IndexedOutput ? true : false>;",
+    "export type ServerOptionsPreserved = Assert<IsEqual<IndexedOutput, number | undefined>>;",
     "export async function checkClient(client: AppRouterClient) {",
     "  const health: string = await client.healthCheck();",
     "  // @ts-expect-error Health check output is not a number.",

--- a/apps/cli/test/generated-builds.test.ts
+++ b/apps/cli/test/generated-builds.test.ts
@@ -66,6 +66,38 @@ const baseConfig = {
 
 const buildSamples: BuildSample[] = [
   {
+    name: "next-self-orpc-prisma-polar",
+    config: {
+      ...baseConfig,
+      frontend: ["next"],
+      backend: "self",
+      runtime: "none",
+      database: "sqlite",
+      orm: "prisma",
+      api: "orpc",
+      auth: "better-auth",
+      payments: "polar",
+      addons: ["none"],
+      examples: ["todo"],
+    },
+  },
+  {
+    name: "expo-orpc-auth-todo",
+    config: {
+      ...baseConfig,
+      frontend: ["native-bare"],
+      backend: "hono",
+      runtime: "bun",
+      database: "sqlite",
+      orm: "drizzle",
+      api: "orpc",
+      auth: "better-auth",
+      payments: "none",
+      addons: ["none"],
+      examples: ["todo"],
+    },
+  },
+  {
     name: "tanstack-start-self-auth-todo",
     config: {
       ...baseConfig,
@@ -1300,6 +1332,72 @@ async function writeSyntheticBuildConfig(projectDir: string) {
   }
 }
 
+async function writeOrpcInferenceChecks(sample: SelectedBuildSample, projectDir: string) {
+  if (sample.config.api !== "orpc") return;
+  const root = z
+    .object({ name: z.string() })
+    .parse(await fs.readJson(path.join(projectDir, "package.json")));
+  await fs.appendFile(
+    path.join(projectDir, "packages/api/src/routers/index.ts"),
+    `\nexport const typeBoundaryProbe = {
+  read: publicProcedure.handler(() => {
+    const values: number[] = [];
+    return values[0];
+  }),
+};
+export type TypeBoundaryProbeClient = RouterClient<typeof typeBoundaryProbe>;\n`,
+  );
+  const checks = [
+    `import type { AppRouterClient, TypeBoundaryProbeClient } from "@${root.name}/api/routers/index";`,
+    "type IsAny<T> = 0 extends (1 & T) ? true : false;",
+    "type Assert<T extends true> = T;",
+    "type Health = Awaited<ReturnType<AppRouterClient['healthCheck']>>;",
+    "export type HealthIsTyped = Assert<IsAny<Health> extends false ? true : false>;",
+    "type IndexedOutput = Awaited<ReturnType<TypeBoundaryProbeClient['read']>>;",
+    "export type ServerOptionsPreserved = Assert<undefined extends IndexedOutput ? true : false>;",
+    "export async function checkClient(client: AppRouterClient) {",
+    "  const health: string = await client.healthCheck();",
+    "  // @ts-expect-error Health check output is not a number.",
+    "  const invalidHealth: number = await client.healthCheck();",
+  ];
+  if (sample.config.examples?.includes("todo")) {
+    checks.push(
+      '  await client.todo.create({ text: "valid" });',
+      "  // @ts-expect-error Todo input must retain its string type in the client.",
+      "  await client.todo.create({ text: 123 });",
+      "  const todos = await client.todo.getAll();",
+      "  const text: string = todos[0]!.text;",
+      "  const completed: boolean = todos[0]!.completed;",
+      "  // @ts-expect-error Database-derived output must not become any.",
+      "  todos[0]!.text = 123;",
+      "  // @ts-expect-error Unknown database fields must be rejected.",
+      "  todos[0]!.nonexistentField;",
+      "  void [text, completed];",
+    );
+  }
+  if (sample.config.auth === "better-auth") {
+    checks.push(
+      "  const privateData = await client.privateData();",
+      "  const email: string = privateData.user!.email;",
+      "  // @ts-expect-error Auth-derived output must not become any.",
+      "  privateData.user!.email = 123;",
+      "  void email;",
+    );
+  }
+  checks.push("  return { health, invalidHealth };", "}");
+  for (const app of ["web", "native", "server"]) {
+    const dir = path.join(projectDir, "apps", app);
+    if (!(await fs.pathExists(dir))) continue;
+    const source =
+      app === "native"
+        ? dir
+        : app === "web" && sample.config.frontend?.includes("nuxt")
+          ? path.join(dir, "app")
+          : path.join(dir, "src");
+    await fs.outputFile(path.join(source, "orpc-inference-check.ts"), checks.join("\n"));
+  }
+}
+
 describe.skipIf(!shouldRunBuildSamples)("Generated project install/build samples", () => {
   for (const sample of getSelectedBuildSamples()) {
     it(
@@ -1315,6 +1413,7 @@ describe.skipIf(!shouldRunBuildSamples)("Generated project install/build samples
 
           const install = getPackageManagerCommand(sample.packageManager, "install");
           await runCommand(sample.name, projectDir, install.command, install.args);
+          await writeOrpcInferenceChecks(sample, projectDir);
           await runWorkspaceTypeChecks(sample.name, projectDir, sample.packageManager);
           const build = getPackageManagerCommand(sample.packageManager, "build");
           await runCommand(sample.name, projectDir, build.command, build.args);

--- a/packages/template-generator/src/post-process/package-configs.ts
+++ b/packages/template-generator/src/post-process/package-configs.ts
@@ -52,6 +52,36 @@ export function processPackageConfigs(vfs: VirtualFileSystem, config: ProjectCon
     updateAuthPackageJson(vfs, config);
     updateApiPackageJson(vfs, config);
   }
+
+  configureOrpcTypeBuilds(vfs, config);
+}
+
+function configureOrpcTypeBuilds(vfs: VirtualFileSystem, config: ProjectConfig): void {
+  if (config.api !== "orpc" || !vfs.exists("packages/api/package.json")) return;
+
+  for (const name of ["db", "auth", "api"]) {
+    const file = `packages/${name}/package.json`;
+    const pkg = vfs.readJson<PackageJson>(file);
+    if (!pkg) continue;
+    pkg.scripts = { ...pkg.scripts, build: "tsc -b", "check-types": "tsc -b" };
+    vfs.writeJson(file, pkg);
+  }
+
+  for (const name of ["web", "native", "server"]) {
+    const file = `apps/${name}/package.json`;
+    const pkg = vfs.readJson<PackageJson>(file);
+    if (!pkg?.scripts) continue;
+    if (name === "web" && config.frontend.includes("nuxt")) {
+      // nuxt typecheck passes --noEmit to every referenced project, including packages.
+      pkg.scripts["check-types"] = "nuxt prepare && vue-tsc -b";
+    }
+    for (const script of ["build", "check-types"]) {
+      if (pkg.scripts[script]) {
+        pkg.scripts[script] = `tsc -b ../../packages/api && ${pkg.scripts[script]}`;
+      }
+    }
+    vfs.writeJson(file, pkg);
+  }
 }
 
 function updateRootPackageJson(vfs: VirtualFileSystem, config: ProjectConfig): void {

--- a/packages/template-generator/src/post-process/package-configs.ts
+++ b/packages/template-generator/src/post-process/package-configs.ts
@@ -64,7 +64,18 @@ function configureOrpcTypeBuilds(vfs: VirtualFileSystem, config: ProjectConfig):
     const pkg = vfs.readJson<PackageJson>(file);
     if (!pkg) continue;
     pkg.scripts = { ...pkg.scripts, build: "tsc -b", "check-types": "tsc -b" };
+    if (name === "api") pkg.scripts.dev = "tsc -b --watch";
     vfs.writeJson(file, pkg);
+  }
+
+  const root = vfs.readJson<PackageJson>("package.json");
+  if (root) {
+    root.scripts ??= {};
+    root.scripts.postinstall = [root.scripts.postinstall, "tsc -b packages/api"]
+      .filter(Boolean)
+      .join(" && ");
+    root.scripts["dev:types"] = "tsc -b packages/api --watch";
+    vfs.writeJson("package.json", root);
   }
 
   for (const name of ["web", "native", "server"]) {

--- a/packages/template-generator/src/post-process/package-configs.ts
+++ b/packages/template-generator/src/post-process/package-configs.ts
@@ -65,13 +65,24 @@ function configureOrpcTypeBuilds(vfs: VirtualFileSystem, config: ProjectConfig):
     if (!pkg) continue;
     pkg.scripts = { ...pkg.scripts, build: "tsc -b", "check-types": "tsc -b" };
     if (name === "api") pkg.scripts.dev = "tsc -b --watch";
+    if (name === "db" && config.orm === "prisma") delete pkg.scripts.postinstall;
     vfs.writeJson(file, pkg);
   }
 
   const root = vfs.readJson<PackageJson>("package.json");
   if (root) {
     root.scripts ??= {};
-    root.scripts.postinstall = [root.scripts.postinstall, "tsc -b packages/api"]
+    const packageManager = getPackageManagerConfig(config.packageManager, {
+      hasTurborepo: false,
+      hasNx: false,
+      hasVitePlus: false,
+    });
+    const generateDatabase =
+      config.orm === "prisma"
+        ? packageManager.filter(`@${config.projectName}/db`, "db:generate")
+        : undefined;
+    // Workspace install hooks can run concurrently; Prisma must finish before declaration builds.
+    root.scripts.postinstall = [root.scripts.postinstall, generateDatabase, "tsc -b packages/api"]
       .filter(Boolean)
       .join(" && ");
     root.scripts["dev:types"] = "tsc -b packages/api --watch";

--- a/packages/template-generator/src/processors/readme-generator.ts
+++ b/packages/template-generator/src/processors/readme-generator.ts
@@ -765,6 +765,9 @@ function generateScriptsList(
   }
 
   scripts += `\n- \`${packageManagerRunCmd} check-types\`: Check TypeScript types across all apps`;
+  if (config.api === "orpc" && !["convex", "none"].includes(backend)) {
+    scripts += `\n- \`${packageManagerRunCmd} dev:types\`: Watch API and dependency declarations when running an app individually. The root \`dev\` command already starts this watcher; installation and builds generate declarations automatically.`;
+  }
 
   if (hasNative) {
     scripts += `\n- \`${packageManagerRunCmd} dev:native\`: Start the React Native/Expo development server`;

--- a/packages/template-generator/src/processors/turbo-generator.ts
+++ b/packages/template-generator/src/processors/turbo-generator.ts
@@ -47,6 +47,9 @@ export function generateTurboConfig(config: ProjectConfig): TurboConfig {
   const hasLocalD1 = getLocalD1Owner(config) === "wrangler";
 
   const tasks: TurboTasks = getBaseTasks(frontend, config.addons);
+  if (config.api === "orpc" && !["convex", "none"].includes(backend)) {
+    tasks["check-types"] = { ...tasks["check-types"], outputs: ["dist/**"] };
+  }
 
   if (config.addons.includes("electrobun")) Object.assign(tasks, getElectrobunTasks());
   if (isConvex) Object.assign(tasks, getConvexTasks());

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -1628,8 +1628,15 @@ export type AppRouter = typeof appRouter;
   ["api/orpc/server/tsconfig.json.hbs", `{
   "extends": "@{{projectName}}/config/tsconfig.base.json",
   "compilerOptions": {
-    "noEmit": true
-  }
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"],
+  "references": [{{#if (ne database "none")}}{ "path": "../db" }{{#if (eq auth "better-auth")}},{{/if}}{{/if}}
+    {{#if (eq auth "better-auth")}}{ "path": "../auth" }{{/if}}]
 }
 `],
   ["api/orpc/web/astro/src/lib/orpc.ts.hbs", `import type { AppRouterClient } from "@{{projectName}}/api/routers/index";
@@ -2771,7 +2778,14 @@ export const trpc = createTRPCOptionsProxy<AppRouter>({
 import { polarClient } from "@polar-sh/better-auth/client";
 {{/if}}
 
-export function createClient(baseURL?: string) {
+type ClientOptions = {
+  baseURL?: string;
+{{#if (eq payments "polar")}}
+  plugins: ReturnType<typeof polarClient>[];
+{{/if}}
+};
+
+export function createClient(baseURL?: string): ReturnType<typeof createAuthClient<ClientOptions>> {
   return createAuthClient({
     baseURL,
 {{#if (eq payments "polar")}}
@@ -8422,9 +8436,21 @@ export function createAuth(env: AuthConfig{{#if (ne database "none")}}, database
 `],
   ["auth/better-auth/server/base/tsconfig.json.hbs", `{
   "extends": "@{{projectName}}/config/tsconfig.base.json",
+  {{#if (eq api "orpc")}}
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"],
+  "references": [{{#if (ne database "none")}}{ "path": "../db" }{{/if}}]
+  {{else}}
   "compilerOptions": {
     "noEmit": true
   }
+  {{/if}}
 }
 `],
   ["auth/better-auth/server/db/drizzle/mysql/src/schema/auth.ts.hbs", `import { relations } from "drizzle-orm";
@@ -14476,6 +14502,9 @@ next-env.d.ts
 }
 `],
   ["backend/server/base/tsconfig.json.hbs", `{
+  {{#if (and (eq api "orpc") (ne backend "convex") (ne backend "none"))}}
+  "references": [{ "path": "../../packages/api" }],
+  {{/if}}
   "extends": "@{{projectName}}/config/tsconfig.base.json",
   "compilerOptions": {
     "composite": true,
@@ -15501,9 +15530,21 @@ export type DatabaseConfig = {
 `],
   ["db/base/tsconfig.json.hbs", `{
   "extends": "@{{projectName}}/config/tsconfig.base.json",
+  {{#if (eq api "orpc")}}
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"{{#if (eq orm "prisma")}}, "prisma/generated/**/*.ts"{{/if}}],
+  "references": []
+  {{else}}
   "compilerOptions": {
     "noEmit": true
   }
+  {{/if}}
 }
 `],
   ["db/drizzle/base/src/schema/index.ts.hbs", `{{#if (eq auth "better-auth")}}
@@ -26288,6 +26329,9 @@ const TITLE_TEXT = \`
 }
 `],
   ["frontend/astro/tsconfig.json.hbs", `{
+  {{#if (and (eq api "orpc") (ne backend "convex") (ne backend "none"))}}
+  "references": [{ "path": "../../packages/api" }],
+  {{/if}}
   "extends": "astro/tsconfigs/strict",
   "include": [".astro/types.d.ts", "**/*"],
   "exclude": ["dist"]
@@ -27516,6 +27560,9 @@ module.exports = withVarlockMetroConfig(config);
 }
 `],
   ["frontend/native/bare/tsconfig.json.hbs", `{
+  {{#if (and (eq api "orpc") (ne backend "convex") (ne backend "none"))}}
+  "references": [{ "path": "../../packages/api" }],
+  {{/if}}
 	"extends": "expo/tsconfig.base",
 	"compilerOptions": {
 		"strict": true,
@@ -28965,6 +29012,9 @@ export const darkTheme = {
 } as const;
 `],
   ["frontend/native/unistyles/tsconfig.json.hbs", `{
+  {{#if (and (eq api "orpc") (ne backend "convex") (ne backend "none"))}}
+  "references": [{ "path": "../../packages/api" }],
+  {{/if}}
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,
@@ -30060,6 +30110,9 @@ module.exports = withVarlockMetroConfig(uniwindConfig);
 }
 `],
   ["frontend/native/uniwind/tsconfig.json.hbs", `{
+  {{#if (and (eq api "orpc") (ne backend "convex") (ne backend "none"))}}
+  "references": [{ "path": "../../packages/api" }],
+  {{/if}}
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,
@@ -30294,7 +30347,12 @@ onServerPrefetch(async () => {
   </UContainer>
 </template>
 `],
-  ["frontend/nuxt/nuxt.config.ts.hbs", `{{#if (and (eq webDeploy "cloudflare") (eq backend "self") (eq orm "prisma"))}}
+  ["frontend/nuxt/nuxt.config.ts.hbs", `{{#if (and (eq api "orpc") (ne backend "convex") (ne backend "none"))}}
+import { fileURLToPath } from "node:url";
+
+const apiReference = { path: fileURLToPath(new URL("../../packages/api", import.meta.url)) };
+{{/if}}
+{{#if (and (eq webDeploy "cloudflare") (eq backend "self") (eq orm "prisma"))}}
 import { defineNuxtModule } from "nuxt/kit";
 import { unwasm } from "unwasm/plugin";
 
@@ -30309,6 +30367,19 @@ const prismaWasm = defineNuxtModule({
 
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
+  {{#if (and (eq api "orpc") (ne backend "convex") (ne backend "none"))}}
+  hooks: {
+    "prepare:types"({ tsConfig, nodeTsConfig, sharedTsConfig }) {
+      for (const config of [tsConfig, nodeTsConfig, sharedTsConfig]) {
+        (config.references ??= []).push(apiReference);
+      }
+    },
+    "nitro:config"(config) {
+      const tsConfig = (config.typescript ??= {}).tsConfig ??= {};
+      (tsConfig.references ??= []).push(apiReference);
+    },
+  },
+  {{/if}}
   compatibilityDate: 'latest',
   devtools: { enabled: true },
   experimental: {
@@ -30826,6 +30897,9 @@ export function ThemeProvider({
 }
 `],
   ["frontend/react/next/tsconfig.json.hbs", `{
+  {{#if (and (eq api "orpc") (ne backend "convex") (ne backend "none"))}}
+  "references": [{ "path": "../../packages/api" }],
+  {{/if}}
   "compilerOptions": {
     "target": "ES2017",
     "lib": ["dom", "dom.iterable", "esnext"],
@@ -31353,6 +31427,9 @@ export default function Home() {
 }
 `],
   ["frontend/react/react-router/tsconfig.json.hbs", `{
+  {{#if (and (eq api "orpc") (ne backend "convex") (ne backend "none"))}}
+  "references": [{ "path": "../../packages/api" }],
+  {{/if}}
   "include": [
     "**/*",
     "**/.server/**/*",
@@ -31853,6 +31930,9 @@ function HomeComponent() {
 }
 `],
   ["frontend/react/tanstack-router/tsconfig.json.hbs", `{
+  {{#if (and (eq api "orpc") (ne backend "convex") (ne backend "none"))}}
+  "references": [{ "path": "../../packages/api" }],
+  {{/if}}
   "compilerOptions": {
     "strict": true,
     "esModuleInterop": true,
@@ -32445,6 +32525,9 @@ function HomeComponent() {
 }
 `],
   ["frontend/react/tanstack-start/tsconfig.json.hbs", `{
+  {{#if (and (eq api "orpc") (ne backend "convex") (ne backend "none"))}}
+  "references": [{ "path": "../../packages/api" }],
+  {{/if}}
   "include": ["**/*.ts", "**/*.tsx"],
   "compilerOptions": {
     "target": "ES2022",
@@ -32960,6 +33043,9 @@ body {
 /// <reference types="filesystem-routing/types" />
 `],
   ["frontend/solid/tsconfig.json.hbs", `{
+  {{#if (and (eq api "orpc") (ne backend "convex") (ne backend "none"))}}
+  "references": [{ "path": "../../packages/api" }],
+  {{/if}}
   "compilerOptions": {
     "target": "ESNext",
     "module": "ESNext",
@@ -33408,6 +33494,9 @@ const config = {
 export default config;
 `],
   ["frontend/svelte/tsconfig.json.hbs", `{
+  {{#if (and (eq api "orpc") (ne backend "convex") (ne backend "none"))}}
+  "references": [{ "path": "../../packages/api" }],
+  {{/if}}
 	"extends": "./.svelte-kit/tsconfig.json",
 	"compilerOptions": {
 		"allowJs": true,

--- a/packages/template-generator/src/templates.generated.ts
+++ b/packages/template-generator/src/templates.generated.ts
@@ -1504,9 +1504,11 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
   "name": "@{{projectName}}/api",
   "exports": {
     ".": {
+      "types": "./dist/src/index.d.ts",
       "default": "./src/index.ts"
     },
     "./*": {
+      "types": "./dist/src/*.d.ts",
       "default": "./src/*.ts"
     }
   },
@@ -8339,9 +8341,15 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
   "name": "@{{projectName}}/auth",
   "exports": {
     ".": {
+      {{#if (eq api "orpc")}}
+      "types": "./dist/src/index.d.ts",
+      {{/if}}
       "default": "./src/index.ts"
     },
     "./*": {
+      {{#if (eq api "orpc")}}
+      "types": "./dist/src/*.d.ts",
+      {{/if}}
       "default": "./src/*.ts"
     }
   },
@@ -15499,9 +15507,15 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
   "type": "module",
   "exports": {
     ".": {
+      {{#if (eq api "orpc")}}
+      "types": "./dist/src/index.d.ts",
+      {{/if}}
       "default": "./src/index.ts"
     },
     "./*": {
+      {{#if (eq api "orpc")}}
+      "types": "./dist/src/*.d.ts",
+      {{/if}}
       "default": "./src/*.ts"
     }
   },
@@ -33499,6 +33513,9 @@ export default config;
   {{/if}}
 	"extends": "./.svelte-kit/tsconfig.json",
 	"compilerOptions": {
+    {{#if (and (eq api "orpc") (ne backend "convex") (ne backend "none"))}}
+    "disableSourceOfProjectReferenceRedirect": true,
+    {{/if}}
 		"allowJs": true,
 		"checkJs": true,
 		"esModuleInterop": true,

--- a/packages/template-generator/src/utils/generated-ignore-patterns.ts
+++ b/packages/template-generator/src/utils/generated-ignore-patterns.ts
@@ -48,6 +48,10 @@ export function getStackGeneratedIgnorePatterns(config: ProjectConfig): string[]
   if (config.database !== "none" && config.orm !== "none") {
     patterns.add("packages/db/dist/**");
   }
+  if (config.api === "orpc" && !["convex", "none"].includes(config.backend)) {
+    patterns.add("packages/api/dist/**");
+    if (config.auth === "better-auth") patterns.add("packages/auth/dist/**");
+  }
 
   if (
     config.database === "sqlite" &&

--- a/packages/template-generator/templates/api/orpc/server/package.json.hbs
+++ b/packages/template-generator/templates/api/orpc/server/package.json.hbs
@@ -2,9 +2,11 @@
   "name": "@{{projectName}}/api",
   "exports": {
     ".": {
+      "types": "./dist/src/index.d.ts",
       "default": "./src/index.ts"
     },
     "./*": {
+      "types": "./dist/src/*.d.ts",
       "default": "./src/*.ts"
     }
   },

--- a/packages/template-generator/templates/api/orpc/server/tsconfig.json.hbs
+++ b/packages/template-generator/templates/api/orpc/server/tsconfig.json.hbs
@@ -1,6 +1,13 @@
 {
   "extends": "@{{projectName}}/config/tsconfig.base.json",
   "compilerOptions": {
-    "noEmit": true
-  }
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"],
+  "references": [{{#if (ne database "none")}}{ "path": "../db" }{{#if (eq auth "better-auth")}},{{/if}}{{/if}}
+    {{#if (eq auth "better-auth")}}{ "path": "../auth" }{{/if}}]
 }

--- a/packages/template-generator/templates/auth/better-auth/client/solid/src/client.ts.hbs
+++ b/packages/template-generator/templates/auth/better-auth/client/solid/src/client.ts.hbs
@@ -3,7 +3,14 @@ import { createAuthClient } from "better-auth/client";
 import { polarClient } from "@polar-sh/better-auth/client";
 {{/if}}
 
-export function createClient(baseURL?: string) {
+type ClientOptions = {
+  baseURL?: string;
+{{#if (eq payments "polar")}}
+  plugins: ReturnType<typeof polarClient>[];
+{{/if}}
+};
+
+export function createClient(baseURL?: string): ReturnType<typeof createAuthClient<ClientOptions>> {
   return createAuthClient({
     baseURL,
 {{#if (eq payments "polar")}}

--- a/packages/template-generator/templates/auth/better-auth/server/base/package.json.hbs
+++ b/packages/template-generator/templates/auth/better-auth/server/base/package.json.hbs
@@ -2,9 +2,15 @@
   "name": "@{{projectName}}/auth",
   "exports": {
     ".": {
+      {{#if (eq api "orpc")}}
+      "types": "./dist/src/index.d.ts",
+      {{/if}}
       "default": "./src/index.ts"
     },
     "./*": {
+      {{#if (eq api "orpc")}}
+      "types": "./dist/src/*.d.ts",
+      {{/if}}
       "default": "./src/*.ts"
     }
   },

--- a/packages/template-generator/templates/auth/better-auth/server/base/tsconfig.json.hbs
+++ b/packages/template-generator/templates/auth/better-auth/server/base/tsconfig.json.hbs
@@ -1,6 +1,18 @@
 {
   "extends": "@{{projectName}}/config/tsconfig.base.json",
+  {{#if (eq api "orpc")}}
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"],
+  "references": [{{#if (ne database "none")}}{ "path": "../db" }{{/if}}]
+  {{else}}
   "compilerOptions": {
     "noEmit": true
   }
+  {{/if}}
 }

--- a/packages/template-generator/templates/backend/server/base/tsconfig.json.hbs
+++ b/packages/template-generator/templates/backend/server/base/tsconfig.json.hbs
@@ -1,4 +1,7 @@
 {
+  {{#if (and (eq api "orpc") (ne backend "convex") (ne backend "none"))}}
+  "references": [{ "path": "../../packages/api" }],
+  {{/if}}
   "extends": "@{{projectName}}/config/tsconfig.base.json",
   "compilerOptions": {
     "composite": true,

--- a/packages/template-generator/templates/db/base/package.json.hbs
+++ b/packages/template-generator/templates/db/base/package.json.hbs
@@ -3,9 +3,15 @@
   "type": "module",
   "exports": {
     ".": {
+      {{#if (eq api "orpc")}}
+      "types": "./dist/src/index.d.ts",
+      {{/if}}
       "default": "./src/index.ts"
     },
     "./*": {
+      {{#if (eq api "orpc")}}
+      "types": "./dist/src/*.d.ts",
+      {{/if}}
       "default": "./src/*.ts"
     }
   },

--- a/packages/template-generator/templates/db/base/tsconfig.json.hbs
+++ b/packages/template-generator/templates/db/base/tsconfig.json.hbs
@@ -1,6 +1,18 @@
 {
   "extends": "@{{projectName}}/config/tsconfig.base.json",
+  {{#if (eq api "orpc")}}
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"{{#if (eq orm "prisma")}}, "prisma/generated/**/*.ts"{{/if}}],
+  "references": []
+  {{else}}
   "compilerOptions": {
     "noEmit": true
   }
+  {{/if}}
 }

--- a/packages/template-generator/templates/frontend/astro/tsconfig.json.hbs
+++ b/packages/template-generator/templates/frontend/astro/tsconfig.json.hbs
@@ -1,4 +1,7 @@
 {
+  {{#if (and (eq api "orpc") (ne backend "convex") (ne backend "none"))}}
+  "references": [{ "path": "../../packages/api" }],
+  {{/if}}
   "extends": "astro/tsconfigs/strict",
   "include": [".astro/types.d.ts", "**/*"],
   "exclude": ["dist"]

--- a/packages/template-generator/templates/frontend/native/bare/tsconfig.json.hbs
+++ b/packages/template-generator/templates/frontend/native/bare/tsconfig.json.hbs
@@ -1,4 +1,7 @@
 {
+  {{#if (and (eq api "orpc") (ne backend "convex") (ne backend "none"))}}
+  "references": [{ "path": "../../packages/api" }],
+  {{/if}}
 	"extends": "expo/tsconfig.base",
 	"compilerOptions": {
 		"strict": true,

--- a/packages/template-generator/templates/frontend/native/unistyles/tsconfig.json.hbs
+++ b/packages/template-generator/templates/frontend/native/unistyles/tsconfig.json.hbs
@@ -1,4 +1,7 @@
 {
+  {{#if (and (eq api "orpc") (ne backend "convex") (ne backend "none"))}}
+  "references": [{ "path": "../../packages/api" }],
+  {{/if}}
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,

--- a/packages/template-generator/templates/frontend/native/uniwind/tsconfig.json.hbs
+++ b/packages/template-generator/templates/frontend/native/uniwind/tsconfig.json.hbs
@@ -1,4 +1,7 @@
 {
+  {{#if (and (eq api "orpc") (ne backend "convex") (ne backend "none"))}}
+  "references": [{ "path": "../../packages/api" }],
+  {{/if}}
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,

--- a/packages/template-generator/templates/frontend/nuxt/nuxt.config.ts.hbs
+++ b/packages/template-generator/templates/frontend/nuxt/nuxt.config.ts.hbs
@@ -1,3 +1,8 @@
+{{#if (and (eq api "orpc") (ne backend "convex") (ne backend "none"))}}
+import { fileURLToPath } from "node:url";
+
+const apiReference = { path: fileURLToPath(new URL("../../packages/api", import.meta.url)) };
+{{/if}}
 {{#if (and (eq webDeploy "cloudflare") (eq backend "self") (eq orm "prisma"))}}
 import { defineNuxtModule } from "nuxt/kit";
 import { unwasm } from "unwasm/plugin";
@@ -13,6 +18,19 @@ const prismaWasm = defineNuxtModule({
 
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
+  {{#if (and (eq api "orpc") (ne backend "convex") (ne backend "none"))}}
+  hooks: {
+    "prepare:types"({ tsConfig, nodeTsConfig, sharedTsConfig }) {
+      for (const config of [tsConfig, nodeTsConfig, sharedTsConfig]) {
+        (config.references ??= []).push(apiReference);
+      }
+    },
+    "nitro:config"(config) {
+      const tsConfig = (config.typescript ??= {}).tsConfig ??= {};
+      (tsConfig.references ??= []).push(apiReference);
+    },
+  },
+  {{/if}}
   compatibilityDate: 'latest',
   devtools: { enabled: true },
   experimental: {

--- a/packages/template-generator/templates/frontend/react/next/tsconfig.json.hbs
+++ b/packages/template-generator/templates/frontend/react/next/tsconfig.json.hbs
@@ -1,4 +1,7 @@
 {
+  {{#if (and (eq api "orpc") (ne backend "convex") (ne backend "none"))}}
+  "references": [{ "path": "../../packages/api" }],
+  {{/if}}
   "compilerOptions": {
     "target": "ES2017",
     "lib": ["dom", "dom.iterable", "esnext"],

--- a/packages/template-generator/templates/frontend/react/react-router/tsconfig.json.hbs
+++ b/packages/template-generator/templates/frontend/react/react-router/tsconfig.json.hbs
@@ -1,4 +1,7 @@
 {
+  {{#if (and (eq api "orpc") (ne backend "convex") (ne backend "none"))}}
+  "references": [{ "path": "../../packages/api" }],
+  {{/if}}
   "include": [
     "**/*",
     "**/.server/**/*",

--- a/packages/template-generator/templates/frontend/react/tanstack-router/tsconfig.json.hbs
+++ b/packages/template-generator/templates/frontend/react/tanstack-router/tsconfig.json.hbs
@@ -1,4 +1,7 @@
 {
+  {{#if (and (eq api "orpc") (ne backend "convex") (ne backend "none"))}}
+  "references": [{ "path": "../../packages/api" }],
+  {{/if}}
   "compilerOptions": {
     "strict": true,
     "esModuleInterop": true,

--- a/packages/template-generator/templates/frontend/react/tanstack-start/tsconfig.json.hbs
+++ b/packages/template-generator/templates/frontend/react/tanstack-start/tsconfig.json.hbs
@@ -1,4 +1,7 @@
 {
+  {{#if (and (eq api "orpc") (ne backend "convex") (ne backend "none"))}}
+  "references": [{ "path": "../../packages/api" }],
+  {{/if}}
   "include": ["**/*.ts", "**/*.tsx"],
   "compilerOptions": {
     "target": "ES2022",

--- a/packages/template-generator/templates/frontend/solid/tsconfig.json.hbs
+++ b/packages/template-generator/templates/frontend/solid/tsconfig.json.hbs
@@ -1,4 +1,7 @@
 {
+  {{#if (and (eq api "orpc") (ne backend "convex") (ne backend "none"))}}
+  "references": [{ "path": "../../packages/api" }],
+  {{/if}}
   "compilerOptions": {
     "target": "ESNext",
     "module": "ESNext",

--- a/packages/template-generator/templates/frontend/svelte/tsconfig.json.hbs
+++ b/packages/template-generator/templates/frontend/svelte/tsconfig.json.hbs
@@ -1,4 +1,7 @@
 {
+  {{#if (and (eq api "orpc") (ne backend "convex") (ne backend "none"))}}
+  "references": [{ "path": "../../packages/api" }],
+  {{/if}}
 	"extends": "./.svelte-kit/tsconfig.json",
 	"compilerOptions": {
 		"allowJs": true,

--- a/packages/template-generator/templates/frontend/svelte/tsconfig.json.hbs
+++ b/packages/template-generator/templates/frontend/svelte/tsconfig.json.hbs
@@ -4,6 +4,9 @@
   {{/if}}
 	"extends": "./.svelte-kit/tsconfig.json",
 	"compilerOptions": {
+    {{#if (and (eq api "orpc") (ne backend "convex") (ne backend "none"))}}
+    "disableSourceOfProjectReferenceRedirect": true,
+    {{/if}}
 		"allowJs": true,
 		"checkJs": true,
 		"esModuleInterop": true,


### PR DESCRIPTION
Generated oRPC clients could re-infer server output using the frontend's compiler settings. For example, an indexed value typed as `number | undefined` under the API package's `noUncheckedIndexedAccess` became `number` in a client without that option. A source-exporting reproduction passes with project references and fails when the reference is removed. The generated-project checks now verify that server-side type information survives in the client.

Restore `composite` and declaration maps for the oRPC API and its auth/database dependencies, and connect consuming apps to the API reference graph. Package builds emit declarations only. Type exports point to these declarations; runtime exports continue to point to TypeScript source. Installation generates Prisma first, then builds declarations in one ordered root hook, avoiding concurrent workspace-hook races. Root development starts a TypeScript watcher. A documented `dev:types` command supports running individual apps. App build/typecheck scripts build the graph first, including when run directly from an app. Prisma-generated sources are included in the database project, and Turbo restores declaration outputs from typecheck caches.

Svelte uses TypeScript's documented [`disableSourceOfProjectReferenceRedirect`](https://www.typescriptlang.org/tsconfig/disableSourceOfProjectReferenceRedirect.html) option so its language service consumes the declaration boundary instead of re-inferring server source.

Nuxt's public configuration hooks add references to its generated TypeScript configs. Its check script runs `nuxt prepare` and `vue-tsc -b`, because `nuxt typecheck` forces `--noEmit` onto referenced packages. Solid's shared auth client uses an explicit return type based on the public Better Auth/Polar factories, avoiding a private Polar type leaking into declarations.

This follows [oRPC's monorepo guidance](https://v1.orpc.dev/docs/best-practices/monorepo-setup). Templates remain on TypeScript 6.0.3 for framework compiler API compatibility; no dependency versions or new packages are introduced.

Validation:
- CLI build/publint, formatting/lint, CLI source/test typechecks, template-generator typecheck, full repository build, and 86 website/shared tests passed.
- All 1,038 CLI tests passed.
- Local generated builds passed for TanStack Start auth/todo, Nuxt oRPC, Solid + Prisma + Polar, Next + Prisma + Polar, and Svelte auth/todo/AI. Start's auth/todo HTTP runtime check passed.
- A fresh project created through the built CLI in `~/dev/test` passed install, typecheck, and build. Changing a server response while the declaration watcher ran also updated the client type successfully.
- Generated oRPC tests now check client inputs, database/auth response types, and preservation of the server's compiler settings with an exact output-type assertion that also rejects `any` and `unknown`. The CI matrix includes new Next and Expo oRPC cases, for 48 generated projects total.
- Expo passed typechecking, build, and iOS/Android JavaScript bundle exports. The pnpm + Solid + Prisma sample passed install, typecheck, and build after ordering Prisma generation before declarations. All 11 PR checks passed on `1a40e544`, including all eight generated-build shards covering 48 projects. [CI results](https://github.com/AmanVarshney01/create-better-t-stack/actions/runs/34381227109).
