### PR TITLE
fix(release): promote website after CLI publication

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   release:
-    name: Release to NPM
+    name: Release CLI and website
     if: github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(release):')
     permissions:
       contents: write
@@ -20,7 +20,7 @@ jobs:
       group: release-${{ github.ref }}
       cancel-in-progress: false
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 35
     steps:
       - name: Checkout Code
         uses: actions/checkout@v7
@@ -47,6 +47,15 @@ jobs:
           VERSION="${{ steps.version.outputs.version }}"
           if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Error: Invalid version format '$VERSION'. Expected semver (x.y.z)"
+            exit 1
+          fi
+
+      - name: Check website promotion credentials
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          if [[ -z "$VERCEL_TOKEN" ]]; then
+            echo "::error::Add the VERCEL_TOKEN repository secret before releasing."
             exit 1
           fi
 
@@ -198,3 +207,59 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### GitHub Release" >> $GITHUB_STEP_SUMMARY
           echo "[v$VERSION](https://github.com/${{ github.repository }}/releases/tag/v$VERSION)" >> $GITHUB_STEP_SUMMARY
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@59.15.1
+
+      - name: Promote the release website
+        timeout-minutes: 15
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_SCOPE: better-t-stack
+          VERCEL_PROJECT: create-better-t-stack-web
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          for attempt in {1..60}; do
+            deployments=$(vercel list "$VERCEL_PROJECT" \
+              --scope "$VERCEL_SCOPE" --token "$VERCEL_TOKEN" \
+              --environment production --meta "githubCommitSha=$GITHUB_SHA" --json)
+            deployment=$(jq -c --arg sha "$GITHUB_SHA" --arg project "$VERCEL_PROJECT" '
+              [.deployments[] | select(
+                .meta.githubCommitSha == $sha and
+                .name == $project and .target == "production"
+              )] | sort_by(.createdAt) | last // empty
+            ' <<< "$deployments")
+            state=$(jq -r '.state // empty' <<< "$deployment")
+
+            case "$state" in
+              READY)
+                deployment_url=$(jq -er '.url | select(type == "string" and length > 0)' <<< "$deployment")
+                break
+                ;;
+              ERROR|CANCELED)
+                echo "::error::The release website build is $state. Redeploy commit $GITHUB_SHA in Vercel, then rerun this workflow."
+                exit 1
+                ;;
+            esac
+
+            echo "Waiting for the production build of $GITHUB_SHA ($attempt/60)."
+            sleep 10
+          done
+
+          if [[ -z "${deployment_url:-}" ]]; then
+            echo "::error::No ready production build found for $GITHUB_SHA. Check Vercel's build and ignored-build settings, then rerun this workflow."
+            exit 1
+          fi
+
+          # Prevent partial releases and reruns of older releases from advancing the website.
+          for package in @better-t-stack/types @better-t-stack/template-generator create-better-t-stack create-bts; do
+            published_version=$(npm view "$package@latest" version)
+            if [[ "$published_version" != "$RELEASE_VERSION" ]]; then
+              echo "::error::$package@latest is $published_version, expected $RELEASE_VERSION. Website promotion stopped."
+              exit 1
+            fi
+          done
+
+          vercel promote "$deployment_url" \
+            --scope "$VERCEL_SCOPE" --token "$VERCEL_TOKEN" --timeout 5m
+          echo "Website for v$RELEASE_VERSION promoted from commit $GITHUB_SHA: https://$deployment_url" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
       group: release-${{ github.ref }}
       cancel-in-progress: false
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: 40
     steps:
       - name: Checkout Code
         uses: actions/checkout@v7
@@ -59,57 +59,68 @@ jobs:
             exit 1
           fi
 
-      - name: Check if version already exists
-        id: check-version
+      - name: Check published package versions
+        id: published
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          if npm view create-better-t-stack@$VERSION version 2>/dev/null; then
-            echo "Version $VERSION already exists on NPM"
-            echo "exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "Version $VERSION is new"
-            echo "exists=false" >> $GITHUB_OUTPUT
-          fi
+          needs_publish=false
+          for entry in types=@better-t-stack/types generator=@better-t-stack/template-generator cli=create-better-t-stack alias=create-bts; do
+            key=${entry%%=*}
+            package=${entry#*=}
+            versions=$(npm view "$package" versions --json)
+            exists=$(jq -r --arg version "$VERSION" 'if type == "array" then index($version) != null else error("Expected an npm version list") end' <<< "$versions")
+            echo "${key}_exists=$exists" >> "$GITHUB_OUTPUT"
+            if [[ "$exists" == false ]]; then
+              needs_publish=true
+            else
+              published_commit=$(npm view "$package@$VERSION" gitHead)
+              if [[ "$published_commit" != "$GITHUB_SHA" ]]; then
+                echo "::error::$package@$VERSION was not published from $GITHUB_SHA. Use a new release version."
+                exit 1
+              fi
+            fi
+          done
+          echo "needs_publish=$needs_publish" >> "$GITHUB_OUTPUT"
 
       - name: Setup Bun
-        if: steps.check-version.outputs.exists == 'false'
         uses: oven-sh/setup-bun@v2
 
       - name: Install Dependencies
-        if: steps.check-version.outputs.exists == 'false'
+        if: steps.published.outputs.needs_publish == 'true'
         run: bun install --frozen-lockfile
 
       - name: Update types package version
-        if: steps.check-version.outputs.exists == 'false'
+        if: steps.published.outputs.needs_publish == 'true'
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           cd packages/types
           jq --arg v "$VERSION" '.version = $v' package.json > tmp.json && mv tmp.json package.json
 
       - name: Build types package
-        if: steps.check-version.outputs.exists == 'false'
+        if: steps.published.outputs.needs_publish == 'true'
         run: cd packages/types && bun run build
 
       - name: Update template-generator package version and types dependency
-        if: steps.check-version.outputs.exists == 'false'
+        if: steps.published.outputs.needs_publish == 'true'
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           cd packages/template-generator
           jq --arg v "$VERSION" --arg dep "^$VERSION" '.version = $v | .dependencies["@better-t-stack/types"] = $dep' package.json > tmp.json && mv tmp.json package.json
 
       - name: Build template-generator package
-        if: steps.check-version.outputs.exists == 'false'
+        if: steps.published.outputs.needs_publish == 'true'
         run: cd packages/template-generator && bun run build
 
       - name: Update CLI types and template-generator dependencies and version
-        if: steps.check-version.outputs.exists == 'false'
+        if: steps.published.outputs.needs_publish == 'true'
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           cd apps/cli
           jq --arg v "^$VERSION" '.dependencies["@better-t-stack/types"] = $v | .dependencies["@better-t-stack/template-generator"] = $v' package.json > tmp.json && mv tmp.json package.json
 
       - name: Build CLI
-        if: steps.check-version.outputs.exists == 'false'
+        if: steps.published.outputs.needs_publish == 'true'
         run: cd apps/cli && bun run build
         env:
           BTS_TELEMETRY: 1
@@ -117,14 +128,14 @@ jobs:
           UMAMI_CLI_WEBSITE_ID: ${{ secrets.UMAMI_CLI_WEBSITE_ID }}
 
       - name: Update create-bts alias package version
-        if: steps.check-version.outputs.exists == 'false'
+        if: steps.published.outputs.needs_publish == 'true'
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           cd packages/create-bts
           jq --arg v "$VERSION" --arg dep "^$VERSION" '.version = $v | .dependencies["create-better-t-stack"] = $dep' package.json > tmp.json && mv tmp.json package.json
 
       - name: Setup pnpm
-        if: steps.check-version.outputs.exists == 'false'
+        if: steps.published.outputs.needs_publish == 'true'
         uses: pnpm/action-setup@v6
         with:
           version: latest
@@ -133,11 +144,11 @@ jobs:
       # partial release on npm (e.g. types/template-generator published but
       # create-better-t-stack broken).
       - name: Publish smoke test (npm, pnpm, bun)
-        if: steps.check-version.outputs.exists == 'false'
+        if: steps.published.outputs.needs_publish == 'true'
         run: bun run smoke:publish
 
       - name: Publish types to NPM
-        if: steps.check-version.outputs.exists == 'false'
+        if: steps.published.outputs.types_exists == 'false'
         run: cd packages/types && npm publish --access public
         env:
           BTS_TELEMETRY: 1
@@ -145,7 +156,7 @@ jobs:
           UMAMI_CLI_WEBSITE_ID: ${{ secrets.UMAMI_CLI_WEBSITE_ID }}
 
       - name: Publish template-generator to NPM
-        if: steps.check-version.outputs.exists == 'false'
+        if: steps.published.outputs.generator_exists == 'false'
         run: cd packages/template-generator && npm publish --access public
         env:
           BTS_TELEMETRY: 1
@@ -153,7 +164,7 @@ jobs:
           UMAMI_CLI_WEBSITE_ID: ${{ secrets.UMAMI_CLI_WEBSITE_ID }}
 
       - name: Publish CLI to NPM
-        if: steps.check-version.outputs.exists == 'false'
+        if: steps.published.outputs.cli_exists == 'false'
         run: cd apps/cli && npm publish --access public
         env:
           BTS_TELEMETRY: 1
@@ -161,7 +172,7 @@ jobs:
           UMAMI_CLI_WEBSITE_ID: ${{ secrets.UMAMI_CLI_WEBSITE_ID }}
 
       - name: Publish create-bts alias to NPM
-        if: steps.check-version.outputs.exists == 'false'
+        if: steps.published.outputs.alias_exists == 'false'
         run: cd packages/create-bts && npm publish --access public
         env:
           BTS_TELEMETRY: 1
@@ -169,7 +180,6 @@ jobs:
           UMAMI_CLI_WEBSITE_ID: ${{ secrets.UMAMI_CLI_WEBSITE_ID }}
 
       - name: Create and push tag
-        if: steps.check-version.outputs.exists == 'false'
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           git config --local user.email "amanvarshney.work@gmail.com"
@@ -178,11 +188,14 @@ jobs:
             git tag -a "v$VERSION" -m "Release v$VERSION"
             git push --tags
           else
+            if [[ "$(git rev-parse "v$VERSION^{commit}")" != "$GITHUB_SHA" ]]; then
+              echo "::error::Tag v$VERSION belongs to a different commit."
+              exit 1
+            fi
             echo "Tag v$VERSION already exists, skipping"
           fi
 
       - name: Create GitHub Release
-        if: steps.check-version.outputs.exists == 'false'
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           if ! gh release view "v$VERSION" >/dev/null 2>&1; then
@@ -194,10 +207,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Release Summary
-        if: steps.check-version.outputs.exists == 'false'
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          echo "## Release v$VERSION Complete!" >> $GITHUB_STEP_SUMMARY
+          echo "## Packages published for v$VERSION" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Published Packages" >> $GITHUB_STEP_SUMMARY
           echo "- [create-better-t-stack@$VERSION](https://www.npmjs.com/package/create-better-t-stack/v/$VERSION)" >> $GITHUB_STEP_SUMMARY
@@ -212,42 +224,31 @@ jobs:
         run: npm install --global vercel@59.15.1
 
       - name: Promote the release website
-        timeout-minutes: 15
+        timeout-minutes: 20
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_SCOPE: better-t-stack
           VERCEL_PROJECT: create-better-t-stack-web
           RELEASE_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          for attempt in {1..60}; do
-            deployments=$(vercel list "$VERCEL_PROJECT" \
-              --scope "$VERCEL_SCOPE" --token "$VERCEL_TOKEN" \
-              --environment production --meta "githubCommitSha=$GITHUB_SHA" --json)
-            deployment=$(jq -c --arg sha "$GITHUB_SHA" --arg project "$VERCEL_PROJECT" '
-              [.deployments[] | select(
-                .meta.githubCommitSha == $sha and
-                .name == $project and .target == "production"
-              )] | sort_by(.createdAt) | last // empty
-            ' <<< "$deployments")
-            state=$(jq -r '.state // empty' <<< "$deployment")
+          deployments=$(vercel list "$VERCEL_PROJECT" \
+            --scope "$VERCEL_SCOPE" --token "$VERCEL_TOKEN" \
+            --environment production --meta "githubCommitSha=$GITHUB_SHA" --json)
+          if ! deployment_url=$(jq -er --arg sha "$GITHUB_SHA" --arg project "$VERCEL_PROJECT" '
+            [.deployments[] | select(
+              .meta.githubCommitSha == $sha and
+              .name == $project and .target == "production"
+            )] | sort_by(.createdAt) | last | .url // empty
+          ' <<< "$deployments"); then
+            echo "::error::No production deployment found for $GITHUB_SHA. Create or redeploy that commit in Vercel, then rerun this workflow."
+            exit 1
+          fi
 
-            case "$state" in
-              READY)
-                deployment_url=$(jq -er '.url | select(type == "string" and length > 0)' <<< "$deployment")
-                break
-                ;;
-              ERROR|CANCELED)
-                echo "::error::The release website build is $state. Redeploy commit $GITHUB_SHA in Vercel, then rerun this workflow."
-                exit 1
-                ;;
-            esac
-
-            echo "Waiting for the production build of $GITHUB_SHA ($attempt/60)."
-            sleep 10
-          done
-
-          if [[ -z "${deployment_url:-}" ]]; then
-            echo "::error::No ready production build found for $GITHUB_SHA. Check Vercel's build and ignored-build settings, then rerun this workflow."
+          deployment=$(vercel inspect "$deployment_url" \
+            --scope "$VERCEL_SCOPE" --token "$VERCEL_TOKEN" \
+            --wait --timeout 10m --json)
+          if ! jq -e '.readyState == "READY"' <<< "$deployment" > /dev/null; then
+            echo "::error::The release website did not become ready. Check the Vercel build, then rerun this workflow."
             exit 1
           fi
 


### PR DESCRIPTION
The stack builder currently ships merged options before the corresponding CLI reaches npm. Keep Vercel builds staged and promote the production deployment for the exact release commit only after all four published packages have that release version on the `latest` tag.

Promotion uses the official Vercel CLI and remains inside the existing serialized release job. It selects the matching production deployment, waits with `vercel inspect --wait`, verifies `READY`, and promotes it. Missing deployments and failed or timed-out builds stop promotion; create or redeploy the exact commit in Vercel and rerun the workflow to recover. npm trusted publishing stays in `release.yaml`.

Check each package independently so retries publish only missing packages after a partial release. Existing packages must record the same commit in npm's `gitHead`, and an existing release tag must point to that commit. Tag and GitHub release creation are also retryable. The promotion step has 20 minutes and the job 40 minutes to accommodate build waiting and promotion.

Setup: production domain auto-assignment has been disabled in the Vercel dashboard and the `VERCEL_TOKEN` GitHub Actions repository secret is present. The token needs access to the `better-t-stack` team. The existing Vercel check identifies the project as `create-better-t-stack-web`; no project linking or additional ID secrets are needed.

Validation:
- `bun run check`, `git diff --check`, and actionlint passed.
- Executed the final workflow shell with mocked commands: 21 package-resume/commit-identity scenarios and 15 deployment-selection/promotion scenarios passed. These cover all 16 combinations of published packages, wrong or missing npm commits, unrelated newer deployments, wrong SHA/project/environment, missing/failed/timed-out builds, mismatched releases, API failures, and promotion failures.
- Verified list/inspect JSON flags, commit filtering, build waiting, and promotion options against Vercel CLI 59.15.1.
- No npm packages published or live deployments promoted; authenticated end-to-end validation still requires a release.

Official references: [staged production deployments](https://vercel.com/docs/deployments/promoting-a-deployment), [deployment filtering by commit](https://vercel.com/docs/cli/list), [waiting for a build](https://vercel.com/docs/cli/inspect), [promotion](https://vercel.com/docs/cli/promote).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process**
  * Release automation now promotes the release website on Vercel alongside publishing packages to NPM.
  * Added validation for required Vercel authentication and deployment readiness.
  * Releases now verify package versions and commit consistency before publishing, tagging, and promoting the website.
  * Website promotion confirms that all published packages match the release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->